### PR TITLE
fix: fix postprocessing projection in provable `GROUP BY`s & allow `WHERE` clause to be omitted

### DIFF
--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -224,10 +224,6 @@ impl<C: Commitment> TryFrom<&QueryContext> for Option<GroupByExpr<C>> {
     type Error = ConversionError;
 
     fn try_from(value: &QueryContext) -> Result<Option<GroupByExpr<C>>, Self::Error> {
-        // Currently if there is no where clause, we can't prove the query
-        if value.where_expr.is_none() {
-            return Ok(None);
-        }
         let where_clause = WhereExprBuilder::new(&value.column_mapping)
             .build(value.where_expr.clone())?
             .unwrap_or_else(|| ProvableExprPlan::new_literal(LiteralValue::Boolean(true)));
@@ -283,6 +279,7 @@ impl<C: Commitment> TryFrom<&QueryContext> for Option<GroupByExpr<C>> {
                     false
                 }
             });
+
         // Check sums
         let sum_expr = sum_expr_columns
             .iter()
@@ -318,6 +315,7 @@ impl<C: Commitment> TryFrom<&QueryContext> for Option<GroupByExpr<C>> {
         } else {
             false
         };
+
         if !group_by_compliance || sum_expr.is_none() || !count_column_compliant {
             return Ok(None);
         }

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1094,7 +1094,6 @@ fn we_can_parse_a_query_having_a_simple_limit_and_offset_clause_preceded_by_wher
 ///////////////////////////
 // Group By Expressions - Prover
 ///////////////////////////
-#[ignore]
 #[test]
 fn we_can_do_provable_group_by() {
     let t = "sxt.employees".parse().unwrap();
@@ -1121,14 +1120,14 @@ fn we_can_do_provable_group_by() {
             const_bool(true),
         ),
         composite_result(vec![select(&[
-            pc("department").first().alias("department"),
-            pc("salary").sum().alias("total_salary"),
-            pc("department").count().alias("num_employee"),
+            pc("department").alias("department"),
+            pc("total_salary").alias("total_salary"),
+            pc("num_employee").alias("num_employee"),
         ])]),
     );
     assert_eq!(ast, expected_ast);
 }
-#[ignore]
+
 #[test]
 fn we_can_do_provable_group_by_without_sum() {
     let t = "sxt.employees".parse().unwrap();
@@ -1155,13 +1154,13 @@ fn we_can_do_provable_group_by_without_sum() {
             const_bool(true),
         ),
         composite_result(vec![select(&[
-            pc("department").first().alias("department"),
-            pc("department").count().alias("num_employee"),
+            pc("department").alias("department"),
+            pc("num_employee").alias("num_employee"),
         ])]),
     );
     assert_eq!(ast, expected_ast);
 }
-#[ignore]
+
 #[test]
 fn we_can_do_provable_group_by_with_two_group_by_columns() {
     let t = "sxt.employees".parse().unwrap();
@@ -1189,10 +1188,10 @@ fn we_can_do_provable_group_by_with_two_group_by_columns() {
             const_bool(true),
         ),
         composite_result(vec![select(&[
-            pc("state").first().alias("state"),
-            pc("department").first().alias("department"),
-            pc("salary").sum().alias("total_salary"),
-            pc("department").count().alias("num_employee"),
+            pc("state").alias("state"),
+            pc("department").alias("department"),
+            pc("total_salary").alias("total_salary"),
+            pc("num_employee").alias("num_employee"),
         ])]),
     );
     assert_eq!(ast, expected_ast);
@@ -1228,17 +1227,17 @@ fn we_can_do_provable_group_by_with_two_sums_and_dense_filter() {
             lte(column(t, "tax", &accessor), const_bigint(1)),
         ),
         composite_result(vec![select(&[
-            pc("department").first().alias("department"),
-            pc("salary").sum().alias("total_salary"),
-            pc("tax").sum().alias("total_tax"),
-            pc("department").count().alias("num_employee"),
+            pc("department").alias("department"),
+            pc("total_salary").alias("total_salary"),
+            pc("total_tax").alias("total_tax"),
+            pc("num_employee").alias("num_employee"),
         ])]),
     );
     assert_eq!(ast, expected_ast);
 }
 
 ///////////////////////////
-// Group By Expressions - Polars
+// Group By Expressions - Postprocessing
 ///////////////////////////
 #[test]
 fn we_can_group_by_without_using_aggregate_functions() {


### PR DESCRIPTION
# Rationale for this change
Recently we found weird postprocessing bugs for group bys. What we found is that
1. Currently provable `GROUP BY`s without a `WHERE` clause are not supported even though to support it is trivial.
2. Currently if a `GROUP BY` clause is provable the `ResultExpr` still incorrectly contains aggregate functions.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- fix postprocessing projection with provable `GROUP BY`
- allow provable group by without `WHERE` clause
- enable 3 ignored tests
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
