### PR TITLE
refactor: conversion error decimal variant

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -1,5 +1,8 @@
 use super::{scalar_conversion_to_int, Scalar, ScalarConversionError};
-use crate::{base::math::decimal::MAX_SUPPORTED_PRECISION, sql::parse::ConversionError};
+use crate::{
+    base::math::decimal::{DecimalError, MAX_SUPPORTED_PRECISION},
+    sql::parse::ConversionError,
+};
 use ark_ff::{BigInteger, Field, Fp, Fp256, MontBackend, MontConfig, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bytemuck::TransparentWrapper;
@@ -163,11 +166,11 @@ impl<T: MontConfig<4>> TryFrom<num_bigint::BigInt> for MontScalar<T> {
 
         // Check if the number of digits exceeds the maximum precision allowed
         if digits.len() > MAX_SUPPORTED_PRECISION.into() {
-            return Err(ConversionError::InvalidDecimal(format!(
+            return Err(ConversionError::Decimal(DecimalError::InvalidDecimal(format!(
                 "Attempted to parse a number with {} digits, which exceeds the max supported precision of {}",
                 digits.len(),
                 MAX_SUPPORTED_PRECISION
-            )));
+            ))));
         }
 
         // Continue with the previous logic

--- a/crates/proof-of-sql/src/sql/ast/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/comparison_util.rs
@@ -1,5 +1,9 @@
 use crate::{
-    base::{database::Column, math::decimal::Precision, scalar::Scalar},
+    base::{
+        database::Column,
+        math::decimal::{DecimalError, Precision},
+        scalar::Scalar,
+    },
     sql::parse::{type_check_binary_operation, ConversionError, ConversionResult},
 };
 use bumpalo::Bump;
@@ -67,8 +71,11 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
             rhs_precision_value + (max_scale - rhs_scale) as u8,
         );
         // Check if the precision is valid
-        let _max_precision = Precision::new(max_precision_value)
-            .map_err(|_| ConversionError::InvalidPrecision(max_precision_value as i16))?;
+        let _max_precision = Precision::new(max_precision_value).map_err(|_| {
+            ConversionError::Decimal(DecimalError::InvalidPrecision(
+                max_precision_value.to_string(),
+            ))
+        })?;
     }
     unchecked_subtract_impl(
         alloc,

--- a/crates/proof-of-sql/src/sql/ast/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/numerical_util.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         database::{Column, ColumnType},
-        math::decimal::{scale_scalar, Precision},
+        math::decimal::{scale_scalar, DecimalError, Precision},
         scalar::Scalar,
     },
     sql::parse::{ConversionError, ConversionResult},
@@ -41,9 +41,15 @@ pub(crate) fn try_add_subtract_column_types(
                 .max(right_precision_value - right_scale as i16)
             + 1_i16;
         let precision = u8::try_from(precision_value)
-            .map_err(|_| ConversionError::InvalidPrecision(precision_value))
+            .map_err(|_| {
+                ConversionError::Decimal(DecimalError::InvalidPrecision(
+                    precision_value.to_string(),
+                ))
+            })
             .and_then(|p| {
-                Precision::new(p).map_err(|_| ConversionError::InvalidPrecision(p as i16))
+                Precision::new(p).map_err(|_| {
+                    ConversionError::Decimal(DecimalError::InvalidPrecision(p.to_string()))
+                })
             })?;
         Ok(ColumnType::Decimal75(precision, scale))
     }

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -1,5 +1,5 @@
-use crate::base::database::ColumnType;
-use proof_of_sql_parser::{intermediate_decimal::DecimalError, Identifier, ResourceId};
+use crate::base::{database::ColumnType, math::decimal::DecimalError};
+use proof_of_sql_parser::{intermediate_decimal::IntermediateDecimalError, Identifier, ResourceId};
 use thiserror::Error;
 
 /// Errors from converting an intermediate AST into a provable AST.
@@ -50,21 +50,17 @@ pub enum ConversionError {
     /// General error for invalid expressions
     InvalidExpression(String),
 
-    #[error("Unsupported operation: cannot round decimal: {0}")]
-    /// Decimal rounding is not supported
-    DecimalRoundingError(String),
-
-    #[error("Error while parsing precision from query: {0}")]
-    /// Error in parsing precision in a query
-    PrecisionParseError(String),
-
-    #[error("Decimal precision is not valid: {0}")]
-    /// Decimal precision is an integer but exceeds the allowed limit. We use i16 here to include all kinds of invalid precision values.
-    InvalidPrecision(i16),
-
     #[error("Encountered parsing error: {0}")]
     /// General parsing error
     ParseError(String),
+
+    #[error(transparent)]
+    /// Errors related to decimal operations
+    Decimal(#[from] DecimalError),
+
+    #[error(transparent)]
+    /// Errors related to decimal operations
+    IntermediateDecimal(#[from] IntermediateDecimalError),
 
     #[error("Unsupported operation: cannot round literal: {0}")]
     /// Error when a rounding operation is not supported
@@ -73,27 +69,6 @@ pub enum ConversionError {
     #[error("Query not provable because: {0}")]
     /// Query requires unprovable feature
     Unprovable(String),
-
-    #[error("Invalid decimal format or value: {0}")]
-    /// Error when a decimal format or value is incorrect
-    InvalidDecimal(String),
-}
-
-impl From<DecimalError> for ConversionError {
-    fn from(error: DecimalError) -> Self {
-        match error {
-            DecimalError::ParseError(e) => ConversionError::ParseError(e.to_string()),
-            DecimalError::OutOfRange => ConversionError::ParseError(
-                "Intermediate decimal cannot be cast to primitive".into(),
-            ),
-            DecimalError::LossyCast => ConversionError::ParseError(
-                "Intermediate decimal has non-zero fractional part".into(),
-            ),
-            DecimalError::ConversionFailure => {
-                ConversionError::ParseError("Could not cast into intermediate decimal.".into())
-            }
-        }
-    }
 }
 
 impl From<String> for ConversionError {

--- a/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{ColumnRef, LiteralValue},
-        math::decimal::{try_into_to_scalar, Precision},
+        math::decimal::{try_into_to_scalar, DecimalError, Precision},
     },
     sql::ast::{ColumnExpr, ProvableExprPlan},
 };
@@ -72,8 +72,11 @@ impl ProvableExprPlanBuilder<'_> {
             Literal::Int128(i) => Ok(ProvableExprPlan::new_literal(LiteralValue::Int128(*i))),
             Literal::Decimal(d) => {
                 let scale = d.scale();
-                let precision = Precision::new(d.precision())
-                    .map_err(|_| ConversionError::InvalidPrecision(d.precision() as i16))?;
+                let precision = Precision::new(d.precision()).map_err(|_| {
+                    ConversionError::Decimal(DecimalError::InvalidPrecision(
+                        d.precision().to_string(),
+                    ))
+                })?;
                 Ok(ProvableExprPlan::new_literal(LiteralValue::Decimal75(
                     precision,
                     scale,


### PR DESCRIPTION
# Rationale for this change

The ```ConversionError``` error type has grown quite large with the addition of new features and types. This PR categorizes some timestamp and decimal errors into different modules and reduces the size and complexity of ```ConversionError```.

# What changes are included in this PR?

IntermediateDecimal, Decimal, IntermediateTimeStamp, Timestamp errors are moved to respective modules. Native thiserr ```#from``` is used in place of manual ```From``` conversions.

# Are these changes tested?

yes
