### PR TITLE
refactor: add `AliasedProvableExprPlan`

### DIFF
--- a/crates/proof-of-sql/src/sql/ast/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/add_subtract_expr_test.rs
@@ -34,10 +34,7 @@ fn we_can_prove_a_typical_add_subtract_query() {
         vec![
             col_expr_plan(t, "a", &accessor),
             col_expr_plan(t, "c", &accessor),
-            (
-                add(column(t, "b", &accessor), const_bigint(4)),
-                "res".parse().unwrap(),
-            ),
+            aliased_plan(add(column(t, "b", &accessor), const_bigint(4)), "res"),
             col_expr_plan(t, "d", &accessor),
         ],
         tab(t),
@@ -72,7 +69,7 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
     let ast = dense_filter(
         vec![
             col_expr_plan(t, "a", &accessor),
-            (
+            aliased_plan(
                 add(
                     add(
                         add(column(t, "a", &accessor), column(t, "b", &accessor)),
@@ -80,7 +77,7 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
                     ),
                     const_decimal75(2, 1, 4),
                 ),
-                "c".parse().unwrap(),
+                "c",
             ),
             col_expr_plan(t, "d", &accessor),
         ],
@@ -124,9 +121,9 @@ fn result_expr_can_overflow() {
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let ast: ProofPlan<RistrettoPoint> = dense_filter(
-        vec![(
+        vec![aliased_plan(
             add(column(t, "a", &accessor), column(t, "b", &accessor)),
-            "c".parse().unwrap(),
+            "c",
         )],
         tab(t),
         equal(column(t, "b", &accessor), const_bigint(1)),
@@ -149,9 +146,9 @@ fn overflow_in_nonselected_rows_doesnt_error_out() {
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let ast: ProofPlan<RistrettoPoint> = dense_filter(
-        vec![(
+        vec![aliased_plan(
             add(column(t, "a", &accessor), column(t, "b", &accessor)),
-            "c".parse().unwrap(),
+            "c",
         )],
         tab(t),
         equal(column(t, "b", &accessor), const_bigint(0)),
@@ -197,13 +194,13 @@ fn result_expr_can_overflow_more() {
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let ast: ProofPlan<RistrettoPoint> = dense_filter(
         vec![
-            (
+            aliased_plan(
                 add(column(t, "a", &accessor), column(t, "b", &accessor)),
-                "c".parse().unwrap(),
+                "c",
             ),
-            (
+            aliased_plan(
                 subtract(column(t, "a", &accessor), column(t, "b", &accessor)),
-                "d".parse().unwrap(),
+                "d",
             ),
         ],
         tab(t),
@@ -251,12 +248,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
         let ast = dense_filter(
             vec![
                 col_expr_plan(t, "d", &accessor),
-                (
+                aliased_plan(
                     subtract(
                         add(column(t, "a", &accessor), column(t, "c", &accessor)),
                         const_int128(4),
                     ),
-                    "f".parse().unwrap(),
+                    "f",
                 ),
             ],
             tab(t),

--- a/crates/proof-of-sql/src/sql/ast/aliased_provable_expr_plan.rs
+++ b/crates/proof-of-sql/src/sql/ast/aliased_provable_expr_plan.rs
@@ -1,0 +1,11 @@
+use super::ProvableExprPlan;
+use crate::base::commitment::Commitment;
+use proof_of_sql_parser::Identifier;
+use serde::{Deserialize, Serialize};
+
+/// A `ProvableExprPlan` with an alias.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AliasedProvableExprPlan<C: Commitment> {
+    pub expr: ProvableExprPlan<C>,
+    pub alias: Identifier,
+}

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test.rs
@@ -1,9 +1,6 @@
 use crate::{
     base::{database::owned_table_utility::*, math::decimal::Precision},
-    sql::ast::{
-        test_utility::{and, not, or},
-        ProvableExprPlan,
-    },
+    sql::ast::{test_utility::*, ProvableExprPlan},
 };
 use crate::{
     base::{
@@ -46,21 +43,21 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     let b = Identifier::try_new("b").unwrap();
     let provable_ast = DenseFilterExpr::<RistrettoPoint>::new(
         vec![
-            (
+            aliased_plan(
                 ProvableExprPlan::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     a,
                     ColumnType::BigInt,
                 ))),
-                a,
+                "a",
             ),
-            (
+            aliased_plan(
                 ProvableExprPlan::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     b,
                     ColumnType::BigInt,
                 ))),
-                b,
+                "b",
             ),
         ],
         TableExpr { table_ref },
@@ -98,21 +95,21 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     let f = Identifier::try_new("f").unwrap();
     let provable_ast = DenseFilterExpr::new(
         vec![
-            (
+            aliased_plan(
                 ProvableExprPlan::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     a,
                     ColumnType::BigInt,
                 ))),
-                a,
+                "a",
             ),
-            (
+            aliased_plan(
                 ProvableExprPlan::Column(ColumnExpr::new(ColumnRef::new(
                     table_ref,
                     f,
                     ColumnType::BigInt,
                 ))),
-                f,
+                "f",
             ),
         ],
         TableExpr { table_ref },
@@ -438,10 +435,10 @@ fn we_can_prove_a_dense_filter() {
             col_expr_plan(t, "c", &accessor),
             col_expr_plan(t, "d", &accessor),
             col_expr_plan(t, "e", &accessor),
-            (const_int128(105), "const".parse().unwrap()),
-            (
+            aliased_plan(const_int128(105), "const"),
+            aliased_plan(
                 equal(column(t, "b", &accessor), column(t, "c", &accessor)),
-                "bool".parse().unwrap(),
+                "bool",
             ),
         ],
         tab(t),

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test_dishonest_prover.rs
@@ -48,11 +48,11 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestDenseFilterExpr<RistrettoPoin
             .as_boolean()
             .expect("selection is not boolean");
         // 2. columns
-        let columns = Vec::from_iter(
-            self.aliased_results
-                .iter()
-                .map(|(expr, _)| expr.result_evaluate(builder.table_length(), alloc, accessor)),
-        );
+        let columns = Vec::from_iter(self.aliased_results.iter().map(|aliased_expr| {
+            aliased_expr
+                .expr
+                .result_evaluate(builder.table_length(), alloc, accessor)
+        }));
         // Compute filtered_columns and indexes
         let (filtered_columns, result_len) = filter_columns(alloc, &columns, selection);
         let filtered_columns = tamper_column(alloc, filtered_columns);
@@ -87,7 +87,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestDenseFilterExpr<RistrettoPoin
         let columns = Vec::from_iter(
             self.aliased_results
                 .iter()
-                .map(|(expr, _)| expr.prover_evaluate(builder, alloc, accessor)),
+                .map(|aliased_expr| aliased_expr.expr.prover_evaluate(builder, alloc, accessor)),
         );
         // Compute filtered_columns and indexes
         let (filtered_columns, result_len) = filter_columns(alloc, &columns, selection);

--- a/crates/proof-of-sql/src/sql/ast/mod.rs
+++ b/crates/proof-of-sql/src/sql/ast/mod.rs
@@ -1,4 +1,7 @@
 //! This module proves provable ASTs.
+mod aliased_provable_expr_plan;
+pub(crate) use aliased_provable_expr_plan::AliasedProvableExprPlan;
+
 mod filter_result_expr;
 pub(crate) use filter_result_expr::FilterResultExpr;
 

--- a/crates/proof-of-sql/src/sql/ast/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/multiply_expr_test.rs
@@ -33,21 +33,18 @@ fn we_can_prove_a_typical_multiply_query() {
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let ast = dense_filter(
         vec![
-            (
-                multiply(column(t, "a", &accessor), const_int(2)),
-                "a".parse().unwrap(),
-            ),
+            aliased_plan(multiply(column(t, "a", &accessor), const_int(2)), "a"),
             col_expr_plan(t, "c", &accessor),
-            (
+            aliased_plan(
                 multiply(column(t, "b", &accessor), const_decimal75(2, 1, 45)),
-                "b".parse().unwrap(),
+                "b",
             ),
-            (
+            aliased_plan(
                 add(
                     multiply(column(t, "d", &accessor), const_smallint(3)),
                     const_decimal75(2, 1, 47),
                 ),
-                "d".parse().unwrap(),
+                "d",
             ),
             col_expr_plan(t, "e", &accessor),
         ],
@@ -96,9 +93,9 @@ fn result_expr_can_overflow() {
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let ast: ProofPlan<RistrettoPoint> = dense_filter(
-        vec![(
+        vec![aliased_plan(
             multiply(column(t, "a", &accessor), column(t, "b", &accessor)),
-            "c".parse().unwrap(),
+            "c",
         )],
         tab(t),
         equal(column(t, "b", &accessor), const_bigint(2)),
@@ -121,9 +118,9 @@ fn overflow_in_nonselected_rows_doesnt_error_out() {
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let ast: ProofPlan<RistrettoPoint> = dense_filter(
-        vec![(
+        vec![aliased_plan(
             multiply(column(t, "a", &accessor), column(t, "b", &accessor)),
-            "c".parse().unwrap(),
+            "c",
         )],
         tab(t),
         equal(column(t, "b", &accessor), const_bigint(0)),
@@ -171,9 +168,9 @@ fn result_expr_can_overflow_more() {
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let ast: ProofPlan<RistrettoPoint> = dense_filter(
-        vec![(
+        vec![aliased_plan(
             multiply(column(t, "a", &accessor), column(t, "b", &accessor)),
-            "c".parse().unwrap(),
+            "c",
         )],
         tab(t),
         const_bool(true),
@@ -268,12 +265,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
         let ast = dense_filter(
             vec![
                 col_expr_plan(t, "d", &accessor),
-                (
+                aliased_plan(
                     add(
                         multiply(column(t, "a", &accessor), column(t, "c", &accessor)),
                         const_int128(4),
                     ),
-                    "f".parse().unwrap(),
+                    "f",
                 ),
             ],
             tab(t),
@@ -331,12 +328,12 @@ fn we_can_compute_the_correct_output_of_a_multiply_expr_using_result_evaluate() 
     ]);
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
-    let add_subtract_expr: ProvableExprPlan<RistrettoPoint> = multiply(
+    let arithmetic_expr: ProvableExprPlan<RistrettoPoint> = multiply(
         column(t, "b", &accessor),
         subtract(column(t, "a", &accessor), const_decimal75(2, 1, 15)),
     );
     let alloc = Bump::new();
-    let res = add_subtract_expr.result_evaluate(4, &alloc, &accessor);
+    let res = arithmetic_expr.result_evaluate(4, &alloc, &accessor);
     let expected_res_scalar = [0, 5, 75, 25]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -520,12 +520,12 @@ fn we_can_convert_an_ast_with_conds_not_and_or() {
         dense_filter(
             vec![
                 col_expr_plan(t, "a", &accessor),
-                (
+                aliased_plan(
                     not(or(
                         equal(column(t, "a", &accessor), column(t, "b", &accessor)),
                         equal(column(t, "c", &accessor), column(t, "f", &accessor)),
                     )),
-                    "boolean".parse().unwrap(),
+                    "boolean",
                 ),
             ],
             tab(t),
@@ -561,7 +561,7 @@ fn we_can_convert_an_ast_with_the_min_i128_filter_value_and_const() {
         dense_filter(
             vec![
                 col_expr_plan(t, "a", &accessor),
-                (const_int128(i128::MIN), "b".parse().unwrap()),
+                aliased_plan(const_int128(i128::MIN), "b"),
             ],
             tab(t),
             equal(column(t, "a", &accessor), const_int128(i128::MIN)),
@@ -590,7 +590,7 @@ fn we_can_convert_an_ast_with_the_max_i128_filter_value_and_const() {
         dense_filter(
             vec![
                 col_expr_plan(t, "a", &accessor),
-                (const_int128(i128::MAX), "ma".parse().unwrap()),
+                aliased_plan(const_int128(i128::MAX), "ma"),
             ],
             tab(t),
             equal(column(t, "a", &accessor), const_int128(i128::MAX)),
@@ -620,9 +620,9 @@ fn we_can_convert_an_ast_using_an_aliased_column() {
         dense_filter(
             vec![
                 aliased_col_expr_plan(t, "a", "b_rename", &accessor),
-                (
+                aliased_plan(
                     equal(column(t, "a", &accessor), column(t, "b", &accessor)),
-                    "boolean".parse().unwrap(),
+                    "boolean",
                 ),
             ],
             tab(t),
@@ -695,7 +695,7 @@ fn we_can_convert_an_ast_without_any_dense_filter() {
         dense_filter(
             vec![
                 col_expr_plan(t, "a", &accessor),
-                (const_bigint(3), "b".parse().unwrap()),
+                aliased_plan(const_bigint(3), "b"),
             ],
             tab(t),
             const_bool(true),
@@ -1071,12 +1071,12 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_wher
         dense_filter(
             vec![
                 col_expr_plan(t, "a", &accessor),
-                (
+                aliased_plan(
                     and(
                         column(t, "boolean", &accessor),
                         gte(column(t, "a", &accessor), const_bigint(4)),
                     ),
-                    "res".parse().unwrap(),
+                    "res",
                 ),
             ],
             tab(t),
@@ -1274,7 +1274,7 @@ fn we_can_group_by_without_using_aggregate_functions() {
     let expected_ast = QueryExpr::new(
         dense_filter(
             vec![
-                (const_bool(true), "is_remote".parse().unwrap()),
+                aliased_plan(const_bool(true), "is_remote"),
                 col_expr_plan(t, "department", &accessor),
             ],
             tab(t),
@@ -1625,21 +1625,18 @@ fn we_can_parse_a_simple_add_mul_sub_div_arithmetic_expressions_in_the_result_ex
     let expected_ast = QueryExpr::new(
         dense_filter(
             vec![
-                (
+                aliased_plan(
                     add(column(t, "a", &accessor), column(t, "b", &accessor)),
-                    "__expr__".parse().unwrap(),
+                    "__expr__",
                 ),
-                (
-                    multiply(const_bigint(2), column(t, "f", &accessor)),
-                    "f2".parse().unwrap(),
-                ),
-                (
+                aliased_plan(multiply(const_bigint(2), column(t, "f", &accessor)), "f2"),
+                aliased_plan(
                     subtract(const_bigint(-77), column(t, "h", &accessor)),
-                    "col".parse().unwrap(),
+                    "col",
                 ),
-                (
+                aliased_plan(
                     add(column(t, "a", &accessor), column(t, "f", &accessor)),
-                    "af".parse().unwrap(),
+                    "af",
                 ),
             ],
             tab(t),
@@ -1680,7 +1677,7 @@ fn we_can_parse_multiple_arithmetic_expression_where_multiplication_has_preceden
     let expected_ast = QueryExpr::new(
         dense_filter(
             vec![
-                (
+                aliased_plan(
                     multiply(
                         add(const_bigint(2), column(t, "f", &accessor)),
                         add(
@@ -1688,9 +1685,9 @@ fn we_can_parse_multiple_arithmetic_expression_where_multiplication_has_preceden
                             multiply(const_bigint(2), column(t, "h", &accessor)),
                         ),
                     ),
-                    "__expr__".parse().unwrap(),
+                    "__expr__",
                 ),
-                (
+                aliased_plan(
                     multiply(
                         add(
                             add(
@@ -1704,7 +1701,7 @@ fn we_can_parse_multiple_arithmetic_expression_where_multiplication_has_preceden
                         ),
                         add(column(t, "f", &accessor), const_bigint(2)),
                     ),
-                    "d".parse().unwrap(),
+                    "d",
                 ),
             ],
             tab(t),


### PR DESCRIPTION
# Rationale for this change
In new versions of `GroupByExpr` tuple `(ProvableExprPlan<C>, Identifier)` is extremely common. We may as well add a struct for this.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- add `AliasedProvableExprPlan`
- one instance of minor typo fix
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
