### PR TITLE
fix: bump blitzar version to 3.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ arrow-csv = { version = "45.0" }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", features = ["serde"] }
 blake3 = { version = "1.3.3" }
-blitzar = { version = "3.0.1" }
+blitzar = { version = "3.0.2" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.14.2" }
 byte-slice-cast = { version = "1.2.1" }

--- a/crates/proof-of-sql/src/sql/ast/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/add_subtract_expr_test.rs
@@ -167,10 +167,7 @@ fn overflow_in_nonselected_rows_doesnt_error_out() {
 // select a, b from sxt.t where a + b >= 0
 #[test]
 fn overflow_in_where_clause_doesnt_error_out() {
-    let data = owned_table([
-        bigint("a", [i64::MAX, i64::MIN + 1]),
-        smallint("b", [1_i16, 0]),
-    ]);
+    let data = owned_table([bigint("a", [i64::MAX, i64::MIN]), smallint("b", [1_i16, 0])]);
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let ast: ProofPlan<RistrettoPoint> = dense_filter(

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -162,6 +162,85 @@ fn we_can_prove_a_basic_inequality_query_with_curve25519() {
 
 #[test]
 #[cfg(feature = "blitzar")]
+fn we_can_prove_a_basic_query_containing_extrema_with_curve25519() {
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(
+        "sxt.table".parse().unwrap(),
+        owned_table([
+            smallint("smallint", [i16::MIN, 0, i16::MAX]),
+            int("int", [i32::MIN, 0, i32::MAX]),
+            bigint("bigint", [i64::MIN, 0, i64::MAX]),
+            int128("int128", [i128::MIN, 0, i128::MAX]),
+        ]),
+        0,
+    );
+    let query = QueryExpr::try_new(
+        "SELECT * FROM table".parse().unwrap(),
+        "sxt".parse().unwrap(),
+        &accessor,
+    )
+    .unwrap();
+    let (proof, serialized_result) =
+        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = proof
+        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .unwrap()
+        .table;
+    let expected_result = owned_table([
+        smallint("smallint", [i16::MIN, 0, i16::MAX]),
+        int("int", [i32::MIN, 0, i32::MAX]),
+        bigint("bigint", [i64::MIN, 0, i64::MAX]),
+        int128("int128", [i128::MIN, 0, i128::MAX]),
+    ]);
+    assert_eq!(owned_table_result, expected_result);
+}
+
+#[test]
+#[cfg(feature = "blitzar")]
+fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
+    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
+    let dory_verifier_setup = (&dory_prover_setup).into();
+    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
+        dory_prover_setup.clone(),
+    );
+    accessor.add_table(
+        "sxt.table".parse().unwrap(),
+        owned_table([
+            smallint("smallint", [i16::MIN, 0, i16::MAX]),
+            int("int", [i32::MIN, 0, i32::MAX]),
+            bigint("bigint", [i64::MIN, 0, i64::MAX]),
+            int128("int128", [i128::MIN, 0, i128::MAX]),
+        ]),
+        0,
+    );
+    let query = QueryExpr::try_new(
+        "SELECT * FROM table".parse().unwrap(),
+        "sxt".parse().unwrap(),
+        &accessor,
+    )
+    .unwrap();
+    let (proof, serialized_result) =
+        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
+    let owned_table_result = proof
+        .verify(
+            query.proof_expr(),
+            &accessor,
+            &serialized_result,
+            &dory_verifier_setup,
+        )
+        .unwrap()
+        .table;
+    let expected_result = owned_table([
+        smallint("smallint", [i16::MIN, 0, i16::MAX]),
+        int("int", [i32::MIN, 0, i32::MAX]),
+        bigint("bigint", [i64::MIN, 0, i64::MAX]),
+        int128("int128", [i128::MIN, 0, i128::MAX]),
+    ]);
+    assert_eq!(owned_table_result, expected_result);
+}
+
+#[test]
+#[cfg(feature = "blitzar")]
 fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(


### PR DESCRIPTION
# Rationale for this change
We need to check and make sure that [this fix](https://github.com/spaceandtimelabs/blitzar/pull/144) is properly used.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- bump blitzar version to 3.0.2
- add tests to ensure that commitments work on integer extrema
- fix existing tests that once require workarounds
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
