### PR TITLE
feat: add `AddSubtractExpr`

### DIFF
--- a/crates/proof-of-sql/src/sql/ast/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/add_subtract_expr.rs
@@ -1,0 +1,113 @@
+use super::{
+    add_subtract_columns, scale_and_add_subtract_eval, try_add_subtract_column_types, ProvableExpr,
+    ProvableExprPlan,
+};
+use crate::{
+    base::{
+        commitment::Commitment,
+        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        proof::ProofError,
+    },
+    sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+};
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Provable numerical `+` / `-` expression
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AddSubtractExpr<C: Commitment> {
+    lhs: Box<ProvableExprPlan<C>>,
+    rhs: Box<ProvableExprPlan<C>>,
+    is_subtract: bool,
+}
+
+impl<C: Commitment> AddSubtractExpr<C> {
+    /// Create numerical `+` / `-` expression
+    pub fn new(
+        lhs: Box<ProvableExprPlan<C>>,
+        rhs: Box<ProvableExprPlan<C>>,
+        is_subtract: bool,
+    ) -> Self {
+        Self {
+            lhs,
+            rhs,
+            is_subtract,
+        }
+    }
+}
+
+impl<C: Commitment> ProvableExpr<C> for AddSubtractExpr<C> {
+    fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
+        self.lhs.count(builder)?;
+        self.rhs.count(builder)?;
+        Ok(())
+    }
+
+    fn data_type(&self) -> ColumnType {
+        try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type())
+            .expect("Failed to add/subtract column types")
+    }
+
+    fn result_evaluate<'a>(
+        &self,
+        table_length: usize,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<C::Scalar>,
+    ) -> Column<'a, C::Scalar> {
+        let lhs_column: Column<'a, C::Scalar> =
+            self.lhs.result_evaluate(table_length, alloc, accessor);
+        let rhs_column: Column<'a, C::Scalar> =
+            self.rhs.result_evaluate(table_length, alloc, accessor);
+        Column::Scalar(add_subtract_columns(
+            lhs_column,
+            rhs_column,
+            self.lhs.data_type().scale().unwrap_or(0),
+            self.rhs.data_type().scale().unwrap_or(0),
+            alloc,
+            self.is_subtract,
+        ))
+    }
+
+    #[tracing::instrument(
+        name = "proofs.sql.ast.not_expr.prover_evaluate",
+        level = "info",
+        skip_all
+    )]
+    fn prover_evaluate<'a>(
+        &self,
+        builder: &mut ProofBuilder<'a, C::Scalar>,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<C::Scalar>,
+    ) -> Column<'a, C::Scalar> {
+        let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
+        let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
+        Column::Scalar(add_subtract_columns(
+            lhs_column,
+            rhs_column,
+            self.lhs.data_type().scale().unwrap_or(0),
+            self.rhs.data_type().scale().unwrap_or(0),
+            alloc,
+            self.is_subtract,
+        ))
+    }
+
+    fn verifier_evaluate(
+        &self,
+        builder: &mut VerificationBuilder<C>,
+        accessor: &dyn CommitmentAccessor<C>,
+    ) -> Result<C::Scalar, ProofError> {
+        let lhs_eval = self.lhs.verifier_evaluate(builder, accessor)?;
+        let rhs_eval = self.rhs.verifier_evaluate(builder, accessor)?;
+        let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);
+        let rhs_scale = self.rhs.data_type().scale().unwrap_or(0);
+        let res =
+            scale_and_add_subtract_eval(lhs_eval, rhs_eval, lhs_scale, rhs_scale, self.is_subtract);
+        Ok(res)
+    }
+
+    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+        self.lhs.get_column_references(columns);
+        self.rhs.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/ast/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/add_subtract_expr_test.rs
@@ -1,0 +1,318 @@
+use crate::{
+    base::{
+        commitment::InnerProductProof,
+        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        scalar::Curve25519Scalar,
+    },
+    sql::{
+        ast::{test_utility::*, ProofPlan, ProvableExpr, ProvableExprPlan},
+        proof::{exercise_verification, QueryError, VerifiableQueryResult},
+    },
+};
+use bumpalo::Bump;
+use curve25519_dalek::ristretto::RistrettoPoint;
+use itertools::{multizip, MultiUnzip};
+use rand::{
+    distributions::{Distribution, Uniform},
+    rngs::StdRng,
+};
+use rand_core::SeedableRng;
+
+// select a, c, b + 4 as res, d from sxt.t where a - b = 3
+#[test]
+fn we_can_prove_a_typical_add_subtract_query() {
+    let data = owned_table([
+        smallint("a", [1_i16, 2, 3, 4]),
+        int("b", [0_i32, 1, 0, 1]),
+        varchar("d", ["ab", "t", "efg", "g"]),
+        bigint("c", [0_i64, 2, 2, 0]),
+    ]);
+    let t = "sxt.t".parse().unwrap();
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let ast = dense_filter(
+        vec![
+            col_expr_plan(t, "a", &accessor),
+            col_expr_plan(t, "c", &accessor),
+            (
+                add(column(t, "b", &accessor), const_bigint(4)),
+                "res".parse().unwrap(),
+            ),
+            col_expr_plan(t, "d", &accessor),
+        ],
+        tab(t),
+        equal(
+            subtract(column(t, "a", &accessor), column(t, "b", &accessor)),
+            const_bigint(3),
+        ),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        smallint("a", [3_i16, 4]),
+        bigint("c", [2_i16, 0]),
+        bigint("res", [4_i64, 5]),
+        varchar("d", ["efg", "g"]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+// select a, a + b + c + 0.4 as c, d from sxt.t where a - b = 0.5
+#[test]
+fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
+    let data = owned_table([
+        decimal75("a", 12, 1, [4_i64, 2, 2, 7]),
+        decimal75("b", 12, 2, [5_i64, -15, 42, 8]),
+        varchar("d", ["ab", "t", "efg", "g"]),
+        decimal75("c", 12, 3, [190_i64, 27, 253, 120]),
+    ]);
+    let t = "sxt.t".parse().unwrap();
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let ast = dense_filter(
+        vec![
+            col_expr_plan(t, "a", &accessor),
+            (
+                add(
+                    add(
+                        add(column(t, "a", &accessor), column(t, "b", &accessor)),
+                        column(t, "c", &accessor),
+                    ),
+                    const_decimal75(2, 1, 4),
+                ),
+                "c".parse().unwrap(),
+            ),
+            col_expr_plan(t, "d", &accessor),
+        ],
+        tab(t),
+        equal(
+            subtract(column(t, "a", &accessor), column(t, "b", &accessor)),
+            const_decimal75(12, 4, 3500),
+        ),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        decimal75("a", 12, 1, [4_i64, 2]),
+        decimal75("c", 17, 3, [1040_i64, 477]),
+        varchar("d", ["ab", "t"]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+// select a + b as c from sxt.t where b = 1
+#[test]
+fn result_expr_can_overflow() {
+    let data = owned_table([
+        smallint("a", [i16::MAX, i16::MIN]),
+        smallint("b", [1_i16, 0]),
+    ]);
+    let t = "sxt.t".parse().unwrap();
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let ast: ProofPlan<RistrettoPoint> = dense_filter(
+        vec![(
+            add(column(t, "a", &accessor), column(t, "b", &accessor)),
+            "c".parse().unwrap(),
+        )],
+        tab(t),
+        equal(column(t, "b", &accessor), const_bigint(1)),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    assert!(matches!(
+        verifiable_res.verify(&ast, &accessor, &()),
+        Err(QueryError::Overflow)
+    ));
+}
+
+// select a + b as c from sxt.t where b == 0
+#[test]
+fn overflow_in_nonselected_rows_doesnt_error_out() {
+    let data = owned_table([
+        smallint("a", [i16::MAX, i16::MIN + 1]),
+        smallint("b", [1_i16, 0]),
+    ]);
+    let t = "sxt.t".parse().unwrap();
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let ast: ProofPlan<RistrettoPoint> = dense_filter(
+        vec![(
+            add(column(t, "a", &accessor), column(t, "b", &accessor)),
+            "c".parse().unwrap(),
+        )],
+        tab(t),
+        equal(column(t, "b", &accessor), const_bigint(0)),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([smallint("c", [i16::MIN + 1])]);
+    assert_eq!(res, expected_res);
+}
+
+// select a, b from sxt.t where a + b >= 0
+#[test]
+fn overflow_in_where_clause_doesnt_error_out() {
+    let data = owned_table([
+        bigint("a", [i64::MAX, i64::MIN + 1]),
+        smallint("b", [1_i16, 0]),
+    ]);
+    let t = "sxt.t".parse().unwrap();
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let ast: ProofPlan<RistrettoPoint> = dense_filter(
+        cols_expr_plan(t, &["a", "b"], &accessor),
+        tab(t),
+        gte(
+            add(column(t, "a", &accessor), column(t, "b", &accessor)),
+            const_bigint(0),
+        ),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([bigint("a", [i64::MAX]), smallint("b", [1_i16])]);
+    assert_eq!(res, expected_res);
+}
+
+// select a + b as c, a - b as d from sxt.t
+#[test]
+fn result_expr_can_overflow_more() {
+    let data = owned_table([
+        bigint("a", [i64::MAX, i64::MIN, i64::MAX, i64::MIN]),
+        bigint("b", [i64::MAX, i64::MAX, i64::MIN, i64::MIN]),
+    ]);
+    let t = "sxt.t".parse().unwrap();
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let ast: ProofPlan<RistrettoPoint> = dense_filter(
+        vec![
+            (
+                add(column(t, "a", &accessor), column(t, "b", &accessor)),
+                "c".parse().unwrap(),
+            ),
+            (
+                subtract(column(t, "a", &accessor), column(t, "b", &accessor)),
+                "d".parse().unwrap(),
+            ),
+        ],
+        tab(t),
+        const_bool(true),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    assert!(matches!(
+        verifiable_res.verify(&ast, &accessor, &()),
+        Err(QueryError::Overflow)
+    ));
+}
+
+fn test_random_tables_with_given_offset(offset: usize) {
+    let dist = Uniform::new(-3, 4);
+    let mut rng = StdRng::from_seed([0u8; 32]);
+    for _ in 0..20 {
+        // Generate random table
+        let n = Uniform::new(1, 21).sample(&mut rng);
+        let data = owned_table([
+            bigint("a", dist.sample_iter(&mut rng).take(n)),
+            varchar(
+                "b",
+                dist.sample_iter(&mut rng).take(n).map(|v| format!("s{v}")),
+            ),
+            bigint("c", dist.sample_iter(&mut rng).take(n)),
+            varchar(
+                "d",
+                dist.sample_iter(&mut rng).take(n).map(|v| format!("s{v}")),
+            ),
+        ]);
+
+        // Generate random values to filter by
+        let filter_val1 = format!("s{}", dist.sample(&mut rng));
+        let filter_val2 = dist.sample(&mut rng);
+
+        // Create and verify proof
+        let t = "sxt.t".parse().unwrap();
+        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+            t,
+            data.clone(),
+            offset,
+            (),
+        );
+        let ast = dense_filter(
+            vec![
+                col_expr_plan(t, "d", &accessor),
+                (
+                    subtract(
+                        add(column(t, "a", &accessor), column(t, "c", &accessor)),
+                        const_int128(4),
+                    ),
+                    "f".parse().unwrap(),
+                ),
+            ],
+            tab(t),
+            and(
+                equal(
+                    column(t, "b", &accessor),
+                    const_scalar(filter_val1.as_str()),
+                ),
+                equal(column(t, "c", &accessor), const_scalar(filter_val2)),
+            ),
+        );
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        exercise_verification(&verifiable_res, &ast, &accessor, t);
+        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+
+        // Calculate/compare expected result
+        let (expected_f, expected_d): (Vec<_>, Vec<_>) = multizip((
+            data["a"].i64_iter(),
+            data["b"].string_iter(),
+            data["c"].i64_iter(),
+            data["d"].string_iter(),
+        ))
+        .filter_map(|(a, b, c, d)| {
+            if b == &filter_val1 && c == &filter_val2 {
+                Some(((*a + *c - 4) as i128, d.clone()))
+            } else {
+                None
+            }
+        })
+        .multiunzip();
+        let expected_result = owned_table([varchar("d", expected_d), int128("f", expected_f)]);
+
+        assert_eq!(expected_result, res)
+    }
+}
+
+#[test]
+fn we_can_query_random_tables_using_a_zero_offset() {
+    test_random_tables_with_given_offset(0);
+}
+
+#[test]
+fn we_can_query_random_tables_using_a_non_zero_offset() {
+    test_random_tables_with_given_offset(123);
+}
+
+// b + a - 1
+#[test]
+fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_result_evaluate() {
+    let data = owned_table([
+        smallint("a", [1_i16, 2, 3, 4]),
+        int("b", [0_i32, 1, 0, 1]),
+        varchar("d", ["ab", "t", "efg", "g"]),
+        bigint("c", [0_i64, 2, 2, 0]),
+    ]);
+    let t = "sxt.t".parse().unwrap();
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let add_subtract_expr: ProvableExprPlan<RistrettoPoint> = add(
+        column(t, "b", &accessor),
+        subtract(column(t, "a", &accessor), const_bigint(1)),
+    );
+    let alloc = Bump::new();
+    let res = add_subtract_expr.result_evaluate(4, &alloc, &accessor);
+    let expected_res_scalar = [0, 2, 2, 4]
+        .iter()
+        .map(|v| Curve25519Scalar::from(*v))
+        .collect::<Vec<_>>();
+    let expected_res = Column::Scalar(&expected_res_scalar);
+    assert_eq!(res, expected_res);
+}

--- a/crates/proof-of-sql/src/sql/ast/mod.rs
+++ b/crates/proof-of-sql/src/sql/ast/mod.rs
@@ -2,6 +2,11 @@
 mod filter_result_expr;
 pub(crate) use filter_result_expr::FilterResultExpr;
 
+mod add_subtract_expr;
+pub(crate) use add_subtract_expr::AddSubtractExpr;
+#[cfg(all(test, feature = "blitzar"))]
+mod add_subtract_expr_test;
+
 mod filter_expr;
 pub(crate) use filter_expr::FilterExpr;
 #[cfg(test)]
@@ -50,7 +55,12 @@ use not_expr::NotExpr;
 mod not_expr_test;
 
 mod comparison_util;
-pub(crate) use comparison_util::{scale_and_subtract, scale_and_subtract_eval};
+pub(crate) use comparison_util::scale_and_subtract;
+
+mod numerical_util;
+pub(crate) use numerical_util::{
+    add_subtract_columns, scale_and_add_subtract_eval, try_add_subtract_column_types,
+};
 
 mod equals_expr;
 use equals_expr::*;

--- a/crates/proof-of-sql/src/sql/ast/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/numerical_util.rs
@@ -1,0 +1,99 @@
+use crate::{
+    base::{
+        database::{Column, ColumnType},
+        math::decimal::{scale_scalar, Precision},
+        scalar::Scalar,
+    },
+    sql::parse::{ConversionError, ConversionResult},
+};
+use bumpalo::Bump;
+
+// For decimal type manipulation please refer to
+// https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-ver16
+
+/// Determine the output type of an add or subtract operation if it is possible
+/// to add or subtract the two input types. If the types are not compatible, return
+/// an error.
+pub(crate) fn try_add_subtract_column_types(
+    lhs: ColumnType,
+    rhs: ColumnType,
+) -> ConversionResult<ColumnType> {
+    if !lhs.is_numeric() || !rhs.is_numeric() {
+        return Err(ConversionError::DataTypeMismatch(
+            lhs.to_string(),
+            rhs.to_string(),
+        ));
+    }
+    if lhs.is_integer() && rhs.is_integer() {
+        // We can unwrap here because we know that both types are integers
+        return Ok(lhs.max_integer_type(&rhs).unwrap());
+    }
+    if lhs == ColumnType::Scalar || rhs == ColumnType::Scalar {
+        Ok(ColumnType::Scalar)
+    } else {
+        let left_precision_value = lhs.precision_value().unwrap_or(0) as i16;
+        let right_precision_value = rhs.precision_value().unwrap_or(0) as i16;
+        let left_scale = lhs.scale().unwrap_or(0);
+        let right_scale = rhs.scale().unwrap_or(0);
+        let scale = left_scale.max(right_scale);
+        let precision_value: i16 = scale as i16
+            + (left_precision_value - left_scale as i16)
+                .max(right_precision_value - right_scale as i16)
+            + 1_i16;
+        let precision = u8::try_from(precision_value)
+            .map_err(|_| ConversionError::InvalidPrecision(precision_value))
+            .and_then(|p| {
+                Precision::new(p).map_err(|_| ConversionError::InvalidPrecision(p as i16))
+            })?;
+        Ok(ColumnType::Decimal75(precision, scale))
+    }
+}
+
+/// Add or subtract two columns together.
+pub(crate) fn add_subtract_columns<'a, S: Scalar>(
+    lhs: Column<'a, S>,
+    rhs: Column<'a, S>,
+    lhs_scale: i8,
+    rhs_scale: i8,
+    alloc: &'a Bump,
+    is_subtract: bool,
+) -> &'a [S] {
+    let lhs_len = lhs.len();
+    let rhs_len = rhs.len();
+    assert!(
+        lhs_len == rhs_len,
+        "lhs and rhs should have the same length"
+    );
+    let _res: &mut [S] = alloc.alloc_slice_fill_default(lhs_len);
+    let max_scale = lhs_scale.max(rhs_scale);
+    let lhs_scalar = lhs.to_scalar_with_scaling(max_scale - lhs_scale);
+    let rhs_scalar = rhs.to_scalar_with_scaling(max_scale - rhs_scale);
+    let res = alloc.alloc_slice_fill_with(lhs_len, |i| {
+        if is_subtract {
+            lhs_scalar[i] - rhs_scalar[i]
+        } else {
+            lhs_scalar[i] + rhs_scalar[i]
+        }
+    });
+    res
+}
+
+/// The counterpart of `add_subtract_columns` for evaluating decimal expressions.
+pub(crate) fn scale_and_add_subtract_eval<S: Scalar>(
+    lhs_eval: S,
+    rhs_eval: S,
+    lhs_scale: i8,
+    rhs_scale: i8,
+    is_subtract: bool,
+) -> S {
+    let max_scale = lhs_scale.max(rhs_scale);
+    let scaled_lhs_eval = scale_scalar(lhs_eval, max_scale - lhs_scale)
+        .expect("scaling factor should not be negative");
+    let scaled_rhs_eval = scale_scalar(rhs_eval, max_scale - rhs_scale)
+        .expect("scaling factor should not be negative");
+    if is_subtract {
+        scaled_lhs_eval - scaled_rhs_eval
+    } else {
+        scaled_lhs_eval + scaled_rhs_eval
+    }
+}

--- a/crates/proof-of-sql/src/sql/ast/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/ast/test_utility.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::base::{
     commitment::Commitment,
     database::{ColumnField, ColumnRef, ColumnType, LiteralValue, SchemaAccessor, TableRef},
+    math::decimal::Precision,
 };
 use proof_of_sql_parser::Identifier;
 
@@ -63,6 +64,20 @@ pub fn or<C: Commitment>(
     ProvableExprPlan::try_new_or(left, right).unwrap()
 }
 
+pub fn add<C: Commitment>(
+    left: ProvableExprPlan<C>,
+    right: ProvableExprPlan<C>,
+) -> ProvableExprPlan<C> {
+    ProvableExprPlan::try_new_add(left, right).unwrap()
+}
+
+pub fn subtract<C: Commitment>(
+    left: ProvableExprPlan<C>,
+    right: ProvableExprPlan<C>,
+) -> ProvableExprPlan<C> {
+    ProvableExprPlan::try_new_subtract(left, right).unwrap()
+}
+
 pub fn const_bool<C: Commitment>(val: bool) -> ProvableExprPlan<C> {
     ProvableExprPlan::new_literal(LiteralValue::Boolean(val))
 }
@@ -84,6 +99,18 @@ pub fn const_varchar<C: Commitment>(val: &str) -> ProvableExprPlan<C> {
 
 pub fn const_scalar<C: Commitment, T: Into<C::Scalar>>(val: T) -> ProvableExprPlan<C> {
     ProvableExprPlan::new_literal(LiteralValue::Scalar(val.into()))
+}
+
+pub fn const_decimal75<C: Commitment, T: Into<C::Scalar>>(
+    precision: u8,
+    scale: i8,
+    val: T,
+) -> ProvableExprPlan<C> {
+    ProvableExprPlan::new_literal(LiteralValue::Decimal75(
+        Precision::new(precision).unwrap(),
+        scale,
+        val.into(),
+    ))
 }
 
 pub fn tab(tab: TableRef) -> TableExpr {

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -59,8 +59,8 @@ pub enum ConversionError {
     PrecisionParseError(String),
 
     #[error("Decimal precision is not valid: {0}")]
-    /// Decimal precision exceeds the allowed limit
-    InvalidPrecision(u8),
+    /// Decimal precision is an integer but exceeds the allowed limit. We use i16 here to include all kinds of invalid precision values.
+    InvalidPrecision(i16),
 
     #[error("Encountered parsing error: {0}")]
     /// General parsing error

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -1,10 +1,10 @@
-use super::QueryContext;
+use super::{ConversionError, ConversionResult, QueryContext};
 use crate::{
     base::{
         database::{ColumnRef, ColumnType, SchemaAccessor, TableRef},
         math::decimal::Precision,
     },
-    sql::parse::{ConversionError, ConversionResult},
+    sql::ast::try_add_subtract_column_types,
 };
 use proof_of_sql_parser::{
     intermediate_ast::{
@@ -310,10 +310,12 @@ pub(crate) fn type_check_binary_operation(
                     (ColumnType::Boolean, ColumnType::Boolean)
                 )
         }
-        BinaryOperator::Multiply
-        | BinaryOperator::Division
-        | BinaryOperator::Subtract
-        | BinaryOperator::Add => left_dtype.is_numeric() && right_dtype.is_numeric(),
+        BinaryOperator::Add | BinaryOperator::Subtract => {
+            try_add_subtract_column_types(*left_dtype, *right_dtype).is_ok()
+        }
+        BinaryOperator::Multiply | BinaryOperator::Division => {
+            left_dtype.is_numeric() && right_dtype.is_numeric()
+        }
     }
 }
 

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -351,7 +351,7 @@ fn we_can_prove_a_complex_query_with_curve25519() {
         bigint("t", [2]),
         decimal75("g", 3, 1, [457]),
         boolean("h", [false]),
-        decimal75("dr", 16, 4, [14402]),
+        decimal75("dr", 16, 4, [14203]),
     ]);
     assert_eq!(owned_table_result, expected_result);
 }

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -13,7 +13,7 @@ use proof_of_sql::{
     record_batch,
     sql::{
         parse::{ConversionError, QueryExpr},
-        proof::QueryProof,
+        proof::{QueryError, QueryProof},
     },
 };
 
@@ -160,41 +160,68 @@ fn we_can_prove_a_basic_inequality_query_with_curve25519() {
     assert_eq!(owned_table_result, expected_result);
 }
 
-//TODO: Once arithmetic is supported, this test should be updated to use arithmetic.
 #[test]
 #[cfg(feature = "blitzar")]
-fn we_cannot_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
+fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
         "sxt.table".parse().unwrap(),
-        owned_table([bigint("a", [1, 2, 3]), bigint("b", [1, 0, 2])]),
+        owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 1, 2])]),
         0,
     );
-    let res_query = QueryExpr::<RistrettoPoint>::try_new(
+    let query = QueryExpr::<RistrettoPoint>::try_new(
         "SELECT * FROM table WHERE b >= a + 1".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
-    );
-    assert!(matches!(res_query, Err(ConversionError::Unprovable(_))));
+    )
+    .unwrap();
+    let (proof, serialized_result) =
+        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = proof
+        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .unwrap()
+        .table;
+    let owned_table_result: OwnedTable<Curve25519Scalar> = query
+        .result()
+        .transform_results(owned_table_result.try_into().unwrap())
+        .unwrap()
+        .try_into()
+        .unwrap();
+    let expected_result = owned_table([bigint("a", [1]), bigint("b", [4])]);
+    assert_eq!(owned_table_result, expected_result);
 }
 
 #[test]
-fn we_cannot_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
+fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
     let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
+    let dory_verifier_setup = (&dory_prover_setup).into();
     let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
         dory_prover_setup.clone(),
     );
     accessor.add_table(
         "sxt.table".parse().unwrap(),
-        owned_table([bigint("a", [1, 2, 3]), bigint("b", [1, 0, 2])]),
+        owned_table([bigint("a", [1, -1, 3]), bigint("b", [0, 0, 2])]),
         0,
     );
-    let res_query = QueryExpr::<DoryCommitment>::try_new(
-        "SELECT * FROM table WHERE b >= -(a)".parse().unwrap(),
+    let query = QueryExpr::<DoryCommitment>::try_new(
+        "SELECT * FROM table WHERE b > 1 - a".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
-    );
-    assert!(matches!(res_query, Err(ConversionError::Unprovable(_))));
+    )
+    .unwrap();
+    let (proof, serialized_result) =
+        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
+    let owned_table_result = proof
+        .verify(
+            query.proof_expr(),
+            &accessor,
+            &serialized_result,
+            &dory_verifier_setup,
+        )
+        .unwrap()
+        .table;
+    let expected_result = owned_table([bigint("a", [3]), bigint("b", [2])]);
+    assert_eq!(owned_table_result, expected_result);
 }
 
 #[test]
@@ -269,22 +296,45 @@ fn we_can_prove_a_basic_inequality_query_with_dory() {
 
 #[test]
 #[cfg(feature = "blitzar")]
+fn decimal_type_issues_should_cause_provable_ast_to_fail() {
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(
+        "sxt.table".parse().unwrap(),
+        owned_table([decimal75("d0", 12, 0, [10])]),
+        0,
+    );
+    let large_decimal = format!("0.{}", "1".repeat(75));
+    let query_string = format!("SELECT d0 + {} as res FROM table", large_decimal);
+    assert!(matches!(
+        QueryExpr::<RistrettoPoint>::try_new(
+            query_string.parse().unwrap(),
+            "sxt".parse().unwrap(),
+            &accessor,
+        ),
+        Err(ConversionError::DataTypeMismatch(..))
+    ));
+}
+
+#[test]
+#[cfg(feature = "blitzar")]
 fn we_can_prove_a_complex_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([
-            bigint("a", [1, 2, 3]),
-            bigint("b", [1, 0, 1]),
-            bigint("c", [3, 3, -3]),
-            bigint("d", [1, 2, 3]),
+            smallint("a", [1_i16, 2, 3]),
+            int("b", [1_i32, 0, 1]),
+            bigint("c", [3_i64, 3, -3]),
+            bigint("d", [1_i64, 2, 3]),
             varchar("e", ["d", "e", "f"]),
             boolean("f", [true, false, false]),
+            decimal75("d0", 12, 4, [1, 2, 3]),
+            decimal75("d1", 12, 2, [3, 4, 2]),
         ]),
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT *, 45 as g, (a = b) or f as h FROM table WHERE (a >= b) = (c < d) and (e = 'e') = f"
+        "SELECT a + b + c + 1 as t, 45.7 as g, (a = b) or f as h, d0 + d1 + 1.4 as dr FROM table WHERE (a >= b) = (c < d) and (e = 'e') = f"
             .parse()
             .unwrap(),
         "sxt".parse().unwrap(),
@@ -298,14 +348,10 @@ fn we_can_prove_a_complex_query_with_curve25519() {
         .unwrap()
         .table;
     let expected_result = owned_table([
-        bigint("a", [3]),
-        bigint("b", [1]),
-        bigint("c", [-3]),
-        bigint("d", [3]),
-        varchar("e", ["f"]),
-        boolean("f", [false]),
-        bigint("g", [45]),
+        bigint("t", [2]),
+        decimal75("g", 3, 1, [457]),
         boolean("h", [false]),
+        decimal75("dr", 16, 4, [14402]),
     ]);
     assert_eq!(owned_table_result, expected_result);
 }
@@ -327,11 +373,13 @@ fn we_can_prove_a_complex_query_with_dory() {
             bigint("d", [1, 2, 3]),
             varchar("e", ["d", "e", "f"]),
             boolean("f", [true, false, true]),
+            decimal75("d0", 12, 4, [1, 2, 3]),
+            decimal75("d1", 12, 2, [3, 4, 2]),
         ]),
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT *, 32 as g, (c >= d) and f as h FROM table WHERE (a < b) = (c <= d) and e <> 'f' and f"
+        "SELECT 0.5 + a - b + c - d as res, 32 as g, (c >= d) and f as h, a + b + 1 + c + d + d0 - d1 + 0.5 as res2 FROM table WHERE (a < b) = (c <= d) and e <> 'f' and f and d1 - d0 > 0.01"
             .parse()
             .unwrap(),
         "sxt".parse().unwrap(),
@@ -350,14 +398,10 @@ fn we_can_prove_a_complex_query_with_dory() {
         .unwrap()
         .table;
     let expected_result = owned_table([
-        smallint("a", [1_i16]),
-        int("b", [1]),
-        bigint("c", [3]),
-        bigint("d", [1]),
-        varchar("e", ["d"]),
-        boolean("f", [true]),
+        decimal75("res", 22, 1, [25]),
         bigint("g", [32]),
         boolean("h", [true]),
+        decimal75("res2", 26, 4, [74701]),
     ]);
     assert_eq!(owned_table_result, expected_result);
 }
@@ -436,4 +480,60 @@ fn we_can_prove_a_basic_group_by_query_with_dory() {
         bigint("e", [1, 2, 1]),
     ]);
     assert_eq!(owned_table_result, expected_result);
+}
+
+// Overflow checks
+#[test]
+#[cfg(feature = "blitzar")]
+fn we_can_prove_a_query_with_overflow_with_curve25519() {
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(
+        "sxt.table".parse().unwrap(),
+        owned_table([smallint("a", [i16::MAX]), smallint("b", [1_i16])]),
+        0,
+    );
+    let query = QueryExpr::try_new(
+        "SELECT a + b as c from table".parse().unwrap(),
+        "sxt".parse().unwrap(),
+        &accessor,
+    )
+    .unwrap();
+    let (proof, serialized_result) =
+        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    assert!(matches!(
+        proof.verify(query.proof_expr(), &accessor, &serialized_result, &()),
+        Err(QueryError::Overflow)
+    ));
+}
+
+#[test]
+fn we_can_prove_a_query_with_overflow_with_dory() {
+    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
+    let dory_verifier_setup = (&dory_prover_setup).into();
+
+    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
+        dory_prover_setup.clone(),
+    );
+    accessor.add_table(
+        "sxt.table".parse().unwrap(),
+        owned_table([bigint("a", [i64::MIN]), smallint("b", [1_i16])]),
+        0,
+    );
+    let query = QueryExpr::try_new(
+        "SELECT a - b as c from table".parse().unwrap(),
+        "sxt".parse().unwrap(),
+        &accessor,
+    )
+    .unwrap();
+    let (proof, serialized_result) =
+        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
+    assert!(matches!(
+        proof.verify(
+            query.proof_expr(),
+            &accessor,
+            &serialized_result,
+            &dory_verifier_setup
+        ),
+        Err(QueryError::Overflow)
+    ));
 }


### PR DESCRIPTION
# Rationale for this change
We need to add support for arithmetic. Let's start from + and -.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- Add support for + and - in `proof-of-sql` crate
- generalize `scale_and_subtract_eval` to `scale_and_add_subtract_eval`
- make sure we pass in scales in any operation that can involve decimals
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
