### PR TITLE
fix!: separate element decoding error from verification error

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -242,16 +242,11 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let column_result_fields = expr.get_column_result_fields();
 
         // compute the evaluation of the result MLEs
-        let result_evaluations = match result.evaluate(
+        let result_evaluations = result.evaluate(
             &subclaim.evaluation_point,
             table_length,
             &column_result_fields[..],
-        ) {
-            Some(evaluations) => evaluations,
-            _ => Err(ProofError::VerificationError(
-                "failed to evaluate intermediate result MLEs",
-            ))?,
-        };
+        )?;
 
         // pass over the provable AST to fill in the verification builder
         let sumcheck_evaluations = SumcheckMleEvaluations::new(

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -17,6 +17,15 @@ pub enum QueryError {
     /// This just means that the database was supposed to respond with a string that was not valid UTF-8.
     #[error("String decode error")]
     InvalidString,
+    /// Decoding errors other than overflow and invalid string.
+    #[error("Miscellaneous decoding error")]
+    MiscellaneousDecodingError,
+    /// Indexes are invalid.
+    #[error("Invalid indexes")]
+    InvalidIndexes,
+    /// Miscellaneous evaluation error.
+    #[error("Miscellaneous evaluation error")]
+    MiscellaneousEvaluationError,
     /// The proof failed to verify.
     #[error(transparent)]
     ProofError(#[from] ProofError),


### PR DESCRIPTION
# Rationale for this change
For arithmetic (such as #14) to work it is necessary to separate element decoding error from verification error. There are already `QueryError::Overflow` and `QueryError::InvalidString` that handle some decoding errors. However currently in practice if overflows do take place we get `VerificationError`. This PR will fix this issue.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- add `QueryError::MiscellaneousDecodingError`, `QueryError::InvalidIndexes` and `QueryError::MiscellaneousEvaluationError` to account for decoding errors beyond overflows and invalid strings
- if decoding errors happen we will use them instead of `VerificationError`
- add overflow test in `crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
