### PR TITLE
fix: add check for group by result uniqueness

### DIFF
--- a/crates/proof-of-sql/src/sql/ast/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/column_expr.rs
@@ -8,6 +8,7 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
+use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, marker::PhantomData};
 /// Provable expression for a column
@@ -36,6 +37,11 @@ impl<C: Commitment> ColumnExpr<C> {
     /// Wrap the column output name and its type within the ColumnField
     pub fn get_column_field(&self) -> ColumnField {
         ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
+    }
+
+    /// Get the column identifier
+    pub fn column_id(&self) -> Identifier {
+        self.column_ref.column_id()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_expr.rs
@@ -9,6 +9,7 @@ use crate::{
         commitment::Commitment,
         database::{
             Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
+            OwnedTable,
         },
         proof::ProofError,
         scalar::Scalar,
@@ -90,6 +91,7 @@ where
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
+        _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<(), ProofError> {
         // 1. selection
         let selection_eval = self.where_clause.verifier_evaluate(builder, accessor)?;

--- a/crates/proof-of-sql/src/sql/ast/filter_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/filter_expr.rs
@@ -4,6 +4,7 @@ use crate::{
         commitment::Commitment,
         database::{
             Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
+            OwnedTable,
         },
         proof::ProofError,
     },
@@ -77,6 +78,7 @@ where
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
+        _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<(), ProofError> {
         let selection_eval = self.where_clause.verifier_evaluate(builder, accessor)?;
         for expr in self.results.iter() {

--- a/crates/proof-of-sql/src/sql/ast/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/ast/proof_plan.rs
@@ -64,11 +64,12 @@ impl<C: Commitment> ProofExpr<C> for ProofPlan<C> {
         &self,
         builder: &mut crate::sql::proof::VerificationBuilder<C>,
         accessor: &dyn crate::base::database::CommitmentAccessor<C>,
+        result: Option<&crate::base::database::OwnedTable<C::Scalar>>,
     ) -> Result<(), crate::base::proof::ProofError> {
         match self {
-            ProofPlan::Filter(expr) => expr.verifier_evaluate(builder, accessor),
-            ProofPlan::GroupBy(expr) => expr.verifier_evaluate(builder, accessor),
-            ProofPlan::DenseFilter(expr) => expr.verifier_evaluate(builder, accessor),
+            ProofPlan::Filter(expr) => expr.verifier_evaluate(builder, accessor, result),
+            ProofPlan::GroupBy(expr) => expr.verifier_evaluate(builder, accessor, result),
+            ProofPlan::DenseFilter(expr) => expr.verifier_evaluate(builder, accessor, result),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof/proof_exprs.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_exprs.rs
@@ -1,7 +1,9 @@
 use super::{CountBuilder, ProofBuilder, ResultBuilder, VerificationBuilder};
 use crate::base::{
     commitment::Commitment,
-    database::{ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor},
+    database::{
+        ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable,
+    },
     proof::ProofError,
     scalar::Scalar,
 };
@@ -33,6 +35,7 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
+        result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<(), ProofError>;
 
     /// Return all the result column fields

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -271,7 +271,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             &evaluation_random_scalars,
             post_result_challenges,
         );
-        expr.verifier_evaluate(&mut builder, accessor)?;
+        let owned_table_result = result.to_owned_table(&column_result_fields[..])?;
+        expr.verifier_evaluate(&mut builder, accessor, Some(&owned_table_result))?;
 
         // perform the evaluation check of the sumcheck polynomial
         if builder.sumcheck_evaluation() != subclaim.expected_evaluation {
@@ -302,12 +303,10 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             MessageLabel::VerificationHash.as_bytes(),
             &mut verification_hash,
         );
-        result
-            .to_owned_table(&column_result_fields[..])
-            .map(|table| QueryData {
-                table,
-                verification_hash,
-            })
+        Ok(QueryData {
+            table: owned_table_result,
+            verification_hash,
+        })
     }
 
     fn validate_sizes(&self, counts: &ProofCounts, result: &ProvableQueryResult) -> bool {

--- a/crates/proof-of-sql/src/sql/proof/test_query_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof/test_query_expr.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::base::{
     database::{
         ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor,
+        OwnedTable,
     },
     proof::ProofError,
     scalar::Curve25519Scalar,
@@ -77,6 +78,7 @@ impl ProofExpr<RistrettoPoint> for TestQueryExpr {
         &self,
         builder: &mut VerificationBuilder<RistrettoPoint>,
         accessor: &dyn CommitmentAccessor<RistrettoPoint>,
+        _result: Option<&OwnedTable<Curve25519Scalar>>,
     ) -> Result<(), ProofError> {
         if let Some(f) = &self.verifier_fn {
             f(builder, accessor);


### PR DESCRIPTION
# Rationale for this change

The `GroupByExpr` needs to have the result checked for uniqueness of the groups in order to prevent a malicious prover from returning a result that is only partially aggregated.

# What changes are included in this PR?

* `ProofExpr::verifier_evaluate` now accepts an optional result as a parameter.
* `GroupByExpr` uses this result to check that the groups are strictly increasing. This guarantees uniqueness.

# Are these changes tested?

Yes.