### PR TITLE
perf: Dory's compute_T_vec_prime should be able to use Blitzar's fixed MSM (PROOF-876)

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -1,147 +1,11 @@
-use super::{pairings, DoryCommitment, DoryProverPublicSetup, DoryScalar, G1Affine};
+use super::{pairings, transpose, DoryCommitment, DoryProverPublicSetup, DoryScalar, G1Affine};
 use crate::base::commitment::CommittableColumn;
 use ark_bls12_381::Fr;
 use ark_ec::CurveGroup;
 use ark_std::ops::Mul;
 use blitzar::{compute::ElementP2, sequence::Sequence};
-use num_traits::ToBytes;
 use rayon::prelude::*;
 use zerocopy::AsBytes;
-
-trait OffsetToBytes {
-    const IS_SIGNED: bool;
-    fn min_as_fr() -> Fr;
-    fn offset_to_bytes(&self) -> Vec<u8>;
-}
-
-impl OffsetToBytes for u8 {
-    const IS_SIGNED: bool = false;
-
-    fn min_as_fr() -> Fr {
-        Fr::from(0)
-    }
-
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        vec![*self]
-    }
-}
-
-impl OffsetToBytes for i16 {
-    const IS_SIGNED: bool = true;
-
-    fn min_as_fr() -> Fr {
-        Fr::from(i16::MIN)
-    }
-
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        let shifted = self.wrapping_sub(i16::MIN);
-        shifted.to_le_bytes().to_vec()
-    }
-}
-
-impl OffsetToBytes for i32 {
-    const IS_SIGNED: bool = true;
-
-    fn min_as_fr() -> Fr {
-        Fr::from(i32::MIN)
-    }
-
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        let shifted = self.wrapping_sub(i32::MIN);
-        shifted.to_le_bytes().to_vec()
-    }
-}
-
-impl OffsetToBytes for i64 {
-    const IS_SIGNED: bool = true;
-
-    fn min_as_fr() -> Fr {
-        Fr::from(i64::MIN)
-    }
-
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        let shifted = self.wrapping_sub(i64::MIN);
-        shifted.to_le_bytes().to_vec()
-    }
-}
-
-impl OffsetToBytes for i128 {
-    const IS_SIGNED: bool = true;
-
-    fn min_as_fr() -> Fr {
-        Fr::from(i128::MIN)
-    }
-
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        let shifted = self.wrapping_sub(i128::MIN);
-        shifted.to_le_bytes().to_vec()
-    }
-}
-
-impl OffsetToBytes for bool {
-    const IS_SIGNED: bool = false;
-
-    fn min_as_fr() -> Fr {
-        Fr::from(false)
-    }
-
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        vec![*self as u8]
-    }
-}
-
-impl OffsetToBytes for u64 {
-    const IS_SIGNED: bool = false;
-
-    fn min_as_fr() -> Fr {
-        Fr::from(0)
-    }
-
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        let bytes = self.to_le_bytes();
-        bytes.to_vec()
-    }
-}
-
-impl OffsetToBytes for [u64; 4] {
-    const IS_SIGNED: bool = false;
-
-    fn min_as_fr() -> Fr {
-        Fr::from(0)
-    }
-
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        let slice = self.as_bytes();
-        slice.to_vec()
-    }
-}
-
-#[tracing::instrument(name = "transpose_column (gpu)", level = "debug", skip_all)]
-fn transpose_column<T: AsBytes + Copy + OffsetToBytes>(
-    column: &[T],
-    offset: usize,
-    num_columns: usize,
-    data_size: usize,
-) -> Vec<u8> {
-    let column_len_with_offset = column.len() + offset;
-    let total_length_bytes =
-        data_size * (((column_len_with_offset + num_columns - 1) / num_columns) * num_columns);
-    let cols = num_columns;
-    let rows = total_length_bytes / (data_size * cols);
-
-    let mut transpose = vec![0_u8; total_length_bytes];
-    for n in offset..(column.len() + offset) {
-        let i = n / cols;
-        let j = n % cols;
-        let t_idx = (j * rows + i) * data_size;
-        let p_idx = (i * cols + j) - offset;
-
-        transpose[t_idx..t_idx + data_size]
-            .copy_from_slice(column[p_idx].offset_to_bytes().as_slice());
-    }
-
-    transpose
-}
 
 #[tracing::instrument(name = "get_offset_commits (gpu)", level = "debug", skip_all)]
 fn get_offset_commits(
@@ -167,7 +31,7 @@ fn get_offset_commits(
         // Get the commit of the first non-zero row
         let first_row_offset = offset - (num_zero_commits * num_columns);
         let first_row_transpose =
-            transpose_column(first_row, first_row_offset, num_columns, data_size);
+            transpose::transpose_for_fixed_msm(first_row, first_row_offset, num_columns, data_size);
 
         setup.public_parameters().blitzar_handle.msm(
             &mut ones_blitzar_commits[num_zero_commits..num_zero_commits + 1],
@@ -179,7 +43,8 @@ fn get_offset_commits(
         let mut chunks = remaining_elements.chunks(num_columns);
         if chunks.len() > 1 {
             if let Some(middle_row) = chunks.next() {
-                let middle_row_transpose = transpose_column(middle_row, 0, num_columns, data_size);
+                let middle_row_transpose =
+                    transpose::transpose_for_fixed_msm(middle_row, 0, num_columns, data_size);
                 let mut middle_row_blitzar_commit =
                     vec![ElementP2::<ark_bls12_381::g1::Config>::default(); 1];
 
@@ -197,7 +62,8 @@ fn get_offset_commits(
 
         // Get the commit of the last row to handle an zero padding at the end of the column
         if let Some(last_row) = remaining_elements.chunks(num_columns).last() {
-            let last_row_transpose = transpose_column(last_row, 0, num_columns, data_size);
+            let last_row_transpose =
+                transpose::transpose_for_fixed_msm(last_row, 0, num_columns, data_size);
 
             setup.public_parameters().blitzar_handle.msm(
                 &mut ones_blitzar_commits[num_of_commits - 1..num_of_commits],
@@ -223,13 +89,14 @@ fn compute_dory_commitment_impl<'a, T>(
 where
     &'a T: Into<DoryScalar>,
     &'a [T]: Into<Sequence<'a>>,
-    T: AsBytes + Copy + OffsetToBytes,
+    T: AsBytes + Copy + transpose::OffsetToBytes,
 {
     let num_columns = 1 << setup.sigma();
     let data_size = std::mem::size_of::<T>();
 
     // Format column to match column major data layout required by blitzar's msm
-    let column_transpose = transpose_column(column, offset, num_columns, data_size);
+    let column_transpose =
+        transpose::transpose_for_fixed_msm(column, offset, num_columns, data_size);
     let num_of_commits = column_transpose.len() / (data_size * num_columns);
     let gamma_2_slice = &setup.public_parameters().Gamma_2[0..num_of_commits];
 
@@ -292,195 +159,4 @@ pub(super) fn compute_dory_commitments(
         .iter()
         .map(|column| compute_dory_commitment(column, offset, setup))
         .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn we_can_transpose_empty_column() {
-        type T = u64;
-        let column: Vec<T> = vec![];
-        let offset = 0;
-        let num_columns = 2;
-        let data_size = std::mem::size_of::<T>();
-
-        let expected_len = data_size * (column.len() + offset);
-
-        let transpose = transpose_column(&column, offset, num_columns, data_size);
-
-        assert_eq!(transpose.len(), expected_len);
-        assert!(transpose.is_empty());
-    }
-
-    #[test]
-    fn we_can_transpose_u64_column() {
-        type T = u64;
-        let column: Vec<T> = vec![0, 1, 2, 3];
-        let offset = 0;
-        let num_columns = 2;
-        let data_size = std::mem::size_of::<T>();
-
-        let expected_len = data_size * (column.len() + offset);
-
-        let transpose = transpose_column(&column, offset, num_columns, data_size);
-
-        assert_eq!(transpose.len(), expected_len);
-
-        assert_eq!(&transpose[0..data_size], column[0].as_bytes());
-        assert_eq!(&transpose[data_size..2 * data_size], column[2].as_bytes());
-        assert_eq!(
-            &transpose[2 * data_size..3 * data_size],
-            column[1].as_bytes()
-        );
-        assert_eq!(
-            &transpose[3 * data_size..4 * data_size],
-            column[3].as_bytes()
-        );
-    }
-
-    #[test]
-    fn we_can_transpose_u64_column_with_offset() {
-        type T = u64;
-        let column: Vec<T> = vec![1, 2, 3];
-        let offset = 2;
-        let num_columns = 3;
-        let data_size = std::mem::size_of::<T>();
-
-        let expected_len = data_size * (column.len() + offset + 1);
-
-        let transpose = transpose_column(&column, offset, num_columns, data_size);
-
-        assert_eq!(transpose.len(), expected_len);
-
-        assert_eq!(&transpose[0..data_size], 0_u64.as_bytes());
-        assert_eq!(&transpose[data_size..2 * data_size], column[1].as_bytes());
-        assert_eq!(&transpose[2 * data_size..3 * data_size], 0_u64.as_bytes());
-        assert_eq!(
-            &transpose[3 * data_size..4 * data_size],
-            column[2].as_bytes()
-        );
-        assert_eq!(
-            &transpose[4 * data_size..5 * data_size],
-            column[0].as_bytes()
-        );
-        assert_eq!(&transpose[5 * data_size..6 * data_size], 0_u64.as_bytes());
-    }
-
-    #[test]
-    fn we_can_transpose_boolean_column_with_offset() {
-        type T = bool;
-        let column: Vec<T> = vec![true, false, true];
-        let offset = 1;
-        let num_columns = 2;
-        let data_size = std::mem::size_of::<T>();
-
-        let expected_len = data_size * (column.len() + offset);
-
-        let transpose = transpose_column(&column, offset, num_columns, data_size);
-
-        assert_eq!(transpose.len(), expected_len);
-
-        assert_eq!(&transpose[0..data_size], 0_u8.as_bytes());
-        assert_eq!(&transpose[data_size..2 * data_size], column[1].as_bytes());
-        assert_eq!(
-            &transpose[2 * data_size..3 * data_size],
-            column[0].as_bytes()
-        );
-        assert_eq!(
-            &transpose[3 * data_size..4 * data_size],
-            column[2].as_bytes()
-        );
-    }
-
-    #[test]
-    fn we_can_transpose_i64_column() {
-        type T = i64;
-        let column: Vec<T> = vec![0, 1, 2, 3];
-        let offset = 0;
-        let num_columns = 2;
-        let data_size = std::mem::size_of::<T>();
-
-        let expected_len = data_size * (column.len() + offset);
-
-        let transpose = transpose_column(&column, offset, num_columns, data_size);
-
-        assert_eq!(transpose.len(), expected_len);
-
-        assert_eq!(
-            &transpose[0..data_size],
-            column[0].wrapping_sub(T::MIN).as_bytes()
-        );
-        assert_eq!(
-            &transpose[data_size..2 * data_size],
-            column[2].wrapping_sub(T::MIN).as_bytes()
-        );
-        assert_eq!(
-            &transpose[2 * data_size..3 * data_size],
-            column[1].wrapping_sub(T::MIN).as_bytes()
-        );
-        assert_eq!(
-            &transpose[3 * data_size..4 * data_size],
-            column[3].wrapping_sub(T::MIN).as_bytes()
-        );
-    }
-
-    #[test]
-    fn we_can_transpose_i128_column() {
-        type T = i128;
-        let column: Vec<T> = vec![0, 1, 2, 3];
-        let offset = 0;
-        let num_columns = 2;
-        let data_size = std::mem::size_of::<T>();
-
-        let expected_len = data_size * (column.len() + offset);
-
-        let transpose = transpose_column(&column, offset, num_columns, data_size);
-
-        assert_eq!(transpose.len(), expected_len);
-
-        assert_eq!(
-            &transpose[0..data_size],
-            column[0].wrapping_sub(T::MIN).as_bytes()
-        );
-        assert_eq!(
-            &transpose[data_size..2 * data_size],
-            column[2].wrapping_sub(T::MIN).as_bytes()
-        );
-        assert_eq!(
-            &transpose[2 * data_size..3 * data_size],
-            column[1].wrapping_sub(T::MIN).as_bytes()
-        );
-        assert_eq!(
-            &transpose[3 * data_size..4 * data_size],
-            column[3].wrapping_sub(T::MIN).as_bytes()
-        );
-    }
-
-    #[test]
-    fn we_can_transpose_u64_array_column() {
-        type T = [u64; 4];
-        let column: Vec<T> = vec![[0, 0, 0, 0], [1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]];
-        let offset = 0;
-        let num_columns = 2;
-        let data_size = std::mem::size_of::<T>();
-
-        let expected_len = data_size * (column.len() + offset);
-
-        let transpose = transpose_column(&column, offset, num_columns, data_size);
-
-        assert_eq!(transpose.len(), expected_len);
-
-        assert_eq!(&transpose[0..data_size], column[0].as_bytes());
-        assert_eq!(&transpose[data_size..2 * data_size], column[2].as_bytes());
-        assert_eq!(
-            &transpose[2 * data_size..3 * data_size],
-            column[1].as_bytes()
-        );
-        assert_eq!(
-            &transpose[3 * data_size..4 * data_size],
-            column[3].as_bytes()
-        );
-    }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -33,7 +33,7 @@ fn get_offset_commits(
         let first_row_transpose =
             transpose::transpose_for_fixed_msm(first_row, first_row_offset, num_columns, data_size);
 
-        setup.public_parameters().blitzar_handle.msm(
+        setup.public_parameters().blitzar_msm(
             &mut ones_blitzar_commits[num_zero_commits..num_zero_commits + 1],
             data_size as u32,
             first_row_transpose.as_slice(),
@@ -48,7 +48,7 @@ fn get_offset_commits(
                 let mut middle_row_blitzar_commit =
                     vec![ElementP2::<ark_bls12_381::g1::Config>::default(); 1];
 
-                setup.public_parameters().blitzar_handle.msm(
+                setup.public_parameters().blitzar_msm(
                     &mut middle_row_blitzar_commit,
                     data_size as u32,
                     middle_row_transpose.as_slice(),
@@ -65,7 +65,7 @@ fn get_offset_commits(
             let last_row_transpose =
                 transpose::transpose_for_fixed_msm(last_row, 0, num_columns, data_size);
 
-            setup.public_parameters().blitzar_handle.msm(
+            setup.public_parameters().blitzar_msm(
                 &mut ones_blitzar_commits[num_of_commits - 1..num_of_commits],
                 data_size as u32,
                 last_row_transpose.as_slice(),
@@ -103,7 +103,7 @@ where
     // Compute the commitment for the entire data set
     let mut blitzar_commits =
         vec![ElementP2::<ark_bls12_381::g1::Config>::default(); num_of_commits];
-    setup.public_parameters().blitzar_handle.msm(
+    setup.public_parameters().blitzar_msm(
         &mut blitzar_commits,
         data_size as u32,
         column_transpose.as_slice(),

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
@@ -23,16 +23,12 @@ pub(super) fn compute_v_vec(a: &[F], L_vec: &[F], sigma: usize, nu: usize) -> Ve
 
 /// Converts a bls12-381 scalar to a u64 array.
 #[cfg(feature = "blitzar")]
-fn convert_scalar_to_padded_array(
+fn convert_scalar_to_array(
     scalars: &[ark_ff::Fp<MontBackend<ark_bls12_381::FrConfig, 4>, 4>],
-    num_columns: usize,
-    num_outputs: usize,
 ) -> Vec<[u64; 4]> {
     scalars
         .iter()
         .map(|&element| BigInt::<4>::from(element).0)
-        .chain(core::iter::repeat([0, 0, 0, 0]))
-        .take(num_columns * num_outputs)
         .collect()
 }
 
@@ -49,8 +45,9 @@ pub(super) fn compute_T_vec_prime(
     let num_outputs = 1 << nu;
     let data_size = std::mem::size_of::<F>();
 
-    let a_array = convert_scalar_to_padded_array(a, num_columns, num_outputs);
-    let a_transpose = transpose::transpose_for_fixed_msm(&a_array, 0, num_columns, data_size);
+    let a_array = convert_scalar_to_array(a);
+    let a_transpose =
+        transpose::transpose_for_fixed_msm(&a_array, 0, num_outputs, num_columns, data_size);
 
     let mut blitzar_commits = vec![ElementP2::<ark_bls12_381::g1::Config>::default(); num_outputs];
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
@@ -42,12 +42,6 @@ pub(super) fn compute_T_vec_prime(
     let num_columns = 1 << sigma;
     let data_size = std::mem::size_of::<F>();
     let mut blitzar_commit = vec![ElementP2::<ark_bls12_381::g1::Config>::default(); 1];
-    let gs: Vec<_> = prover_setup.Gamma_1[nu]
-        .iter()
-        .copied()
-        .map(Into::into)
-        .collect();
-    let blitzar_handle = blitzar::compute::MsmHandle::new(&gs);
 
     a.chunks(1 << sigma)
         .map(|row| {
@@ -55,7 +49,7 @@ pub(super) fn compute_T_vec_prime(
             let column_transpose =
                 transpose::transpose_for_fixed_msm(&row_array, 0, num_columns, data_size);
 
-            blitzar_handle.msm(
+            prover_setup.blitzar_handle.msm(
                 &mut blitzar_commit,
                 data_size as u32,
                 column_transpose.as_slice(),

--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use ark_ec::VariableBaseMSM;
 use merlin::Transcript;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 /// This is the prover side of the Eval-VMV-RE algorithm in section 5 of https://eprint.iacr.org/2020/1274.pdf.
 ///
@@ -35,7 +34,7 @@ pub fn eval_vmv_re_prove(
     messages.prover_send_G1_message(transcript, E_1);
     let v2 = state
         .v_vec
-        .par_iter()
+        .iter()
         .map(|c| (setup.Gamma_2_fin * c).into())
         .collect::<Vec<_>>();
     ExtendedProverState::from_vmv_prover_state(state, v2)

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -140,3 +140,4 @@ type DeferredG1 = deferred_msm::DeferredMSM<G1Affine, F>;
 type DeferredG2 = deferred_msm::DeferredMSM<G2Affine, F>;
 
 mod pairings;
+mod transpose;

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -21,7 +21,7 @@ pub struct PublicParameters {
     pub(super) max_nu: usize,
     /// The handle to the `blitzar` Gamma_1 instances.
     #[cfg(feature = "blitzar")]
-    pub(super) blitzar_handle: MsmHandle<ElementP2<ark_bls12_381::g1::Config>>,
+    blitzar_handle: MsmHandle<ElementP2<ark_bls12_381::g1::Config>>,
 }
 
 impl Clone for PublicParameters {
@@ -71,6 +71,12 @@ impl PublicParameters {
             #[cfg(feature = "blitzar")]
             blitzar_handle,
         }
+    }
+
+    /// Get a reference to the blitzar handle.
+    #[cfg(feature = "blitzar")]
+    pub fn get_blitzar_handle(&self) -> &MsmHandle<ElementP2<ark_bls12_381::g1::Config>> {
+        &self.blitzar_handle
     }
 
     #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -21,7 +21,7 @@ pub struct PublicParameters {
     pub(super) max_nu: usize,
     /// The handle to the `blitzar` Gamma_1 instances.
     #[cfg(feature = "blitzar")]
-    blitzar_handle: MsmHandle<ElementP2<ark_bls12_381::g1::Config>>,
+    pub(super) blitzar_handle: MsmHandle<ElementP2<ark_bls12_381::g1::Config>>,
 }
 
 impl Clone for PublicParameters {
@@ -71,12 +71,6 @@ impl PublicParameters {
             #[cfg(feature = "blitzar")]
             blitzar_handle,
         }
-    }
-
-    /// Get a reference to the blitzar handle.
-    #[cfg(feature = "blitzar")]
-    pub fn get_blitzar_handle(&self) -> &MsmHandle<ElementP2<ark_bls12_381::g1::Config>> {
-        &self.blitzar_handle
     }
 
     #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -72,4 +72,15 @@ impl PublicParameters {
             blitzar_handle,
         }
     }
+
+    #[cfg(feature = "blitzar")]
+    #[tracing::instrument(name = "PublicParameters::blitzar_msm", level = "debug", skip_all)]
+    pub(super) fn blitzar_msm(
+        &self,
+        res: &mut [ElementP2<ark_bls12_381::g1::Config>],
+        element_num_bytes: u32,
+        scalars: &[u8],
+    ) {
+        self.blitzar_handle.msm(res, element_num_bytes, scalars)
+    }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -30,7 +30,7 @@ pub struct ProverSetup<'a> {
     pub(super) max_nu: usize,
     /// The handle to the `blitzar` Gamma_1 instances.
     #[cfg(feature = "blitzar")]
-    pub(super) blitzar_handle: &'a MsmHandle<ElementP2<ark_bls12_381::g1::Config>>,
+    blitzar_handle: &'a MsmHandle<ElementP2<ark_bls12_381::g1::Config>>,
 }
 
 impl<'a> ProverSetup<'a> {
@@ -85,7 +85,7 @@ impl<'a> From<&'a PublicParameters> for ProverSetup<'a> {
             value.Gamma_2_fin,
             value.max_nu,
             #[cfg(feature = "blitzar")]
-            &value.blitzar_handle,
+            value.get_blitzar_handle(),
         )
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -85,7 +85,7 @@ impl<'a> From<&'a PublicParameters> for ProverSetup<'a> {
             value.Gamma_2_fin,
             value.max_nu,
             #[cfg(feature = "blitzar")]
-            value.get_blitzar_handle(),
+            &value.blitzar_handle,
         )
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -62,6 +62,17 @@ impl<'a> ProverSetup<'a> {
             blitzar_handle,
         }
     }
+
+    #[cfg(feature = "blitzar")]
+    #[tracing::instrument(name = "ProverSetup::blitzar_msm", level = "debug", skip_all)]
+    pub(super) fn blitzar_msm(
+        &self,
+        res: &mut [ElementP2<ark_bls12_381::g1::Config>],
+        element_num_bytes: u32,
+        scalars: &[u8],
+    ) {
+        self.blitzar_handle.msm(res, element_num_bytes, scalars)
+    }
 }
 
 impl<'a> From<&'a PublicParameters> for ProverSetup<'a> {

--- a/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
@@ -1,0 +1,328 @@
+use ark_bls12_381::Fr;
+use zerocopy::AsBytes;
+
+pub trait OffsetToBytes {
+    const IS_SIGNED: bool;
+    fn min_as_fr() -> Fr;
+    fn offset_to_bytes(&self) -> Vec<u8>;
+}
+
+impl OffsetToBytes for u8 {
+    const IS_SIGNED: bool = false;
+
+    fn min_as_fr() -> Fr {
+        Fr::from(0)
+    }
+
+    fn offset_to_bytes(&self) -> Vec<u8> {
+        vec![*self]
+    }
+}
+
+impl OffsetToBytes for i16 {
+    const IS_SIGNED: bool = true;
+
+    fn min_as_fr() -> Fr {
+        Fr::from(i16::MIN)
+    }
+
+    fn offset_to_bytes(&self) -> Vec<u8> {
+        let shifted = self.wrapping_sub(i16::MIN);
+        shifted.to_le_bytes().to_vec()
+    }
+}
+
+impl OffsetToBytes for i32 {
+    const IS_SIGNED: bool = true;
+
+    fn min_as_fr() -> Fr {
+        Fr::from(i32::MIN)
+    }
+
+    fn offset_to_bytes(&self) -> Vec<u8> {
+        let shifted = self.wrapping_sub(i32::MIN);
+        shifted.to_le_bytes().to_vec()
+    }
+}
+
+impl OffsetToBytes for i64 {
+    const IS_SIGNED: bool = true;
+
+    fn min_as_fr() -> Fr {
+        Fr::from(i64::MIN)
+    }
+
+    fn offset_to_bytes(&self) -> Vec<u8> {
+        let shifted = self.wrapping_sub(i64::MIN);
+        shifted.to_le_bytes().to_vec()
+    }
+}
+
+impl OffsetToBytes for i128 {
+    const IS_SIGNED: bool = true;
+
+    fn min_as_fr() -> Fr {
+        Fr::from(i128::MIN)
+    }
+
+    fn offset_to_bytes(&self) -> Vec<u8> {
+        let shifted = self.wrapping_sub(i128::MIN);
+        shifted.to_le_bytes().to_vec()
+    }
+}
+
+impl OffsetToBytes for bool {
+    const IS_SIGNED: bool = false;
+
+    fn min_as_fr() -> Fr {
+        Fr::from(false)
+    }
+
+    fn offset_to_bytes(&self) -> Vec<u8> {
+        vec![*self as u8]
+    }
+}
+
+impl OffsetToBytes for u64 {
+    const IS_SIGNED: bool = false;
+
+    fn min_as_fr() -> Fr {
+        Fr::from(0)
+    }
+
+    fn offset_to_bytes(&self) -> Vec<u8> {
+        let bytes = self.to_le_bytes();
+        bytes.to_vec()
+    }
+}
+
+impl OffsetToBytes for [u64; 4] {
+    const IS_SIGNED: bool = false;
+
+    fn min_as_fr() -> Fr {
+        Fr::from(0)
+    }
+
+    fn offset_to_bytes(&self) -> Vec<u8> {
+        let slice = self.as_bytes();
+        slice.to_vec()
+    }
+}
+
+#[tracing::instrument(name = "transpose_for_fixed_msm (gpu)", level = "debug", skip_all)]
+pub fn transpose_for_fixed_msm<T: AsBytes + Copy + OffsetToBytes>(
+    column: &[T],
+    offset: usize,
+    num_columns: usize,
+    data_size: usize,
+) -> Vec<u8> {
+    let column_len_with_offset = column.len() + offset;
+    let total_length_bytes =
+        data_size * (((column_len_with_offset + num_columns - 1) / num_columns) * num_columns);
+    let cols = num_columns;
+    let rows = total_length_bytes / (data_size * cols);
+
+    let mut transpose = vec![0_u8; total_length_bytes];
+    for n in offset..(column.len() + offset) {
+        let i = n / cols;
+        let j = n % cols;
+        let t_idx = (j * rows + i) * data_size;
+        let p_idx = (i * cols + j) - offset;
+
+        transpose[t_idx..t_idx + data_size]
+            .copy_from_slice(column[p_idx].offset_to_bytes().as_slice());
+    }
+
+    transpose
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn we_can_transpose_empty_column() {
+        type T = u64;
+        let column: Vec<T> = vec![];
+        let offset = 0;
+        let num_columns = 2;
+        let data_size = std::mem::size_of::<T>();
+
+        let expected_len = data_size * (column.len() + offset);
+
+        let transpose = transpose_for_fixed_msm(&column, offset, num_columns, data_size);
+
+        assert_eq!(transpose.len(), expected_len);
+        assert!(transpose.is_empty());
+    }
+
+    #[test]
+    fn we_can_transpose_u64_column() {
+        type T = u64;
+        let column: Vec<T> = vec![0, 1, 2, 3];
+        let offset = 0;
+        let num_columns = 2;
+        let data_size = std::mem::size_of::<T>();
+
+        let expected_len = data_size * (column.len() + offset);
+
+        let transpose = transpose_for_fixed_msm(&column, offset, num_columns, data_size);
+
+        assert_eq!(transpose.len(), expected_len);
+
+        assert_eq!(&transpose[0..data_size], column[0].as_bytes());
+        assert_eq!(&transpose[data_size..2 * data_size], column[2].as_bytes());
+        assert_eq!(
+            &transpose[2 * data_size..3 * data_size],
+            column[1].as_bytes()
+        );
+        assert_eq!(
+            &transpose[3 * data_size..4 * data_size],
+            column[3].as_bytes()
+        );
+    }
+
+    #[test]
+    fn we_can_transpose_u64_column_with_offset() {
+        type T = u64;
+        let column: Vec<T> = vec![1, 2, 3];
+        let offset = 2;
+        let num_columns = 3;
+        let data_size = std::mem::size_of::<T>();
+
+        let expected_len = data_size * (column.len() + offset + 1);
+
+        let transpose = transpose_for_fixed_msm(&column, offset, num_columns, data_size);
+
+        assert_eq!(transpose.len(), expected_len);
+
+        assert_eq!(&transpose[0..data_size], 0_u64.as_bytes());
+        assert_eq!(&transpose[data_size..2 * data_size], column[1].as_bytes());
+        assert_eq!(&transpose[2 * data_size..3 * data_size], 0_u64.as_bytes());
+        assert_eq!(
+            &transpose[3 * data_size..4 * data_size],
+            column[2].as_bytes()
+        );
+        assert_eq!(
+            &transpose[4 * data_size..5 * data_size],
+            column[0].as_bytes()
+        );
+        assert_eq!(&transpose[5 * data_size..6 * data_size], 0_u64.as_bytes());
+    }
+
+    #[test]
+    fn we_can_transpose_boolean_column_with_offset() {
+        type T = bool;
+        let column: Vec<T> = vec![true, false, true];
+        let offset = 1;
+        let num_columns = 2;
+        let data_size = std::mem::size_of::<T>();
+
+        let expected_len = data_size * (column.len() + offset);
+
+        let transpose = transpose_for_fixed_msm(&column, offset, num_columns, data_size);
+
+        assert_eq!(transpose.len(), expected_len);
+
+        assert_eq!(&transpose[0..data_size], 0_u8.as_bytes());
+        assert_eq!(&transpose[data_size..2 * data_size], column[1].as_bytes());
+        assert_eq!(
+            &transpose[2 * data_size..3 * data_size],
+            column[0].as_bytes()
+        );
+        assert_eq!(
+            &transpose[3 * data_size..4 * data_size],
+            column[2].as_bytes()
+        );
+    }
+
+    #[test]
+    fn we_can_transpose_i64_column() {
+        type T = i64;
+        let column: Vec<T> = vec![0, 1, 2, 3];
+        let offset = 0;
+        let num_columns = 2;
+        let data_size = std::mem::size_of::<T>();
+
+        let expected_len = data_size * (column.len() + offset);
+
+        let transpose = transpose_for_fixed_msm(&column, offset, num_columns, data_size);
+
+        assert_eq!(transpose.len(), expected_len);
+
+        assert_eq!(
+            &transpose[0..data_size],
+            column[0].wrapping_sub(T::MIN).as_bytes()
+        );
+        assert_eq!(
+            &transpose[data_size..2 * data_size],
+            column[2].wrapping_sub(T::MIN).as_bytes()
+        );
+        assert_eq!(
+            &transpose[2 * data_size..3 * data_size],
+            column[1].wrapping_sub(T::MIN).as_bytes()
+        );
+        assert_eq!(
+            &transpose[3 * data_size..4 * data_size],
+            column[3].wrapping_sub(T::MIN).as_bytes()
+        );
+    }
+
+    #[test]
+    fn we_can_transpose_i128_column() {
+        type T = i128;
+        let column: Vec<T> = vec![0, 1, 2, 3];
+        let offset = 0;
+        let num_columns = 2;
+        let data_size = std::mem::size_of::<T>();
+
+        let expected_len = data_size * (column.len() + offset);
+
+        let transpose = transpose_for_fixed_msm(&column, offset, num_columns, data_size);
+
+        assert_eq!(transpose.len(), expected_len);
+
+        assert_eq!(
+            &transpose[0..data_size],
+            column[0].wrapping_sub(T::MIN).as_bytes()
+        );
+        assert_eq!(
+            &transpose[data_size..2 * data_size],
+            column[2].wrapping_sub(T::MIN).as_bytes()
+        );
+        assert_eq!(
+            &transpose[2 * data_size..3 * data_size],
+            column[1].wrapping_sub(T::MIN).as_bytes()
+        );
+        assert_eq!(
+            &transpose[3 * data_size..4 * data_size],
+            column[3].wrapping_sub(T::MIN).as_bytes()
+        );
+    }
+
+    #[test]
+    fn we_can_transpose_u64_array_column() {
+        type T = [u64; 4];
+        let column: Vec<T> = vec![[0, 0, 0, 0], [1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]];
+        let offset = 0;
+        let num_columns = 2;
+        let data_size = std::mem::size_of::<T>();
+
+        let expected_len = data_size * (column.len() + offset);
+
+        let transpose = transpose_for_fixed_msm(&column, offset, num_columns, data_size);
+
+        assert_eq!(transpose.len(), expected_len);
+
+        assert_eq!(&transpose[0..data_size], column[0].as_bytes());
+        assert_eq!(&transpose[data_size..2 * data_size], column[2].as_bytes());
+        assert_eq!(
+            &transpose[2 * data_size..3 * data_size],
+            column[1].as_bytes()
+        );
+        assert_eq!(
+            &transpose[3 * data_size..4 * data_size],
+            column[3].as_bytes()
+        );
+    }
+}


### PR DESCRIPTION
# Rationale for this change
When creating a Dory proof the `compute_T_vec_prime` function requires multiple MSMs. The current implementation of this function only supports the use of the Arkworks library, which only runs on the CPU. In an effort to improve the performance of Dory, this PR introduces the Blitzar fixed MSM to `compute_T_vec_prime` when appropriate to perform the MSM computations.

The commit focusing only on performance changes is available [here](https://github.com/spaceandtimelabs/sxt-proof-of-sql/commit/ba506b0b5c4be809ca424e07423c67f15fee6c15).

# What changes are included in this PR?
- `compute_T_vec_prime` now supports Blitzar's fixed MSM if the feature flag `"blitzar"` is turned on. The CPU version using Arkworks is still supported.
- The `transpose_column` and related functions appearing in the `dory_commitment_helper_gpu` class are moved into a separate class, `transpose`.
- Added a reference to the `blitzar_handle` to the `ProverSetup`.
  - Removed `par_iter()` in `eval_vmv_re.rs` because `*mut blitzar_sys::sxt_multiexp_handle` cannot be shared between threads safely.

# Are these changes tested?
Yes, on both CPU and GPU.