### PR TITLE
feat: generalize `count_exprs` and `result_exprs` in `GroupByExpr`

### DIFF
--- a/crates/proof-of-sql/src/sql/ast/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/aggregate_expr.rs
@@ -17,8 +17,8 @@ use std::collections::HashSet;
 /// Currently it doesn't do much since aggregation logic is implemented elsewhere
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AggregateExpr<C: Commitment> {
-    op: AggregationOperator,
-    expr: Box<ProvableExprPlan<C>>,
+    pub(crate) op: AggregationOperator,
+    pub(crate) expr: Box<ProvableExprPlan<C>>,
 }
 
 impl<C: Commitment> AggregateExpr<C> {

--- a/crates/proof-of-sql/src/sql/ast/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/ast/test_utility.rs
@@ -254,17 +254,29 @@ pub fn sum_expr<C: Commitment>(
     }
 }
 
+pub fn count_expr<C: Commitment>(
+    expr: ProvableExprPlan<C>,
+    alias: &str,
+) -> AliasedProvableExprPlan<C> {
+    AliasedProvableExprPlan {
+        expr: ProvableExprPlan::new_aggregate(AggregationOperator::Count, expr),
+        alias: alias.parse().unwrap(),
+    }
+}
+
 pub fn group_by<C: Commitment>(
     group_by_exprs: Vec<ColumnExpr<C>>,
-    sum_expr: Vec<AliasedProvableExprPlan<C>>,
-    count_alias: &str,
+    result_exprs: Vec<AliasedProvableExprPlan<C>>,
+    sum_exprs: Vec<AliasedProvableExprPlan<C>>,
+    count_exprs: Vec<AliasedProvableExprPlan<C>>,
     table: TableExpr,
     where_clause: ProvableExprPlan<C>,
 ) -> ProofPlan<C> {
     ProofPlan::GroupBy(GroupByExpr::new(
         group_by_exprs,
-        sum_expr,
-        count_alias.parse().unwrap(),
+        result_exprs,
+        sum_exprs,
+        count_exprs,
         table,
         where_clause,
     ))

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -29,11 +29,13 @@ impl<C: Commitment> EnrichedExpr<C> {
     pub fn new(
         expression: AliasedResultExpr,
         column_mapping: HashMap<Identifier, ColumnRef>,
+        allow_aggregates: bool,
     ) -> Self {
-        // TODO: Using new_agg (ironically) disables aggregations in `QueryExpr` for now.
-        // Re-enable aggregations when we add `GroupByExpr` generalizations.
-        let res_provable_expr_plan =
-            ProvableExprPlanBuilder::new_agg(&column_mapping).build(&expression.expr);
+        let res_provable_expr_plan = if allow_aggregates {
+            ProvableExprPlanBuilder::new(&column_mapping).build(&expression.expr)
+        } else {
+            ProvableExprPlanBuilder::new_agg(&column_mapping).build(&expression.expr)
+        };
         match res_provable_expr_plan {
             Ok(provable_expr_plan) => {
                 let alias = expression.alias;

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -140,19 +140,11 @@ impl<'a> QueryContextBuilder<'a> {
 
     //TODO: Actually support multicolumn expressions
     fn visit_wildcard_expr(&mut self, expr: &mut Expression) -> ConversionResult<ColumnType> {
-        let (col_name, col_type) = match self.context.get_any_result_column_ref() {
-            Some((name, col_type)) => (name, col_type),
-            None => self.lookup_schema().into_iter().next().unwrap(),
-        };
-
-        // Replace `count(*)` with `count(col_name)` to overcome limitations in Polars.
-        *expr = Expression::Column(col_name);
-
-        // Visit the column to ensure its inclusion in the result column set.
-        self.visit_column_expr(expr)?;
+        // Replace `count(*)` with `count(1)` to overcome limitations in Polars.
+        *expr = Expression::Literal(Literal::BigInt(1));
 
         // Return the column type
-        Ok(col_type)
+        Ok(ColumnType::BigInt)
     }
 
     fn visit_column_expr(&mut self, expr: &mut Expression) -> ConversionResult<ColumnType> {

--- a/crates/proof-of-sql/src/sql/parse/query_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr.rs
@@ -59,6 +59,7 @@ impl<C: Commitment> QueryExpr<C> {
                 .build()?,
         };
         let result_aliased_exprs = context.get_aliased_result_exprs()?;
+        let column_mapping = context.get_column_mapping();
         let group_by = context.get_group_by_exprs();
         if !group_by.is_empty() {
             if let Some(group_by_expr) = Option::<GroupByExpr<C>>::try_from(&context)? {
@@ -72,10 +73,11 @@ impl<C: Commitment> QueryExpr<C> {
                 });
             }
         }
-        let column_mapping = context.get_column_mapping();
         let enriched_exprs = result_aliased_exprs
             .iter()
-            .map(|aliased_expr| EnrichedExpr::new(aliased_expr.clone(), column_mapping.clone()))
+            .map(|aliased_expr| {
+                EnrichedExpr::new(aliased_expr.clone(), column_mapping.clone(), false)
+            })
             .collect::<Vec<_>>();
         let select_exprs = enriched_exprs
             .iter()

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1115,8 +1115,13 @@ fn we_can_do_provable_group_by() {
     let expected_ast = QueryExpr::new(
         group_by(
             cols_expr(t, &["department"], &accessor),
+            vec![
+                aliased_plan(column(t, "department", &accessor), "department"),
+                sum_expr(column(t, "salary", &accessor), "total_salary"),
+                count_expr(const_bigint(1), "num_employee"),
+            ],
             vec![sum_expr(column(t, "salary", &accessor), "total_salary")],
-            "num_employee",
+            vec![count_expr(const_bigint(1), "num_employee")],
             tab(t),
             const_bool(true),
         ),
@@ -1149,8 +1154,12 @@ fn we_can_do_provable_group_by_without_sum() {
     let expected_ast = QueryExpr::new(
         group_by(
             cols_expr(t, &["department"], &accessor),
+            vec![
+                aliased_plan(column(t, "department", &accessor), "department"),
+                count_expr(const_bigint(1), "num_employee"),
+            ],
             vec![],
-            "num_employee",
+            vec![count_expr(const_bigint(1), "num_employee")],
             tab(t),
             const_bool(true),
         ),
@@ -1183,8 +1192,14 @@ fn we_can_do_provable_group_by_with_two_group_by_columns() {
     let expected_ast = QueryExpr::new(
         group_by(
             cols_expr(t, &["state", "department"], &accessor),
+            vec![
+                aliased_plan(column(t, "state", &accessor), "state"),
+                aliased_plan(column(t, "department", &accessor), "department"),
+                sum_expr(column(t, "salary", &accessor), "total_salary"),
+                count_expr(const_bigint(1), "num_employee"),
+            ],
             vec![sum_expr(column(t, "salary", &accessor), "total_salary")],
-            "num_employee",
+            vec![count_expr(const_bigint(1), "num_employee")],
             tab(t),
             const_bool(true),
         ),
@@ -1220,10 +1235,16 @@ fn we_can_do_provable_group_by_with_two_sums_and_dense_filter() {
         group_by(
             cols_expr(t, &["department"], &accessor),
             vec![
+                aliased_plan(column(t, "department", &accessor), "department"),
+                sum_expr(column(t, "salary", &accessor), "total_salary"),
+                sum_expr(column(t, "tax", &accessor), "total_tax"),
+                count_expr(const_bigint(1), "num_employee"),
+            ],
+            vec![
                 sum_expr(column(t, "salary", &accessor), "total_salary"),
                 sum_expr(column(t, "tax", &accessor), "total_tax"),
             ],
-            "num_employee",
+            vec![count_expr(const_bigint(1), "num_employee")],
             tab(t),
             lte(column(t, "tax", &accessor), const_bigint(1)),
         ),

--- a/crates/proof-of-sql/src/sql/proof/indexes.rs
+++ b/crates/proof-of-sql/src/sql/proof/indexes.rs
@@ -3,7 +3,7 @@ use core::ops::Range;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 /// Indexes of a table for use in the ProvableQueryResult
 pub enum Indexes {
     /// Sparse indexes. (i.e. explicitly specified indexes)

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// An intermediate form of a query result that can be transformed
 /// to either the finalized query result form or a query error
-#[derive(Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ProvableQueryResult {
     num_columns: u64,
     indexes: Indexes,
@@ -84,6 +84,8 @@ impl ProvableQueryResult {
         table_length: usize,
         column_result_fields: &[ColumnField],
     ) -> Result<Vec<S>, QueryError> {
+        dbg!(self.num_columns);
+        dbg!(column_result_fields);
         assert_eq!(self.num_columns as usize, column_result_fields.len());
 
         if !self.indexes.valid(table_length) {
@@ -198,6 +200,8 @@ impl ProvableQueryResult {
         )?;
 
         assert_eq!(offset, self.data.len());
+        println!("Owned Table: {:?}", owned_table);
+        println!("Provable Query Result: {:?}", self);
         assert_eq!(owned_table.num_columns(), self.num_columns());
 
         Ok(owned_table)

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -273,6 +273,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         // perform the evaluation check of the sumcheck polynomial
         if builder.sumcheck_evaluation() != subclaim.expected_evaluation {
+            dbg!(builder.sumcheck_evaluation());
+            dbg!(subclaim.expected_evaluation);
             Err(ProofError::VerificationError(
                 "sumcheck evaluation check failed",
             ))?;
@@ -307,6 +309,12 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     }
 
     fn validate_sizes(&self, counts: &ProofCounts, result: &ProvableQueryResult) -> bool {
+        dbg!(result.num_columns());
+        dbg!(counts.result_columns);
+        dbg!(self.commitments.num_commitments());
+        dbg!(counts.intermediate_mles);
+        dbg!(self.pre_result_mle_evaluations.len());
+        dbg!(counts.intermediate_mles + counts.anchored_mles);
         result.num_columns() == counts.result_columns
             && self.commitments.num_commitments() == counts.intermediate_mles
             && self.pre_result_mle_evaluations.len()

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -24,6 +24,7 @@ pub fn exercise_verification(
     accessor: &impl TestAccessor<RistrettoPoint>,
     table_ref: TableRef,
 ) {
+    dbg!(&res.verify(expr, accessor, &()).err());
     assert!(res.verify(expr, accessor, &()).is_ok());
 
     // try changing the result

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -533,7 +533,6 @@ fn we_can_prove_a_minimal_group_by_query_with_curve25519() {
 }
 
 #[test]
-#[cfg(feature = "blitzar")]
 fn we_can_prove_a_basic_group_by_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(


### PR DESCRIPTION
# Rationale for this change
This PR further generalizes `GroupByExpr`.
Note that we should do a final generalization that allows queries such as `select a + b + count(c) + sum(d) as res from tab where f > 3 group by a, b`
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
1. There can be multiple or none `count` in a provable GROUP BY clause
2. Result expressions can be arbitrary combinations of columns in the GROUP BY clause.

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
