### PR TITLE
ci: update semantic release to dry run cargo publish 

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-VERSION=${1?expected version as argument}
-echo "Would build version $VERSION, but publishing is manual for now"

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+
+# number to be used to tag the compressed files
+NEW_VERSION=$1
+
+if ! [[ ${NEW_VERSION} =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
+then
+    echo "Incorrect version format: " $NEW_VERSION
+    exit 1
+fi
+
+# configure rust lib to release
+sed -i 's/version = "*.*.*" # DO NOT CHANGE THIS LINE! This will be automatically updated/version = "'${NEW_VERSION}'"/' Cargo.toml
+sed -i 's/path = "[^"]*"/version = "'${NEW_VERSION}'"/g' Cargo.toml
+
+cargo publish -p proof-of-sql-parser --dry-run
+cargo publish -p proof-of-sql --dry-run

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
             [
                 "@semantic-release/exec",
                 {
-                    "prepareCmd": "bash ./ci/build.sh ${nextRelease.version}"
+                    "prepareCmd": "bash ./ci/publish.sh ${nextRelease.version}"
                 }
             ],
             [


### PR DESCRIPTION
# Rationale for this change

We should automate the release process, including publishing to crates.io.

# What changes are included in this PR?

* `ci/build.sh` is renamed to `ci/publish.sh` and a cargo publish dry run is added.

Note: `cargo publish -p proof-of-sql --dry-run` will fail because it relies on `proof-of-sql-parser` actually being published.

# Are these changes tested?

Yes. This script is what was used to publish versions 0.2.1 through 0.3.1. (By removing `--dry-run`.)