### PR TITLE
feat: generalize `DenseFilterExpr`

### DIFF
--- a/crates/proof-of-sql/src/sql/ast/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/and_expr.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 /// Provable logical AND expression
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AndExpr<C: Commitment> {
     lhs: Box<ProvableExprPlan<C>>,
     rhs: Box<ProvableExprPlan<C>>,

--- a/crates/proof-of-sql/src/sql/ast/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/equals_expr.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 /// Provable AST expression for an equals expression
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct EqualsExpr<C: Commitment> {
     lhs: Box<ProvableExprPlan<C>>,
     rhs: Box<ProvableExprPlan<C>>,

--- a/crates/proof-of-sql/src/sql/ast/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/inequality_expr.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 /// Provable AST expression for an inequality expression
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct InequalityExpr<C: Commitment> {
     lhs: Box<ProvableExprPlan<C>>,
     rhs: Box<ProvableExprPlan<C>>,

--- a/crates/proof-of-sql/src/sql/ast/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/literal_expr.rs
@@ -23,7 +23,7 @@ use std::collections::HashSet;
 /// While this wouldn't be as efficient as using a new custom expression for
 /// such queries, it allows us to easily support projects with minimal code
 /// changes, and the performance is sufficient for present.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiteralExpr<S: Scalar> {
     value: LiteralValue<S>,
 }

--- a/crates/proof-of-sql/src/sql/ast/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/not_expr.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 /// Provable logical NOT expression
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct NotExpr<C: Commitment> {
     expr: Box<ProvableExprPlan<C>>,
 }

--- a/crates/proof-of-sql/src/sql/ast/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/or_expr.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 /// Provable logical OR expression
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OrExpr<C: Commitment> {
     lhs: Box<ProvableExprPlan<C>>,
     rhs: Box<ProvableExprPlan<C>>,

--- a/crates/proof-of-sql/src/sql/ast/provable_expr_plan.rs
+++ b/crates/proof-of-sql/src/sql/ast/provable_expr_plan.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, fmt::Debug};
 
 /// Enum of AST column expression types that implement `ProvableExpr`. Is itself a `ProvableExpr`.
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ProvableExprPlan<C: Commitment> {
     /// Column
     Column(ColumnExpr<C>),

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -1,0 +1,66 @@
+use super::ProvableExprPlanBuilder;
+use crate::{
+    base::{commitment::Commitment, database::ColumnRef},
+    sql::ast::ProvableExprPlan,
+};
+use proof_of_sql_parser::{
+    intermediate_ast::{AliasedResultExpr, Expression},
+    Identifier,
+};
+use std::collections::HashMap;
+/// Enriched expression
+///
+/// An enriched expression consists of an `proof_of_sql_parser::intermediate_ast::AliasedResultExpr`
+/// and an optional `ProvableExprPlan`.
+/// If the `ProvableExprPlan` is `None`, the `EnrichedExpr` is not provable.
+pub struct EnrichedExpr<C: Commitment> {
+    /// The remaining expression after the provable expression plan has been extracted.
+    pub residue_expression: AliasedResultExpr,
+    /// The extracted provable expression plan if it exists.
+    pub provable_expr_plan: Option<ProvableExprPlan<C>>,
+}
+
+impl<C: Commitment> EnrichedExpr<C> {
+    /// Create a new `EnrichedExpr` with a provable expression.
+    ///
+    /// If the expression is not provable, the `provable_expr_plan` will be `None`.
+    /// Otherwise the `provable_expr_plan` will contain the provable expression plan
+    /// and the `residue_expression` will contain the remaining expression.
+    pub fn new(
+        expression: AliasedResultExpr,
+        column_mapping: HashMap<Identifier, ColumnRef>,
+    ) -> Self {
+        let res_provable_expr_plan =
+            ProvableExprPlanBuilder::new(&column_mapping).build(&expression.expr);
+        match res_provable_expr_plan {
+            Ok(provable_expr_plan) => {
+                let alias = expression.alias;
+                Self {
+                    residue_expression: AliasedResultExpr {
+                        expr: Box::new(Expression::Column(alias)),
+                        alias,
+                    },
+                    provable_expr_plan: Some(provable_expr_plan),
+                }
+            }
+            Err(_) => Self {
+                residue_expression: expression,
+                provable_expr_plan: None,
+            },
+        }
+    }
+
+    /// Get the alias of the `EnrichedExpr`.
+    ///
+    /// Since we plan to support unaliased expressions in the future, this method returns an `Option`.
+    #[allow(dead_code)]
+    pub fn get_alias(&self) -> Option<&Identifier> {
+        self.residue_expression.try_as_identifier()
+    }
+
+    /// Is the `EnrichedExpr` provable
+    #[allow(dead_code)]
+    pub fn is_provable(&self) -> bool {
+        self.provable_expr_plan.is_some()
+    }
+}

--- a/crates/proof-of-sql/src/sql/parse/mod.rs
+++ b/crates/proof-of-sql/src/sql/parse/mod.rs
@@ -4,6 +4,9 @@ mod where_expr_builder_tests;
 pub use error::ConversionError;
 pub(crate) use error::ConversionResult;
 
+mod enriched_expr;
+pub(crate) use enriched_expr::EnrichedExpr;
+
 #[cfg(all(test, feature = "blitzar"))]
 mod query_expr_tests;
 
@@ -21,6 +24,9 @@ pub(crate) use query_context::QueryContext;
 
 mod query_context_builder;
 pub(crate) use query_context_builder::{type_check_binary_operation, QueryContextBuilder};
+
+mod provable_expr_plan_builder;
+pub(crate) use provable_expr_plan_builder::ProvableExprPlanBuilder;
 
 mod where_expr_builder;
 pub(crate) use where_expr_builder::WhereExprBuilder;

--- a/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
@@ -1,0 +1,142 @@
+use super::ConversionError;
+use crate::{
+    base::{
+        commitment::Commitment,
+        database::{ColumnRef, LiteralValue},
+        math::decimal::{try_into_to_scalar, Precision},
+    },
+    sql::ast::{ColumnExpr, ProvableExprPlan},
+};
+use proof_of_sql_parser::{
+    intermediate_ast::{BinaryOperator, Expression, Literal, UnaryOperator},
+    Identifier,
+};
+use std::collections::HashMap;
+
+/// Builder that enables building a `proofs::sql::ast::ProvableExprPlan` from
+/// a `proof_of_sql_parser::intermediate_ast::Expression`.
+pub struct ProvableExprPlanBuilder<'a> {
+    column_mapping: &'a HashMap<Identifier, ColumnRef>,
+}
+
+impl<'a> ProvableExprPlanBuilder<'a> {
+    /// Creates a new `ProvableExprPlanBuilder` with the given column mapping.
+    pub fn new(column_mapping: &'a HashMap<Identifier, ColumnRef>) -> Self {
+        Self { column_mapping }
+    }
+    /// Builds a `proofs::sql::ast::ProvableExprPlan` from a `proof_of_sql_parser::intermediate_ast::Expression`
+    pub fn build<C: Commitment>(
+        &self,
+        expr: &Expression,
+    ) -> Result<ProvableExprPlan<C>, ConversionError> {
+        self.visit_expr(expr)
+    }
+}
+
+// Private interface
+impl ProvableExprPlanBuilder<'_> {
+    fn visit_expr<C: Commitment>(
+        &self,
+        expr: &Expression,
+    ) -> Result<ProvableExprPlan<C>, ConversionError> {
+        match expr {
+            Expression::Column(identifier) => self.visit_column(*identifier),
+            Expression::Literal(lit) => self.visit_literal(lit),
+            Expression::Binary { op, left, right } => self.visit_binary_expr(*op, left, right),
+            Expression::Unary { op, expr } => self.visit_unary_expr(*op, expr),
+            _ => Err(ConversionError::Unprovable(format!(
+                "Expression {:?} is not supported yet",
+                expr
+            ))),
+        }
+    }
+
+    fn visit_column<C: Commitment>(
+        &self,
+        identifier: Identifier,
+    ) -> Result<ProvableExprPlan<C>, ConversionError> {
+        Ok(ProvableExprPlan::Column(ColumnExpr::new(
+            *self.column_mapping.get(&identifier).ok_or(
+                ConversionError::MissingColumnWithoutTable(Box::new(identifier)),
+            )?,
+        )))
+    }
+
+    fn visit_literal<C: Commitment>(
+        &self,
+        lit: &Literal,
+    ) -> Result<ProvableExprPlan<C>, ConversionError> {
+        match lit {
+            Literal::Boolean(b) => Ok(ProvableExprPlan::new_literal(LiteralValue::Boolean(*b))),
+            Literal::BigInt(i) => Ok(ProvableExprPlan::new_literal(LiteralValue::BigInt(*i))),
+            Literal::Int128(i) => Ok(ProvableExprPlan::new_literal(LiteralValue::Int128(*i))),
+            Literal::Decimal(d) => {
+                let scale = d.scale();
+                let precision = Precision::new(d.precision())
+                    .map_err(|_| ConversionError::InvalidPrecision(d.precision()))?;
+                Ok(ProvableExprPlan::new_literal(LiteralValue::Decimal75(
+                    precision,
+                    scale,
+                    try_into_to_scalar(d, precision, scale)?,
+                )))
+            }
+            Literal::VarChar(s) => Ok(ProvableExprPlan::new_literal(LiteralValue::VarChar((
+                s.clone(),
+                s.into(),
+            )))),
+        }
+    }
+
+    fn visit_unary_expr<C: Commitment>(
+        &self,
+        op: UnaryOperator,
+        expr: &Expression,
+    ) -> Result<ProvableExprPlan<C>, ConversionError> {
+        let expr = self.visit_expr(expr);
+        match op {
+            UnaryOperator::Not => ProvableExprPlan::try_new_not(expr?),
+        }
+    }
+
+    fn visit_binary_expr<C: Commitment>(
+        &self,
+        op: BinaryOperator,
+        left: &Expression,
+        right: &Expression,
+    ) -> Result<ProvableExprPlan<C>, ConversionError> {
+        match op {
+            BinaryOperator::And => {
+                let left = self.visit_expr(left);
+                let right = self.visit_expr(right);
+                ProvableExprPlan::try_new_and(left?, right?)
+            }
+            BinaryOperator::Or => {
+                let left = self.visit_expr(left);
+                let right = self.visit_expr(right);
+                ProvableExprPlan::try_new_or(left?, right?)
+            }
+            BinaryOperator::Equal => {
+                let left = self.visit_expr(left);
+                let right = self.visit_expr(right);
+                ProvableExprPlan::try_new_equals(left?, right?)
+            }
+            BinaryOperator::GreaterThanOrEqual => {
+                let left = self.visit_expr(left);
+                let right = self.visit_expr(right);
+                ProvableExprPlan::try_new_inequality(left?, right?, false)
+            }
+            BinaryOperator::LessThanOrEqual => {
+                let left = self.visit_expr(left);
+                let right = self.visit_expr(right);
+                ProvableExprPlan::try_new_inequality(left?, right?, true)
+            }
+            BinaryOperator::Add
+            | BinaryOperator::Subtract
+            | BinaryOperator::Multiply
+            | BinaryOperator::Division => Err(ConversionError::Unprovable(format!(
+                "Binary operator {:?} is not supported yet",
+                op
+            ))),
+        }
+    }
+}

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -1,27 +1,25 @@
-use super::ConversionError;
+use super::{ConversionError, ProvableExprPlanBuilder};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{ColumnRef, ColumnType, LiteralValue},
-        math::decimal::{try_into_to_scalar, Precision},
+        database::{ColumnRef, ColumnType},
     },
-    sql::ast::{ColumnExpr, ProvableExpr, ProvableExprPlan},
+    sql::ast::{ProvableExpr, ProvableExprPlan},
 };
-use proof_of_sql_parser::{
-    intermediate_ast::{BinaryOperator, Expression, Literal, UnaryOperator},
-    Identifier,
-};
+use proof_of_sql_parser::{intermediate_ast::Expression, Identifier};
 use std::collections::HashMap;
 
 /// Builder that enables building a `proof_of_sql::sql::ast::ProvableExprPlan` from a `proof_of_sql_parser::intermediate_ast::Expression` that is
 /// intended to be used as the where clause in a filter expression or group by expression.
 pub struct WhereExprBuilder<'a> {
-    column_mapping: &'a HashMap<Identifier, ColumnRef>,
+    builder: ProvableExprPlanBuilder<'a>,
 }
 impl<'a> WhereExprBuilder<'a> {
     /// Creates a new `WhereExprBuilder` with the given column mapping.
     pub fn new(column_mapping: &'a HashMap<Identifier, ColumnRef>) -> Self {
-        Self { column_mapping }
+        Self {
+            builder: ProvableExprPlanBuilder::new(column_mapping),
+        }
     }
     /// Builds a `proof_of_sql::sql::ast::ProvableExprPlan` from a `proof_of_sql_parser::intermediate_ast::Expression` that is
     /// intended to be used as the where clause in a filter expression or group by expression.
@@ -31,7 +29,7 @@ impl<'a> WhereExprBuilder<'a> {
     ) -> Result<Option<ProvableExprPlan<C>>, ConversionError> {
         where_expr
             .map(|where_expr| {
-                let expr_plan = self.visit_expr(*where_expr)?;
+                let expr_plan = self.builder.build(&where_expr)?;
                 // Ensure that the expression is a boolean expression
                 match expr_plan.data_type() {
                     ColumnType::Boolean => Ok(expr_plan),
@@ -41,110 +39,5 @@ impl<'a> WhereExprBuilder<'a> {
                 }
             })
             .transpose()
-    }
-}
-
-// Private interface
-impl WhereExprBuilder<'_> {
-    fn visit_expr<C: Commitment>(
-        &self,
-        expr: proof_of_sql_parser::intermediate_ast::Expression,
-    ) -> Result<ProvableExprPlan<C>, ConversionError> {
-        match expr {
-            Expression::Column(identifier) => self.visit_column(identifier),
-            Expression::Literal(lit) => self.visit_literal(lit),
-            Expression::Binary { op, left, right } => self.visit_binary_expr(op, *left, *right),
-            Expression::Unary { op, expr } => self.visit_unary_expr(op, *expr),
-            _ => panic!("The parser must ensure that the expression is a boolean expression"),
-        }
-    }
-
-    fn visit_column<C: Commitment>(
-        &self,
-        identifier: Identifier,
-    ) -> Result<ProvableExprPlan<C>, ConversionError> {
-        Ok(ProvableExprPlan::Column(ColumnExpr::new(
-            *self.column_mapping.get(&identifier).ok_or(
-                ConversionError::MissingColumnWithoutTable(Box::new(identifier)),
-            )?,
-        )))
-    }
-
-    fn visit_literal<C: Commitment>(
-        &self,
-        lit: Literal,
-    ) -> Result<ProvableExprPlan<C>, ConversionError> {
-        match lit {
-            Literal::Boolean(b) => Ok(ProvableExprPlan::new_literal(LiteralValue::Boolean(b))),
-            Literal::BigInt(i) => Ok(ProvableExprPlan::new_literal(LiteralValue::BigInt(i))),
-            Literal::Int128(i) => Ok(ProvableExprPlan::new_literal(LiteralValue::Int128(i))),
-            Literal::Decimal(d) => {
-                let scale = d.scale();
-                let precision = Precision::new(d.precision())
-                    .map_err(|_| ConversionError::InvalidPrecision(d.precision()))?;
-                Ok(ProvableExprPlan::new_literal(LiteralValue::Decimal75(
-                    precision,
-                    scale,
-                    try_into_to_scalar(&d, precision, scale)?,
-                )))
-            }
-            Literal::VarChar(s) => Ok(ProvableExprPlan::new_literal(LiteralValue::VarChar((
-                s.clone(),
-                s.into(),
-            )))),
-        }
-    }
-
-    fn visit_unary_expr<C: Commitment>(
-        &self,
-        op: UnaryOperator,
-        expr: Expression,
-    ) -> Result<ProvableExprPlan<C>, ConversionError> {
-        let expr = self.visit_expr(expr);
-        match op {
-            UnaryOperator::Not => ProvableExprPlan::try_new_not(expr?),
-        }
-    }
-
-    fn visit_binary_expr<C: Commitment>(
-        &self,
-        op: BinaryOperator,
-        left: Expression,
-        right: Expression,
-    ) -> Result<ProvableExprPlan<C>, ConversionError> {
-        match op {
-            BinaryOperator::And => {
-                let left = self.visit_expr(left);
-                let right = self.visit_expr(right);
-                ProvableExprPlan::try_new_and(left?, right?)
-            }
-            BinaryOperator::Or => {
-                let left = self.visit_expr(left);
-                let right = self.visit_expr(right);
-                ProvableExprPlan::try_new_or(left?, right?)
-            }
-            BinaryOperator::Equal => {
-                let left = self.visit_expr(left);
-                let right = self.visit_expr(right);
-                ProvableExprPlan::try_new_equals(left?, right?)
-            }
-            BinaryOperator::GreaterThanOrEqual => {
-                let left = self.visit_expr(left);
-                let right = self.visit_expr(right);
-                ProvableExprPlan::try_new_inequality(left?, right?, false)
-            }
-            BinaryOperator::LessThanOrEqual => {
-                let left = self.visit_expr(left);
-                let right = self.visit_expr(right);
-                ProvableExprPlan::try_new_inequality(left?, right?, true)
-            }
-            BinaryOperator::Add
-            | BinaryOperator::Subtract
-            | BinaryOperator::Multiply
-            | BinaryOperator::Division => Err(ConversionError::Unprovable(format!(
-                "Binary operator {:?} is not supported in the where clause",
-                op
-            ))),
-        }
     }
 }

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -284,7 +284,7 @@ fn we_can_prove_a_complex_query_with_curve25519() {
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT * FROM table WHERE (a >= b) = (c < d) and (e = 'e') = f"
+        "SELECT *, 45 as g, (a = b) or f as h FROM table WHERE (a >= b) = (c < d) and (e = 'e') = f"
             .parse()
             .unwrap(),
         "sxt".parse().unwrap(),
@@ -304,6 +304,8 @@ fn we_can_prove_a_complex_query_with_curve25519() {
         bigint("d", [3]),
         varchar("e", ["f"]),
         boolean("f", [false]),
+        bigint("g", [45]),
+        boolean("h", [false]),
     ]);
     assert_eq!(owned_table_result, expected_result);
 }
@@ -329,7 +331,7 @@ fn we_can_prove_a_complex_query_with_dory() {
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT * FROM table WHERE (a < b) = (c <= d) and e <> 'f' and f"
+        "SELECT *, 32 as g, (c >= d) and f as h FROM table WHERE (a < b) = (c <= d) and e <> 'f' and f"
             .parse()
             .unwrap(),
         "sxt".parse().unwrap(),
@@ -354,6 +356,8 @@ fn we_can_prove_a_complex_query_with_dory() {
         bigint("d", [1]),
         varchar("e", ["d"]),
         boolean("f", [true]),
+        bigint("g", [32]),
+        boolean("h", [true]),
     ]);
     assert_eq!(owned_table_result, expected_result);
 }


### PR DESCRIPTION
# Rationale for this change
It is necessary to move provable projections into the prover so that provable queries do not need postprocessing. This is the first PR of the change which is to move provable projections to the prover for filter queries.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- Move `Expression` -> `ProvableExprPlan` to a separate struct, `ProvableExprPlanBuilder` since the process is no longer for where clauses only.
- Add `EnrichedExpr` to be equivalent to the provable version of [Expr](https://docs.rs/datafusion/latest/datafusion/logical_expr/enum.Expr.html#method.alias) in DataFusion for tamperproof queries.
- Allow arbitrary aliased provable expressions as result expressions in dense filters. 
- Remove constraints in `QueryContext` that prevents constants from being used in select.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass. New tests will be added to cover nontrivial results such as `select a and b as c, d, 4 as f from tab where d = e`.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
