### PR TITLE
feat: add `SelectExpr` and `PostprocessingEvaluator`

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -56,6 +56,23 @@ impl<S: Scalar> OwnedColumn<S> {
         }
     }
 
+    /// Returns element at index as scalar
+    ///
+    /// Note that if index is out of bounds, this function will return None
+    pub(crate) fn scalar_at(&self, index: usize) -> Option<S> {
+        (index < self.len()).then_some(match self {
+            Self::Boolean(col) => S::from(col[index]),
+            Self::SmallInt(col) => S::from(col[index]),
+            Self::Int(col) => S::from(col[index]),
+            Self::BigInt(col) => S::from(col[index]),
+            Self::Int128(col) => S::from(col[index]),
+            Self::Scalar(col) => col[index],
+            Self::Decimal75(_, _, col) => col[index],
+            Self::VarChar(col) => S::from(col[index]),
+            Self::TimestampTZ(_, _, col) => S::from(col[index]),
+        })
+    }
+
     /// Returns the column with its entries permutated
     pub fn try_permute(&self, permutation: &Permutation) -> Result<Self, PermutationError> {
         Ok(match self {
@@ -209,7 +226,7 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
                 OwnedColumn::Int(col) => col[i].cmp(&col[j]),
                 OwnedColumn::BigInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::Int128(col) => col[i].cmp(&col[j]),
-                OwnedColumn::Decimal75(_, _, col) => col[i].cmp(&col[j]),
+                OwnedColumn::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
                 OwnedColumn::Scalar(col) => col[i].cmp(&col[j]),
                 OwnedColumn::VarChar(col) => col[i].cmp(&col[j]),
                 OwnedColumn::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),

--- a/crates/proof-of-sql/src/sql/ast/mod.rs
+++ b/crates/proof-of-sql/src/sql/ast/mod.rs
@@ -75,8 +75,9 @@ pub(crate) use comparison_util::scale_and_subtract;
 
 mod numerical_util;
 pub(crate) use numerical_util::{
-    add_subtract_columns, multiply_columns, scale_and_add_subtract_eval,
-    try_add_subtract_column_types, try_multiply_column_types,
+    add_subtract_columns, add_subtract_owned_columns, divide_owned_columns, multiply_columns,
+    multiply_owned_columns, scale_and_add_subtract_eval, try_add_subtract_column_types,
+    try_divide_column_types, try_multiply_column_types,
 };
 
 mod equals_expr;

--- a/crates/proof-of-sql/src/sql/postprocessing/error.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/error.rs
@@ -9,6 +9,12 @@ pub enum PostprocessingError {
     /// Column not found
     #[error("Column not found: {0}")]
     ColumnNotFound(String),
+    /// Errors related to decimal operations
+    #[error(transparent)]
+    DecimalConversionError(#[from] crate::base::math::decimal::DecimalError),
+    /// Unsupported operation
+    #[error("Unsupported operation: {0}")]
+    Unsupported(String),
 }
 
 /// Result type for postprocessing

--- a/crates/proof-of-sql/src/sql/postprocessing/evaluate.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/evaluate.rs
@@ -1,0 +1,270 @@
+use super::PostprocessingError;
+use crate::{
+    base::{
+        commitment::Commitment,
+        database::{ColumnRef, LiteralValue},
+        math::decimal::{try_into_to_scalar, DecimalError::InvalidPrecision, Precision},
+    },
+    sql::{
+        ast::{
+            add_subtract_owned_columns, divide_owned_columns, multiply_owned_columns, ColumnExpr,
+            ProvableExpr, ProvableExprPlan,
+        },
+        parse::PostprocessingError::DecimalPostprocessingError,
+    },
+};
+use proof_of_sql_parser::{
+    intermediate_ast::{AggregationOperator, BinaryOperator, Expression, Literal, UnaryOperator},
+    Identifier,
+};
+use std::collections::HashMap;
+
+/// Evaluator that evaluates a `proof_of_sql_parser::intermediate_ast::Expression`
+/// on an `OwnedTable` and returns an `OwnedColumn`.
+pub struct PostprocessingEvaluator<S: Scalar> {
+    table: OwnedTable<S>,
+    in_agg_scope: bool,
+}
+
+impl<'a> PostprocessingEvaluator<'a> {
+    /// Creates a new `PostprocessingEvaluator` with the given column mapping.
+    pub fn new(table: OwnedTable<S>) -> Self {
+        Self {
+            table,
+            in_agg_scope: false,
+        }
+    }
+    /// Creates a new `PostprocessingEvaluator` with the given column mapping and within aggregation scope.
+    pub(crate) fn new_agg(table: OwnedTable<S>) -> Self {
+        Self {
+            table,
+            in_agg_scope: true,
+        }
+    }
+    /// Builds a `proofs::sql::ast::ProvableExprPlan` from a `proof_of_sql_parser::intermediate_ast::Expression`
+    pub fn build<S: Scalar>(
+        &self,
+        expr: &Expression,
+    ) -> Result<OwnedColumn<S>, PostprocessingError> {
+        self.visit_expr(expr)
+    }
+}
+
+// Private interface
+impl PostprocessingEvaluator<'_> {
+    fn visit_expr<S: Scalar>(
+        &self,
+        expr: &Expression,
+    ) -> Result<OwnedColumn<S>, PostprocessingError> {
+        match expr {
+            Expression::Column(identifier) => self.visit_column(*identifier),
+            Expression::Literal(lit) => self.visit_literal(lit),
+            Expression::Binary { op, left, right } => self.visit_binary_expr(*op, left, right),
+            Expression::Unary { op, expr } => self.visit_unary_expr(*op, expr),
+            _ => Err(PostprocessingError::Unsupported(format!(
+                "Expression {:?} is not supported yet",
+                expr
+            ))),
+        }
+    }
+
+    fn visit_column<S: Scalar>(
+        &self,
+        identifier: Identifier,
+    ) -> Result<OwnedColumn<S>, PostprocessingError> {
+        Ok(self
+            .table
+            .inner_table()
+            .get(&identifier)
+            .ok_or(PostprocessingError::ColumnNotFound(identifier.to_string()))?)
+    }
+
+    fn visit_literal<S: Scalar>(
+        &self,
+        lit: &Literal,
+    ) -> Result<OwnedColumn<S>, PostprocessingError> {
+        let len = self.table.num_rows();
+        match lit {
+            Literal::Boolean(b) => Ok(OwnedColumn::Boolean(vec![*b; len])),
+            Literal::BigInt(i) => Ok(OwnedColumn::BigInt(vec![*i; len])),
+            Literal::Int128(i) => Ok(OwnedColumn::Int128(vec![*i; len])),
+            Literal::Decimal(d) => {
+                let scale = d.scale();
+                let precision = Precision::new(d.precision())?;
+                let scalar = try_into_to_scalar(d, precision, scale)?;
+                Ok(OwnedColumn::Decimal75(precision, scale, vec![scalar; len]))
+            }
+            Literal::VarChar(s) => Ok(OwnedColumn::VarChar(vec![s.clone(); len])),
+            Literal::Timestamp(its) => Ok(OwnedColumn::Timestamp(
+                its.timeunit,
+                its.timezone,
+                vec![its.timestamp.timestamp(); len],
+            )),
+        }
+    }
+
+    fn visit_unary_expr<S: Scalar>(
+        &self,
+        op: UnaryOperator,
+        expr: &Expression,
+    ) -> Result<OwnedColumn<S>, PostprocessingError> {
+        let column = self.visit_expr(expr)?;
+        match op {
+            UnaryOperator::Not => {
+                if column.data_type() == &DataType::Boolean {
+                    Ok(OwnedColumn::Boolean(
+                        column.into_iter().map(|b| !b).collect(),
+                    ))
+                } else {
+                    Err(PostprocessingError::InvalidExpression(
+                        "Unary operator NOT is only valid for boolean expressions".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+
+    fn visit_binary_expr<S: Scalar>(
+        &self,
+        op: BinaryOperator,
+        left: &Expression,
+        right: &Expression,
+    ) -> Result<OwnedColumn<S>, PostprocessingError> {
+        let left = self.visit_expr(left?);
+        let right = self.visit_expr(right?);
+        check_dtypes(left.data_type(), right.data_type(), op)?;
+        match op {
+            BinaryOperator::And => Ok(OwnedColumn::Boolean(
+                left.into_iter()
+                    .zip(right.into_iter())
+                    .map(|(l, r)| l && r)
+                    .collect(),
+            )),
+            BinaryOperator::Or => Ok(OwnedColumn::Boolean(
+                left.into_iter()
+                    .zip(right.into_iter())
+                    .map(|(l, r)| l || r)
+                    .collect(),
+            )),
+            BinaryOperator::Equal
+            | BinaryOperator::GreaterThanOrEqual
+            | BinaryOperator::LessThanOrEqual => {
+                let left_scale = left.data_type().scale();
+                let right_scale = right.data_type().scale();
+                let max_scale = left_scale.max(right_scale);
+                let lhs_upscale_factor =
+                    scale_scalar(S::ONE, max_scale - lhs_scale).expect("Invalid scale factor");
+                let rhs_upscale_factor =
+                    scale_scalar(S::ONE, max_scale - rhs_scale).expect("Invalid scale factor");
+                match op {
+                    BinaryOperator::Equal => {
+                        let res: Vec<bool> = (0..lhs_len)
+                            .map(|i| {
+                                lhs.scalar_at(i) * lhs_upscale_factor
+                                    == rhs.scalar_at(i) * rhs_upscale_factor
+                            })
+                            .collect();
+                        OwnedColumn::Boolean(res)
+                    }
+                    BinaryOperator::GreaterThanOrEqual => {
+                        let res: Vec<bool> = (0..lhs_len)
+                            .map(|i| {
+                                lhs.scalar_at(i)
+                                    * lhs_upscale_factor
+                                        .signed_cmp(rhs.scalar_at(i) * rhs_upscale_factor)
+                                    != Ordering::Less
+                            })
+                            .collect();
+                        OwnedColumn::Boolean(res)
+                    }
+                    BinaryOperator::LessThanOrEqual => {
+                        let res: Vec<bool> = (0..lhs_len)
+                            .map(|i| {
+                                lhs.scalar_at(i)
+                                    * lhs_upscale_factor
+                                        .signed_cmp(rhs.scalar_at(i) * rhs_upscale_factor)
+                                    != Ordering::Greater
+                            })
+                            .collect();
+                        OwnedColumn::Boolean(res)
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            BinaryOperator::Add => add_subtract_owned_columns(left, right, false),
+            BinaryOperator::Subtract => add_subtract_owned_columns(left, right, true),
+            BinaryOperator::Multiply => multiply_owned_columns(left, right),
+            BinaryOperator::Division => divide_owned_columns(left, right),
+        }
+    }
+}
+
+/// If the two column types are compatible for a binary operation, return the result type.
+/// Otherwise, return None.
+pub(crate) fn get_binary_operation_result_type(
+    left_dtype: &ColumnType,
+    right_dtype: &ColumnType,
+    binary_operator: BinaryOperator,
+) -> Option<ColumnType> {
+    match binary_operator {
+        BinaryOperator::And | BinaryOperator::Or => matches!(
+            (left_dtype, right_dtype),
+            (ColumnType::Boolean, ColumnType::Boolean)
+        )
+        .then_some(ColumnType::Boolean),
+        BinaryOperator::Equal => {
+            matches!(
+                (left_dtype, right_dtype),
+                (ColumnType::VarChar, ColumnType::VarChar)
+                    | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
+                    | (ColumnType::Boolean, ColumnType::Boolean)
+                    | (_, ColumnType::Scalar)
+                    | (ColumnType::Scalar, _)
+            ) || (left_dtype.is_numeric() && right_dtype.is_numeric())
+                .then_some(ColumnType::Boolean)
+        }
+        BinaryOperator::GreaterThanOrEqual | BinaryOperator::LessThanOrEqual => {
+            if left_dtype == &ColumnType::VarChar || right_dtype == &ColumnType::VarChar {
+                return None;
+            }
+            // Due to constraints in bitwise_verification we limit the precision of decimal types to 38
+            if let ColumnType::Decimal75(precision, _) = left_dtype {
+                if precision.value() > 38 {
+                    return None;
+                }
+            }
+            if let ColumnType::Decimal75(precision, _) = right_dtype {
+                if precision.value() > 38 {
+                    return None;
+                }
+            }
+            // TODO: inequality support for timestamps
+            left_dtype.is_numeric() && right_dtype.is_numeric()
+                || matches!(
+                    (left_dtype, right_dtype),
+                    (ColumnType::Boolean, ColumnType::Boolean)
+                )
+                .then_some(ColumnType::Boolean)
+        }
+        BinaryOperator::Add | BinaryOperator::Subtract => {
+            try_add_subtract_column_types(*left_dtype, *right_dtype).ok()
+        }
+        BinaryOperator::Multiply => try_multiply_column_types(*left_dtype, *right_dtype).ok(),
+        BinaryOperator::Division => try_divide_column_types(*left_dtype, *right_dtype).ok(),
+    }
+}
+
+fn check_dtypes(
+    left_dtype: ColumnType,
+    right_dtype: ColumnType,
+    binary_operator: BinaryOperator,
+) -> ConversionResult<()> {
+    if type_check_binary_operation(&left_dtype, &right_dtype, binary_operator) {
+        Ok(())
+    } else {
+        Err(ConversionError::DataTypeMismatch(
+            left_dtype.to_string(),
+            right_dtype.to_string(),
+        ))
+    }
+}

--- a/crates/proof-of-sql/src/sql/postprocessing/mod.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/mod.rs
@@ -1,5 +1,9 @@
 //! This module contains new lightweight postprocessing for non-provable components.
 mod error;
+
+mod evaluate;
+pub use evaluate::PostprocessingEvaluator;
+
 #[allow(unused_imports)]
 pub use error::{PostprocessingError, PostprocessingResult};
 mod owned_table_postprocessing;

--- a/crates/proof-of-sql/src/sql/postprocessing/order_by_expr.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/order_by_expr.rs
@@ -26,7 +26,7 @@ impl<S: Scalar> OrderByExpr<S> {
 }
 
 impl<S: Scalar> PostprocessingStep<S> for OrderByExpr<S> {
-    /// Apply the slice transformation to the given `OwnedTable`.
+    /// Apply the ordering transformation to the given `OwnedTable`.
     fn apply(&self, owned_table: OwnedTable<S>) -> PostprocessingResult<OwnedTable<S>> {
         let mut indexes = (0..owned_table.num_rows()).collect::<Vec<_>>();
         // Evaluate the columns by which we order

--- a/crates/proof-of-sql/src/sql/postprocessing/owned_table_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/owned_table_postprocessing.rs
@@ -1,4 +1,4 @@
-use super::{OrderByExpr, PostprocessingResult, PostprocessingStep, SliceExpr};
+use super::{OrderByExpr, PostprocessingResult, PostprocessingStep, SelectExpr, SliceExpr};
 use crate::base::{database::OwnedTable, scalar::Scalar};
 
 /// An enum for nodes that can apply postprocessing to a `OwnedTable`.
@@ -8,6 +8,8 @@ pub enum OwnedTablePostprocessing<S: Scalar> {
     Slice(SliceExpr<S>),
     /// Order the `OwnedTable` with the given `OrderByExpr`.
     OrderBy(OrderByExpr<S>),
+    /// Select the `OwnedTable` with the given `SelectExpr`.
+    Select(SelectExpr<S>),
 }
 
 impl<S: Scalar> PostprocessingStep<S> for OwnedTablePostprocessing<S> {
@@ -16,6 +18,7 @@ impl<S: Scalar> PostprocessingStep<S> for OwnedTablePostprocessing<S> {
         match self {
             OwnedTablePostprocessing::Slice(slice_expr) => slice_expr.apply(owned_table),
             OwnedTablePostprocessing::OrderBy(order_by_expr) => order_by_expr.apply(owned_table),
+            OwnedTablePostprocessing::Select(select_expr) => select_expr.apply(owned_table),
         }
     }
 }
@@ -28,6 +31,10 @@ impl<S: Scalar> OwnedTablePostprocessing<S> {
     /// Create a new `OwnedTablePostprocessing` with the given `OrderByExpr`.
     pub fn new_order_by(order_by_expr: OrderByExpr<S>) -> Self {
         Self::OrderBy(order_by_expr)
+    }
+    /// Create a new `OwnedTablePostprocessing` with the given `SelectExpr`.
+    pub fn new_select(select_expr: SelectExpr<S>) -> Self {
+        Self::Select(select_expr)
     }
 }
 

--- a/crates/proof-of-sql/src/sql/postprocessing/select_expr.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_expr.rs
@@ -1,0 +1,41 @@
+use super::{PostprocessingError, PostprocessingEvaluator, PostprocessingResult, PostprocessingStep};
+use crate::base::{
+    database::{OwnedColumn, OwnedTable},
+    scalar::Scalar,
+};
+use indexmap::IndexMap;
+use proof_of_sql_parser::{Identifier, intermediate_ast::AliasedResultExpr};
+use serde::{Deserialize, Serialize};
+
+/// The select expression used to select, reorder, and apply alias transformations
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SelectExpr<S: Scalar> {
+    /// The aliased result expressions we select
+    aliased_result_exprs: Vec<AliasedResultExpr>,
+    _phantom: core::marker::PhantomData<S>,
+}
+
+impl<S: Scalar> SelectExpr<S> {
+    /// Create a new `SelectExpr` node.
+    pub fn new(aliased_result_exprs: Vec<AliasedResultExpr>) -> Self {
+        Self {
+            aliased_result_exprs,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<S: Scalar> PostprocessingStep<S> for SelectExpr<S> {
+    /// Apply the select transformation to the given `OwnedTable`.
+    fn apply(&self, owned_table: OwnedTable<S>) -> PostprocessingResult<OwnedTable<S>> {
+        let cols: IndexMap<Identifier, OwnedColumn<S>> = self.aliased_result_exprs
+            .iter()
+            .map(|aliased_result_expr| -> PostprocessingResult<(Identifier, OwnedColumn<S>)> {
+                let evaluator = PostprocessingEvaluator::new(owned_table.clone(), false);
+                let result_column = evaluator.build(aliased_result_expr.expr)?;
+                Ok((aliased_result_expr.alias, result_column))
+            })
+            .collect::<PostprocessingResult<_>>()?;
+        OwnedTable::try_new(cols)
+    }
+}

--- a/crates/proof-of-sql/src/sql/postprocessing/select_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_expr_test.rs
@@ -1,0 +1,72 @@
+use crate::{
+    base::{database::owned_table_utility::*, scalar::Curve25519Scalar},
+    sql::postprocessing::{apply_postprocessing_steps, test_utility::*, OwnedTablePostprocessing},
+};
+use proof_of_sql_parser::test_utility::*;
+use rand::{seq::SliceRandom, Rng};
+
+#[test]
+fn we_can_filter_out_owned_table_columns() {
+    let data = owned_table([bigint("c", [-5_i64, 1, -56, 2]), varchar("a", ["d", "a", "f", "b"])]);
+    let plans = cols_expr_plan(&["a"]);
+    let postprocessing: [OwnedTablePostprocessing<Curve25519Scalar>; 1] = [select(&[aliased_col_expr_plan("a")])];
+    let expected_table = owned_table([
+        varchar("a", ["d", "a", "f", "b"]),
+    ]);
+    let actual_table = apply_postprocessing_steps(table, &postprocessing).unwrap();
+    assert_eq!(actual_table, expected_table);
+}
+
+#[test]
+fn we_can_filter_out_owned_table_columns_with_i128_data() {
+    let data = owned_table("c" => [-5_i128, 1, -56, 2], "a" => ["d", "a", "f", "b"]);
+    let plans = aliased_cols_expr_plan(&["a"]);
+    let postprocessing: [OwnedTablePostprocessing<Curve25519Scalar>; 2] = [select(&[aliased_col_expr_plans("a")])];
+    let data = result_expr.transform_results(data).unwrap();
+    let expected_data = owned_table!("a2" => ["d", "a", "f", "b"]);
+    assert_eq!(data, expected_data);
+}
+
+#[test]
+#[should_panic]
+fn result_expr_panics_with_batches_containing_duplicate_columns() {
+    let data = owned_table!("a" => [-5_i64, 1, -56, 2], "a" => [-5_i64, 1, -56, 2]);
+    let result_expr = ResultExpr::new(select(&[col("a").alias("a2"), col("a").alias("a3")]));
+    result_expr.transform_results(data).unwrap();
+}
+
+#[test]
+fn we_can_reorder_the_owned_table_columns_without_changing_their_names() {
+    let data = owned_table!("c" => [-5_i64, 1, -56, 2], "a" => ["d", "a", "f", "b"]);
+    let result_expr = ResultExpr::new(select(&[col("a").alias("a"), col("c").alias("c")]));
+    let data = result_expr.transform_results(data).unwrap();
+    let expected_data = owned_table!("a" => ["d", "a", "f", "b"], "c" => [-5_i64, 1, -56, 2]);
+    assert_eq!(data, expected_data);
+}
+
+#[test]
+fn we_can_remap_the_owned_table_columns_to_different_names() {
+    let data = owned_table!("c" => [-5_i64, 1, -56, 2], "a" => ["d", "a", "f", "b"]);
+    let result_expr = ResultExpr::new(select(&[
+        col("a").alias("b_test"),
+        col("c").alias("col_c_test"),
+    ]));
+    let data = result_expr.transform_results(data).unwrap();
+    let expected_data =
+        owned_table!("b_test" => ["d", "a", "f", "b"], "col_c_test" => [-5_i64, 1, -56, 2]);
+    assert_eq!(data, expected_data);
+}
+
+#[test]
+fn we_can_remap_the_owned_table_columns_to_new_columns() {
+    let data = owned_table!("c" => [-5_i64, 1, -56, 2], "a" => ["d", "a", "f", "b"]);
+    let result_expr = ResultExpr::new(select(&[
+        col("c").alias("abc"),
+        col("a").alias("b_test"),
+        col("a").alias("d2"),
+        col("c").alias("c"),
+    ]));
+    let data = result_expr.transform_results(data).unwrap();
+    let expected_data = owned_table!("abc" => [-5_i64, 1, -56, 2], "b_test" => ["d", "a", "f", "b"], "d2" => ["d", "a", "f", "b"], "c" => [-5_i64, 1, -56, 2]);
+    assert_eq!(data, expected_data);
+}

--- a/crates/proof-of-sql/src/sql/postprocessing/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/test_utility.rs
@@ -2,6 +2,10 @@ use super::*;
 use crate::base::scalar::Scalar;
 use proof_of_sql_parser::intermediate_ast::{OrderBy, OrderByDirection};
 
+pub fn select(result_exprs: &[AliasedResultExpr]) -> OwnedTablePostprocessing<S>  {
+    OwnedTablePostprocessing::<S>::new_select(SelectExpr::new(result_exprs.to_vec()))
+}
+
 pub fn slice<S: Scalar>(limit: Option<u64>, offset: Option<i64>) -> OwnedTablePostprocessing<S> {
     OwnedTablePostprocessing::<S>::new_slice(SliceExpr::new(limit, offset))
 }


### PR DESCRIPTION
# Rationale for this change
Evaluation of `Expression` on `OwnedTable`s is crucial in native Rust postprocessing of not-yet-provable `Expression`. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- add `SelectExpr`
- add `PostprocessingEvaluator`
- add division utils
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Will be.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
