### PR TITLE
ci: automate cargo publish

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -14,5 +14,5 @@ fi
 sed -i 's/version = "*.*.*" # DO NOT CHANGE THIS LINE! This will be automatically updated/version = "'${NEW_VERSION}'"/' Cargo.toml
 sed -i 's/path = "[^"]*"/version = "'${NEW_VERSION}'"/g' Cargo.toml
 
-cargo publish -p proof-of-sql-parser --dry-run
-#cargo publish -p proof-of-sql --dry-run
+cargo publish -p proof-of-sql-parser --token ${CRATES_TOKEN}
+cargo publish -p proof-of-sql --token ${CRATES_TOKEN}


### PR DESCRIPTION
# Rationale for this change

This PR automates `cargo publish`.

# What changes are included in this PR?

`--dry-run` is removed and a crates token is added

# Are these changes tested?

Not possible.