### PR TITLE
refactor!: tidy dory setups

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
+++ b/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
@@ -22,7 +22,7 @@ impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {
         &mut self,
         table_ref: TableRef,
         columns: &[(Identifier, Column<'a, C::Scalar>)],
-        setup: &C::PublicSetup,
+        setup: &C::PublicSetup<'_>,
     ) {
         self.table_schemas.insert(
             table_ref,

--- a/crates/proof-of-sql/benches/scaffold/mod.rs
+++ b/crates/proof-of-sql/benches/scaffold/mod.rs
@@ -16,7 +16,7 @@ fn scaffold<'a, CP: CommitmentEvaluationProof>(
     query: &str,
     columns: &[(&str, ColumnType, OptionalRandBound)],
     size: usize,
-    prover_setup: &CP::ProverPublicSetup,
+    prover_setup: &CP::ProverPublicSetup<'_>,
     alloc: &'a Bump,
     accessor: &mut BenchmarkAccessor<'a, CP::Commitment>,
     rng: &mut impl Rng,
@@ -41,8 +41,8 @@ pub fn jaeger_scaffold<CP: CommitmentEvaluationProof>(
     query: &str,
     columns: &[(&str, ColumnType, OptionalRandBound)],
     size: usize,
-    prover_setup: &CP::ProverPublicSetup,
-    verifier_setup: &CP::VerifierPublicSetup,
+    prover_setup: &CP::ProverPublicSetup<'_>,
+    verifier_setup: &CP::VerifierPublicSetup<'_>,
 ) {
     let mut accessor = BenchmarkAccessor::default();
     let mut rng = rand::thread_rng();
@@ -68,8 +68,8 @@ pub fn criterion_scaffold<CP: CommitmentEvaluationProof>(
     query: &str,
     columns: &[(&str, ColumnType, OptionalRandBound)],
     sizes: &[usize],
-    prover_setup: &CP::ProverPublicSetup,
-    verifier_setup: &CP::VerifierPublicSetup,
+    prover_setup: &CP::ProverPublicSetup<'_>,
+    verifier_setup: &CP::VerifierPublicSetup<'_>,
 ) {
     let mut group = c.benchmark_group(format!("{} - {}", title, query));
     group.sample_size(10);

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -38,7 +38,7 @@ where
 
 /// Private convenience aliases.
 type Decompressed<C> = <Vec<C> as VecCommitmentExt>::DecompressedCommitment;
-type Setup<C> = <Vec<C> as VecCommitmentExt>::CommitmentPublicSetup;
+type Setup<'a, C> = <Vec<C> as VecCommitmentExt>::CommitmentPublicSetup<'a>;
 
 impl<C> ColumnCommitments<C>
 where

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
@@ -7,8 +7,8 @@ use merlin::Transcript;
 use num_traits::{One, Zero};
 
 pub fn test_simple_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
-    prover_setup: &CP::ProverPublicSetup,
-    verifier_setup: &CP::VerifierPublicSetup,
+    prover_setup: &CP::ProverPublicSetup<'_>,
+    verifier_setup: &CP::VerifierPublicSetup<'_>,
 ) {
     let mut transcript = Transcript::new(b"evaluation_proof");
     let proof = CP::new(
@@ -44,8 +44,8 @@ pub fn test_simple_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
 }
 
 pub fn test_commitment_evaluation_proof_with_length_1<CP: CommitmentEvaluationProof>(
-    prover_setup: &CP::ProverPublicSetup,
-    verifier_setup: &CP::VerifierPublicSetup,
+    prover_setup: &CP::ProverPublicSetup<'_>,
+    verifier_setup: &CP::VerifierPublicSetup<'_>,
 ) {
     let mut rng = ark_std::test_rng();
     let r = CP::Scalar::rand(&mut rng);
@@ -64,8 +64,8 @@ pub fn test_commitment_evaluation_proof_with_length_1<CP: CommitmentEvaluationPr
 pub fn test_random_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     table_length: usize,
     offset: usize,
-    prover_setup: &CP::ProverPublicSetup,
-    verifier_setup: &CP::VerifierPublicSetup,
+    prover_setup: &CP::ProverPublicSetup<'_>,
+    verifier_setup: &CP::VerifierPublicSetup<'_>,
 ) {
     let nu = table_length.next_power_of_two().trailing_zeros() as usize;
     assert!(table_length <= 1 << nu);

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -63,14 +63,14 @@ pub trait Commitment:
         + for<'a> serde::Deserialize<'a>;
 
     /// The public setup for the commitment scheme.
-    type PublicSetup;
+    type PublicSetup<'a>;
 
     /// Compute the commitments for the given columns.
     fn compute_commitments(
         commitments: &mut [Self],
         committable_columns: &[CommittableColumn],
         offset: usize,
-        setup: &Self::PublicSetup,
+        setup: &Self::PublicSetup<'_>,
     );
 
     /// Compute a linear combination of the given commitments: `sum commitment[i] * multiplier[i]`.
@@ -79,13 +79,13 @@ pub trait Commitment:
 
 impl Commitment for RistrettoPoint {
     type Scalar = Curve25519Scalar;
-    type PublicSetup = ();
+    type PublicSetup<'a> = ();
     #[cfg(feature = "blitzar")]
     fn compute_commitments(
         commitments: &mut [Self],
         committable_columns: &[CommittableColumn],
         offset: usize,
-        _setup: &Self::PublicSetup,
+        _setup: &Self::PublicSetup<'_>,
     ) {
         let sequences = Vec::from_iter(committable_columns.iter().map(Into::into));
         let mut compressed_commitments = vec![Default::default(); committable_columns.len()];
@@ -108,7 +108,7 @@ impl Commitment for RistrettoPoint {
         _commitments: &mut [Self],
         _committable_columns: &[CommittableColumn],
         _offset: usize,
-        _setup: &Self::PublicSetup,
+        _setup: &Self::PublicSetup<'_>,
     ) {
         unimplemented!()
     }

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -143,9 +143,11 @@ mod tests {
             },
             scalar::Curve25519Scalar,
         },
-        proof_primitive::dory::{DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup},
+        proof_primitive::dory::{
+            test_rng, DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, ProverSetup,
+            PublicParameters,
+        },
     };
-    use ark_std::test_rng;
     use curve25519_dalek::RistrettoPoint;
 
     #[test]
@@ -328,7 +330,9 @@ mod tests {
 
     #[test]
     fn we_can_get_query_commitments_from_accessor() {
-        let setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
+        let public_parameters = PublicParameters::rand(4, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 3);
 
         let column_a_id: Identifier = "column_a".parse().unwrap();
         let column_b_id: Identifier = "column_b".parse().unwrap();

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -97,7 +97,7 @@ where
 }
 
 /// Private convenience alias.
-type Setup<C> = <Vec<C> as VecCommitmentExt>::CommitmentPublicSetup;
+type Setup<'a, C> = <Vec<C> as VecCommitmentExt>::CommitmentPublicSetup<'a>;
 type Decompressed<C> = <Vec<C> as VecCommitmentExt>::DecompressedCommitment;
 
 impl<C> TableCommitment<C>

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -13,13 +13,13 @@ pub struct NumColumnsMismatch;
 pub trait VecCommitmentExt {
     /// The public setup parameters required to compute the commitments.
     /// This is simply precomputed data that is required to compute the commitments.
-    type CommitmentPublicSetup;
+    type CommitmentPublicSetup<'a>;
 
     /// Returns a collection of commitments to the provided columns using the given generator offset.
     fn from_columns_with_offset<'a, C>(
         columns: impl IntoIterator<Item = C>,
         offset: usize,
-        setup: &Self::CommitmentPublicSetup,
+        setup: &Self::CommitmentPublicSetup<'_>,
     ) -> Self
     where
         C: Into<CommittableColumn<'a>>;
@@ -28,7 +28,7 @@ pub trait VecCommitmentExt {
     fn from_commitable_columns_with_offset(
         committable_columns: &[CommittableColumn],
         offset: usize,
-        setup: &Self::CommitmentPublicSetup,
+        setup: &Self::CommitmentPublicSetup<'_>,
     ) -> Self;
 
     /// Append rows of data from the provided columns to the existing commitments.
@@ -41,7 +41,7 @@ pub trait VecCommitmentExt {
         &mut self,
         columns: impl IntoIterator<Item = C>,
         offset: usize,
-        setup: &Self::CommitmentPublicSetup,
+        setup: &Self::CommitmentPublicSetup<'_>,
     ) -> Result<(), NumColumnsMismatch>
     where
         C: Into<CommittableColumn<'a>>;
@@ -51,7 +51,7 @@ pub trait VecCommitmentExt {
         &mut self,
         columns: impl IntoIterator<Item = C>,
         offset: usize,
-        setup: &Self::CommitmentPublicSetup,
+        setup: &Self::CommitmentPublicSetup<'_>,
     ) where
         C: Into<CommittableColumn<'a>>;
 
@@ -92,11 +92,11 @@ fn unsafe_sub_assign<C: Commitment>(a: &mut [C], b: &[C]) {
 }
 
 impl<C: Commitment> VecCommitmentExt for Vec<C> {
-    type CommitmentPublicSetup = C::PublicSetup;
+    type CommitmentPublicSetup<'a> = C::PublicSetup<'a>;
     fn from_columns_with_offset<'a, COL>(
         columns: impl IntoIterator<Item = COL>,
         offset: usize,
-        setup: &Self::CommitmentPublicSetup,
+        setup: &Self::CommitmentPublicSetup<'_>,
     ) -> Self
     where
         COL: Into<CommittableColumn<'a>>,
@@ -110,7 +110,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
     fn from_commitable_columns_with_offset(
         committable_columns: &[CommittableColumn],
         offset: usize,
-        setup: &Self::CommitmentPublicSetup,
+        setup: &Self::CommitmentPublicSetup<'_>,
     ) -> Self {
         let mut commitments = vec![C::default(); committable_columns.len()];
         C::compute_commitments(&mut commitments, committable_columns, offset, setup);
@@ -122,7 +122,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
         &mut self,
         columns: impl IntoIterator<Item = COL>,
         offset: usize,
-        setup: &Self::CommitmentPublicSetup,
+        setup: &Self::CommitmentPublicSetup<'_>,
     ) -> Result<(), NumColumnsMismatch>
     where
         COL: Into<CommittableColumn<'a>>,
@@ -145,7 +145,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
         &mut self,
         columns: impl IntoIterator<Item = COL>,
         offset: usize,
-        setup: &Self::CommitmentPublicSetup,
+        setup: &Self::CommitmentPublicSetup<'_>,
     ) where
         COL: Into<CommittableColumn<'a>>,
     {

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -118,13 +118,17 @@ mod tests {
             commitment::{NumColumnsMismatch, VecCommitmentExt},
             database::{Column, OwnedColumn},
         },
-        proof_primitive::dory::rand_util::test_rng,
+        proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };
     use ark_ec::pairing::Pairing;
 
     #[test]
     fn we_can_convert_from_columns() {
-        let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+        let public_parameters = PublicParameters::rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+        let Gamma_1 = &public_parameters.Gamma_1;
+        let Gamma_2 = &public_parameters.Gamma_2;
 
         // empty case
         let commitments = Vec::<DoryCommitment>::from_columns_with_offset(
@@ -148,32 +152,16 @@ mod tests {
 
         let mut expected_commitments = vec![DoryCommitment::default(); 2];
         expected_commitments[0] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_a[0]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[1]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[2]).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_a[0]).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * DoryScalar::from(column_a[1]).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * DoryScalar::from(column_a[2]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_b[0].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[1].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[2].clone()).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_b[0].clone()).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0])
+                    * DoryScalar::from(column_b[1].clone()).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0])
+                    * DoryScalar::from(column_b[2].clone()).0,
         );
 
         assert_eq!(commitments, expected_commitments);
@@ -181,7 +169,11 @@ mod tests {
 
     #[test]
     fn we_can_append_rows() {
-        let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+        let public_parameters = PublicParameters::rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+        let Gamma_1 = &public_parameters.Gamma_1;
+        let Gamma_2 = &public_parameters.Gamma_2;
 
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
@@ -204,48 +196,22 @@ mod tests {
 
         let mut expected_commitments = vec![DoryCommitment::default(); 2];
         expected_commitments[0] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_a[0]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[1]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[2]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[3],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[3]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[0],
-                    setup.public_parameters().Gamma_2[1],
-                ) * DoryScalar::from(column_a[4]).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_a[0]).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * DoryScalar::from(column_a[1]).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * DoryScalar::from(column_a[2]).0
+                + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * DoryScalar::from(column_a[3]).0
+                + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * DoryScalar::from(column_a[4]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_b[0].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[1].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[2].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[3],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[3].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[0],
-                    setup.public_parameters().Gamma_2[1],
-                ) * DoryScalar::from(column_b[4].clone()).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_b[0].clone()).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0])
+                    * DoryScalar::from(column_b[1].clone()).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0])
+                    * DoryScalar::from(column_b[2].clone()).0
+                + Pairing::pairing(Gamma_1[3], Gamma_2[0])
+                    * DoryScalar::from(column_b[3].clone()).0
+                + Pairing::pairing(Gamma_1[0], Gamma_2[1])
+                    * DoryScalar::from(column_b[4].clone()).0,
         );
 
         assert_eq!(commitments, expected_commitments);
@@ -253,7 +219,9 @@ mod tests {
 
     #[test]
     fn we_cannot_append_rows_with_different_column_count() {
-        let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+        let public_parameters = PublicParameters::rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
@@ -290,7 +258,11 @@ mod tests {
 
     #[test]
     fn we_can_extend_columns() {
-        let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+        let public_parameters = PublicParameters::rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+        let Gamma_1 = &public_parameters.Gamma_1;
+        let Gamma_2 = &public_parameters.Gamma_2;
 
         let column_a = [12i64, 34, 56];
         let column_b = ["Lorem", "ipsum", "dolor"].map(String::from);
@@ -314,60 +286,28 @@ mod tests {
         let mut expected_commitments = vec![DoryCommitment::default(); 4];
 
         expected_commitments[0] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_a[0]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[1]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[2]).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_a[0]).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * DoryScalar::from(column_a[1]).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * DoryScalar::from(column_a[2]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_b[0].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[1].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[2].clone()).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_b[0].clone()).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0])
+                    * DoryScalar::from(column_b[1].clone()).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0])
+                    * DoryScalar::from(column_b[2].clone()).0,
         );
         expected_commitments[2] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_c[0].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_c[1].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_c[2].clone()).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_c[0].clone()).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0])
+                    * DoryScalar::from(column_c[1].clone()).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0])
+                    * DoryScalar::from(column_c[2].clone()).0,
         );
         expected_commitments[3] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_d[0]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_d[1]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_d[2]).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_d[0]).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * DoryScalar::from(column_d[1]).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * DoryScalar::from(column_d[2]).0,
         );
 
         assert_eq!(commitments, expected_commitments);
@@ -375,7 +315,11 @@ mod tests {
 
     #[test]
     fn we_can_add_commitment_collections() {
-        let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+        let public_parameters = PublicParameters::rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+        let Gamma_1 = &public_parameters.Gamma_1;
+        let Gamma_2 = &public_parameters.Gamma_2;
 
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
@@ -399,48 +343,22 @@ mod tests {
 
         let mut expected_commitments = vec![DoryCommitment::default(); 2];
         expected_commitments[0] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_a[0]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[1]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[2]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[3],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_a[3]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[0],
-                    setup.public_parameters().Gamma_2[1],
-                ) * DoryScalar::from(column_a[4]).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_a[0]).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * DoryScalar::from(column_a[1]).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * DoryScalar::from(column_a[2]).0
+                + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * DoryScalar::from(column_a[3]).0
+                + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * DoryScalar::from(column_a[4]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[0],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_b[0].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[1],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[1].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[2],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[2].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[3],
-                    setup.public_parameters().Gamma_2[0],
-                ) * DoryScalar::from(column_b[3].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[0],
-                    setup.public_parameters().Gamma_2[1],
-                ) * DoryScalar::from(column_b[4].clone()).0,
+            Pairing::pairing(Gamma_1[0], Gamma_2[0]) * DoryScalar::from(column_b[0].clone()).0
+                + Pairing::pairing(Gamma_1[1], Gamma_2[0])
+                    * DoryScalar::from(column_b[1].clone()).0
+                + Pairing::pairing(Gamma_1[2], Gamma_2[0])
+                    * DoryScalar::from(column_b[2].clone()).0
+                + Pairing::pairing(Gamma_1[3], Gamma_2[0])
+                    * DoryScalar::from(column_b[3].clone()).0
+                + Pairing::pairing(Gamma_1[0], Gamma_2[1])
+                    * DoryScalar::from(column_b[4].clone()).0,
         );
 
         assert_eq!(commitments, expected_commitments);
@@ -448,7 +366,9 @@ mod tests {
 
     #[test]
     fn we_cannot_add_commitment_collections_of_mixed_column_counts() {
-        let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+        let public_parameters = PublicParameters::rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
@@ -491,7 +411,11 @@ mod tests {
 
     #[test]
     fn we_can_sub_commitment_collections() {
-        let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+        let public_parameters = PublicParameters::rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+        let Gamma_1 = &public_parameters.Gamma_1;
+        let Gamma_2 = &public_parameters.Gamma_2;
 
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);
@@ -516,24 +440,13 @@ mod tests {
         let mut expected_commitments = vec![DoryCommitment::default(); 2];
 
         expected_commitments[0] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[3],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_a[3]).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[0],
-                    setup.public_parameters().Gamma_2[1],
-                ) * DoryScalar::from(column_a[4]).0,
+            Pairing::pairing(Gamma_1[3], Gamma_2[0]) * DoryScalar::from(column_a[3]).0
+                + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * DoryScalar::from(column_a[4]).0,
         );
         expected_commitments[1] = DoryCommitment(
-            Pairing::pairing(
-                setup.public_parameters().Gamma_1[3],
-                setup.public_parameters().Gamma_2[0],
-            ) * DoryScalar::from(column_b[3].clone()).0
-                + Pairing::pairing(
-                    setup.public_parameters().Gamma_1[0],
-                    setup.public_parameters().Gamma_2[1],
-                ) * DoryScalar::from(column_b[4].clone()).0,
+            Pairing::pairing(Gamma_1[3], Gamma_2[0]) * DoryScalar::from(column_b[3].clone()).0
+                + Pairing::pairing(Gamma_1[0], Gamma_2[1])
+                    * DoryScalar::from(column_b[4].clone()).0,
         );
 
         assert_eq!(commitments, expected_commitments);
@@ -541,7 +454,9 @@ mod tests {
 
     #[test]
     fn we_cannot_sub_commitment_collections_of_mixed_column_counts() {
-        let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+        let public_parameters = PublicParameters::rand(5, &mut test_rng());
+        let prover_setup = ProverSetup::from(&public_parameters);
+        let setup = DoryProverPublicSetup::new(&prover_setup, 2);
 
         let column_a = [12i64, 34, 56, 78, 90];
         let column_b = ["Lorem", "ipsum", "dolor", "sit", "amet"].map(String::from);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -89,13 +89,13 @@ impl<'a> Mul<&'a DoryCommitment> for DoryScalar {
 }
 impl Commitment for DoryCommitment {
     type Scalar = DoryScalar;
-    type PublicSetup = DoryProverPublicSetup;
+    type PublicSetup<'a> = DoryProverPublicSetup<'a>;
 
     fn compute_commitments(
         commitments: &mut [Self],
         committable_columns: &[CommittableColumn],
         offset: usize,
-        setup: &Self::PublicSetup,
+        setup: &Self::PublicSetup<'_>,
     ) {
         assert_eq!(commitments.len(), committable_columns.len());
         let c = super::compute_dory_commitments(committable_columns, offset, setup);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -27,12 +27,12 @@ where
 
     // Compute commitments for the rows.
     let first_row_commit = G1Projective::msm_unchecked(
-        &setup.public_parameters().Gamma_1[first_row_offset..num_columns],
+        &setup.prover_setup().Gamma_1.last().unwrap()[first_row_offset..num_columns],
         &Vec::from_iter(first_row.iter().map(|s| s.into().0)),
     );
     let remaining_row_commits = remaining_rows.map(|row| {
         G1Projective::msm_unchecked(
-            &setup.public_parameters().Gamma_1[..num_columns],
+            &setup.prover_setup().Gamma_1.last().unwrap()[..num_columns],
             &Vec::from_iter(row.iter().map(|s| s.into().0)),
         )
     });
@@ -40,7 +40,8 @@ where
     // Compute the commitment for the entire matrix.
     DoryCommitment(pairings::multi_pairing(
         once(first_row_commit).chain(remaining_row_commits),
-        &setup.public_parameters().Gamma_2[rows_offset..(rows_offset + remaining_row_count + 1)],
+        &setup.prover_setup().Gamma_2.last().unwrap()
+            [rows_offset..(rows_offset + remaining_row_count + 1)],
     ))
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -38,7 +38,7 @@ fn get_offset_commits(
             data_size,
         );
 
-        setup.public_parameters().blitzar_msm(
+        setup.prover_setup().blitzar_msm(
             &mut ones_blitzar_commits[num_zero_commits..num_zero_commits + 1],
             data_size as u32,
             first_row_transpose.as_slice(),
@@ -53,7 +53,7 @@ fn get_offset_commits(
                 let mut middle_row_blitzar_commit =
                     vec![ElementP2::<ark_bls12_381::g1::Config>::default(); 1];
 
-                setup.public_parameters().blitzar_msm(
+                setup.prover_setup().blitzar_msm(
                     &mut middle_row_blitzar_commit,
                     data_size as u32,
                     middle_row_transpose.as_slice(),
@@ -70,7 +70,7 @@ fn get_offset_commits(
             let last_row_transpose =
                 transpose::transpose_for_fixed_msm(last_row, 0, 1, num_columns, data_size);
 
-            setup.public_parameters().blitzar_msm(
+            setup.prover_setup().blitzar_msm(
                 &mut ones_blitzar_commits[num_of_commits - 1..num_of_commits],
                 data_size as u32,
                 last_row_transpose.as_slice(),
@@ -103,12 +103,12 @@ where
     let num_of_commits = ((column.len() + offset) + num_columns - 1) / num_columns;
     let column_transpose =
         transpose::transpose_for_fixed_msm(column, offset, num_of_commits, num_columns, data_size);
-    let gamma_2_slice = &setup.public_parameters().Gamma_2[0..num_of_commits];
+    let gamma_2_slice = &setup.prover_setup().Gamma_2.last().unwrap()[0..num_of_commits];
 
     // Compute the commitment for the entire data set
     let mut blitzar_commits =
         vec![ElementP2::<ark_bls12_381::g1::Config>::default(); num_of_commits];
-    setup.public_parameters().blitzar_msm(
+    setup.prover_setup().blitzar_msm(
         &mut blitzar_commits,
         data_size as u32,
         column_transpose.as_slice(),

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::commitment::CommittableColumn,
-    proof_primitive::dory::{compute_dory_commitments, DoryProverPublicSetup, F, GT},
+    proof_primitive::dory::{
+        compute_dory_commitments, DoryProverPublicSetup, ProverSetup, PublicParameters, F, GT,
+    },
 };
 use ark_ec::pairing::Pairing;
 use ark_std::test_rng;
@@ -8,10 +10,12 @@ use num_traits::Zero;
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::Int128(&[0, -1, 2])], 0, &setup);
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0_i128)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(-1_i128)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2_i128);
@@ -20,14 +24,16 @@ fn we_can_compute_a_dory_commitment_with_int128_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_boolean_values() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::Boolean(&[true, false, true])],
         0,
         &setup,
     );
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(true)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(false)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(true);
@@ -36,10 +42,12 @@ fn we_can_compute_a_dory_commitment_with_boolean_values() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_only_one_row() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2])], 0, &setup);
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2);
@@ -48,10 +56,12 @@ fn we_can_compute_a_dory_commitment_with_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3])], 0, &setup);
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -61,10 +71,12 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[2, 3])], 2, &setup);
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(3);
     assert_eq!(res[0].0, expected);
@@ -72,10 +84,12 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with_signed_data() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[-2, -3])], 2, &setup);
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(-2)
         + Pairing::pairing(Gamma_1[3], Gamma_2[0]) * F::from(-3);
     assert_eq!(res[0].0, expected);
@@ -83,14 +97,16 @@ fn we_can_compute_a_dory_commitment_with_exactly_one_full_row_and_an_offset_with
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         0,
         &setup,
     );
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -106,7 +122,9 @@ fn we_can_compute_a_dory_commitment_with_fewer_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -114,8 +132,8 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
         0,
         &setup,
     );
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(1)
         + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(2)
@@ -140,10 +158,12 @@ fn we_can_compute_a_dory_commitment_with_more_rows_than_columns() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1])], 5, &setup);
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1);
     assert_eq!(res[0].0, expected);
@@ -151,14 +171,16 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_only_one_row() {
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])],
         5,
         &setup,
     );
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -174,7 +196,9 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_fewer_rows_than_columns()
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(
         &[CommittableColumn::BigInt(&[
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
@@ -182,8 +206,8 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
         5,
         &setup,
     );
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[1], Gamma_2[1]) * F::from(0)
         + Pairing::pairing(Gamma_1[2], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[3], Gamma_2[1]) * F::from(2)
@@ -208,7 +232,9 @@ fn we_can_compute_a_dory_commitment_with_an_offset_and_more_rows_than_columns() 
 
 #[test]
 fn we_can_compute_an_empty_dory_commitment() {
-    let setup = DoryProverPublicSetup::rand(5, 2, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 0])], 5, &setup);
@@ -219,10 +245,12 @@ fn we_can_compute_an_empty_dory_commitment() {
 
 #[test]
 fn test_compute_dory_commitment_when_sigma_is_zero() {
-    let setup = DoryProverPublicSetup::rand(5, 0, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 0, &setup);
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[1]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[2]) * F::from(2)
@@ -233,10 +261,12 @@ fn test_compute_dory_commitment_when_sigma_is_zero() {
 
 #[test]
 fn test_compute_dory_commitment_with_zero_sigma_and_with_an_offset() {
-    let setup = DoryProverPublicSetup::rand(5, 0, &mut test_rng());
+    let public_parameters = PublicParameters::rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 0);
     let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 1, 2, 3, 4])], 5, &setup);
-    let Gamma_1 = &setup.public_parameters().Gamma_1;
-    let Gamma_2 = &setup.public_parameters().Gamma_2;
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
     let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[5]) * F::from(0)
         + Pairing::pairing(Gamma_1[0], Gamma_2[6]) * F::from(1)
         + Pairing::pairing(Gamma_1[0], Gamma_2[7]) * F::from(2)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
@@ -1,19 +1,18 @@
-use super::{PublicParameters, VerifierSetup};
-use serde::{Deserialize, Serialize};
+use super::{ProverSetup, VerifierSetup};
 
 /// The public setup required for the Dory PCS by the prover and the commitment computation.
-#[derive(Clone)]
-pub struct DoryProverPublicSetup {
-    public_parameters: PublicParameters,
+#[derive(Clone, Copy)]
+pub struct DoryProverPublicSetup<'a> {
+    prover_setup: &'a ProverSetup<'a>,
     sigma: usize,
 }
-impl DoryProverPublicSetup {
+impl<'a> DoryProverPublicSetup<'a> {
     /// Create a new public setup for the Dory PCS.
     /// public_parameters: The public parameters for the Dory protocol.
     /// sigma: A commitment with this setup is a matrix commitment with `1 << sigma` columns.
-    pub fn new(public_parameters: PublicParameters, sigma: usize) -> Self {
+    pub fn new(prover_setup: &'a ProverSetup<'a>, sigma: usize) -> Self {
         Self {
-            public_parameters,
+            prover_setup,
             sigma,
         }
     }
@@ -21,32 +20,23 @@ impl DoryProverPublicSetup {
     pub fn sigma(&self) -> usize {
         self.sigma
     }
-    /// The public parameters for the Dory protocol.
-    pub fn public_parameters(&self) -> &PublicParameters {
-        &self.public_parameters
-    }
-
-    #[cfg(any(test, feature = "test"))]
-    /// Create a random public setup for the Dory PCS.
-    pub fn rand<R>(max_nu: usize, sigma: usize, rng: &mut R) -> Self
-    where
-        R: ark_std::rand::Rng + ?Sized,
-    {
-        Self::new(PublicParameters::rand(max_nu, rng), sigma)
+    /// The public setup for the Dory protocol.
+    pub fn prover_setup(&self) -> &ProverSetup {
+        self.prover_setup
     }
 }
 
 /// The verifier's public setup for the Dory PCS.
-#[derive(Serialize, Deserialize)]
-pub struct DoryVerifierPublicSetup {
-    verifier_setup: VerifierSetup,
+#[derive(Clone, Copy)]
+pub struct DoryVerifierPublicSetup<'a> {
+    verifier_setup: &'a VerifierSetup,
     sigma: usize,
 }
-impl DoryVerifierPublicSetup {
+impl<'a> DoryVerifierPublicSetup<'a> {
     /// Create a new public setup for the Dory PCS.
     /// verifier_setup: The verifier's setup parameters for the Dory protocol.
     /// sigma: A commitment with this setup is a matrix commitment with `1 << sigma` columns.
-    pub fn new(verifier_setup: VerifierSetup, sigma: usize) -> Self {
+    pub fn new(verifier_setup: &'a VerifierSetup, sigma: usize) -> Self {
         Self {
             verifier_setup,
             sigma,
@@ -58,14 +48,6 @@ impl DoryVerifierPublicSetup {
     }
     /// The verifier's setup parameters for the Dory protocol.
     pub fn verifier_setup(&self) -> &VerifierSetup {
-        &self.verifier_setup
-    }
-}
-impl From<&DoryProverPublicSetup> for DoryVerifierPublicSetup {
-    fn from(prover_setup: &DoryProverPublicSetup) -> Self {
-        Self {
-            verifier_setup: prover_setup.public_parameters().into(),
-            sigma: prover_setup.sigma(),
-        }
+        self.verifier_setup
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use dory_messages::DoryMessages;
 mod dory_messages_test;
 
 mod setup;
-pub(crate) use setup::{ProverSetup, VerifierSetup};
+pub use setup::{ProverSetup, VerifierSetup};
 #[cfg(test)]
 mod setup_test;
 
@@ -103,8 +103,7 @@ pub(crate) use vmv_state::{VMVProverState, VMVVerifierState};
 mod vmv_state_test;
 
 mod dory_public_setup;
-pub use dory_public_setup::DoryProverPublicSetup;
-pub(crate) use dory_public_setup::DoryVerifierPublicSetup;
+pub use dory_public_setup::{DoryProverPublicSetup, DoryVerifierPublicSetup};
 
 mod dory_commitment;
 #[cfg(test)]

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -1,6 +1,4 @@
 use super::{G1Affine, G2Affine};
-#[cfg(feature = "blitzar")]
-use blitzar::compute::{ElementP2, MsmHandle};
 /// The public parameters for the Dory protocol. See section 5 of https://eprint.iacr.org/2020/1274.pdf for details.
 ///
 /// Note: even though H_1 and H_2 are marked as blue, they are still needed.
@@ -19,32 +17,6 @@ pub struct PublicParameters {
     pub(super) Gamma_2_fin: G2Affine,
     /// `max_nu` is the maximum nu that this setup will work for.
     pub(super) max_nu: usize,
-    /// The handle to the `blitzar` Gamma_1 instances.
-    #[cfg(feature = "blitzar")]
-    pub(super) blitzar_handle: MsmHandle<ElementP2<ark_bls12_381::g1::Config>>,
-}
-
-impl Clone for PublicParameters {
-    fn clone(&self) -> Self {
-        #[cfg(feature = "blitzar")]
-        let blitzar_handle = compute_handle(&self.Gamma_1);
-        Self {
-            Gamma_1: self.Gamma_1.clone(),
-            Gamma_2: self.Gamma_2.clone(),
-            H_1: self.H_1,
-            H_2: self.H_2,
-            Gamma_2_fin: self.Gamma_2_fin,
-            max_nu: self.max_nu,
-            #[cfg(feature = "blitzar")]
-            blitzar_handle,
-        }
-    }
-}
-
-#[cfg(feature = "blitzar")]
-fn compute_handle(Gamma_1: &[G1Affine]) -> MsmHandle<ElementP2<ark_bls12_381::g1::Config>> {
-    let gs: Vec<_> = Gamma_1.iter().copied().map(Into::into).collect();
-    blitzar::compute::MsmHandle::new(&gs)
 }
 
 impl PublicParameters {
@@ -59,8 +31,6 @@ impl PublicParameters {
         let (H_1, H_2) = (G1Affine::rand(rng), G2Affine::rand(rng));
         let Gamma_2_fin = G2Affine::rand(rng);
 
-        #[cfg(feature = "blitzar")]
-        let blitzar_handle = compute_handle(&Gamma_1);
         Self {
             Gamma_1,
             Gamma_2,
@@ -68,19 +38,6 @@ impl PublicParameters {
             H_1,
             H_2,
             Gamma_2_fin,
-            #[cfg(feature = "blitzar")]
-            blitzar_handle,
         }
-    }
-
-    #[cfg(feature = "blitzar")]
-    #[tracing::instrument(name = "PublicParameters::blitzar_msm", level = "debug", skip_all)]
-    pub(super) fn blitzar_msm(
-        &self,
-        res: &mut [ElementP2<ark_bls12_381::g1::Config>],
-        element_num_bytes: u32,
-        scalars: &[u8],
-    ) {
-        self.blitzar_handle.msm(res, element_num_bytes, scalars)
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/proof_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder.rs
@@ -102,7 +102,7 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
     pub fn commit_intermediate_mles<V: VecCommitmentExt>(
         &self,
         offset_generators: usize,
-        setup: &V::CommitmentPublicSetup,
+        setup: &V::CommitmentPublicSetup<'_>,
     ) -> V {
         V::from_commitable_columns_with_offset(
             &self.commitment_descriptor,

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -45,7 +45,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     pub fn new(
         expr: &(impl ProofExpr<CP::Commitment> + Serialize),
         accessor: &impl DataAccessor<CP::Scalar>,
-        setup: &CP::ProverPublicSetup,
+        setup: &CP::ProverPublicSetup<'_>,
     ) -> (Self, ProvableQueryResult) {
         let table_length = expr.get_length(accessor);
         let num_sumcheck_variables = cmp::max(log2_up(table_length), 1);
@@ -85,7 +85,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         builder: ProofBuilder<CP::Scalar>,
         generator_offset: usize,
         mut transcript: Transcript,
-        setup: &CP::ProverPublicSetup,
+        setup: &CP::ProverPublicSetup<'_>,
     ) -> Self {
         let num_sumcheck_variables = builder.num_sumcheck_variables();
         let table_length = builder.table_length();
@@ -156,7 +156,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         expr: &(impl ProofExpr<CP::Commitment> + Serialize),
         accessor: &impl CommitmentAccessor<CP::Commitment>,
         result: &ProvableQueryResult,
-        setup: &CP::VerifierPublicSetup,
+        setup: &CP::VerifierPublicSetup<'_>,
     ) -> QueryResult<CP::Scalar> {
         let table_length = expr.get_length(accessor);
         let generator_offset = expr.get_offset(accessor);

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -81,7 +81,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
     pub fn new(
         expr: &(impl ProofExpr<CP::Commitment> + Serialize),
         accessor: &impl DataAccessor<CP::Scalar>,
-        setup: &CP::ProverPublicSetup,
+        setup: &CP::ProverPublicSetup<'_>,
     ) -> Self {
         // a query must have at least one result column; if not, it should
         // have been rejected at the parsing stage.
@@ -112,7 +112,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         &self,
         expr: &(impl ProofExpr<CP::Commitment> + Serialize),
         accessor: &impl CommitmentAccessor<CP::Commitment>,
-        setup: &CP::VerifierPublicSetup,
+        setup: &CP::VerifierPublicSetup<'_>,
     ) -> QueryResult<CP::Scalar> {
         // a query must have at least one result column; if not, it should
         // have been rejected at the parsing stage.

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -9,7 +9,10 @@ use proof_of_sql::{
         database::{owned_table_utility::*, OwnedTable, OwnedTableTestAccessor, TestAccessor},
         scalar::Curve25519Scalar,
     },
-    proof_primitive::dory::{DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup},
+    proof_primitive::dory::{
+        DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup,
+        ProverSetup, PublicParameters, VerifierSetup,
+    },
     record_batch,
     sql::{
         parse::{ConversionError, QueryExpr},
@@ -44,12 +47,14 @@ fn we_can_prove_a_minimal_filter_query_with_curve25519() {
 
 #[test]
 fn we_can_prove_a_minimal_filter_query_with_dory() {
-    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
-    let dory_verifier_setup = (&dory_prover_setup).into();
+    let public_parameters = PublicParameters::rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3);
 
-    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
-        dory_prover_setup.clone(),
-    );
+    let mut accessor =
+        OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([boolean("a", [true, false])]),
@@ -103,12 +108,14 @@ fn we_can_prove_a_basic_equality_query_with_curve25519() {
 
 #[test]
 fn we_can_prove_a_basic_equality_query_with_dory() {
-    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
-    let dory_verifier_setup = (&dory_prover_setup).into();
+    let public_parameters = PublicParameters::rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3);
 
-    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
-        dory_prover_setup.clone(),
-    );
+    let mut accessor =
+        OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([bigint("a", [1, 2, 3]), bigint("b", [1, 0, 1])]),
@@ -198,11 +205,13 @@ fn we_can_prove_a_basic_query_containing_extrema_with_curve25519() {
 #[test]
 #[cfg(feature = "blitzar")]
 fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
-    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
-    let dory_verifier_setup = (&dory_prover_setup).into();
-    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
-        dory_prover_setup.clone(),
-    );
+    let public_parameters = PublicParameters::rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3);
+    let mut accessor =
+        OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([
@@ -272,11 +281,13 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
 
 #[test]
 fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
-    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
-    let dory_verifier_setup = (&dory_prover_setup).into();
-    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
-        dory_prover_setup.clone(),
-    );
+    let public_parameters = PublicParameters::rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3);
+    let mut accessor =
+        OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([bigint("a", [1, -1, 3]), bigint("b", [0, 0, 2])]),
@@ -341,12 +352,14 @@ fn we_can_prove_a_basic_equality_with_out_of_order_results_with_curve25519() {
 
 #[test]
 fn we_can_prove_a_basic_inequality_query_with_dory() {
-    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
-    let dory_verifier_setup = (&dory_prover_setup).into();
+    let public_parameters = PublicParameters::rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3);
 
-    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
-        dory_prover_setup.clone(),
-    );
+    let mut accessor =
+        OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([bigint("a", [1, 2, 3]), bigint("b", [1, 0, 4])]),
@@ -437,12 +450,14 @@ fn we_can_prove_a_complex_query_with_curve25519() {
 
 #[test]
 fn we_can_prove_a_complex_query_with_dory() {
-    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
-    let dory_verifier_setup = (&dory_prover_setup).into();
+    let public_parameters = PublicParameters::rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3);
 
-    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
-        dory_prover_setup.clone(),
-    );
+    let mut accessor =
+        OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([
@@ -519,12 +534,14 @@ fn we_can_prove_a_minimal_group_by_query_with_curve25519() {
 
 #[test]
 fn we_can_prove_a_basic_group_by_query_with_dory() {
-    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
-    let dory_verifier_setup = (&dory_prover_setup).into();
+    let public_parameters = PublicParameters::rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3);
 
-    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
-        dory_prover_setup.clone(),
-    );
+    let mut accessor =
+        OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([
@@ -587,12 +604,14 @@ fn we_can_prove_a_query_with_overflow_with_curve25519() {
 
 #[test]
 fn we_can_prove_a_query_with_overflow_with_dory() {
-    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
-    let dory_verifier_setup = (&dory_prover_setup).into();
+    let public_parameters = PublicParameters::rand(4, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3);
 
-    let mut accessor = OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(
-        dory_prover_setup.clone(),
-    );
+    let mut accessor =
+        OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([bigint("a", [i64::MIN]), smallint("b", [1_i16])]),


### PR DESCRIPTION
# Rationale for this change

The setups in Dory are somewhat unwieldy, in particular, there isn't a separation between the public parameters, the precomputed setups, and the parameters for a particular proofs.

# What changes are included in this PR?

The major change involves `PublicParameters`, `ProverSetup`, `VerifierSetup`, `DoryProverPublicSetup`, and `DoryVerifierPublicSetup`. The code for constructing these was made more explicit and broken apart better.
### Old
```
    let dory_prover_setup = DoryProverPublicSetup::rand(4, 3, &mut test_rng());
    let dory_verifier_setup = (&dory_prover_setup).into();
```
### New
```
    let public_parameters = PublicParameters::rand(4, &mut test_rng()); // This can be stored on disc and is the actual data from which everything else is generated.
    let prover_setup = ProverSetup::from(&public_parameters); // This largely is just a reference to `PublicParameters`, but also contains a blitzar handle, which takes significant computation to obtain.
    let verifier_setup = VerifierSetup::from(&public_parameters); // This can be stored on disc, and contains only the digest of `PublicParameters` that is needed to do verification.
    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3); // This is essentially just a tuple `(&ProverSetup, sigma)`
    let dory_verifier_setup = DoryVerifierPublicSetup::new(&verifier_setup, 3); // This is essentially just a tuple `(&VerifierSetup, sigma)`
```

In order to achieve this, several changes were needed:
* The `CommitmentEvaluationProof::ProverPublicSetup` and `CommitmentEvaluationProof::VerifierPublicSetup` have lifetime generics added because `DoryProverPublicSetup` and `DoryVerifierPublicSetup` now have lifetime generics.
* `rand` and `from` methods are removed in some places to enforce the above flow.
* Tests are refactored. This is the majority of the LOC.

# Are these changes tested?

They are tested by existing tests.