### PR TITLE
feat!: initial support for timestamp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ bytemuck = {version = "1.14.2" }
 byte-slice-cast = { version = "1.2.1" }
 clap = { version = "4.5.4" }
 criterion = { version = "0.5.1" }
+chrono-tz = {version = "0.9.0", features = ["serde"]}
 curve25519-dalek = { version = "4", features = ["rand_core"] }
 derive_more = { version = "0.99" }
 dyn_partial_eq = { version = "0.1.2" }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -30,6 +30,7 @@ bumpalo = { workspace = true, features = ["collections"] }
 bytemuck = { workspace = true }
 byte-slice-cast = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
+chrono-tz = {workspace = true, features = ["serde"]}
 derive_more = { workspace = true }
 dyn_partial_eq = { workspace = true }
 hashbrown = { workspace = true }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -246,6 +246,9 @@ impl ColumnBounds {
             (ColumnBounds::BigInt(bounds_a), ColumnBounds::BigInt(bounds_b)) => {
                 Ok(ColumnBounds::BigInt(bounds_a.union(bounds_b)))
             }
+            (ColumnBounds::Timestamp(bounds_a), ColumnBounds::Timestamp(bounds_b)) => {
+                Ok(ColumnBounds::Timestamp(bounds_a.union(bounds_b)))
+            }
             (ColumnBounds::Int128(bounds_a), ColumnBounds::Int128(bounds_b)) => {
                 Ok(ColumnBounds::Int128(bounds_a.union(bounds_b)))
             }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -277,7 +277,9 @@ impl ColumnBounds {
             (ColumnBounds::Int128(bounds_a), ColumnBounds::Int128(bounds_b)) => {
                 Ok(ColumnBounds::Int128(bounds_a.difference(bounds_b)))
             }
-
+            (ColumnBounds::TimestampTZ(bounds_a), ColumnBounds::TimestampTZ(bounds_b)) => {
+                Ok(ColumnBounds::TimestampTZ(bounds_a.difference(bounds_b)))
+            }
             (_, _) => Err(ColumnBoundsMismatch(Box::new(self), Box::new(other))),
         }
     }
@@ -286,7 +288,12 @@ impl ColumnBounds {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::{database::OwnedColumn, math::decimal::Precision, scalar::Curve25519Scalar};
+    use crate::base::{
+        database::OwnedColumn,
+        math::decimal::Precision,
+        scalar::Curve25519Scalar,
+        time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
+    };
     use itertools::Itertools;
 
     #[test]
@@ -526,8 +533,19 @@ mod tests {
         );
         let committable_decimal75_column = CommittableColumn::from(&decimal75_column);
         let decimal75_column_bounds = ColumnBounds::from_column(&committable_decimal75_column);
-
         assert_eq!(decimal75_column_bounds, ColumnBounds::NoOrder);
+
+        let timestamp_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            vec![1_i64, 2, 3, 4],
+        );
+        let committable_timestamp_column = CommittableColumn::from(&timestamp_column);
+        let timestamp_column_bounds = ColumnBounds::from_column(&committable_timestamp_column);
+        assert_eq!(
+            timestamp_column_bounds,
+            ColumnBounds::TimestampTZ(Bounds::Sharp(BoundsInner { min: 1, max: 4 }))
+        );
     }
 
     #[test]
@@ -569,6 +587,14 @@ mod tests {
             int128_a.try_union(int128_b).unwrap(),
             ColumnBounds::Int128(Bounds::Bounded(BoundsInner { min: 1, max: 6 }))
         );
+
+        let timestamp_a = ColumnBounds::TimestampTZ(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
+        let timestamp_b =
+            ColumnBounds::TimestampTZ(Bounds::Bounded(BoundsInner { min: 4, max: 6 }));
+        assert_eq!(
+            timestamp_a.try_union(timestamp_b).unwrap(),
+            ColumnBounds::TimestampTZ(Bounds::Bounded(BoundsInner { min: 1, max: 6 }))
+        );
     }
 
     #[test]
@@ -578,6 +604,7 @@ mod tests {
         let int = ColumnBounds::Int(Bounds::Sharp(BoundsInner { min: -10, max: 10 }));
         let bigint = ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let int128 = ColumnBounds::Int128(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
+        let timestamp = ColumnBounds::TimestampTZ(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
 
         let bounds = [
             (no_order, "NoOrder"),
@@ -585,6 +612,7 @@ mod tests {
             (int, "Int"),
             (bigint, "BigInt"),
             (int128, "Int128"),
+            (timestamp, "Timestamp"),
         ];
 
         for ((bound_a, name_a), (bound_b, name_b)) in bounds.iter().tuple_combinations() {
@@ -626,6 +654,13 @@ mod tests {
             int128_a.try_difference(int128_b).unwrap(),
             ColumnBounds::Int128(Bounds::Bounded(BoundsInner { min: 1, max: 4 }))
         );
+
+        let timestamp_a = ColumnBounds::TimestampTZ(Bounds::Sharp(BoundsInner { min: 1, max: 4 }));
+        let timestamp_b = ColumnBounds::TimestampTZ(Bounds::Sharp(BoundsInner { min: 3, max: 6 }));
+        assert_eq!(
+            timestamp_a.try_difference(timestamp_b).unwrap(),
+            ColumnBounds::TimestampTZ(Bounds::Bounded(BoundsInner { min: 1, max: 4 }))
+        );
     }
 
     #[test]
@@ -633,6 +668,8 @@ mod tests {
         let no_order = ColumnBounds::NoOrder;
         let bigint = ColumnBounds::BigInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
         let int128 = ColumnBounds::Int128(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
+        let timestamp = ColumnBounds::TimestampTZ(Bounds::Sharp(BoundsInner { min: 4, max: 6 }));
+        let smallint = ColumnBounds::SmallInt(Bounds::Sharp(BoundsInner { min: 1, max: 3 }));
 
         assert!(no_order.try_difference(bigint).is_err());
         assert!(bigint.try_difference(no_order).is_err());
@@ -642,5 +679,8 @@ mod tests {
 
         assert!(bigint.try_difference(int128).is_err());
         assert!(int128.try_difference(bigint).is_err());
+
+        assert!(smallint.try_difference(timestamp).is_err());
+        assert!(timestamp.try_difference(smallint).is_err());
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -208,7 +208,7 @@ pub enum ColumnBounds {
     /// The bounds of an Int128 column.
     Int128(Bounds<i128>),
     /// The bounds of a Timestamp column.
-    Timestamp(Bounds<i64>),
+    TimestampTZ(Bounds<i64>),
 }
 
 impl ColumnBounds {
@@ -221,8 +221,8 @@ impl ColumnBounds {
             CommittableColumn::Int(ints) => ColumnBounds::Int(Bounds::from_iter(*ints)),
             CommittableColumn::BigInt(ints) => ColumnBounds::BigInt(Bounds::from_iter(*ints)),
             CommittableColumn::Int128(ints) => ColumnBounds::Int128(Bounds::from_iter(*ints)),
-            CommittableColumn::Timestamp(_, _, times) => {
-                ColumnBounds::Timestamp(Bounds::from_iter(*times))
+            CommittableColumn::TimestampTZ(_, _, times) => {
+                ColumnBounds::TimestampTZ(Bounds::from_iter(*times))
             }
             CommittableColumn::Boolean(_)
             | CommittableColumn::Decimal75(_, _, _)
@@ -246,8 +246,8 @@ impl ColumnBounds {
             (ColumnBounds::BigInt(bounds_a), ColumnBounds::BigInt(bounds_b)) => {
                 Ok(ColumnBounds::BigInt(bounds_a.union(bounds_b)))
             }
-            (ColumnBounds::Timestamp(bounds_a), ColumnBounds::Timestamp(bounds_b)) => {
-                Ok(ColumnBounds::Timestamp(bounds_a.union(bounds_b)))
+            (ColumnBounds::TimestampTZ(bounds_a), ColumnBounds::TimestampTZ(bounds_b)) => {
+                Ok(ColumnBounds::TimestampTZ(bounds_a.union(bounds_b)))
             }
             (ColumnBounds::Int128(bounds_a), ColumnBounds::Int128(bounds_b)) => {
                 Ok(ColumnBounds::Int128(bounds_a.union(bounds_b)))

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -207,6 +207,8 @@ pub enum ColumnBounds {
     BigInt(Bounds<i64>),
     /// The bounds of an Int128 column.
     Int128(Bounds<i128>),
+    /// The bounds of a Timestamp column.
+    Timestamp(Bounds<u64>),
 }
 
 impl ColumnBounds {
@@ -219,6 +221,9 @@ impl ColumnBounds {
             CommittableColumn::Int(ints) => ColumnBounds::Int(Bounds::from_iter(*ints)),
             CommittableColumn::BigInt(ints) => ColumnBounds::BigInt(Bounds::from_iter(*ints)),
             CommittableColumn::Int128(ints) => ColumnBounds::Int128(Bounds::from_iter(*ints)),
+            CommittableColumn::Timestamp(times) => {
+                ColumnBounds::Timestamp(Bounds::from_iter(*times))
+            }
             CommittableColumn::Boolean(_)
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -208,7 +208,7 @@ pub enum ColumnBounds {
     /// The bounds of an Int128 column.
     Int128(Bounds<i128>),
     /// The bounds of a Timestamp column.
-    Timestamp(Bounds<u64>),
+    Timestamp(Bounds<i64>),
 }
 
 impl ColumnBounds {
@@ -221,7 +221,7 @@ impl ColumnBounds {
             CommittableColumn::Int(ints) => ColumnBounds::Int(Bounds::from_iter(*ints)),
             CommittableColumn::BigInt(ints) => ColumnBounds::BigInt(Bounds::from_iter(*ints)),
             CommittableColumn::Int128(ints) => ColumnBounds::Int128(Bounds::from_iter(*ints)),
-            CommittableColumn::Timestamp(times) => {
+            CommittableColumn::Timestamp(_, _, times) => {
                 ColumnBounds::Timestamp(Bounds::from_iter(*times))
             }
             CommittableColumn::Boolean(_)

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -40,7 +40,7 @@ impl ColumnCommitmentMetadata {
             | (ColumnType::Int, ColumnBounds::Int(_))
             | (ColumnType::BigInt, ColumnBounds::BigInt(_))
             | (ColumnType::Int128, ColumnBounds::Int128(_))
-            | (ColumnType::Timestamp(_, _), ColumnBounds::Timestamp(_))
+            | (ColumnType::TimestampTZ(_, _), ColumnBounds::TimestampTZ(_))
             | (
                 ColumnType::Boolean
                 | ColumnType::VarChar
@@ -73,7 +73,7 @@ impl ColumnCommitmentMetadata {
                 BoundsInner::try_new(i64::MIN, i64::MAX)
                     .expect("i64::MIN and i64::MAX are valid bounds for BigInt"),
             )),
-            ColumnType::Timestamp(_, _) => ColumnBounds::Timestamp(super::Bounds::Bounded(
+            ColumnType::TimestampTZ(_, _) => ColumnBounds::TimestampTZ(super::Bounds::Bounded(
                 BoundsInner::try_new(i64::MIN, i64::MAX)
                     .expect("i64::MIN and i64::MAX are valid bounds for TimeStamp"),
             )),

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -40,6 +40,7 @@ impl ColumnCommitmentMetadata {
             | (ColumnType::Int, ColumnBounds::Int(_))
             | (ColumnType::BigInt, ColumnBounds::BigInt(_))
             | (ColumnType::Int128, ColumnBounds::Int128(_))
+            | (ColumnType::Timestamp(_, _), ColumnBounds::Timestamp(_))
             | (
                 ColumnType::Boolean
                 | ColumnType::VarChar
@@ -71,6 +72,10 @@ impl ColumnCommitmentMetadata {
             ColumnType::BigInt => ColumnBounds::BigInt(super::Bounds::Bounded(
                 BoundsInner::try_new(i64::MIN, i64::MAX)
                     .expect("i64::MIN and i64::MAX are valid bounds for BigInt"),
+            )),
+            ColumnType::Timestamp(_, _) => ColumnBounds::Timestamp(super::Bounds::Bounded(
+                BoundsInner::try_new(i64::MIN, i64::MAX)
+                    .expect("i64::MIN and i64::MAX are valid bounds for TimeStamp"),
             )),
             ColumnType::Int128 => ColumnBounds::Int128(super::Bounds::Bounded(
                 BoundsInner::try_new(i128::MIN, i128::MAX)

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -3,7 +3,7 @@ use crate::base::{
     math::decimal::Precision,
     ref_into::RefInto,
     scalar::Scalar,
-    time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+    time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
 };
 #[cfg(feature = "blitzar")]
 use blitzar::sequence::Sequence;
@@ -39,7 +39,7 @@ pub enum CommittableColumn<'a> {
     /// Column of limbs for committing to scalars, hashed from a VarChar column.
     VarChar(Vec<[u64; 4]>),
     /// Borrowed Timestamp column with Timezone, mapped to `i64`.
-    TimestampTZ(ProofsTimeUnit, ProofsTimeZone, &'a [i64]),
+    TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, &'a [i64]),
 }
 
 impl<'a> CommittableColumn<'a> {
@@ -134,7 +134,9 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
-            OwnedColumn::TimestampTZ(_, _, times) => (times as &[_]).into(),
+            OwnedColumn::TimestampTZ(tu, tz, times) => {
+                CommittableColumn::TimestampTZ(*tu, *tz, times as &[_])
+            }
         }
     }
 }
@@ -150,7 +152,6 @@ impl<'a> From<&'a [i32]> for CommittableColumn<'a> {
     }
 }
 
-// TODO: make sure this does not conflict with TimeStamp
 impl<'a> From<&'a [i64]> for CommittableColumn<'a> {
     fn from(value: &'a [i64]) -> Self {
         CommittableColumn::BigInt(value)
@@ -217,6 +218,31 @@ mod tests {
         );
 
         assert_eq!(res_committable_column, test_committable_column)
+    }
+
+    #[test]
+    fn we_can_get_type_and_length_of_timestamp_column() {
+        // empty case
+        let smallint_committable_column =
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &[]);
+        assert_eq!(smallint_committable_column.len(), 0);
+        assert!(smallint_committable_column.is_empty());
+        assert_eq!(
+            smallint_committable_column.column_type(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC)
+        );
+
+        let smallint_committable_column = CommittableColumn::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            &[12, 34, 56],
+        );
+        assert_eq!(smallint_committable_column.len(), 3);
+        assert!(!smallint_committable_column.is_empty());
+        assert_eq!(
+            smallint_committable_column.column_type(),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC)
+        );
     }
 
     #[test]
@@ -356,6 +382,34 @@ mod tests {
         assert_eq!(bool_committable_column.len(), 3);
         assert!(!bool_committable_column.is_empty());
         assert_eq!(bool_committable_column.column_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn we_can_convert_from_borrowing_timestamp_column() {
+        // empty case
+        let from_borrowed_column =
+            CommittableColumn::from(&Column::<Curve25519Scalar>::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::UTC,
+                &[],
+            ));
+        assert_eq!(
+            from_borrowed_column,
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &[])
+        );
+
+        // non-empty case
+        let timestamps = [1625072400, 1625076000, 1625083200];
+        let from_borrowed_column =
+            CommittableColumn::from(&Column::<Curve25519Scalar>::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::UTC,
+                &timestamps,
+            ));
+        assert_eq!(
+            from_borrowed_column,
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &timestamps)
+        );
     }
 
     #[test]
@@ -509,6 +563,34 @@ mod tests {
         assert_eq!(
             from_owned_column,
             CommittableColumn::SmallInt(&[12, 34, 56])
+        );
+    }
+
+    #[test]
+    fn we_can_convert_from_owned_timestamp_column() {
+        // empty case
+        let owned_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            Vec::new(),
+        );
+        let from_owned_column = CommittableColumn::from(&owned_column);
+        assert_eq!(
+            from_owned_column,
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &[])
+        );
+
+        // non-empty case
+        let timestamps = vec![1625072400, 1625076000, 1625083200];
+        let owned_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            timestamps.clone(),
+        );
+        let from_owned_column = CommittableColumn::from(&owned_column);
+        assert_eq!(
+            from_owned_column,
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &timestamps)
         );
     }
 
@@ -782,6 +864,32 @@ mod tests {
 
         let sequence_actual = Sequence::from(&committable_column);
         let sequence_expected = Sequence::from(values.as_slice());
+        let mut commitment_buffer = [CompressedRistretto::default(); 2];
+        compute_curve25519_commitments(
+            &mut commitment_buffer,
+            &[sequence_actual, sequence_expected],
+            0,
+        );
+        assert_eq!(commitment_buffer[0], commitment_buffer[1]);
+    }
+
+    #[test]
+    fn we_can_commit_to_timestamp_column_through_committable_column() {
+        // Empty case
+        let committable_column =
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &[]);
+        let sequence = Sequence::from(&committable_column);
+        let mut commitment_buffer = [CompressedRistretto::default()];
+        compute_curve25519_commitments(&mut commitment_buffer, &[sequence], 0);
+        assert_eq!(commitment_buffer[0], CompressedRistretto::default());
+
+        // Non-empty case
+        let timestamps = [1625072400, 1625076000, 1625083200];
+        let committable_column =
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &timestamps);
+
+        let sequence_actual = Sequence::from(&committable_column);
+        let sequence_expected = Sequence::from(timestamps.as_slice());
         let mut commitment_buffer = [CompressedRistretto::default(); 2];
         compute_curve25519_commitments(
             &mut commitment_buffer,

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -38,8 +38,8 @@ pub enum CommittableColumn<'a> {
     Scalar(Vec<[u64; 4]>),
     /// Column of limbs for committing to scalars, hashed from a VarChar column.
     VarChar(Vec<[u64; 4]>),
-    /// Borrowed Timestamp column, mapped to `i64`.
-    Timestamp(ProofsTimeUnit, ProofsTimeZone, &'a [i64]),
+    /// Borrowed Timestamp column with Timezone, mapped to `i64`.
+    TimestampTZ(ProofsTimeUnit, ProofsTimeZone, &'a [i64]),
 }
 
 impl<'a> CommittableColumn<'a> {
@@ -54,7 +54,7 @@ impl<'a> CommittableColumn<'a> {
             CommittableColumn::Scalar(col) => col.len(),
             CommittableColumn::VarChar(col) => col.len(),
             CommittableColumn::Boolean(col) => col.len(),
-            CommittableColumn::Timestamp(_, _, col) => col.len(),
+            CommittableColumn::TimestampTZ(_, _, col) => col.len(),
         }
     }
 
@@ -82,7 +82,7 @@ impl<'a> From<&CommittableColumn<'a>> for ColumnType {
             CommittableColumn::Scalar(_) => ColumnType::Scalar,
             CommittableColumn::VarChar(_) => ColumnType::VarChar,
             CommittableColumn::Boolean(_) => ColumnType::Boolean,
-            CommittableColumn::Timestamp(tu, tz, _) => ColumnType::Timestamp(*tu, *tz),
+            CommittableColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
     }
 }
@@ -104,7 +104,7 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
                 let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
                 CommittableColumn::VarChar(as_limbs)
             }
-            Column::Timestamp(tu, tz, times) => CommittableColumn::Timestamp(*tu, *tz, times),
+            Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
         }
     }
 }
@@ -134,7 +134,7 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
-            OwnedColumn::Timestamp(_, _, times) => (times as &[_]).into(),
+            OwnedColumn::TimestampTZ(_, _, times) => (times as &[_]).into(),
         }
     }
 }
@@ -185,7 +185,7 @@ impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
             CommittableColumn::Scalar(limbs) => Sequence::from(limbs),
             CommittableColumn::VarChar(limbs) => Sequence::from(limbs),
             CommittableColumn::Boolean(bools) => Sequence::from(*bools),
-            CommittableColumn::Timestamp(_, _, times) => Sequence::from(*times),
+            CommittableColumn::TimestampTZ(_, _, times) => Sequence::from(*times),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -38,7 +38,7 @@ pub enum CommittableColumn<'a> {
     Scalar(Vec<[u64; 4]>),
     /// Column of limbs for committing to scalars, hashed from a VarChar column.
     VarChar(Vec<[u64; 4]>),
-    /// Borrowed Timestamp column, mapped to `u64`.
+    /// Borrowed Timestamp column, mapped to `i64`.
     Timestamp(ProofsTimeUnit, ProofsTimeZone, &'a [i64]),
 }
 
@@ -149,11 +149,14 @@ impl<'a> From<&'a [i32]> for CommittableColumn<'a> {
         CommittableColumn::Int(value)
     }
 }
+
+// TODO: make sure this does not conflict with TimeStamp
 impl<'a> From<&'a [i64]> for CommittableColumn<'a> {
     fn from(value: &'a [i64]) -> Self {
         CommittableColumn::BigInt(value)
     }
 }
+
 impl<'a> From<&'a [i128]> for CommittableColumn<'a> {
     fn from(value: &'a [i128]) -> Self {
         CommittableColumn::Int128(value)

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -4,7 +4,7 @@ use crate::{
         database::Column,
         math::decimal::Precision,
         scalar::Scalar,
-        time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+        time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     sql::parse::ConversionError,
 };
@@ -279,9 +279,9 @@ impl ArrayRefExt for ArrayRef {
                 ArrowTimeUnit::Second => {
                     if let Some(array) = self.as_any().downcast_ref::<TimestampSecondArray>() {
                         Ok(Column::TimestampTZ(
-                            ProofsTimeUnit::Second,
-                            ProofsTimeZone::try_from(tz.clone())?,
-                            array.values(),
+                            PoSQLTimeUnit::Second,
+                            PoSQLTimeZone::try_from(tz.clone())?,
+                            &array.values()[range.start..range.end],
                         ))
                     } else {
                         Err(ArrowArrayToColumnConversionError::UnsupportedType(
@@ -292,9 +292,9 @@ impl ArrayRefExt for ArrayRef {
                 ArrowTimeUnit::Millisecond => {
                     if let Some(array) = self.as_any().downcast_ref::<TimestampMillisecondArray>() {
                         Ok(Column::TimestampTZ(
-                            ProofsTimeUnit::Millisecond,
-                            ProofsTimeZone::try_from(tz.clone())?,
-                            array.values(),
+                            PoSQLTimeUnit::Millisecond,
+                            PoSQLTimeZone::try_from(tz.clone())?,
+                            &array.values()[range.start..range.end],
                         ))
                     } else {
                         Err(ArrowArrayToColumnConversionError::UnsupportedType(
@@ -305,9 +305,9 @@ impl ArrayRefExt for ArrayRef {
                 ArrowTimeUnit::Microsecond => {
                     if let Some(array) = self.as_any().downcast_ref::<TimestampMicrosecondArray>() {
                         Ok(Column::TimestampTZ(
-                            ProofsTimeUnit::Microsecond,
-                            ProofsTimeZone::try_from(tz.clone())?,
-                            array.values(),
+                            PoSQLTimeUnit::Microsecond,
+                            PoSQLTimeZone::try_from(tz.clone())?,
+                            &array.values()[range.start..range.end],
                         ))
                     } else {
                         Err(ArrowArrayToColumnConversionError::UnsupportedType(
@@ -318,9 +318,9 @@ impl ArrayRefExt for ArrayRef {
                 ArrowTimeUnit::Nanosecond => {
                     if let Some(array) = self.as_any().downcast_ref::<TimestampNanosecondArray>() {
                         Ok(Column::TimestampTZ(
-                            ProofsTimeUnit::Nanosecond,
-                            ProofsTimeZone::try_from(tz.clone())?,
-                            array.values(),
+                            PoSQLTimeUnit::Nanosecond,
+                            PoSQLTimeZone::try_from(tz.clone())?,
+                            &array.values()[range.start..range.end],
                         ))
                     } else {
                         Err(ArrowArrayToColumnConversionError::UnsupportedType(
@@ -364,6 +364,88 @@ mod tests {
     use crate::{base::scalar::Curve25519Scalar, proof_primitive::dory::DoryScalar};
     use arrow::array::Decimal256Builder;
     use std::{str::FromStr, sync::Arc};
+
+    #[test]
+    fn we_can_convert_timestamp_array_normal_range() {
+        let alloc = Bump::new();
+        let data = vec![1625072400, 1625076000, 1625083200]; // Example Unix timestamps
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.clone().into(),
+            Some("UTC"),
+        ));
+
+        let result = array.to_column::<Curve25519Scalar>(&alloc, &(1..3), None);
+        assert_eq!(
+            result.unwrap(),
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &data[1..3])
+        );
+    }
+
+    #[test]
+    fn we_can_build_an_empty_column_from_an_empty_range_timestamp() {
+        let alloc = Bump::new();
+        let data = vec![1625072400, 1625076000]; // Example Unix timestamps
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.into(),
+            Some("UTC"),
+        ));
+
+        let result = array
+            .to_column::<DoryScalar>(&alloc, &(2..2), None)
+            .unwrap();
+        assert_eq!(
+            result,
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &[])
+        );
+    }
+
+    #[test]
+    fn we_can_convert_timestamp_array_empty_range() {
+        let alloc = Bump::new();
+        let data = vec![1625072400, 1625076000, 1625083200]; // Example Unix timestamps
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.into(),
+            Some("UTC"),
+        ));
+
+        let result = array.to_column::<DoryScalar>(&alloc, &(1..1), None);
+        assert_eq!(
+            result.unwrap(),
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &[])
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_timestamp_array_oob_range() {
+        let alloc = Bump::new();
+        let data = vec![1625072400, 1625076000, 1625083200];
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.into(),
+            Some("UTC"),
+        ));
+
+        let result = array.to_column::<Curve25519Scalar>(&alloc, &(3..5), None);
+        assert_eq!(
+            result,
+            Err(ArrowArrayToColumnConversionError::IndexOutOfBounds(3, 5))
+        );
+    }
+
+    #[test]
+    fn we_can_convert_timestamp_array_with_nulls() {
+        let alloc = Bump::new();
+        let data = vec![Some(1625072400), None, Some(1625083200)];
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.into(),
+            Some("UTC"),
+        ));
+
+        let result = array.to_column::<DoryScalar>(&alloc, &(0..3), None);
+        assert!(matches!(
+            result,
+            Err(ArrowArrayToColumnConversionError::ArrayContainsNulls)
+        ));
+    }
 
     #[test]
     fn we_cannot_convert_utf8_array_oob_range() {
@@ -909,6 +991,24 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_valid_timestamp_array_refs_into_valid_columns() {
+        let alloc = Bump::new();
+        let data = vec![1625072400, 1625076000]; // Example Unix timestamps
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.clone().into(),
+            Some("UTC"),
+        ));
+
+        let result = array
+            .to_column::<Curve25519Scalar>(&alloc, &(0..2), None)
+            .unwrap();
+        assert_eq!(
+            result,
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &data[..])
+        );
+    }
+
+    #[test]
     fn we_can_convert_valid_boolean_array_refs_into_valid_columns_using_ranges_smaller_than_arrays()
     {
         let alloc = Bump::new();
@@ -948,6 +1048,25 @@ mod tests {
                 .to_column::<Curve25519Scalar>(&alloc, &(1..3), None)
                 .unwrap(),
             Column::BigInt(&[1, 545])
+        );
+    }
+
+    #[test]
+    fn we_can_convert_valid_timestamp_array_refs_into_valid_columns_using_ranges_smaller_than_arrays(
+    ) {
+        let alloc = Bump::new();
+        let data = vec![1625072400, 1625076000, 1625083200]; // Example Unix timestamps
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.clone().into(),
+            Some("UTC"),
+        ));
+
+        // Test using a range smaller than the array size
+        assert_eq!(
+            array
+                .to_column::<Curve25519Scalar>(&alloc, &(1..3), None)
+                .unwrap(),
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &data[1..3])
         );
     }
 
@@ -993,6 +1112,23 @@ mod tests {
     }
 
     #[test]
+    fn we_can_convert_valid_timestamp_array_refs_into_valid_columns_using_ranges_with_zero_size() {
+        let alloc = Bump::new();
+        let data = vec![1625072400, 1625076000]; // Example Unix timestamps
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.clone().into(),
+            Some("UTC"),
+        ));
+        let result = array
+            .to_column::<DoryScalar>(&alloc, &(0..0), None)
+            .unwrap();
+        assert_eq!(
+            result,
+            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &[])
+        );
+    }
+
+    #[test]
     fn we_can_convert_valid_boolean_array_refs_into_valid_vec_scalars() {
         let data = vec![false, true];
         let array: ArrayRef = Arc::new(arrow::array::BooleanArray::from(data.clone()));
@@ -1001,6 +1137,23 @@ mod tests {
             Ok(data
                 .iter()
                 .map(|v| v.into())
+                .collect::<Vec<Curve25519Scalar>>())
+        );
+    }
+
+    #[test]
+    fn we_can_convert_valid_timestamp_array_refs_into_valid_vec_scalars() {
+        let data = vec![1625072400, 1625076000]; // Example Unix timestamps
+        let array: ArrayRef = Arc::new(TimestampSecondArray::with_timezone_opt(
+            data.clone().into(),
+            Some("UTC"),
+        ));
+
+        assert_eq!(
+            array.to_curve25519_scalars(),
+            Ok(data
+                .iter()
+                .map(|&v| Curve25519Scalar::from(v))
                 .collect::<Vec<Curve25519Scalar>>())
         );
     }

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -136,6 +136,24 @@ impl ArrayRefExt for ArrayRef {
                     })
                     .collect()
             }),
+            DataType::Timestamp(time_unit, _) => match time_unit {
+                ArrowTimeUnit::Second => self
+                    .as_any()
+                    .downcast_ref::<TimestampSecondArray>()
+                    .map(|array| array.values().iter().map(|v| Ok((*v).into())).collect()),
+                ArrowTimeUnit::Millisecond => self
+                    .as_any()
+                    .downcast_ref::<TimestampMillisecondArray>()
+                    .map(|array| array.values().iter().map(|v| Ok((*v).into())).collect()),
+                ArrowTimeUnit::Microsecond => self
+                    .as_any()
+                    .downcast_ref::<TimestampMicrosecondArray>()
+                    .map(|array| array.values().iter().map(|v| Ok((*v).into())).collect()),
+                ArrowTimeUnit::Nanosecond => self
+                    .as_any()
+                    .downcast_ref::<TimestampNanosecondArray>()
+                    .map(|array| array.values().iter().map(|v| Ok((*v).into())).collect()),
+            },
             _ => None,
         };
 

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -278,7 +278,7 @@ impl ArrayRefExt for ArrayRef {
             DataType::Timestamp(time_unit, tz) => match time_unit {
                 ArrowTimeUnit::Second => {
                     if let Some(array) = self.as_any().downcast_ref::<TimestampSecondArray>() {
-                        Ok(Column::Timestamp(
+                        Ok(Column::TimestampTZ(
                             ProofsTimeUnit::Second,
                             ProofsTimeZone::try_from(tz.clone())?,
                             array.values(),
@@ -291,7 +291,7 @@ impl ArrayRefExt for ArrayRef {
                 }
                 ArrowTimeUnit::Millisecond => {
                     if let Some(array) = self.as_any().downcast_ref::<TimestampMillisecondArray>() {
-                        Ok(Column::Timestamp(
+                        Ok(Column::TimestampTZ(
                             ProofsTimeUnit::Millisecond,
                             ProofsTimeZone::try_from(tz.clone())?,
                             array.values(),
@@ -304,7 +304,7 @@ impl ArrayRefExt for ArrayRef {
                 }
                 ArrowTimeUnit::Microsecond => {
                     if let Some(array) = self.as_any().downcast_ref::<TimestampMicrosecondArray>() {
-                        Ok(Column::Timestamp(
+                        Ok(Column::TimestampTZ(
                             ProofsTimeUnit::Microsecond,
                             ProofsTimeZone::try_from(tz.clone())?,
                             array.values(),
@@ -317,7 +317,7 @@ impl ArrayRefExt for ArrayRef {
                 }
                 ArrowTimeUnit::Nanosecond => {
                     if let Some(array) = self.as_any().downcast_ref::<TimestampNanosecondArray>() {
-                        Ok(Column::Timestamp(
+                        Ok(Column::TimestampTZ(
                             ProofsTimeUnit::Nanosecond,
                             ProofsTimeZone::try_from(tz.clone())?,
                             array.values(),

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -1,10 +1,6 @@
 use super::scalar_and_i256_conversions::convert_i256_to_scalar;
 use crate::{
-    base::{
-        database::Column,
-        math::decimal::Precision,
-        scalar::{Curve25519Scalar, Scalar},
-    },
+    base::{database::Column, math::decimal::Precision, scalar::Scalar},
     sql::parse::ConversionError,
 };
 use arrow::{
@@ -48,7 +44,7 @@ pub trait ArrayRefExt {
     #[cfg(feature = "blitzar")]
     fn to_curve25519_scalars(
         &self,
-    ) -> Result<Vec<Curve25519Scalar>, ArrowArrayToColumnConversionError>;
+    ) -> Result<Vec<crate::base::scalar::Curve25519Scalar>, ArrowArrayToColumnConversionError>;
 
     /// Convert an ArrayRef into a Proof of SQL Column type
     ///
@@ -76,7 +72,7 @@ impl ArrayRefExt for ArrayRef {
     #[cfg(feature = "blitzar")]
     fn to_curve25519_scalars(
         &self,
-    ) -> Result<Vec<Curve25519Scalar>, ArrowArrayToColumnConversionError> {
+    ) -> Result<Vec<crate::base::scalar::Curve25519Scalar>, ArrowArrayToColumnConversionError> {
         if self.null_count() != 0 {
             return Err(ArrowArrayToColumnConversionError::ArrayContainsNulls);
         }
@@ -283,7 +279,7 @@ impl ArrayRefExt for ArrayRef {
 mod tests {
 
     use super::*;
-    use crate::proof_primitive::dory::DoryScalar;
+    use crate::{base::scalar::Curve25519Scalar, proof_primitive::dory::DoryScalar};
     use arrow::array::Decimal256Builder;
     use std::{str::FromStr, sync::Arc};
 

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -274,10 +274,9 @@ impl From<&ColumnType> for DataType {
             }
             ColumnType::VarChar => DataType::Utf8,
             ColumnType::Scalar => unimplemented!("Cannot convert Scalar type to arrow type"),
-            ColumnType::Timestamp(timeunit, timezone) => DataType::Timestamp(
-                ArrowTimeUnit::from(*timeunit),
-                Some(Arc::from(timezone)),
-            ),
+            ColumnType::Timestamp(timeunit, timezone) => {
+                DataType::Timestamp(ArrowTimeUnit::from(*timeunit), Some(Arc::from(timezone)))
+            }
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -111,6 +111,9 @@ impl<'a, S: Scalar> Column<'a, S> {
                 *scale,
                 alloc.alloc_slice_fill_copy(length, *value),
             ),
+            LiteralValue::TimeStamp(tu, tz, value) => {
+                Column::Timestamp(*tu, *tz, alloc.alloc_slice_fill_copy(length, *value))
+            }
             LiteralValue::VarChar((string, scalar)) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
                 alloc.alloc_slice_fill_copy(length, *scalar),
@@ -306,7 +309,6 @@ impl TryFrom<DataType> for ColumnType {
                     }
                     None => chrono_tz::Tz::UTC, // Default to UTC if None
                 };
-
                 Ok(ColumnType::Timestamp(
                     custom_time_unit,
                     ProofsTimeZone::from(timezone),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -228,7 +228,7 @@ impl ColumnType {
                 | ColumnType::BigInt
                 | ColumnType::Int128
                 | ColumnType::Scalar
-                | ColumnType::Decimal75(_, _) // TODO: is a timestamp numeric?
+                | ColumnType::Decimal75(_, _)
         )
     }
 
@@ -236,7 +236,7 @@ impl ColumnType {
     pub fn is_integer(&self) -> bool {
         matches!(
             self,
-            ColumnType::SmallInt | ColumnType::Int | ColumnType::BigInt | ColumnType::Int128 // TODO: is a timestamp an integer?
+            ColumnType::SmallInt | ColumnType::Int | ColumnType::BigInt | ColumnType::Int128
         )
     }
 

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -41,7 +41,7 @@ pub enum Column<'a, S: Scalar> {
     VarChar((&'a [&'a str], &'a [S])),
     /// Timestamp columns
     /// - the first element maps to the stored [`TimeUnit`]
-    /// - the second element maps to an optional timezone as a string
+    /// - the second element maps to a timezone
     /// - the third element maps to columns of timeunits since unix epoch
     Timestamp(ProofsTimeUnit, ProofsTimeZone, &'a [i64]),
 }
@@ -300,7 +300,7 @@ impl TryFrom<DataType> for ColumnType {
 
                 let timezone = match timezone_option {
                     Some(tz_arc) => {
-                        let tz_str = &*tz_arc; // Deref Arc<str> to &str
+                        let tz_str = &*tz_arc; // Dereference Arc<str> to &str
                         chrono_tz::Tz::from_str(tz_str)
                             .map_err(|_| format!("Invalid timezone string: {}", tz_str))?
                     }
@@ -309,7 +309,7 @@ impl TryFrom<DataType> for ColumnType {
 
                 Ok(ColumnType::Timestamp(
                     custom_time_unit,
-                    ProofsTimeZone(timezone),
+                    ProofsTimeZone::from(timezone),
                 ))
             }
             DataType::Utf8 => Ok(ColumnType::VarChar),

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -36,7 +36,7 @@ pub enum LiteralValue<S: Scalar> {
     Scalar(S),
     /// TimeStamp defined over a unit (s, ms, ns, etc) and timezone with backing store
     /// mapped to i64, which is time units since unix epoch
-    TimeStamp(ProofsTimeUnit, ProofsTimeZone, i64),
+    TimeStampTZ(ProofsTimeUnit, ProofsTimeZone, i64),
 }
 
 impl<S: Scalar> LiteralValue<S> {
@@ -51,7 +51,7 @@ impl<S: Scalar> LiteralValue<S> {
             Self::Int128(_) => ColumnType::Int128,
             Self::Scalar(_) => ColumnType::Scalar,
             Self::Decimal75(precision, scale, _) => ColumnType::Decimal75(*precision, *scale),
-            Self::TimeStamp(tu, tz, _) => ColumnType::Timestamp(*tu, *tz),
+            Self::TimeStampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
     }
 
@@ -66,7 +66,7 @@ impl<S: Scalar> LiteralValue<S> {
             Self::Int128(i) => i.into(),
             Self::Decimal75(_, _, s) => *s,
             Self::Scalar(scalar) => *scalar,
-            Self::TimeStamp(_, _, time) => time.into(),
+            Self::TimeStampTZ(_, _, time) => time.into(),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -2,7 +2,7 @@ use crate::base::{
     database::ColumnType,
     math::decimal::Precision,
     scalar::Scalar,
-    time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+    time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
 };
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +36,7 @@ pub enum LiteralValue<S: Scalar> {
     Scalar(S),
     /// TimeStamp defined over a unit (s, ms, ns, etc) and timezone with backing store
     /// mapped to i64, which is time units since unix epoch
-    TimeStampTZ(ProofsTimeUnit, ProofsTimeZone, i64),
+    TimeStampTZ(PoSQLTimeUnit, PoSQLTimeZone, i64),
 }
 
 impl<S: Scalar> LiteralValue<S> {

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,4 +1,9 @@
-use crate::base::{database::ColumnType, math::decimal::Precision, scalar::Scalar};
+use crate::base::{
+    database::ColumnType,
+    math::decimal::Precision,
+    scalar::Scalar,
+    time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+};
 use serde::{Deserialize, Serialize};
 
 /// Represents a literal value.
@@ -29,6 +34,9 @@ pub enum LiteralValue<S: Scalar> {
     Decimal75(Precision, i8, S),
     /// Scalar literals
     Scalar(S),
+    /// TimeStamp defined over a unit (s, ms, ns, etc) and timezone with backing store
+    /// mapped to i64, which is time units since unix epoch
+    TimeStamp(ProofsTimeUnit, ProofsTimeZone, i64),
 }
 
 impl<S: Scalar> LiteralValue<S> {
@@ -43,6 +51,7 @@ impl<S: Scalar> LiteralValue<S> {
             Self::Int128(_) => ColumnType::Int128,
             Self::Scalar(_) => ColumnType::Scalar,
             Self::Decimal75(precision, scale, _) => ColumnType::Decimal75(*precision, *scale),
+            Self::TimeStamp(tu, tz, _) => ColumnType::Timestamp(*tu, *tz),
         }
     }
 
@@ -57,6 +66,7 @@ impl<S: Scalar> LiteralValue<S> {
             Self::Int128(i) => i.into(),
             Self::Decimal75(_, _, s) => *s,
             Self::Scalar(scalar) => *scalar,
+            Self::TimeStamp(_, _, time) => time.into(),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -87,7 +87,7 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
             }
             OwnedColumn::Scalar(_) => unimplemented!("Cannot convert Scalar type to arrow type"),
             OwnedColumn::VarChar(col) => Arc::new(StringArray::from(col)),
-            OwnedColumn::Timestamp(time_unit, _, col) => match time_unit {
+            OwnedColumn::TimestampTZ(time_unit, _, col) => match time_unit {
                 ProofsTimeUnit::Second => Arc::new(TimestampSecondArray::from(col)),
                 ProofsTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(col)),
                 ProofsTimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(col)),
@@ -199,7 +199,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                             )
                         })?;
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
-                    Ok(OwnedColumn::Timestamp(
+                    Ok(OwnedColumn::TimestampTZ(
                         ProofsTimeUnit::Second,
                         ProofsTimeZone::try_from(timezone.clone())?,
                         timestamps,
@@ -215,7 +215,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                             )
                         })?;
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
-                    Ok(OwnedColumn::Timestamp(
+                    Ok(OwnedColumn::TimestampTZ(
                         ProofsTimeUnit::Millisecond,
                         ProofsTimeZone::try_from(timezone.clone())?,
                         timestamps,
@@ -231,7 +231,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                             )
                         })?;
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
-                    Ok(OwnedColumn::Timestamp(
+                    Ok(OwnedColumn::TimestampTZ(
                         ProofsTimeUnit::Microsecond,
                         ProofsTimeZone::try_from(timezone.clone())?,
                         timestamps,
@@ -247,7 +247,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                             )
                         })?;
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
-                    Ok(OwnedColumn::Timestamp(
+                    Ok(OwnedColumn::TimestampTZ(
                         ProofsTimeUnit::Nanosecond,
                         ProofsTimeZone::try_from(timezone.clone())?,
                         timestamps,

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -20,7 +20,7 @@ use crate::base::{
     },
     math::decimal::Precision,
     scalar::Scalar,
-    time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+    time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
 };
 use arrow::{
     array::{
@@ -88,10 +88,10 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
             OwnedColumn::Scalar(_) => unimplemented!("Cannot convert Scalar type to arrow type"),
             OwnedColumn::VarChar(col) => Arc::new(StringArray::from(col)),
             OwnedColumn::TimestampTZ(time_unit, _, col) => match time_unit {
-                ProofsTimeUnit::Second => Arc::new(TimestampSecondArray::from(col)),
-                ProofsTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(col)),
-                ProofsTimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(col)),
-                ProofsTimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from(col)),
+                PoSQLTimeUnit::Second => Arc::new(TimestampSecondArray::from(col)),
+                PoSQLTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(col)),
+                PoSQLTimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(col)),
+                PoSQLTimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from(col)),
             },
         }
     }
@@ -200,8 +200,8 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                         })?;
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
-                        ProofsTimeUnit::Second,
-                        ProofsTimeZone::try_from(timezone.clone())?,
+                        PoSQLTimeUnit::Second,
+                        PoSQLTimeZone::try_from(timezone.clone())?,
                         timestamps,
                     ))
                 }
@@ -216,8 +216,8 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                         })?;
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
-                        ProofsTimeUnit::Millisecond,
-                        ProofsTimeZone::try_from(timezone.clone())?,
+                        PoSQLTimeUnit::Millisecond,
+                        PoSQLTimeZone::try_from(timezone.clone())?,
                         timestamps,
                     ))
                 }
@@ -232,8 +232,8 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                         })?;
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
-                        ProofsTimeUnit::Microsecond,
-                        ProofsTimeZone::try_from(timezone.clone())?,
+                        PoSQLTimeUnit::Microsecond,
+                        PoSQLTimeZone::try_from(timezone.clone())?,
                         timestamps,
                     ))
                 }
@@ -248,8 +248,8 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                         })?;
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
-                        ProofsTimeUnit::Nanosecond,
-                        ProofsTimeZone::try_from(timezone.clone())?,
+                        PoSQLTimeUnit::Nanosecond,
+                        PoSQLTimeZone::try_from(timezone.clone())?,
                         timestamps,
                     ))
                 }

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -20,11 +20,13 @@ use crate::base::{
     },
     math::decimal::Precision,
     scalar::Scalar,
+    time::timestamp::ProofsTimeUnit,
 };
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, StringArray, UInt64Array,
+        Int64Array, StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+        TimestampNanosecondArray, TimestampSecondArray,
     },
     datatypes::{i256, DataType, Schema, SchemaRef},
     error::ArrowError,
@@ -79,7 +81,12 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
             }
             OwnedColumn::Scalar(_) => unimplemented!("Cannot convert Scalar type to arrow type"),
             OwnedColumn::VarChar(col) => Arc::new(StringArray::from(col)),
-            OwnedColumn::Timestamp(col) => Arc::new(UInt64Array::from(col)),
+            OwnedColumn::Timestamp(time_unit, _, col) => match time_unit {
+                ProofsTimeUnit::Second => Arc::new(TimestampSecondArray::from(col)),
+                ProofsTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(col)),
+                ProofsTimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(col)),
+                ProofsTimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from(col)),
+            },
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -24,7 +24,7 @@ use crate::base::{
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, StringArray,
+        Int64Array, StringArray, UInt64Array,
     },
     datatypes::{i256, DataType, Schema, SchemaRef},
     error::ArrowError,
@@ -79,6 +79,7 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
             }
             OwnedColumn::Scalar(_) => unimplemented!("Cannot convert Scalar type to arrow type"),
             OwnedColumn::VarChar(col) => Arc::new(StringArray::from(col)),
+            OwnedColumn::Timestamp(col) => Arc::new(UInt64Array::from(col)),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -29,7 +29,7 @@ pub enum OwnedColumn<S: Scalar> {
     /// Scalar columns
     Scalar(Vec<S>),
     /// Timestamp columns
-    Timestamp(ProofsTimeUnit, ProofsTimeZone, Vec<i64>),
+    TimestampTZ(ProofsTimeUnit, ProofsTimeZone, Vec<i64>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {
@@ -44,7 +44,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Int128(col) => col.len(),
             OwnedColumn::Decimal75(_, _, col) => col.len(),
             OwnedColumn::Scalar(col) => col.len(),
-            OwnedColumn::Timestamp(_, _, col) => col.len(),
+            OwnedColumn::TimestampTZ(_, _, col) => col.len(),
         }
     }
     /// Returns true if the column is empty.
@@ -58,7 +58,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Int128(col) => col.is_empty(),
             OwnedColumn::Scalar(col) => col.is_empty(),
             OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
-            OwnedColumn::Timestamp(_, _, col) => col.is_empty(),
+            OwnedColumn::TimestampTZ(_, _, col) => col.is_empty(),
         }
     }
     /// Returns the type of the column.
@@ -74,7 +74,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Decimal75(precision, scale, _) => {
                 ColumnType::Decimal75(*precision, *scale)
             }
-            OwnedColumn::Timestamp(tu, tz, _) => ColumnType::Timestamp(*tu, *tz),
+            OwnedColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -94,6 +94,7 @@ impl<S: Scalar> FromIterator<i32> for OwnedColumn<S> {
         Self::Int(Vec::from_iter(iter))
     }
 }
+// TODO: does this conflict with TimeStamp?
 impl<S: Scalar> FromIterator<i64> for OwnedColumn<S> {
     fn from_iter<T: IntoIterator<Item = i64>>(iter: T) -> Self {
         Self::BigInt(Vec::from_iter(iter))

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -24,6 +24,8 @@ pub enum OwnedColumn<S: Scalar> {
     Decimal75(Precision, i8, Vec<S>),
     /// Scalar columns
     Scalar(Vec<S>),
+    /// i32 columns
+    Timestamp(Vec<u64>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {
@@ -38,6 +40,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Int128(col) => col.len(),
             OwnedColumn::Decimal75(_, _, col) => col.len(),
             OwnedColumn::Scalar(col) => col.len(),
+            OwnedColumn::Timestamp(col) => col.len(),
         }
     }
     /// Returns true if the column is empty.
@@ -51,6 +54,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Int128(col) => col.is_empty(),
             OwnedColumn::Scalar(col) => col.is_empty(),
             OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
+            OwnedColumn::Timestamp(col) => col.is_empty(),
         }
     }
     /// Returns the type of the column.
@@ -66,6 +70,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Decimal75(precision, scale, _) => {
                 ColumnType::Decimal75(*precision, *scale)
             }
+            OwnedColumn::Timestamp(_) => ColumnType::Timestamp,
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -3,7 +3,11 @@
 /// converting to the final result in either Arrow format or JSON.
 /// This is the analog of an arrow Array.
 use super::ColumnType;
-use crate::base::{math::decimal::Precision, scalar::Scalar};
+use crate::base::{
+    math::decimal::Precision,
+    scalar::Scalar,
+    time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+};
 #[derive(Debug, PartialEq, Clone, Eq)]
 #[non_exhaustive]
 /// Supported types for OwnedColumn
@@ -24,8 +28,8 @@ pub enum OwnedColumn<S: Scalar> {
     Decimal75(Precision, i8, Vec<S>),
     /// Scalar columns
     Scalar(Vec<S>),
-    /// i32 columns
-    Timestamp(Vec<u64>),
+    /// Timestamp columns
+    Timestamp(ProofsTimeUnit, ProofsTimeZone, Vec<i64>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {
@@ -40,7 +44,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Int128(col) => col.len(),
             OwnedColumn::Decimal75(_, _, col) => col.len(),
             OwnedColumn::Scalar(col) => col.len(),
-            OwnedColumn::Timestamp(col) => col.len(),
+            OwnedColumn::Timestamp(_, _, col) => col.len(),
         }
     }
     /// Returns true if the column is empty.
@@ -54,7 +58,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Int128(col) => col.is_empty(),
             OwnedColumn::Scalar(col) => col.is_empty(),
             OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
-            OwnedColumn::Timestamp(col) => col.is_empty(),
+            OwnedColumn::Timestamp(_, _, col) => col.is_empty(),
         }
     }
     /// Returns the type of the column.
@@ -70,7 +74,7 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Decimal75(precision, scale, _) => {
                 ColumnType::Decimal75(*precision, *scale)
             }
-            OwnedColumn::Timestamp(_) => ColumnType::Timestamp,
+            OwnedColumn::Timestamp(tu, tz, _) => ColumnType::Timestamp(*tu, *tz),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -6,7 +6,7 @@ use super::ColumnType;
 use crate::base::{
     math::decimal::Precision,
     scalar::Scalar,
-    time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+    time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
 };
 #[derive(Debug, PartialEq, Clone, Eq)]
 #[non_exhaustive]
@@ -29,7 +29,7 @@ pub enum OwnedColumn<S: Scalar> {
     /// Scalar columns
     Scalar(Vec<S>),
     /// Timestamp columns
-    TimestampTZ(ProofsTimeUnit, ProofsTimeZone, Vec<i64>),
+    TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, Vec<i64>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {
@@ -76,47 +76,5 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             OwnedColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
-    }
-}
-
-impl<S: Scalar> FromIterator<bool> for OwnedColumn<S> {
-    fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
-        Self::Boolean(Vec::from_iter(iter))
-    }
-}
-impl<S: Scalar> FromIterator<i16> for OwnedColumn<S> {
-    fn from_iter<T: IntoIterator<Item = i16>>(iter: T) -> Self {
-        Self::SmallInt(Vec::from_iter(iter))
-    }
-}
-impl<S: Scalar> FromIterator<i32> for OwnedColumn<S> {
-    fn from_iter<T: IntoIterator<Item = i32>>(iter: T) -> Self {
-        Self::Int(Vec::from_iter(iter))
-    }
-}
-// TODO: does this conflict with TimeStamp?
-impl<S: Scalar> FromIterator<i64> for OwnedColumn<S> {
-    fn from_iter<T: IntoIterator<Item = i64>>(iter: T) -> Self {
-        Self::BigInt(Vec::from_iter(iter))
-    }
-}
-impl<S: Scalar> FromIterator<i128> for OwnedColumn<S> {
-    fn from_iter<T: IntoIterator<Item = i128>>(iter: T) -> Self {
-        Self::Int128(Vec::from_iter(iter))
-    }
-}
-impl<S: Scalar> FromIterator<String> for OwnedColumn<S> {
-    fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
-        Self::VarChar(Vec::from_iter(iter))
-    }
-}
-impl<S: Scalar> FromIterator<S> for OwnedColumn<S> {
-    fn from_iter<T: IntoIterator<Item = S>>(iter: T) -> Self {
-        Self::Scalar(Vec::from_iter(iter))
-    }
-}
-impl<'a, S: Scalar> FromIterator<&'a str> for OwnedColumn<S> {
-    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
-        Self::from_iter(iter.into_iter().map(|s| s.to_string()))
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -2,6 +2,7 @@ use crate::{
     base::{
         database::{owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableError},
         scalar::Curve25519Scalar,
+        time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -56,8 +57,22 @@ fn we_can_create_an_owned_table_with_data() {
             "boolean",
             [true, false, true, false, true, false, true, false, true],
         ),
+        timestamptz(
+            "timestamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
+        ),
     ]);
     let mut table = IndexMap::new();
+    table.insert(
+        Identifier::try_new("timestamp").unwrap(),
+        OwnedColumn::TimestampTZ(
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX].into(),
+        ),
+    );
     table.insert(
         Identifier::try_new("bigint").unwrap(),
         OwnedColumn::BigInt(vec![0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]),
@@ -109,12 +124,24 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
         int128("b", [0; 0]),
         varchar("c", ["0"; 0]),
         boolean("d", [false; 0]),
+        timestamptz(
+            "timestamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            [0; 0],
+        ),
     ]);
     let owned_table_b: OwnedTable<Curve25519Scalar> = owned_table([
         boolean("d", [false; 0]),
         int128("b", [0; 0]),
         bigint("a", [0; 0]),
         varchar("c", ["0"; 0]),
+        timestamptz(
+            "timestamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            [0; 0],
+        ),
     ]);
     assert_ne!(owned_table_a, owned_table_b);
 }
@@ -125,12 +152,24 @@ fn we_get_inequality_between_tables_with_differing_data() {
         int128("b", [0]),
         varchar("c", ["0"]),
         boolean("d", [true]),
+        timestamptz(
+            "timestamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            [1625072400],
+        ),
     ]);
     let owned_table_b: OwnedTable<DoryScalar> = owned_table([
         bigint("a", [1]),
         int128("b", [0]),
         varchar("c", ["0"]),
         boolean("d", [true]),
+        timestamptz(
+            "timestamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            [1625076000],
+        ),
     ]);
     assert_ne!(owned_table_a, owned_table_b);
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -95,7 +95,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
                 Column::VarChar((col, scals))
             }
-            OwnedColumn::Timestamp(tu, tz, col) => Column::Timestamp(*tu, *tz, col),
+            OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -95,6 +95,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
                 Column::VarChar((col, scals))
             }
+            OwnedColumn::Timestamp(col) => Column::Timestamp(col),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -95,7 +95,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
                 Column::VarChar((col, scals))
             }
-            OwnedColumn::Timestamp(col) => Column::Timestamp(col),
+            OwnedColumn::Timestamp(tu, tz, col) => Column::Timestamp(*tu, *tz, col),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::base::{
     database::owned_table_utility::*,
     scalar::{compute_commitment_for_testing, Curve25519Scalar},
+    time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
 };
 use blitzar::proof::InnerProductProof;
 
@@ -48,6 +49,12 @@ fn we_can_access_the_columns_of_a_table() {
         varchar("varchar", ["a", "bc", "d", "e"]),
         scalar("scalar", [1, 2, 3, 4]),
         boolean("boolean", [true, false, true, false]),
+        timestamptz(
+            "time",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::UTC,
+            [4, 5, 6, 5],
+        ),
     ]);
     accessor.add_table(table_ref_2, data2, 0_usize);
 
@@ -97,6 +104,16 @@ fn we_can_access_the_columns_of_a_table() {
     let column = ColumnRef::new(table_ref_2, "boolean".parse().unwrap(), ColumnType::Boolean);
     match accessor.get_column(column) {
         Column::Boolean(col) => assert_eq!(col.to_vec(), vec![true, false, true, false]),
+        _ => panic!("Invalid column type"),
+    };
+
+    let column = ColumnRef::new(
+        table_ref_2,
+        "time".parse().unwrap(),
+        ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC),
+    );
+    match accessor.get_column(column) {
+        Column::TimestampTZ(_, _, col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
     };
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -14,7 +14,10 @@
 //! ]);
 //! ```
 use super::{OwnedColumn, OwnedTable};
-use crate::base::scalar::Scalar;
+use crate::base::{
+    scalar::Scalar,
+    time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+};
 use core::ops::Deref;
 use proof_of_sql_parser::Identifier;
 
@@ -193,5 +196,37 @@ pub fn decimal75<S: Scalar>(
             scale,
             data.into_iter().map(Into::into).collect(),
         ),
+    )
+}
+
+/// Creates a (Identifier, OwnedColumn) pair for a timestamp column.
+/// This is primarily intended for use in conjunction with [owned_table].
+///
+/// # Parameters
+/// - `name`: The name of the column.
+/// - `time_unit`: The time unit of the timestamps.
+/// - `timezone`: The timezone for the timestamps.
+/// - `data`: The data for the column, provided as an iterator over `i64` values representing time since the unix epoch.
+///
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*,
+///     scalar::Curve25519Scalar,
+///     time::timestamp::{ProofsTimeUnit, ProofsTimeZone}};
+/// use chrono_tz::Europe::London;
+///
+/// let result = owned_table::<Curve25519Scalar>([
+///     timestamp("event_time", ProofsTimeUnit::Second, ProofsTimeZone::new(London), vec![1625072400, 1625076000, 1625079600]),
+/// ]);
+/// ```
+pub fn timestamp<S: Scalar>(
+    name: impl Deref<Target = str>,
+    time_unit: ProofsTimeUnit,
+    timezone: ProofsTimeZone,
+    data: impl IntoIterator<Item = i64>,
+) -> (Identifier, OwnedColumn<S>) {
+    (
+        name.parse().unwrap(),
+        OwnedColumn::Timestamp(time_unit, timezone, data.into_iter().collect()),
     )
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -16,7 +16,7 @@
 use super::{OwnedColumn, OwnedTable};
 use crate::base::{
     scalar::Scalar,
-    time::timestamp::{ProofsTimeUnit, ProofsTimeZone},
+    time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone},
 };
 use core::ops::Deref;
 use proof_of_sql_parser::Identifier;
@@ -212,17 +212,17 @@ pub fn decimal75<S: Scalar>(
 /// ```
 /// use proof_of_sql::base::{database::owned_table_utility::*,
 ///     scalar::Curve25519Scalar,
-///     time::timestamp::{ProofsTimeUnit, ProofsTimeZone}};
+///     time::timestamp::{PoSQLTimeUnit, PoSQLTimeZone}};
 /// use chrono_tz::Europe::London;
 ///
 /// let result = owned_table::<Curve25519Scalar>([
-///     timestamptz("event_time", ProofsTimeUnit::Second, ProofsTimeZone::new(London), vec![1625072400, 1625076000, 1625079600]),
+///     timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::new(London), vec![1625072400, 1625076000, 1625079600]),
 /// ]);
 /// ```
 pub fn timestamptz<S: Scalar>(
     name: impl Deref<Target = str>,
-    time_unit: ProofsTimeUnit,
-    timezone: ProofsTimeZone,
+    time_unit: PoSQLTimeUnit,
+    timezone: PoSQLTimeZone,
     data: impl IntoIterator<Item = i64>,
 ) -> (Identifier, OwnedColumn<S>) {
     (

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -216,7 +216,7 @@ pub fn decimal75<S: Scalar>(
 /// use chrono_tz::Europe::London;
 ///
 /// let result = owned_table::<Curve25519Scalar>([
-///     timestamp("event_time", ProofsTimeUnit::Second, ProofsTimeZone::new(London), vec![1625072400, 1625076000, 1625079600]),
+///     timestamptz("event_time", ProofsTimeUnit::Second, ProofsTimeZone::new(London), vec![1625072400, 1625076000, 1625079600]),
 /// ]);
 /// ```
 pub fn timestamptz<S: Scalar>(

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -219,7 +219,7 @@ pub fn decimal75<S: Scalar>(
 ///     timestamp("event_time", ProofsTimeUnit::Second, ProofsTimeZone::new(London), vec![1625072400, 1625076000, 1625079600]),
 /// ]);
 /// ```
-pub fn timestamp<S: Scalar>(
+pub fn timestamptz<S: Scalar>(
     name: impl Deref<Target = str>,
     time_unit: ProofsTimeUnit,
     timezone: ProofsTimeZone,
@@ -227,6 +227,6 @@ pub fn timestamp<S: Scalar>(
 ) -> (Identifier, OwnedColumn<S>) {
     (
         name.parse().unwrap(),
-        OwnedColumn::Timestamp(time_unit, timezone, data.into_iter().collect()),
+        OwnedColumn::TimestampTZ(time_unit, timezone, data.into_iter().collect()),
     )
 }

--- a/crates/proof-of-sql/src/base/database/record_batch_utility.rs
+++ b/crates/proof-of-sql/src/base/database/record_batch_utility.rs
@@ -1,3 +1,8 @@
+use crate::base::time::timestamp::{PoSQLTimeUnit, Time};
+use arrow::array::{
+    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+    TimestampSecondArray,
+};
 use std::sync::Arc;
 
 /// Extension trait for Vec<T> to convert it to an Arrow array
@@ -15,6 +20,48 @@ impl ToArrow for Vec<bool> {
 
     fn to_array(self) -> Arc<dyn arrow::array::Array> {
         Arc::new(<arrow::array::BooleanArray>::from(self))
+    }
+}
+
+impl ToArrow for Vec<Time> {
+    fn to_type(&self) -> arrow::datatypes::DataType {
+        match self.first().map(|time| time.unit) {
+            Some(PoSQLTimeUnit::Second) => {
+                arrow::datatypes::DataType::Timestamp(arrow::datatypes::TimeUnit::Second, None)
+            }
+            Some(PoSQLTimeUnit::Millisecond) => {
+                arrow::datatypes::DataType::Timestamp(arrow::datatypes::TimeUnit::Millisecond, None)
+            }
+            Some(PoSQLTimeUnit::Microsecond) => {
+                arrow::datatypes::DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, None)
+            }
+            Some(PoSQLTimeUnit::Nanosecond) => {
+                arrow::datatypes::DataType::Timestamp(arrow::datatypes::TimeUnit::Nanosecond, None)
+            }
+            None => panic!("Empty Vec<Time> cannot determine TimeUnit"),
+        }
+    }
+
+    fn to_array(self) -> Arc<dyn arrow::array::Array> {
+        match self.first().map(|time| time.unit) {
+            Some(PoSQLTimeUnit::Second) => {
+                let raw_data: Vec<i64> = self.into_iter().map(|time| time.timestamp).collect();
+                Arc::new(TimestampSecondArray::from(raw_data))
+            }
+            Some(PoSQLTimeUnit::Millisecond) => {
+                let raw_data: Vec<i64> = self.into_iter().map(|time| time.timestamp).collect();
+                Arc::new(TimestampMillisecondArray::from(raw_data))
+            }
+            Some(PoSQLTimeUnit::Microsecond) => {
+                let raw_data: Vec<i64> = self.into_iter().map(|time| time.timestamp).collect();
+                Arc::new(TimestampMicrosecondArray::from(raw_data))
+            }
+            Some(PoSQLTimeUnit::Nanosecond) => {
+                let raw_data: Vec<i64> = self.into_iter().map(|time| time.timestamp).collect();
+                Arc::new(TimestampNanosecondArray::from(raw_data))
+            }
+            None => panic!("Empty Vec<Time> cannot determine TimeUnit"),
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -122,7 +122,6 @@ pub fn make_random_test_accessor_data(
                     DataType::Timestamp(TimeUnit::from(*tu), Some(Arc::from(tz.to_string()))),
                     false,
                 ));
-
                 // Create the correct timestamp array based on the time unit
                 let timestamp_array: Arc<dyn Array> = match tu {
                     ProofsTimeUnit::Second => Arc::new(TimestampSecondArray::from(values.to_vec())),

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -1,11 +1,11 @@
-use crate::base::{database::ColumnType, time::timestamp::ProofsTimeUnit};
+use crate::base::{database::ColumnType, time::timestamp::PoSQLTimeUnit};
 use arrow::{
     array::{
         Array, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array, Int64Array,
         StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
         TimestampNanosecondArray, TimestampSecondArray,
     },
-    datatypes::{i256, DataType, Field, Schema, TimeUnit},
+    datatypes::{i256, DataType, Field, Schema},
     record_batch::RecordBatch,
 };
 use rand::{
@@ -119,19 +119,22 @@ pub fn make_random_test_accessor_data(
             ColumnType::TimestampTZ(tu, tz) => {
                 column_fields.push(Field::new(
                     *col_name,
-                    DataType::Timestamp(TimeUnit::from(*tu), Some(Arc::from(tz.to_string()))),
+                    DataType::Timestamp(
+                        (*tu).into(),
+                        Some(Arc::from(tz.to_string())),
+                    ),
                     false,
                 ));
                 // Create the correct timestamp array based on the time unit
                 let timestamp_array: Arc<dyn Array> = match tu {
-                    ProofsTimeUnit::Second => Arc::new(TimestampSecondArray::from(values.to_vec())),
-                    ProofsTimeUnit::Millisecond => {
+                    PoSQLTimeUnit::Second => Arc::new(TimestampSecondArray::from(values.to_vec())),
+                    PoSQLTimeUnit::Millisecond => {
                         Arc::new(TimestampMillisecondArray::from(values.to_vec()))
                     }
-                    ProofsTimeUnit::Microsecond => {
+                    PoSQLTimeUnit::Microsecond => {
                         Arc::new(TimestampMicrosecondArray::from(values.to_vec()))
                     }
-                    ProofsTimeUnit::Nanosecond => {
+                    PoSQLTimeUnit::Nanosecond => {
                         Arc::new(TimestampNanosecondArray::from(values.to_vec()))
                     }
                 };

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -119,7 +119,7 @@ pub fn make_random_test_accessor_data(
             ColumnType::Timestamp(tu, tz) => {
                 column_fields.push(Field::new(
                     *col_name,
-                    DataType::Timestamp(TimeUnit::from(*tu), Some(Arc::from(tz.0.name()))),
+                    DataType::Timestamp(TimeUnit::from(*tu), Some(Arc::from(tz.to_string()))),
                     false,
                 ));
 

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -116,7 +116,7 @@ pub fn make_random_test_accessor_data(
                 columns.push(Arc::new(StringArray::from(col)));
             }
             ColumnType::Scalar => unimplemented!("Scalar columns are not supported by arrow"),
-            ColumnType::Timestamp(tu, tz) => {
+            ColumnType::TimestampTZ(tu, tz) => {
                 column_fields.push(Field::new(
                     *col_name,
                     DataType::Timestamp(TimeUnit::from(*tu), Some(Arc::from(tz.to_string()))),

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -119,10 +119,7 @@ pub fn make_random_test_accessor_data(
             ColumnType::TimestampTZ(tu, tz) => {
                 column_fields.push(Field::new(
                     *col_name,
-                    DataType::Timestamp(
-                        (*tu).into(),
-                        Some(Arc::from(tz.to_string())),
-                    ),
+                    DataType::Timestamp((*tu).into(), Some(Arc::from(tz.to_string()))),
                     false,
                 ));
                 // Create the correct timestamp array based on the time unit

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -2,9 +2,9 @@ use crate::base::database::ColumnType;
 use arrow::{
     array::{
         Array, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array, Int64Array,
-        StringArray,
+        StringArray, UInt64Array,
     },
-    datatypes::{i256, DataType, Field, Schema},
+    datatypes::{i256, DataType, Field, Schema, TimeUnit},
     record_batch::RecordBatch,
 };
 use rand::{
@@ -115,6 +115,16 @@ pub fn make_random_test_accessor_data(
                 columns.push(Arc::new(StringArray::from(col)));
             }
             ColumnType::Scalar => unimplemented!("Scalar columns are not supported by arrow"),
+            ColumnType::Timestamp => {
+                column_fields.push(Field::new(
+                    *col_name,
+                    DataType::Time64(TimeUnit::Second),
+                    false,
+                ));
+
+                let values: Vec<u64> = values.iter().map(|x| *x as u64).collect();
+                columns.push(Arc::new(UInt64Array::from(values.to_vec())));
+            }
         }
     }
 

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -125,18 +125,16 @@ pub fn make_random_test_accessor_data(
 
                 // Create the correct timestamp array based on the time unit
                 let timestamp_array: Arc<dyn Array> = match tu {
-                    ProofsTimeUnit::Second => Arc::new(TimestampSecondArray::from(
-                        values.to_vec(),
-                    )),
-                    ProofsTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(
-                        values.to_vec(),
-                    )),
-                    ProofsTimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(
-                        values.to_vec(),
-                    )),
-                    ProofsTimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from(
-                        values.to_vec(),
-                    )),
+                    ProofsTimeUnit::Second => Arc::new(TimestampSecondArray::from(values.to_vec())),
+                    ProofsTimeUnit::Millisecond => {
+                        Arc::new(TimestampMillisecondArray::from(values.to_vec()))
+                    }
+                    ProofsTimeUnit::Microsecond => {
+                        Arc::new(TimestampMicrosecondArray::from(values.to_vec()))
+                    }
+                    ProofsTimeUnit::Nanosecond => {
+                        Arc::new(TimestampNanosecondArray::from(values.to_vec()))
+                    }
                 };
                 columns.push(timestamp_array);
             }

--- a/crates/proof-of-sql/src/base/mod.rs
+++ b/crates/proof-of-sql/src/base/mod.rs
@@ -11,3 +11,4 @@ pub mod scalar;
 mod serialize;
 pub(crate) use serialize::{impl_serde_for_ark_serde_checked, impl_serde_for_ark_serde_unchecked};
 pub(crate) mod slice_ops;
+pub(crate) mod time;

--- a/crates/proof-of-sql/src/base/mod.rs
+++ b/crates/proof-of-sql/src/base/mod.rs
@@ -11,4 +11,5 @@ pub mod scalar;
 mod serialize;
 pub(crate) use serialize::{impl_serde_for_ark_serde_checked, impl_serde_for_ark_serde_unchecked};
 pub(crate) mod slice_ops;
-pub(crate) mod time;
+/// Stores all functionality relelvant to time
+pub mod time;

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -102,6 +102,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.inner_product(evaluation_vec),
             Column::Int128(c) => c.inner_product(evaluation_vec),
             Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
+            Column::Timestamp(c) => c.inner_product(evaluation_vec),
         }
     }
 
@@ -115,6 +116,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.mul_add(res, multiplier),
             Column::Int128(c) => c.mul_add(res, multiplier),
             Column::Decimal75(_, _, c) => c.mul_add(res, multiplier),
+            Column::Timestamp(c) => c.mul_add(res, multiplier),
         }
     }
 
@@ -128,6 +130,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.to_sumcheck_term(num_vars),
             Column::Int128(c) => c.to_sumcheck_term(num_vars),
             Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
+            Column::Timestamp(c) => c.to_sumcheck_term(num_vars),
         }
     }
 
@@ -141,6 +144,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => MultilinearExtension::<S>::id(c),
             Column::Int128(c) => MultilinearExtension::<S>::id(c),
             Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
+            Column::Timestamp(c) => MultilinearExtension::<S>::id(c),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -102,7 +102,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.inner_product(evaluation_vec),
             Column::Int128(c) => c.inner_product(evaluation_vec),
             Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
-            Column::Timestamp(c) => c.inner_product(evaluation_vec),
+            Column::Timestamp(_, _, c) => c.inner_product(evaluation_vec),
         }
     }
 
@@ -116,7 +116,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.mul_add(res, multiplier),
             Column::Int128(c) => c.mul_add(res, multiplier),
             Column::Decimal75(_, _, c) => c.mul_add(res, multiplier),
-            Column::Timestamp(c) => c.mul_add(res, multiplier),
+            Column::Timestamp(_, _, c) => c.mul_add(res, multiplier),
         }
     }
 
@@ -130,7 +130,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.to_sumcheck_term(num_vars),
             Column::Int128(c) => c.to_sumcheck_term(num_vars),
             Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
-            Column::Timestamp(c) => c.to_sumcheck_term(num_vars),
+            Column::Timestamp(_, _, c) => c.to_sumcheck_term(num_vars),
         }
     }
 
@@ -144,7 +144,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => MultilinearExtension::<S>::id(c),
             Column::Int128(c) => MultilinearExtension::<S>::id(c),
             Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
-            Column::Timestamp(c) => MultilinearExtension::<S>::id(c),
+            Column::Timestamp(_, _, c) => MultilinearExtension::<S>::id(c),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -102,7 +102,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.inner_product(evaluation_vec),
             Column::Int128(c) => c.inner_product(evaluation_vec),
             Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
-            Column::Timestamp(_, _, c) => c.inner_product(evaluation_vec),
+            Column::TimestampTZ(_, _, c) => c.inner_product(evaluation_vec),
         }
     }
 
@@ -116,7 +116,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.mul_add(res, multiplier),
             Column::Int128(c) => c.mul_add(res, multiplier),
             Column::Decimal75(_, _, c) => c.mul_add(res, multiplier),
-            Column::Timestamp(_, _, c) => c.mul_add(res, multiplier),
+            Column::TimestampTZ(_, _, c) => c.mul_add(res, multiplier),
         }
     }
 
@@ -130,7 +130,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => c.to_sumcheck_term(num_vars),
             Column::Int128(c) => c.to_sumcheck_term(num_vars),
             Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
-            Column::Timestamp(_, _, c) => c.to_sumcheck_term(num_vars),
+            Column::TimestampTZ(_, _, c) => c.to_sumcheck_term(num_vars),
         }
     }
 
@@ -144,7 +144,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
             Column::VarChar((_, c)) => MultilinearExtension::<S>::id(c),
             Column::Int128(c) => MultilinearExtension::<S>::id(c),
             Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
-            Column::Timestamp(_, _, c) => MultilinearExtension::<S>::id(c),
+            Column::TimestampTZ(_, _, c) => MultilinearExtension::<S>::id(c),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -43,7 +43,6 @@ pub trait Scalar:
     + for<'a> std::convert::From<&'a i16> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> std::convert::From<&'a i32> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> std::convert::From<&'a i64> // Required for `Column` to implement `MultilinearExtension`
-    + for<'a> std::convert::From<&'a u64> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> std::convert::From<&'a i128> // Required for `Column` to implement `MultilinearExtension`
     + std::convert::TryInto <i8>
     + std::convert::TryInto <i16>

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -43,6 +43,7 @@ pub trait Scalar:
     + for<'a> std::convert::From<&'a i16> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> std::convert::From<&'a i32> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> std::convert::From<&'a i64> // Required for `Column` to implement `MultilinearExtension`
+    + for<'a> std::convert::From<&'a u64> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> std::convert::From<&'a i128> // Required for `Column` to implement `MultilinearExtension`
     + std::convert::TryInto <i8>
     + std::convert::TryInto <i16>

--- a/crates/proof-of-sql/src/base/time/mod.rs
+++ b/crates/proof-of-sql/src/base/time/mod.rs
@@ -1,1 +1,2 @@
-pub(crate) mod timestamp;
+/// Stores all functionality relelvant to timestamps
+pub mod timestamp;

--- a/crates/proof-of-sql/src/base/time/mod.rs
+++ b/crates/proof-of-sql/src/base/time/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod timestamp;

--- a/crates/proof-of-sql/src/base/time/timestamp.rs
+++ b/crates/proof-of-sql/src/base/time/timestamp.rs
@@ -1,0 +1,81 @@
+use arrow::datatypes::TimeUnit as ArrowTimeUnit;
+use chrono_tz::Tz;
+use core::fmt;
+use serde::{Deserialize, Serialize};
+use std::{str::FromStr, sync::Arc}; // Tz implements the TimeZone trait and provides access to IANA time zones
+
+#[derive(Debug, Clone, Deserialize, Serialize, Hash)]
+pub struct Timestamp {
+    time: i64,
+    timeunit: ProofsTimeUnit,
+    timezone: Tz,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, Hash)]
+pub enum ProofsTimeUnit {
+    Second,
+    Millisecond,
+    Microsecond,
+    Nanosecond,
+}
+
+impl fmt::Display for ProofsTimeUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProofsTimeUnit::Second => write!(f, "Second"),
+            ProofsTimeUnit::Millisecond => write!(f, "Millisecond"),
+            ProofsTimeUnit::Microsecond => write!(f, "Microsecond"),
+            ProofsTimeUnit::Nanosecond => write!(f, "Nanosecond"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct ProofsTimeZone(pub Tz);
+
+impl fmt::Display for ProofsTimeZone {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<ProofsTimeUnit> for ArrowTimeUnit {
+    fn from(unit: ProofsTimeUnit) -> Self {
+        match unit {
+            ProofsTimeUnit::Second => ArrowTimeUnit::Second,
+            ProofsTimeUnit::Millisecond => ArrowTimeUnit::Millisecond,
+            ProofsTimeUnit::Microsecond => ArrowTimeUnit::Microsecond,
+            ProofsTimeUnit::Nanosecond => ArrowTimeUnit::Nanosecond,
+        }
+    }
+}
+
+impl From<ArrowTimeUnit> for ProofsTimeUnit {
+    fn from(unit: ArrowTimeUnit) -> Self {
+        match unit {
+            ArrowTimeUnit::Second => ProofsTimeUnit::Second,
+            ArrowTimeUnit::Millisecond => ProofsTimeUnit::Millisecond,
+            ArrowTimeUnit::Microsecond => ProofsTimeUnit::Microsecond,
+            ArrowTimeUnit::Nanosecond => ProofsTimeUnit::Nanosecond,
+        }
+    }
+}
+
+impl TryFrom<Option<&str>> for ProofsTimeZone {
+    type Error = &'static str; // Or use a more descriptive error type
+
+    fn try_from(value: Option<&str>) -> Result<Self, Self::Error> {
+        match value {
+            Some(tz_str) => Tz::from_str(tz_str)
+                .map(ProofsTimeZone)
+                .map_err(|_| "Invalid timezone string"),
+            None => Ok(ProofsTimeZone(Tz::UTC)), // Default to UTC
+        }
+    }
+}
+
+impl From<&ProofsTimeZone> for Arc<str> {
+    fn from(timezone: &ProofsTimeZone) -> Self {
+        Arc::from(timezone.0.name())
+    }
+}

--- a/crates/proof-of-sql/src/base/time/timestamp.rs
+++ b/crates/proof-of-sql/src/base/time/timestamp.rs
@@ -5,6 +5,16 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::{str::FromStr, sync::Arc};
 
+/// A wrapper around i64 to mitigate conflicting From<i64>
+/// implementations
+#[derive(Clone, Copy)]
+pub struct Time {
+    /// i64 count of timeunits since unix epoch
+    pub timestamp: i64,
+    /// Timeunit of this time
+    pub unit: PoSQLTimeUnit,
+}
+
 /// A typed TimeZone for a [`TimeStamp`]. It is optionally
 /// used to define a timezone other than UTC for a new TimeStamp.
 /// It exists as a wrapper around chrono-tz because chrono-tz does

--- a/crates/proof-of-sql/src/base/time/timestamp.rs
+++ b/crates/proof-of-sql/src/base/time/timestamp.rs
@@ -9,7 +9,7 @@ use std::{str::FromStr, sync::Arc};
 /// a [`TimeUnit`], which is a signed count of units either
 /// after or before the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
 #[derive(Debug, Clone, Deserialize, Serialize, Hash)]
-pub struct Timestamp {
+pub struct TimestampTZ {
     time: i64,
     timeunit: ProofsTimeUnit,
     timezone: Tz,

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -60,6 +60,7 @@ fn compute_dory_commitment(
         }
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Timestamp(column) => compute_dory_commitment_impl(column, offset, setup),
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -60,7 +60,7 @@ fn compute_dory_commitment(
         }
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Timestamp(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Timestamp(_, _, column) => compute_dory_commitment_impl(column, offset, setup),
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -60,7 +60,7 @@ fn compute_dory_commitment(
         }
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Timestamp(_, _, column) => {
+        CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -60,7 +60,9 @@ fn compute_dory_commitment(
         }
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Timestamp(_, _, column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Timestamp(_, _, column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -280,6 +280,7 @@ fn compute_dory_commitment(
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Timestamp(column) => compute_dory_commitment_impl(column, offset, setup),
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -280,7 +280,7 @@ fn compute_dory_commitment(
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Timestamp(_, _, column) => {
+        CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -280,7 +280,9 @@ fn compute_dory_commitment(
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Timestamp(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Timestamp(_, _, column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_util.rs
@@ -65,7 +65,7 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             *scale,
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
         ),
-        Column::Timestamp(tu, tz, col) => Column::Timestamp(
+        Column::TimestampTZ(tu, tz, col) => Column::TimestampTZ(
             *tu,
             *tz,
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_util.rs
@@ -65,6 +65,9 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             *scale,
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
         ),
+        Column::Timestamp(col) => {
+            Column::Timestamp(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_util.rs
@@ -65,9 +65,11 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             *scale,
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
         ),
-        Column::Timestamp(col) => {
-            Column::Timestamp(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
-        }
+        Column::Timestamp(tu, tz, col) => Column::Timestamp(
+            *tu,
+            *tz,
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+        ),
     }
 }
 

--- a/crates/proof-of-sql/src/sql/ast/filter_result_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/filter_result_expr.rs
@@ -75,6 +75,7 @@ impl FilterResultExpr {
             Column::Scalar(_col) => todo!(),
             Column::Decimal75(_, _, col) => prover_evaluate_impl(builder, alloc, selection, col),
             Column::VarChar((_, scals)) => prover_evaluate_impl(builder, alloc, selection, scals),
+            Column::Timestamp(col) => prover_evaluate_impl(builder, alloc, selection, col),
         };
     }
 

--- a/crates/proof-of-sql/src/sql/ast/filter_result_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/filter_result_expr.rs
@@ -75,7 +75,7 @@ impl FilterResultExpr {
             Column::Scalar(_col) => todo!(),
             Column::Decimal75(_, _, col) => prover_evaluate_impl(builder, alloc, selection, col),
             Column::VarChar((_, scals)) => prover_evaluate_impl(builder, alloc, selection, scals),
-            Column::Timestamp(col) => prover_evaluate_impl(builder, alloc, selection, col),
+            Column::Timestamp(_, _, col) => prover_evaluate_impl(builder, alloc, selection, col),
         };
     }
 

--- a/crates/proof-of-sql/src/sql/ast/filter_result_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/filter_result_expr.rs
@@ -75,7 +75,7 @@ impl FilterResultExpr {
             Column::Scalar(_col) => todo!(),
             Column::Decimal75(_, _, col) => prover_evaluate_impl(builder, alloc, selection, col),
             Column::VarChar((_, scals)) => prover_evaluate_impl(builder, alloc, selection, scals),
-            Column::Timestamp(_, _, col) => prover_evaluate_impl(builder, alloc, selection, col),
+            Column::TimestampTZ(_, _, col) => prover_evaluate_impl(builder, alloc, selection, col),
         };
     }
 

--- a/crates/proof-of-sql/src/sql/ast/group_by_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_util.rs
@@ -114,7 +114,7 @@ pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         }
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::VarChar(_) => unimplemented!("Cannot sum varchar columns"),
-        Column::Timestamp(_, _, col) => {
+        Column::TimestampTZ(_, _, col) => {
             sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
     }
@@ -178,7 +178,7 @@ pub(super) fn compare_indexes_by_columns<S: Scalar>(
             Column::Decimal75(_, _, _) => todo!("TODO: unimplemented"),
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
-            Column::Timestamp(_, _, col) => col[i].cmp(&col[j]),
+            Column::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)

--- a/crates/proof-of-sql/src/sql/ast/group_by_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_util.rs
@@ -114,7 +114,9 @@ pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         }
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::VarChar(_) => unimplemented!("Cannot sum varchar columns"),
-        Column::Timestamp(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Timestamp(_, _, col) => {
+            sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
+        }
     }
 }
 
@@ -176,7 +178,7 @@ pub(super) fn compare_indexes_by_columns<S: Scalar>(
             Column::Decimal75(_, _, _) => todo!("TODO: unimplemented"),
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
-            Column::Timestamp(col) => col[i].cmp(&col[j]),
+            Column::Timestamp(_, _, col) => col[i].cmp(&col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)

--- a/crates/proof-of-sql/src/sql/ast/group_by_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_util.rs
@@ -114,6 +114,7 @@ pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         }
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::VarChar(_) => unimplemented!("Cannot sum varchar columns"),
+        Column::Timestamp(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
     }
 }
 
@@ -175,6 +176,7 @@ pub(super) fn compare_indexes_by_columns<S: Scalar>(
             Column::Decimal75(_, _, _) => todo!("TODO: unimplemented"),
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
+            Column::Timestamp(col) => col[i].cmp(&col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -115,6 +115,7 @@ impl ProvableQueryResult {
 
                     ColumnType::Scalar => decode_and_convert::<S, S>(&self.data[offset..]),
                     ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::Timestamp => decode_and_convert::<i32, S>(&self.data[offset..]),
                 }?;
 
                 val += evaluation_vec[index as usize] * x;
@@ -193,6 +194,12 @@ impl ProvableQueryResult {
                             .ok_or(QueryError::Overflow)?;
                         offset += num_read;
                         Ok((field.name(), OwnedColumn::Decimal75(precision, scale, col)))
+                    }
+                    ColumnType::Timestamp => {
+                        let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)
+                            .ok_or(QueryError::Overflow)?;
+                        offset += num_read;
+                        Ok((field.name(), OwnedColumn::Int(col)))
                     }
                 })
                 .collect::<Result<_, QueryError>>()?,

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -115,7 +115,7 @@ impl ProvableQueryResult {
 
                     ColumnType::Scalar => decode_and_convert::<S, S>(&self.data[offset..]),
                     ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
-                    ColumnType::Timestamp(_, _) => {
+                    ColumnType::TimestampTZ(_, _) => {
                         decode_and_convert::<i64, S>(&self.data[offset..])
                     }
                 }?;
@@ -197,11 +197,11 @@ impl ProvableQueryResult {
                         offset += num_read;
                         Ok((field.name(), OwnedColumn::Decimal75(precision, scale, col)))
                     }
-                    ColumnType::Timestamp(tu, tz) => {
+                    ColumnType::TimestampTZ(tu, tz) => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)
                             .ok_or(QueryError::Overflow)?;
                         offset += num_read;
-                        Ok((field.name(), OwnedColumn::Timestamp(tu, tz, col)))
+                        Ok((field.name(), OwnedColumn::TimestampTZ(tu, tz, col)))
                     }
                 })
                 .collect::<Result<_, QueryError>>()?,

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -42,6 +42,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) => col.num_bytes(selection),
             Column::Scalar(col) => col.num_bytes(selection),
             Column::VarChar((col, _)) => col.num_bytes(selection),
+            Column::Timestamp(col) => col.num_bytes(selection),
         }
     }
 
@@ -55,6 +56,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) => col.write(out, selection),
             Column::Scalar(col) => col.write(out, selection),
             Column::VarChar((col, _)) => col.write(out, selection),
+            Column::Timestamp(col) => col.write(out, selection),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -42,7 +42,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) => col.num_bytes(selection),
             Column::Scalar(col) => col.num_bytes(selection),
             Column::VarChar((col, _)) => col.num_bytes(selection),
-            Column::Timestamp(_, _, col) => col.num_bytes(selection),
+            Column::TimestampTZ(_, _, col) => col.num_bytes(selection),
         }
     }
 
@@ -56,7 +56,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) => col.write(out, selection),
             Column::Scalar(col) => col.write(out, selection),
             Column::VarChar((col, _)) => col.write(out, selection),
-            Column::Timestamp(_, _, col) => col.write(out, selection),
+            Column::TimestampTZ(_, _, col) => col.write(out, selection),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -42,7 +42,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) => col.num_bytes(selection),
             Column::Scalar(col) => col.num_bytes(selection),
             Column::VarChar((col, _)) => col.num_bytes(selection),
-            Column::Timestamp(col) => col.num_bytes(selection),
+            Column::Timestamp(_, _, col) => col.num_bytes(selection),
         }
     }
 
@@ -56,7 +56,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Decimal75(_, _, col) => col.write(out, selection),
             Column::Scalar(col) => col.write(out, selection),
             Column::VarChar((col, _)) => col.write(out, selection),
-            Column::Timestamp(col) => col.write(out, selection),
+            Column::Timestamp(_, _, col) => col.write(out, selection),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -155,7 +155,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryR
                     match field.data_type() {
                         ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
                         ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
-                        ColumnType::Int => OwnedColumn::SmallInt(vec![]),
+                        ColumnType::Int => OwnedColumn::Int(vec![]),
                         ColumnType::BigInt => OwnedColumn::BigInt(vec![]),
                         ColumnType::Int128 => OwnedColumn::Int128(vec![]),
                         ColumnType::Decimal75(precision, scale) => {
@@ -163,6 +163,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryR
                         }
                         ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
                         ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
+                        ColumnType::Timestamp => OwnedColumn::Timestamp(vec![]),
                     },
                 )
             })

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -163,7 +163,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryR
                         }
                         ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
                         ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
-                        ColumnType::Timestamp(tu, tz) => OwnedColumn::Timestamp(tu, tz, vec![]),
+                        ColumnType::TimestampTZ(tu, tz) => OwnedColumn::TimestampTZ(tu, tz, vec![]),
                     },
                 )
             })

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -163,7 +163,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryR
                         }
                         ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
                         ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
-                        ColumnType::Timestamp => OwnedColumn::Timestamp(vec![]),
+                        ColumnType::Timestamp(tu, tz) => OwnedColumn::Timestamp(tu, tz, vec![]),
                     },
                 )
             })


### PR DESCRIPTION
# Rationale for this change

Provides the initial typing support for a postgresql-like ```TimeStamp``` type. The proofs ```TimeStampTZ``` is typed over a custom ```TimeUnit``` and ```TimeZone``` type.

The choice is made to type out TimeStamp in this way because the arrow::datatypes::TimeStamp has a required TimeUnit field and an Option TimeZone  field. Typing out our own TimeStamp with these fields gives us greater control over the arrow type if we want. We can also jut default to seconds and UTC if needed, which would simplify this design a bit.

## Typing Rationale

The ```arrow::datatypes::timezone``` is typed over a ```TimeUnit``` and an optional timezone ```Option<Arc<str>>```. Thus in our application it makes sense to have a mapping of this metadata:

example:
```rust
// arrow datatype mapping to our new timestamp type
DataType::Timestamp(time_unit, timezone_option) => Ok(ColumnType::TimestampTZ(
    PoSQLTimeUnit::from(time_unit),
    PoSQLTimeZone::try_from(timezone_option)?,
)),
```
If this becomes burdensome, we could just as easily remove the timezone type and simply default to UTC, and handle any timezone conversion in DML and DDL. We will align with postgresql and store all times as UTC by default.

Finally, the ```PoSQLTimeUnit``` type gives us the flexibility to store times in either seconds, milliseconds, nanoseconds, or microseconds for high precision. This type maps directly to ```TimeUnit``` which we alias as ```ArrowTimeUnit``` in this PR.

# What changes are included in this PR?

## Typing updates:

- [x] Column
- [x] OwnedColumn
- [x] CommittableColumn
- [x] ColumnBounds
- [x] Typed TimeZone
- [x] Typed TimeUnit
- [x] ```impl ArrayRefExt for ArrayRef -> to_curve_25519_scalar & to_column```
- [x] LiteralValue
- [x] owned_and_arrow_conversions
- [x]  ```impl<S: Scalar> FromIterator<i64> for OwnedColumn<S>```
- [x] ```impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestAccessor<CP>```
- [x] owned_table_utility
- [x] test accessor_utility
- [x] multi-linear-extension
- [x] Scalar trait bounds
- [x] compute_dory_commitment
- [x] filter_column_by_index
- [x] prover_evaluate
- [x] sum_aggregate_column_by_index_counts
- [x] compare_indexes_by_columns
- [x] impl ProvableQueryResult
- [x] to_owned_table
- [x] trait ProvableResultColumn 
- [x] make_empty_query_result
- [x] record_batch_dataframe_conversion
- [x] impl ToArrow for RecordBatch 

# Are these changes tested?

## Tests:

- [x] TimeUnit Conversions
- [x] ColumnBounds
- [x] ColumnCommitmentMetadata
- [x] arrow_array_to_column_conversion
- [x] column
- [x] owned_table 

# Split:

- lalrpop grammar update and token parsing
- timestamp.now()
- timestamp.current_time()
