### PR TITLE
bench: add Jaeger benchmarks for Dory proof evaluation (PROOF-892)

### DIFF
--- a/crates/proof-of-sql/benches/README.md
+++ b/crates/proof-of-sql/benches/README.md
@@ -8,9 +8,10 @@ To run benchmarks with Jaeger, you need to do the following
     ```bash
     docker run --rm -d --name jaeger -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:latest
     ```
-2. Run the benchmark.
+2. Run a benchmark.
     ```bash
-    cargo bench -p proof-of-sql --bench jaeger_benches
+    cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof
+    cargo bench -p proof-of-sql --bench jaeger_benches Dory --features="test"
     ```
 3. Navigate to http://localhost:16686/ to see the results.
 4. To end the Jaeger service, run

--- a/crates/proof-of-sql/benches/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger_benches.rs
@@ -54,9 +54,9 @@ fn main() {
             let pp =
                 PublicParameters::rand(10, &mut proof_of_sql::proof_primitive::dory::test_rng());
             let ps = ProverSetup::from(&pp);
-            let prover_public_setup = DoryProverPublicSetup::new(&ps, 10);
+            let prover_setup = DoryProverPublicSetup::new(&ps, 10);
             let vs = VerifierSetup::from(&pp);
-            let verifier_public_setup = DoryVerifierPublicSetup::new(&vs, 10);
+            let verifier_setup = DoryVerifierPublicSetup::new(&vs, 10);
 
             for _ in 0..3 {
                 for (title, query, columns) in QUERIES.iter() {


### PR DESCRIPTION
# Rationale for this change
In order to run benchmarks easily on Dory proof evaluation performance, this PR adds a new benchmark type to `jaeger_benches`. An argument is added to the command line interface to define the benchmark type. 

Previously, the Jaeger benchmarks were only run on the inner product proof with the command:
`cargo bench -p proof-of-sql --bench jaeger_benches`
which has been updated to
`cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof`.

The Dory proof evaluation benchmark can be run with
`cargo bench -p proof-of-sql --bench jaeger_benches Dory features="test"`.

# What changes are included in this PR?
- A Jaeger benchmark is added for Dory.
- A command line argument is added to specify which benchmark to run: `InnerProductProof` or `Dory --features="test"`

# Are these changes tested?
Yes
