### PR TITLE
ci: fix dry-run

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -15,4 +15,4 @@ sed -i 's/version = "*.*.*" # DO NOT CHANGE THIS LINE! This will be automaticall
 sed -i 's/path = "[^"]*"/version = "'${NEW_VERSION}'"/g' Cargo.toml
 
 cargo publish -p proof-of-sql-parser --dry-run
-cargo publish -p proof-of-sql --dry-run
+#cargo publish -p proof-of-sql --dry-run


### PR DESCRIPTION
# Rationale for this change

Semantic release is failing because `cargo publish -p proof-of-sql --dry-run` fails since it needs `proof-of-sql-parser`, which doesn't publish because it is a dry run.

# What changes are included in this PR?

Commented out the dry-run for `proof-of-sql` publishing.

# Are these changes tested?

No