### PR TITLE
fix: make_empty_query_result correct match arms

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -155,7 +155,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryR
                     match field.data_type() {
                         ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
                         ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
-                        ColumnType::Int => OwnedColumn::SmallInt(vec![]),
+                        ColumnType::Int => OwnedColumn::Int(vec![]),
                         ColumnType::BigInt => OwnedColumn::BigInt(vec![]),
                         ColumnType::Int128 => OwnedColumn::Int128(vec![]),
                         ColumnType::Decimal75(precision, scale) => {


### PR DESCRIPTION
# Rationale for this change

Recently it was observed that a function within the verifiable_query_result file has an incorrect type mapping:

```rust
fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryResult<S> {
    let table = OwnedTable::try_new(
        result_fields
            .iter()
            .map(|field| {
                (
                    field.name(),
                    match field.data_type() {
                        ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
                        ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
                        // needs to map to Int
                        ColumnType::Int => OwnedColumn::SmallInt(vec![]),
                        ...
                    },
                )
            })
            .collect(),
    )?;
    Ok(QueryData {
        table,
        verification_hash: Default::default(),
    })
}
```

# What changes are included in this PR?

Mapping is adjusted to correct type.

# Are these changes tested?

Yes.
