### PR TITLE
fix: incorporate leftover feedback from previous PR

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -223,24 +223,24 @@ mod tests {
     #[test]
     fn we_can_get_type_and_length_of_timestamp_column() {
         // empty case
-        let smallint_committable_column =
+        let committable_column =
             CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC, &[]);
-        assert_eq!(smallint_committable_column.len(), 0);
-        assert!(smallint_committable_column.is_empty());
+        assert_eq!(committable_column.len(), 0);
+        assert!(committable_column.is_empty());
         assert_eq!(
-            smallint_committable_column.column_type(),
+            committable_column.column_type(),
             ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC)
         );
 
-        let smallint_committable_column = CommittableColumn::TimestampTZ(
+        let committable_column = CommittableColumn::TimestampTZ(
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::UTC,
             &[12, 34, 56],
         );
-        assert_eq!(smallint_committable_column.len(), 3);
-        assert!(!smallint_committable_column.is_empty());
+        assert_eq!(committable_column.len(), 3);
+        assert!(!committable_column.is_empty());
         assert_eq!(
-            smallint_committable_column.column_type(),
+            committable_column.column_type(),
             ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::UTC)
         );
     }

--- a/crates/proof-of-sql/src/sql/ast/group_by_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_util.rs
@@ -114,7 +114,7 @@ pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         }
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::VarChar(_) => unimplemented!("Cannot sum varchar columns"),
-        Column::TimestampTZ(_, _, col) => {
+        Column::TimestampTZ(_, _, _) => {
             unimplemented!("Cannot sum varchar columns")
         }
     }

--- a/crates/proof-of-sql/src/sql/ast/group_by_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_util.rs
@@ -113,9 +113,9 @@ pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
             todo!("aggregation over decimals not yet supported")
         }
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarChar(_) => unimplemented!("Cannot sum varchar columns"),
+        Column::VarChar(_) => panic!("Cannot sum varchar columns"),
         Column::TimestampTZ(_, _, _) => {
-            unimplemented!("Cannot sum varchar columns")
+            panic!("Cannot sum varchar columns")
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/ast/group_by_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_util.rs
@@ -115,7 +115,7 @@ pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::VarChar(_) => unimplemented!("Cannot sum varchar columns"),
         Column::TimestampTZ(_, _, col) => {
-            sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
+            unimplemented!("Cannot sum varchar columns")
         }
     }
 }


### PR DESCRIPTION
# Rationale for this change

Incorporates a small amount of feedback from #12 

# What changes are included in this PR?

Corrects naming in tests and removes unsupported feature in group_by_util

# Are these changes tested?

yes
