### PR TITLE
build: update Cargo.toml files for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 exclude = ["**/.gitignore", ".gitignore"]
 repository = "https://github.com/spaceandtimelabs/sxt-proof-of-sql"
 version = "0.0.0" # DO NOT CHANGE THIS LINE! This will be automatically updated
+license-file = "LICENSE"
 
 [workspace.dependencies]
 ark-bls12-381 = { version = "0.4.0" }

--- a/crates/proof-of-sql-parser/Cargo.toml
+++ b/crates/proof-of-sql-parser/Cargo.toml
@@ -5,8 +5,9 @@ version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
 build = "build.rs"
-description = "Parse provable SQL queries into Intermediate ASTs"
+description = "Library for SQL parsing for the Proof of SQL execution engine."
 exclude = { workspace = true }
+license-file = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -4,8 +4,9 @@ name = "proof-of-sql"
 version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
-description = "Generates and verifies cryptographic proofs for SxT OLTP queries."
+description = "High performance zero knowledge (ZK) prover for SQL."
 exclude = { workspace = true }
+license-file = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/crates/proof-of-sql/src/lib.rs
+++ b/crates/proof-of-sql/src/lib.rs
@@ -1,4 +1,4 @@
-//! The Proof of SQL library
+//! High performance zero knowledge (ZK) prover for SQL.
 #![doc = include_str!("../../../README.md")]
 pub mod base;
 pub mod proof_primitive;


### PR DESCRIPTION
# Rationale for this change

A few of the fields in the `Cargo.toml` files that are required to publish to crates.io are either missing or out of date. This PR fixes them.