### PR TITLE
fix: fix decimal comparison and aggregation

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -5,7 +5,7 @@ mod mont_scalar;
 #[cfg(test)]
 mod mont_scalar_test;
 use crate::sql::parse::ConversionError;
-use core::ops::Sub;
+use core::{cmp::Ordering, ops::Sub};
 pub use mont_scalar::Curve25519Scalar;
 pub(crate) use mont_scalar::MontScalar;
 mod mont_scalar_from;
@@ -79,6 +79,14 @@ pub trait Scalar:
     const ONE: Self;
     /// 1 + 1
     const TWO: Self;
+    /// Compare two `Scalar`s as signed numbers.
+    fn signed_cmp(&self, other: &Self) -> Ordering {
+        match *self - *other {
+            x if x.is_zero() => Ordering::Equal,
+            x if x > Self::MAX_SIGNED => Ordering::Less,
+            _ => Ordering::Greater,
+        }
+    }
 }
 
 macro_rules! scalar_conversion_to_int {
@@ -207,4 +215,5 @@ macro_rules! scalar_conversion_to_int {
         }
     };
 }
+
 pub(crate) use scalar_conversion_to_int;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -370,4 +370,5 @@ impl super::Scalar for Curve25519Scalar {
     const ONE: Self = Self(ark_ff::MontFp!("1"));
     const TWO: Self = Self(ark_ff::MontFp!("2"));
 }
+
 scalar_conversion_to_int!(Curve25519Scalar);

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
@@ -1,5 +1,6 @@
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::{Curve25519Scalar, Scalar};
 use byte_slice_cast::AsByteSlice;
+use core::cmp::Ordering;
 use num_traits::{One, Zero};
 use rand::{
     distributions::{Distribution, Uniform},
@@ -65,6 +66,20 @@ fn the_one_scalar_is_the_multiplicative_identity() {
             Curve25519Scalar::one()
         );
     }
+}
+
+#[test]
+fn scalar_comparison_works() {
+    let zero = Curve25519Scalar::ZERO;
+    let one = Curve25519Scalar::ONE;
+    let two = Curve25519Scalar::TWO;
+    let max = Curve25519Scalar::MAX_SIGNED;
+    let min = max + one;
+    assert_eq!(max.signed_cmp(&one), Ordering::Greater);
+    assert_eq!(one.signed_cmp(&zero), Ordering::Greater);
+    assert_eq!(min.signed_cmp(&zero), Ordering::Less);
+    assert_eq!((two * max).signed_cmp(&zero), Ordering::Less);
+    assert_eq!(two * max + one, zero);
 }
 
 #[test]

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
@@ -1,5 +1,6 @@
 use super::DoryScalar;
 use crate::base::scalar::{Scalar, ScalarConversionError};
+use core::cmp::Ordering;
 #[test]
 fn test_dory_scalar_to_i8() {
     assert_eq!(TryInto::<i8>::try_into(DoryScalar::from(0)).unwrap(), 0);
@@ -133,4 +134,18 @@ fn test_dory_scalar_to_i128_overflow() {
         TryInto::<i128>::try_into(DoryScalar::from(i128::MIN) - DoryScalar::ONE),
         Err(ScalarConversionError::Overflow(_))
     );
+}
+
+#[test]
+fn scalar_comparison_works() {
+    let zero = DoryScalar::ZERO;
+    let one = DoryScalar::ONE;
+    let two = DoryScalar::TWO;
+    let max = DoryScalar::MAX_SIGNED;
+    let min = max + one;
+    assert_eq!(max.signed_cmp(&one), Ordering::Greater);
+    assert_eq!(one.signed_cmp(&zero), Ordering::Greater);
+    assert_eq!(min.signed_cmp(&zero), Ordering::Less);
+    assert_eq!((two * max).signed_cmp(&zero), Ordering::Less);
+    assert_eq!(two * max + one, zero);
 }

--- a/crates/proof-of-sql/src/sql/ast/group_by_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_util.rs
@@ -107,18 +107,17 @@ pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
     indexes: &[usize],
 ) -> &'a [S] {
     match column {
-        Column::Boolean(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::BigInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int128(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::Decimal75(_, _, _col) => {
-            todo!("aggregation over decimals not yet supported")
+        Column::Decimal75(_, _, col) => {
+            sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarChar(_) => panic!("Cannot sum varchar columns"),
-        Column::TimestampTZ(_, _, _) => {
-            panic!("Cannot sum varchar columns")
+        // The following should never be reached because the `SUM` function can only be applied to numeric types.
+        Column::VarChar(_) | Column::TimestampTZ(_, _, _) | Column::Boolean(_) => {
+            unreachable!("SUM can not be applied to non-numeric types")
         }
     }
 }
@@ -178,7 +177,7 @@ pub(super) fn compare_indexes_by_columns<S: Scalar>(
             Column::Int(col) => col[i].cmp(&col[j]),
             Column::BigInt(col) => col[i].cmp(&col[j]),
             Column::Int128(col) => col[i].cmp(&col[j]),
-            Column::Decimal75(_, _, _) => todo!("TODO: unimplemented"),
+            Column::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
             Column::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
@@ -204,7 +203,7 @@ pub(super) fn compare_indexes_by_owned_columns<S: Scalar>(
             OwnedColumn::Int(col) => col[i].cmp(&col[j]),
             OwnedColumn::BigInt(col) => col[i].cmp(&col[j]),
             OwnedColumn::Int128(col) => col[i].cmp(&col[j]),
-            OwnedColumn::Decimal75(_, _, _) => todo!("TODO: unimplemented"),
+            OwnedColumn::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
             OwnedColumn::Scalar(col) => col[i].cmp(&col[j]),
             OwnedColumn::VarChar(col) => col[i].cmp(&col[j]),
             OwnedColumn::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -598,12 +598,18 @@ fn we_can_prove_a_cat_group_by_query_with_curve25519() {
                     "Charlie",
                 ],
             ),
+            boolean(
+                "is_female",
+                [
+                    true, true, true, true, true, true, false, false, false, false,
+                ],
+            ),
             bigint("proof_order", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
         ]),
         0,
     );
     let query = QueryExpr::try_new(
-        "select human, sum(age) as total_cat_age, count(*) as num_cats from sxt.cats where age = 2 group by human"
+        "select human, sum(age + 0.1) as total_adjusted_cat_age, count(*) as num_cats from sxt.cats where is_female group by human order by human"
             .parse()
             .unwrap(),
         "sxt".parse().unwrap(),
@@ -618,8 +624,8 @@ fn we_can_prove_a_cat_group_by_query_with_curve25519() {
         .table;
     let expected_result = owned_table([
         varchar("human", ["Gretta", "Ian"]),
-        smallint("total_cat_age", [4_i16, 2]),
-        bigint("num_cats", [2, 1]),
+        decimal75("total_adjusted_cat_age", 7, 1, [184_i16, 142]),
+        bigint("num_cats", [4, 2]),
     ]);
     assert_eq!(owned_table_result, expected_result);
 }
@@ -653,7 +659,12 @@ fn we_can_prove_a_cat_group_by_query_with_dory() {
                     "Whiskers",
                 ],
             ),
-            smallint("age", [12_i16, 2, 3, 3, 10, 2, 2, 4, 5, 6]),
+            decimal75(
+                "diff_from_ideal_weight",
+                3,
+                1,
+                [103_i16, -20, 34, 34, 103, -25, -25, 47, 52, 63],
+            ),
             varchar(
                 "human",
                 [
@@ -661,12 +672,18 @@ fn we_can_prove_a_cat_group_by_query_with_dory() {
                     "Charlie",
                 ],
             ),
+            boolean(
+                "is_female",
+                [
+                    true, true, true, true, true, true, false, false, false, false,
+                ],
+            ),
             bigint("proof_order", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
         ]),
         0,
     );
     let query = QueryExpr::try_new(
-        "select human, sum(age) as total_cat_age, count(*) as num_cats from sxt.cats where age = 2 group by human"
+        "select diff_from_ideal_weight, count(*) as num_cats from sxt.cats where is_female group by diff_from_ideal_weight order by diff_from_ideal_weight"
             .parse()
             .unwrap(),
         "sxt".parse().unwrap(),
@@ -685,9 +702,8 @@ fn we_can_prove_a_cat_group_by_query_with_dory() {
         .unwrap()
         .table;
     let expected_result = owned_table([
-        varchar("human", ["Gretta", "Ian"]),
-        smallint("total_cat_age", [4_i16, 2]),
-        bigint("num_cats", [2, 1]),
+        decimal75("diff_from_ideal_weight", 3, 1, [-25, -20, 34, 103]),
+        bigint("num_cats", [1_i64, 1, 2, 2]),
     ]);
     assert_eq!(owned_table_result, expected_result);
 }


### PR DESCRIPTION
# Rationale for this change
It is necessary for us to be able to do comparison and aggregation on decimal columns.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- add `signed_cmp` to `Scalar` definition to do signed Scalar comparison (i.e. `S::MAX_SIGNED` is the largest number and everything "beyond" it wraps around into negative numbers)
- allow decimal comparison
- allow `SUM` of decimals
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
