### PR TITLE
ci: enable `CRATES_TOKEN` in env

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,4 +34,4 @@ jobs:
           npx semantic-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }} #TODO: add CRATES_TOKEN
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
# Rationale for this change

#37 did not enable the `CRATES_TOKEN`. This PR does this.
