### PR TITLE
feat: permit `;` in parser

### DIFF
--- a/crates/proof-of-sql-parser/src/intermediate_ast_tests.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast_tests.rs
@@ -128,7 +128,7 @@ fn we_cannot_parse_strings_having_incorrect_quotes() {
 #[test]
 fn we_can_parse_a_query_with_constants() {
     let ast =
-        "SELECT 3 as bigint, true as boolean, 'proof' as varchar, -2.34 as decimal FROM SXT_TAB"
+        "SELECT 3 as bigint, true as boolean, 'proof' as varchar, -2.34 as decimal FROM SXT_TAB;"
             .parse::<SelectStatement>()
             .unwrap();
     let expected_ast = select(
@@ -171,7 +171,7 @@ fn we_can_parse_a_query_with_a_column_equals_a_simple_bool() {
 
 #[test]
 fn we_can_parse_a_query_with_a_column_equals_a_simple_integer() {
-    let ast = "SELECT A FROM SXT_TAB WHERE A = 3"
+    let ast = "SELECT A FROM SXT_TAB WHERE A = 3;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -207,7 +207,7 @@ fn we_can_parse_a_query_with_a_column_equals_a_string() {
 
 #[test]
 fn we_can_parse_a_query_with_a_column_equals_a_decimal() {
-    let ast = "SELECT A FROM SXT_TAB WHERE A = -0.32"
+    let ast = "SELECT A FROM SXT_TAB WHERE A = -0.32;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -254,7 +254,7 @@ fn we_can_parse_a_query_with_two_result_columns() {
 //(PROOF-864)
 #[test]
 fn we_can_parse_a_query_using_select_star() {
-    let ast = "SELECT * FROM sxt_Tab WHERE A = -(B)"
+    let ast = "SELECT * FROM sxt_Tab WHERE A = -(B);"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -314,7 +314,7 @@ fn we_can_parse_a_query_using_multiple_select_star_expressions() {
 
 #[test]
 fn we_can_parse_a_query_with_one_equals_filter_having_a_positive_literal() {
-    let ast = "select a, true as boolean from sxt_tab where b = +4"
+    let ast = "select a, true as boolean from sxt_tab where b = +4;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -370,7 +370,7 @@ fn we_can_parse_a_query_with_one_not_equals_filter_expression() {
 
 #[test]
 fn we_can_parse_a_query_with_one_logical_not_filter_expression() {
-    let ast = "select a from sxt_tab where not (b = d + 3)"
+    let ast = "select a from sxt_tab where not (b = d + 3);"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -426,7 +426,7 @@ fn we_can_parse_a_query_with_one_logical_and_filter_expression_with_both_left_an
 
 #[test]
 fn we_can_parse_a_query_with_one_logical_or_filter_expression() {
-    let ast = "select a from sxt_tab where (b = 3) or (c = -2.34)"
+    let ast = "select a from sxt_tab where (b = 3) or (c = -2.34);"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -450,7 +450,7 @@ fn we_can_parse_a_query_with_one_logical_or_filter_expression() {
 
 #[test]
 fn we_can_parse_a_query_with_two_logical_and_not_filter_expressions() {
-    let ast = "select a from sxt_tab where (b = 3) and (not (c = d - 2))"
+    let ast = "select a from sxt_tab where (b = 3) and (not (c = d - 2));"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -510,7 +510,7 @@ fn we_can_parse_a_query_with_the_minimum_i128_value_as_the_equal_filter_literal(
     );
     assert_eq!(ast, expected_ast);
 
-    let ast = "select a from sxt_tab where b = -170141183460469231731687303715884105728"
+    let ast = "select a from sxt_tab where b = -170141183460469231731687303715884105728;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -556,7 +556,7 @@ fn we_can_parse_a_query_with_the_maximum_i128_value_as_the_equal_filter_literal(
 
 #[test]
 fn we_can_parse_a_query_and_rename_a_result_column_using_the_as_keyword() {
-    let ast = "select a as a_rename from sxt_tab where b = 4 + d"
+    let ast = "select a as a_rename from sxt_tab where b = 4 + d;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -592,7 +592,7 @@ fn we_can_parse_a_query_and_rename_a_result_column_without_using_the_as_keyword(
 
 #[test]
 fn we_can_parse_logical_not_with_more_precedence_priority_than_logical_and() {
-    let parsed_ast = "select a from sxt_tab where a = 3 and not b = 2.53"
+    let parsed_ast = "select a from sxt_tab where a = 3 and not b = 2.53;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = "select a from sxt_tab where (a = 3) and (not b = 2.53)"
@@ -624,7 +624,7 @@ fn we_can_parse_logical_and_with_more_precedence_priority_than_logical_or() {
     let ast = "select a from sxt_tab where a = -1 or c = -3 and a = 3"
         .parse::<SelectStatement>()
         .unwrap();
-    let expected_ast = "select a from sxt_tab where a = -1 or (c = -3 and a = 3)"
+    let expected_ast = "select a from sxt_tab where a = -1 or (c = -3 and a = 3);"
         .parse::<SelectStatement>()
         .unwrap();
     assert_eq!(ast, expected_ast);
@@ -665,7 +665,7 @@ fn we_can_parse_logical_or_with_left_associativity() {
 
 #[test]
 fn we_can_parse_a_query_with_one_schema_followed_by_a_table_name() {
-    let ast = "select a from eth.sxt_tab where b <= 4"
+    let ast = "select a from eth.sxt_tab where b <= 4;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -702,7 +702,7 @@ fn we_can_parse_a_query_without_a_filter() {
 
 #[test]
 fn we_can_parse_a_single_order_by_with_ascending_direction_as_default() {
-    let ast = "select a from tab order by x"
+    let ast = "select a from tab order by x;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -733,7 +733,7 @@ fn we_can_parse_a_single_order_by_with_a_filter() {
 
 #[test]
 fn we_can_parse_a_single_order_by_in_the_ascending_direction() {
-    let ast = "select a from tab order by x asc"
+    let ast = "select a from tab order by x asc;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -759,7 +759,7 @@ fn we_can_parse_a_single_order_by_in_the_descending_direction() {
 
 #[test]
 fn we_can_parse_multiple_order_by() {
-    let ast = "select * from tab order by x desc, y, z asc"
+    let ast = "select * from tab order by x desc, y, z asc;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -788,6 +788,16 @@ fn we_cannot_parse_order_by_referencing_reserved_keywords_yet() {
 }
 
 #[test]
+fn we_cannot_parse_queries_with_stray_semicolons() {
+    assert!("select a from tab order by ;x"
+        .parse::<SelectStatement>()
+        .is_err());
+    assert!("select a from ; tab".parse::<SelectStatement>().is_err());
+    assert!("select a from tab;;".parse::<SelectStatement>().is_err());
+    assert!("select a ; from tab;".parse::<SelectStatement>().is_err());
+}
+
+#[test]
 fn we_cannot_parse_invalid_order_by_expressions() {
     assert!("select a from tab order by x y"
         .parse::<SelectStatement>()
@@ -805,7 +815,7 @@ fn we_cannot_parse_invalid_order_by_expressions() {
 
 #[test]
 fn we_cannot_parse_a_query_with_two_schemas_followed_by_a_table_name() {
-    assert!("select a from schema.Identifier.tab"
+    assert!("select a from schema.Identifier.tab;"
         .parse::<SelectStatement>()
         .is_err());
 }
@@ -836,13 +846,13 @@ fn we_cannot_parse_a_query_with_select_tablename_followed_by_star() {
 #[test]
 fn we_cannot_parse_a_query_with_schemas_followed_by_column_and_table_names() {
     assert!("select tab.a from tab".parse::<SelectStatement>().is_err());
-    assert!("select tab.a from eth.tab"
+    assert!("select tab.a from eth.tab;"
         .parse::<SelectStatement>()
         .is_err());
     assert!("select eth.tab.a from eth.tab"
         .parse::<SelectStatement>()
         .is_err());
-    assert!("select a from eth.tab where tab.b = 3"
+    assert!("select a from eth.tab where tab.b = 3;"
         .parse::<SelectStatement>()
         .is_err());
 }
@@ -850,13 +860,6 @@ fn we_cannot_parse_a_query_with_schemas_followed_by_column_and_table_names() {
 #[test]
 fn we_cannot_parse_a_query_with_a_subquery() {
     assert!("select a from (select a from tab where b = 4)"
-        .parse::<SelectStatement>()
-        .is_err());
-}
-
-#[test]
-fn we_cannot_parse_a_query_ending_with_a_semicolon() {
-    assert!("select a from tab where b = 3;"
         .parse::<SelectStatement>()
         .is_err());
 }
@@ -883,7 +886,7 @@ fn we_cannot_parse_a_query_having_a_negative_limit_clause() {
 
 #[test]
 fn we_can_parse_a_query_having_a_simple_offset_clause() {
-    let ast = "select a from tab offset 3"
+    let ast = "select a from tab offset 3;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -896,7 +899,7 @@ fn we_can_parse_a_query_having_a_simple_offset_clause() {
 
 #[test]
 fn we_can_parse_a_query_having_a_negative_offset_clause() {
-    let ast = "select a from tab offset -3"
+    let ast = "select a from tab offset -3;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -909,7 +912,7 @@ fn we_can_parse_a_query_having_a_negative_offset_clause() {
 
 #[test]
 fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause() {
-    let ast = "select a from tab limit 55 offset 3"
+    let ast = "select a from tab limit 55 offset 3;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -919,7 +922,7 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause() {
     );
     assert_eq!(ast, expected_ast);
 
-    let ast = "select a from tab offset 3 limit 55"
+    let ast = "select a from tab offset 3 limit 55;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -933,7 +936,7 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause() {
 #[test]
 fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_where_expr_and_order_by(
 ) {
-    let ast = "select a from tab where a = 3 order by a limit 55 offset 3"
+    let ast = "select a from tab where a = 3 order by a limit 55 offset 3;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -952,9 +955,11 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_wher
 #[test]
 fn we_cannot_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_where_expr_but_followed_by_order_by(
 ) {
-    assert!("select a from tab where a = 3 limit 55 offset 3 order by a"
-        .parse::<SelectStatement>()
-        .is_err());
+    assert!(
+        "select a from tab where a = 3 limit 55 offset 3 order by a;"
+            .parse::<SelectStatement>()
+            .is_err()
+    );
 }
 
 #[test]
@@ -977,7 +982,7 @@ fn we_can_parse_a_query_with_filter_ge() {
 
 #[test]
 fn we_can_parse_a_query_with_filter_lt() {
-    let ast = "select a from tab where b < 4"
+    let ast = "select a from tab where b < 4;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -1013,7 +1018,7 @@ fn we_can_parse_a_query_with_filter_le() {
 
 #[test]
 fn we_can_parse_a_query_with_filter_gt() {
-    let ast = "select a from tab where b > 4"
+    let ast = "select a from tab where b > 4;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -1032,7 +1037,7 @@ fn we_can_parse_a_query_with_filter_gt() {
 #[test]
 fn we_cannot_parse_a_query_with_inner_join_keyword() {
     assert!(
-        "select tab1.a from tab1 join tab2 on tab1.c = tab2.c where tab2.b > 4"
+        "select tab1.a from tab1 join tab2 on tab1.c = tab2.c where tab2.b > 4;"
             .parse::<SelectStatement>()
             .is_err()
     );
@@ -1042,7 +1047,7 @@ fn we_cannot_parse_a_query_with_inner_join_keyword() {
 #[test]
 fn we_cannot_parse_a_query_with_case_when_keyword() {
     assert!(
-        "select case when a == 2 then 3 else 5 from tab where b <= 4"
+        "select case when a == 2 then 3 else 5 from tab where b <= 4;"
             .parse::<SelectStatement>()
             .is_err()
     );
@@ -1106,7 +1111,7 @@ fn we_cannot_parse_queries_with_long_identifiers() {
 ////////////////////////////////
 #[test]
 fn we_can_parse_a_simple_group_by_clause() {
-    let ast = "select a from tab group by a"
+    let ast = "select a from tab group by a;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -1118,7 +1123,7 @@ fn we_can_parse_a_simple_group_by_clause() {
 }
 #[test]
 fn we_can_parse_a_simple_group_by_clause_with_multiple_columns() {
-    let ast = "select a from tab group by a, b, d"
+    let ast = "select a from tab group by a, b, d;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -1171,7 +1176,7 @@ fn we_can_parse_a_group_by_clause_containing_multiple_aggregations() {
 #[test]
 fn we_can_parse_a_group_by_clause_containing_multiple_aggregations_where_clause_order_by_and_limit()
 {
-    let ast = "select min(a), max(a) as max_a, sum(c), count(a), count(*) count_all from tab where d = 3 group by a, b order by b limit 2"
+    let ast = "select min(a), max(a) as max_a, sum(c), count(a), count(*) count_all from tab where d = 3 group by a, b order by b limit 2;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(
@@ -1202,7 +1207,7 @@ fn we_cannot_parse_a_group_by_clause_after_order_by() {
 
 #[test]
 fn we_cannot_parse_a_group_by_clause_before_where_expr() {
-    assert!("select a from tab group by a where a = 3"
+    assert!("select a from tab group by a where a = 3;"
         .parse::<SelectStatement>()
         .is_err());
 }
@@ -1239,7 +1244,7 @@ fn we_cannot_parse_a_non_count_aggregations_with_wildcard() {
 
 #[test]
 fn we_can_parse_a_simple_add_mul_sub_arithmetic_expressions_in_the_result_expr() {
-    let ast = "select a + b, 2 * f, -77 - h, sum(a) / sum(b) from tab"
+    let ast = "select a + b, 2 * f, -77 - h, sum(a) / sum(b) from tab;"
         .parse::<SelectStatement>()
         .unwrap();
     let expected_ast = select(

--- a/crates/proof-of-sql-parser/src/sql.lalrpop
+++ b/crates/proof-of-sql-parser/src/sql.lalrpop
@@ -14,7 +14,7 @@ grammar;
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 pub SelectStatement: select_statement::SelectStatement = {
-    <expr: SelectCore> <order_by: ("order" "by" <OrderByList>)?> <slice: SliceClause?> => 
+    <expr: SelectCore> <order_by: ("order" "by" <OrderByList>)?> <slice: SliceClause?> ";"? => 
         select_statement::SelectStatement {
             expr,
             order_by: order_by.unwrap_or(vec![]),
@@ -448,6 +448,7 @@ match {
     "<=" => "<=",
     ">" => ">",
     "<" => "<",
+    ";" => ";",
 } else {
     r"[A-Za-z_][A-Za-z0-9_]*" => ID,
     // Decimal numbers with mandatory fractional part

--- a/crates/proof-of-sql/tests/decimal_integration_tests.rs
+++ b/crates/proof-of-sql/tests/decimal_integration_tests.rs
@@ -68,7 +68,7 @@ mod decimal_query_tests {
     #[test]
     fn we_can_query_decimals_exactly_matching_db_data() {
         run_query(
-            "SELECT * FROM table WHERE c = 1.0",
+            "SELECT * FROM table WHERE c = 1.0;",
             2,
             0,
             vec![S::from(1), S::ZERO, S::ONE],
@@ -90,7 +90,7 @@ mod decimal_query_tests {
     #[test]
     fn we_can_query_negative_valued_decimals_exactly_matching_db_data() {
         run_query(
-            "SELECT * FROM table WHERE c = -1.0",
+            "SELECT * FROM table WHERE c = -1.0;",
             2,
             0,
             vec![S::from(-1), S::ZERO, -S::ONE],
@@ -112,7 +112,7 @@ mod decimal_query_tests {
     #[test]
     fn we_can_query_negative_decimals_with_different_scale_than_db_data() {
         run_query(
-            "SELECT * FROM table WHERE c = -1.0",
+            "SELECT * FROM table WHERE c = -1.0;",
             4,
             2,
             vec![S::from(-100), S::ZERO, S::from(-100)],
@@ -123,7 +123,7 @@ mod decimal_query_tests {
     #[test]
     fn we_can_query_with_negative_values_with_trailing_zeros() {
         run_query(
-            "SELECT * FROM table WHERE c = -1.000",
+            "SELECT * FROM table WHERE c = -1.000;",
             4,
             2,
             vec![S::from(-100), S::ZERO, S::from(-100)],
@@ -145,7 +145,7 @@ mod decimal_query_tests {
     #[test]
     fn we_can_query_decimals_with_leading_zeros() {
         run_query(
-            "SELECT * FROM table WHERE c = 0.1",
+            "SELECT * FROM table WHERE c = 0.1;",
             1,
             1,
             vec![S::from(1), S::ZERO, S::ONE],
@@ -178,7 +178,7 @@ mod decimal_query_tests {
     #[test]
     fn we_can_query_with_varying_scale_and_precision() {
         run_query(
-            "SELECT * FROM table WHERE c = 123.456",
+            "SELECT * FROM table WHERE c = 123.456;",
             6,
             3,
             vec![S::from(123456), S::ZERO, S::from(123456)],
@@ -211,7 +211,7 @@ mod decimal_query_tests {
     #[test]
     fn we_can_query_with_maximum_i64() {
         run_query(
-            &format!("SELECT * FROM table WHERE c = {}.0", i64::MAX),
+            &format!("SELECT * FROM table WHERE c = {}.0;", i64::MAX),
             75,
             0,
             vec![S::from(i64::MAX), S::ZERO, S::from(i64::MAX)],
@@ -222,7 +222,7 @@ mod decimal_query_tests {
     #[test]
     fn we_can_query_with_maximum_i128() {
         run_query(
-            &format!("SELECT * FROM table WHERE c = {}.0", i128::MAX),
+            &format!("SELECT * FROM table WHERE c = {}.0;", i128::MAX),
             75,
             0,
             vec![S::from(i128::MAX), S::ZERO, S::from(i128::MAX)],

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -30,7 +30,7 @@ fn we_can_prove_a_minimal_filter_query_with_curve25519() {
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT * FROM table WHERE a".parse().unwrap(),
+        "SELECT * FROM table WHERE a;".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
     )
@@ -91,7 +91,7 @@ fn we_can_prove_a_basic_equality_query_with_curve25519() {
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT * FROM table WHERE b = 1".parse().unwrap(),
+        "SELECT * FROM table WHERE b = 1;".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
     )
@@ -152,7 +152,7 @@ fn we_can_prove_a_basic_inequality_query_with_curve25519() {
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT * FROM table WHERE b >= 1".parse().unwrap(),
+        "SELECT * FROM table WHERE b >= 1;".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
     )
@@ -223,7 +223,7 @@ fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT * FROM table".parse().unwrap(),
+        "SELECT * FROM table;".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
     )
@@ -294,7 +294,7 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
         0,
     );
     let query = QueryExpr::<DoryCommitment>::try_new(
-        "SELECT * FROM table WHERE b > 1 - a".parse().unwrap(),
+        "SELECT * FROM table WHERE b > 1 - a;".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
     )
@@ -327,7 +327,7 @@ fn we_can_prove_a_basic_equality_with_out_of_order_results_with_curve25519() {
         0,
     );
     let query = QueryExpr::try_new(
-        "select primes, amount from public.test_table where primes = 'abcd'"
+        "select primes, amount from public.test_table where primes = 'abcd';"
             .parse()
             .unwrap(),
         "public".parse().unwrap(),
@@ -396,7 +396,7 @@ fn decimal_type_issues_should_cause_provable_ast_to_fail() {
         0,
     );
     let large_decimal = format!("0.{}", "1".repeat(75));
-    let query_string = format!("SELECT d0 + {} as res FROM table", large_decimal);
+    let query_string = format!("SELECT d0 + {} as res FROM table;", large_decimal);
     assert!(matches!(
         QueryExpr::<RistrettoPoint>::try_new(
             query_string.parse().unwrap(),
@@ -426,7 +426,7 @@ fn we_can_prove_a_complex_query_with_curve25519() {
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT a + (b * c) + 1 as t, 45.7 as g, (a = b) or f as h, d0 * d1 + 1.4 as dr FROM table WHERE (a >= b) = (c < d) and (e = 'e') = f"
+        "SELECT a + (b * c) + 1 as t, 45.7 as g, (a = b) or f as h, d0 * d1 + 1.4 as dr FROM table WHERE (a >= b) = (c < d) and (e = 'e') = f;"
             .parse()
             .unwrap(),
         "sxt".parse().unwrap(),

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -41,7 +41,7 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
         0,
     );
     let query = QueryExpr::try_new(
-        "SELECT times FROM table WHERE times = timestamp '1970-01-01T00:00:00Z'"
+        "SELECT times FROM table WHERE times = timestamp '1970-01-01T00:00:00Z';"
             .parse()
             .unwrap(),
         "sxt".parse().unwrap(),
@@ -128,7 +128,7 @@ mod tests {
         let expected_timestamps = vec![1609459200];
 
         run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2021-01-01T00:00:00Z'",
+            "SELECT * FROM table WHERE times = timestamp '2021-01-01T00:00:00Z';",
             test_timestamps,
             expected_timestamps,
         );
@@ -180,7 +180,7 @@ mod tests {
 
         // Test the query to select the leap second
         run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '1999-01-01T00:00:00Z'",
+            "SELECT * FROM table WHERE times = timestamp '1999-01-01T00:00:00Z';",
             test_timestamps.clone(),
             expected_timestamps[1..2].to_vec(),
         );
@@ -199,7 +199,7 @@ mod tests {
         let expected_timestamps = vec![test_timestamps[1]]; // Expect only the new year start
 
         run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2024-01-01T00:00:00Z'",
+            "SELECT * FROM table WHERE times = timestamp '2024-01-01T00:00:00Z';",
             test_timestamps,
             expected_timestamps,
         );
@@ -238,7 +238,7 @@ mod tests {
         let expected_timestamps = vec![test_timestamps[0]]; // Expect the leap day
 
         run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2024-02-29T12:00:00Z'",
+            "SELECT * FROM table WHERE times = timestamp '2024-02-29T12:00:00Z';",
             test_timestamps,
             expected_timestamps,
         );
@@ -274,7 +274,7 @@ mod tests {
         let expected_timestamps = vec![test_timestamps[0]];
 
         run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2023-10-10T12:34:56.789Z'",
+            "SELECT * FROM table WHERE times = timestamp '2023-10-10T12:34:56.789Z';",
             test_timestamps,
             expected_timestamps,
         );
@@ -296,7 +296,7 @@ mod tests {
         ];
 
         run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = to_timestamp(1231006505)",
+            "SELECT * FROM table WHERE times = to_timestamp(1231006505);",
             test_timestamps,
             expected_timestamps,
         );
@@ -321,7 +321,7 @@ mod tests {
         let expected_timestamps = vec![1582934400];
 
         run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = to_timestamp(1582934400)",
+            "SELECT * FROM table WHERE times = to_timestamp(1582934400);",
             test_timestamps,
             expected_timestamps,
         );


### PR DESCRIPTION
# Rationale for this change
Our non-tamperproof DQL service as well as most query engines allow `;` at the end of queries. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
Permit `;` in parser
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
