### PR TITLE
feat: time unit try from string

### DIFF
--- a/crates/proof-of-sql-parser/src/error.rs
+++ b/crates/proof-of-sql-parser/src/error.rs
@@ -48,6 +48,11 @@ pub enum PoSQLTimestampError {
     /// Represents a catch-all for parsing errors not specifically covered by other variants.
     #[error("Timestamp parsing error: {0}")]
     ParsingError(String),
+
+    /// Represents a failure to parse a provided time unit precision value, PoSQL supports
+    /// Seconds, Milliseconds, Microseconds, and Nanoseconds
+    #[error("Timestamp parsing error: {0}")]
+    UnsupportedPrecision(String),
 }
 
 // This exists because TryFrom<DataType> for ColumnType error is String

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -67,12 +67,61 @@ impl fmt::Display for PoSQLTimeUnit {
 #[cfg(test)]
 #[allow(deprecated)]
 mod time_unit_tests {
-
-    use crate::{
-        error::PoSQLTimestampError,
-        posql_time::{timestamp::PoSQLTimestamp, unit::PoSQLTimeUnit},
-    };
+    use super::*;
+    use crate::{error::PoSQLTimestampError, posql_time::timestamp::PoSQLTimestamp};
     use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn test_valid_precisions() {
+        assert_eq!(PoSQLTimeUnit::try_from("0"), Ok(PoSQLTimeUnit::Second));
+        assert_eq!(PoSQLTimeUnit::try_from("3"), Ok(PoSQLTimeUnit::Millisecond));
+        assert_eq!(PoSQLTimeUnit::try_from("6"), Ok(PoSQLTimeUnit::Microsecond));
+        assert_eq!(PoSQLTimeUnit::try_from("9"), Ok(PoSQLTimeUnit::Nanosecond));
+    }
+
+    #[test]
+    fn test_invalid_precisions() {
+        // Test some random incorrect values
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("1"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "1")
+        );
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("2"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "2")
+        );
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("4"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "4")
+        );
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("5"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "5")
+        );
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("7"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "7")
+        );
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("8"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "8")
+        );
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("10"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "10")
+        );
+        // Non-numeric strings
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("abc"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "abc")
+        );
+        // Empty string
+        assert!(
+            matches!(PoSQLTimeUnit::try_from(""), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x.is_empty())
+        );
+    }
+
+    #[test]
+    fn test_edge_cases_with_non_numeric_inputs() {
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("zero"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "zero")
+        );
+        assert!(
+            matches!(PoSQLTimeUnit::try_from("three"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "three")
+        );
+    }
 
     #[test]
     fn test_invalid_precision() {

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -83,6 +83,9 @@ mod time_unit_tests {
     fn test_invalid_precisions() {
         // Test some random incorrect values
         assert!(
+            matches!(PoSQLTimeUnit::try_from("-1"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "-1")
+        );
+        assert!(
             matches!(PoSQLTimeUnit::try_from("1"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "1")
         );
         assert!(

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -80,62 +80,16 @@ mod time_unit_tests {
     }
 
     #[test]
-    fn test_invalid_precisions() {
-        // Test some random incorrect values
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("-1"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "-1")
-        );
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("1"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "1")
-        );
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("2"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "2")
-        );
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("4"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "4")
-        );
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("5"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "5")
-        );
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("7"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "7")
-        );
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("8"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "8")
-        );
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("10"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "10")
-        );
-        // Non-numeric strings
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("abc"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "abc")
-        );
-        // Empty string
-        assert!(
-            matches!(PoSQLTimeUnit::try_from(""), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x.is_empty())
-        );
-    }
-
-    #[test]
-    fn test_edge_cases_with_non_numeric_inputs() {
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("zero"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "zero")
-        );
-        assert!(
-            matches!(PoSQLTimeUnit::try_from("three"), Err(PoSQLTimestampError::UnsupportedPrecision(x)) if x == "three")
-        );
-    }
-
-    #[test]
     fn test_invalid_precision() {
-        let invalid_precisions = ["1", "2", "4", "5", "7", "8", "10"]; // Testing various invalid inputs
+        let invalid_precisions = [
+            "1", "2", "4", "5", "7", "8", "10", "zero", "three", "cat", "-1", "-2",
+        ]; // Testing all your various invalid inputs
         for &value in invalid_precisions.iter() {
             let result = PoSQLTimeUnit::try_from(value);
-            assert!(
-                matches!(result, Err(PoSQLTimestampError::UnsupportedPrecision(err)) if err == *value),
-                "Failed with value: {}",
-                value
-            );
+            assert!(matches!(
+                result,
+                Err(PoSQLTimestampError::UnsupportedPrecision(_))
+            ));
         }
     }
 

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -505,10 +505,12 @@ mod tests {
 
     #[test]
     fn we_can_deserialize_columns_from_valid_strings() {
-        let expected_column_type = ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
-        let deserialized: ColumnType = serde_json::from_str(r#"{"TimestampTZ":["Second","Utc"]}"#).unwrap();
+        let expected_column_type =
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
+        let deserialized: ColumnType =
+            serde_json::from_str(r#"{"TimestampTZ":["Second","Utc"]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
-        
+
         let expected_column_type = ColumnType::Boolean;
         let deserialized: ColumnType = serde_json::from_str(r#""Boolean""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
@@ -660,7 +662,8 @@ mod tests {
         let deserialized: Result<ColumnType, _> = serde_json::from_str(r#""DecImal75""#);
         assert!(deserialized.is_err());
 
-        let deserialized: Result<ColumnType, _> = serde_json::from_str(r#"{"TimestampTZ":["Utc","Second"]}"#);
+        let deserialized: Result<ColumnType, _> =
+            serde_json::from_str(r#"{"TimestampTZ":["Utc","Second"]}"#);
         assert!(deserialized.is_err());
 
         let deserialized: Result<ColumnType, _> = serde_json::from_str(r#""Varchar""#);

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -380,10 +380,9 @@ impl std::fmt::Display for ColumnType {
             }
             ColumnType::VarChar => write!(f, "VARCHAR"),
             ColumnType::Scalar => write!(f, "SCALAR"),
-            ColumnType::TimestampTZ(timeunit, timezone) => write!(
-                f,
-                "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone})"
-            ),
+            ColumnType::TimestampTZ(timeunit, timezone) => {
+                write!(f, "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone})")
+            }
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -382,8 +382,7 @@ impl std::fmt::Display for ColumnType {
             ColumnType::Scalar => write!(f, "SCALAR"),
             ColumnType::TimestampTZ(timeunit, timezone) => write!(
                 f,
-                "TIMESTAMP(TIMEUNIT: {:?}, TIMEZONE: {timeunit})",
-                timezone
+                "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone})"
             ),
         }
     }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -505,6 +505,10 @@ mod tests {
 
     #[test]
     fn we_can_deserialize_columns_from_valid_strings() {
+        let expected_column_type = ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc);
+        let deserialized: ColumnType = serde_json::from_str(r#"{"TimestampTZ":["Second","Utc"]}"#).unwrap();
+        assert_eq!(deserialized, expected_column_type);
+        
         let expected_column_type = ColumnType::Boolean;
         let deserialized: ColumnType = serde_json::from_str(r#""Boolean""#).unwrap();
         assert_eq!(deserialized, expected_column_type);
@@ -654,6 +658,9 @@ mod tests {
         assert!(deserialized.is_err());
 
         let deserialized: Result<ColumnType, _> = serde_json::from_str(r#""DecImal75""#);
+        assert!(deserialized.is_err());
+
+        let deserialized: Result<ColumnType, _> = serde_json::from_str(r#"{"TimestampTZ":["Utc","Second"]}"#);
         assert!(deserialized.is_err());
 
         let deserialized: Result<ColumnType, _> = serde_json::from_str(r#""Varchar""#);


### PR DESCRIPTION
# Rationale for this change

In DDL, a Timestamp column can be instantiated with the following syntax:

```sql
TIMESTAMP(6)
```

where 6 represents millisecond precision. It appears that the gateway by default supports only nanosecond precision on DDL, however if this changes in the future, we will need a way to parse the time unit from a DDL message in proofs-service. This PR contains a simple string parser that allows for selection of a supported precision for timestamp columns. 

# What changes are included in this PR?

- [x] Implements TryFrom &str for TimeUnit
- [x] updates Display implementation for TImestamp column type to fix a backwards print that is occuring:

```
column type TIMESTAMP(TIMEUNIT: UTC, TIMEZONE: NANOSECONDS (PRECISION: 9)) 
``` 

# Are these changes tested?

yes
