### PR TITLE
fix: bump `bigdecimal` version to 0.4.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ arrayvec = { version = "0.7" }
 arrow = { version = "45.0" }
 arrow-csv = { version = "45.0" }
 bit-iter = { version = "1.1.1" }
-bigdecimal = { version = "0.4.3", features = ["serde"] }
+bigdecimal = { version = "0.4.5", features = ["serde"] }
 blake3 = { version = "1.3.3" }
 blitzar = { version = "3.0.1" }
 bumpalo = { version = "3.11.0" }


### PR DESCRIPTION
# Rationale for this change
Our dependency, `bigdecimal`, restricted `num-bigint` version in 0.4.4, leading to `num-bigint` downgrade to 0.3.3 which caused CI issues for us. Since [the issue](https://github.com/akubera/bigdecimal-rs/issues/128) has been resolved we need to bump our `bigdecimal` version to 0.4.5. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- Bump `bigdecimal` version to 0.4.5
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
