### PR TITLE
ci: add semantic-release

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,9 +1,7 @@
 name: CI-Lint-And-Test
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -137,4 +135,3 @@ jobs:
           cargo install cargo-udeps --locked
       - name: Run cargo udeps
         run: cargo +nightly udeps --all-targets
-  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read # for checkout
+jobs:
+  release:
+    name: Release
+    runs-on: large-8-core-32gb-22-04
+    environment: deploy #!! DO NOT CHANGE THIS LINE !! #
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
+    steps:
+      - uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 0 # download tags, see https://github.com/actions/checkout/issues/100
+      - run: git config --global --add safe.directory $(realpath .)
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20.x"
+      - name: Semantic Release
+        run: |
+          npm install semantic-release
+          npx semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          #CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }} #TODO: add CRATES_TOKEN

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,13 @@ on:
 permissions:
   contents: read # for checkout
 jobs:
+  lint-and-test:
+    uses: ./.github/workflows/lint-and-test.yml
+
   release:
     name: Release
     runs-on: large-8-core-32gb-22-04
+    needs: [lint-and-test]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #
     permissions:
       contents: write # to be able to publish a GitHub release

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+VERSION=${1?expected version as argument}
+echo "Would build version $VERSION, but publishing is manual for now"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,56 @@
+{
+    "name": "proof_of_sql",
+    "version": "0.0.0-development",
+    "devDependencies": {
+        "conventional-changelog-conventionalcommits": "^5.0.0",
+        "semantic-release": "^21.0.5"
+    },
+    "release": {
+        "branches": [
+            "main"
+        ],
+        "tagFormat": "v${version}",
+        "plugins": [
+            [
+                "@semantic-release/commit-analyzer",
+                {
+                    "preset": "conventionalCommits",
+                    "releaseRules": [
+                        { "breaking": true, "release": "minor" },
+                        { "revert": true, "release": "patch" },
+                        { "type": "feat", "release": "patch" },
+                        { "type": "fix", "release": "patch" },
+                        { "type": "build", "release": "patch" },
+                        { "type": "docs", "release": "patch" },
+                        { "type": "chore", "release": "patch" },
+                        { "type": "bench", "release": "patch" },
+                        { "type": "perf", "release": "patch" },
+                        { "type": "refactor", "release": "patch" },
+                        { "type": "test", "release": "patch" },
+                        { "type": "ci", "release": "patch" }
+                    ],
+                    "parserOpts": {
+                        "noteKeywords": [
+                            "BREAKING CHANGE",
+                            "BREAKING CHANGES",
+                            "BREAKING"
+                        ]
+                    }
+                }
+            ],
+            "@semantic-release/release-notes-generator",
+            [
+                "@semantic-release/exec",
+                {
+                    "prepareCmd": "bash ./ci/build.sh ${nextRelease.version}"
+                }
+            ],
+            [
+                "@semantic-release/github"
+            ]
+        ]
+    },
+    "dependencies": {
+        "@semantic-release/exec": "^6.0.3"
+    }
+}


### PR DESCRIPTION
Since we want to use 0.x.y versions for now, we modify the behavior via
releaseRules, e.g.
* breaking is set to minor release (by default it's major)
* feat is set to patch (by default it's minor)

Once we release v1.0.0 we should reset these to their intended behavior.