### PR TITLE
feat: timestamp inequality support

### DIFF
--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -307,11 +307,11 @@ pub(crate) fn type_check_binary_operation(
                 }
             }
             left_dtype.is_numeric() && right_dtype.is_numeric()
-            || matches!(
-                (left_dtype, right_dtype),
-                (ColumnType::Boolean, ColumnType::Boolean) | 
-                (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
-            )
+                || matches!(
+                    (left_dtype, right_dtype),
+                    (ColumnType::Boolean, ColumnType::Boolean)
+                        | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
+                )
         }
         BinaryOperator::Add | BinaryOperator::Subtract => {
             try_add_subtract_column_types(*left_dtype, *right_dtype).is_ok()

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -306,12 +306,12 @@ pub(crate) fn type_check_binary_operation(
                     return false;
                 }
             }
-            // TODO: inequality support for timestamps
             left_dtype.is_numeric() && right_dtype.is_numeric()
-                || matches!(
-                    (left_dtype, right_dtype),
-                    (ColumnType::Boolean, ColumnType::Boolean)
-                )
+            || matches!(
+                (left_dtype, right_dtype),
+                (ColumnType::Boolean, ColumnType::Boolean) | 
+                (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
+            )
         }
         BinaryOperator::Add | BinaryOperator::Subtract => {
             try_add_subtract_column_types(*left_dtype, *right_dtype).is_ok()

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -374,7 +374,7 @@ mod tests {
 
 #[test]
 #[cfg(feature = "blitzar")]
-fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
+fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
     use curve25519_dalek::RistrettoPoint;
     use proof_of_sql::base::{database::OwnedTable, scalar::Curve25519Scalar};
 
@@ -387,14 +387,14 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
                 PoSQLTimeUnit::Nanosecond,
                 PoSQLTimeZone::Utc,
                 [
-                    0, // Beginning of Unix time
-                    444_972_800_000_000_000, // Fall of Berlin Wall: Nov 9, 1989
-                    828_230_400_000_000_000, // Y2K: Jan 1, 2000
+                    0,                         // Beginning of Unix time
+                    444_972_800_000_000_000,   // Fall of Berlin Wall: Nov 9, 1989
+                    828_230_400_000_000_000,   // Y2K: Jan 1, 2000
                     1_231_006_505_000_000_000, // Bitcoin genesis block: Jan 3, 2009
                     1_483_228_800_000_000_000, // Leap second: Dec 31, 2016
                     1_546_300_800_000_000_000, // Unix time for Jan 1, 2019
                     1_609_459_200_000_000_000, // Start of the 2020s: Jan 1, 2020
-                    i64::MAX, // Far future
+                    i64::MAX,                  // Far future
                 ],
             ),
             timestamptz(
@@ -402,14 +402,14 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
                 PoSQLTimeUnit::Nanosecond,
                 PoSQLTimeZone::Utc,
                 [
-                    i64::MIN, // Far past
-                    444_973_500_000_000_000, // 20 minutes after the Fall of Berlin Wall
-                    828_234_000_000_000_000, // 1 hour after Y2K
+                    i64::MIN,                  // Far past
+                    444_973_500_000_000_000,   // 20 minutes after the Fall of Berlin Wall
+                    828_234_000_000_000_000,   // 1 hour after Y2K
                     1_231_006_805_000_000_000, // 5 minutes after Bitcoin genesis block
                     1_483_229_200_000_000_000, // 1 hour after the leap second
                     1_546_304_400_000_000_000, // 1 hour after Jan 1, 2019
                     1_609_462_800_000_000_000, // 1 hour after the start of 2020
-                    i64::MAX, // Far future
+                    i64::MAX,                  // Far future
                 ],
             ),
         ]),

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -439,13 +439,13 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
                 PoSQLTimeZone::Utc,
                 [
                     0,                         // Beginning of Unix time
-                    444_972_800_000_000_000,   // Fall of Berlin Wall: Nov 9, 1989
-                    828_230_400_000_000_000,   // Y2K: Jan 1, 2000
-                    1_231_006_505_000_000_000, // Bitcoin genesis block: Jan 3, 2009
-                    1_483_228_800_000_000_000, // Leap second: Dec 31, 2016
-                    1_546_300_800_000_000_000, // Unix time for Jan 1, 2019
-                    1_609_459_200_000_000_000, // Start of the 2020s: Jan 1, 2020
-                    i64::MAX,                  // Far future
+                    444_972_800_000_000_000,
+                    828_230_400_000_000_000,
+                    1_231_006_505_000_000_000,
+                    1_483_228_800_000_000_000,
+                    1_546_300_800_000_000_000,
+                    1_609_459_200_000_000_000,
+                    i64::MAX,
                 ],
             ),
             timestamptz(
@@ -453,14 +453,14 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
                 PoSQLTimeUnit::Nanosecond,
                 PoSQLTimeZone::Utc,
                 [
-                    i64::MIN,                  // Far past
-                    444_973_500_000_000_000,   // 20 minutes after the Fall of Berlin Wall
-                    828_234_000_000_000_000,   // 1 hour after Y2K
-                    1_231_006_805_000_000_000, // 5 minutes after Bitcoin genesis block
-                    1_483_229_200_000_000_000, // 1 hour after the leap second
-                    1_546_304_400_000_000_000, // 1 hour after Jan 1, 2019
-                    1_609_462_800_000_000_000, // 1 hour after the start of 2020
-                    i64::MAX,                  // Far future
+                    i64::MIN,
+                    444_973_500_000_000_000,
+                    828_234_000_000_000_000,
+                    1_231_006_805_000_000_000,
+                    1_483_229_200_000_000_000,
+                    1_546_304_400_000_000_000,
+                    1_609_462_800_000_000_000,
+                    i64::MAX,
                 ],
             ),
         ]),

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -163,6 +163,99 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_timestamp_inequality_queries_with_timezone_offsets() {
+        let test_timestamps = vec![i64::MIN, -18000, -17999, 0, 1, i64::MAX]; // Test with a range of timestamps around the Unix epoch
+
+        // Test timezone offset +05:00 (e.g., Indian Standard Time)
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00+05:00';",
+            test_timestamps.clone(),
+            vec![-17999, 0, 1, i64::MAX],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00+05:00';",
+            test_timestamps.clone(),
+            vec![i64::MIN],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00+05:00';",
+            test_timestamps.clone(),
+            vec![-18000, -17999, 0, 1, i64::MAX],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00+05:00';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -18000],
+        );
+
+        // Test timezone offset -08:00 (e.g., Pacific Standard Time)
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00-08:00';",
+            test_timestamps.clone(),
+            vec![i64::MAX],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00-08:00';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -18000, -17999, 0, 1],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00-08:00';",
+            test_timestamps.clone(),
+            vec![i64::MAX],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00-08:00';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -18000, -17999, 0, 1],
+        );
+
+        // Test timezone offset +01:00 (e.g., Central European Time)
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times > timestamp '1969-12-31T23:00:00+01:00';",
+            test_timestamps.clone(),
+            vec![0, 1, i64::MAX],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times < timestamp '1969-12-31T23:00:00+01:00';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -18000, -17999],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times >= timestamp '1969-12-31T23:00:00+01:00';",
+            test_timestamps.clone(),
+            vec![0, 1, i64::MAX],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times <= timestamp '1969-12-31T23:00:00+01:00';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -18000, -17999],
+        );
+
+        // Test timezone offset +00:00 (e.g., UTC)
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00+00:00';",
+            test_timestamps.clone(),
+            vec![1, i64::MAX],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00+00:00';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -18000, -17999],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00+00:00';",
+            test_timestamps.clone(),
+            vec![0, 1, i64::MAX],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00+00:00';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -18000, -17999, 0],
+        );
+    }
+
     // This test simulates the following query:
     //
     // 1. Creating a table:

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -134,6 +134,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_basic_timestamp_inequality_query() {
+        let test_timestamps = vec![i64::MIN, -1, 0, 1, i64::MAX];
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00Z';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -1],
+        );
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00Z';",
+            test_timestamps.clone(),
+            vec![1, i64::MAX],
+        );
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00Z';",
+            test_timestamps.clone(),
+            vec![0, 1, i64::MAX],
+        );
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00Z';",
+            test_timestamps.clone(),
+            vec![i64::MIN, -1, 0],
+        );
+
+    }
+
     // This test simulates the following query:
     //
     // 1. Creating a table:

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -165,29 +165,9 @@ mod tests {
 
     #[test]
     fn test_timestamp_inequality_queries_with_timezone_offsets() {
-        let test_timestamps = vec![i64::MIN, -18000, -17999, 0, 1, i64::MAX]; // Test with a range of timestamps around the Unix epoch
-
-        // Test timezone offset +05:00 (e.g., Indian Standard Time)
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00+05:00';",
-            test_timestamps.clone(),
-            vec![-17999, 0, 1, i64::MAX],
-        );
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00+05:00';",
-            test_timestamps.clone(),
-            vec![i64::MIN],
-        );
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00+05:00';",
-            test_timestamps.clone(),
-            vec![-18000, -17999, 0, 1, i64::MAX],
-        );
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00+05:00';",
-            test_timestamps.clone(),
-            vec![i64::MIN, -18000],
-        );
+        // Test with a range of timestamps around the Unix epoch
+        // 60 * 60 = 3600 * 8 (PST offset) = 28800
+        let test_timestamps = vec![i64::MIN, -28800, -28799, 0, 1, i64::MAX];
 
         // Test timezone offset -08:00 (e.g., Pacific Standard Time)
         run_timestamp_query_test(
@@ -198,7 +178,7 @@ mod tests {
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00-08:00';",
             test_timestamps.clone(),
-            vec![i64::MIN, -18000, -17999, 0, 1],
+            vec![i64::MIN, -28800, -28799, 0, 1],
         );
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00-08:00';",
@@ -208,29 +188,7 @@ mod tests {
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00-08:00';",
             test_timestamps.clone(),
-            vec![i64::MIN, -18000, -17999, 0, 1],
-        );
-
-        // Test timezone offset +01:00 (e.g., Central European Time)
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times > timestamp '1969-12-31T23:00:00+01:00';",
-            test_timestamps.clone(),
-            vec![0, 1, i64::MAX],
-        );
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times < timestamp '1969-12-31T23:00:00+01:00';",
-            test_timestamps.clone(),
-            vec![i64::MIN, -18000, -17999],
-        );
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times >= timestamp '1969-12-31T23:00:00+01:00';",
-            test_timestamps.clone(),
-            vec![0, 1, i64::MAX],
-        );
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times <= timestamp '1969-12-31T23:00:00+01:00';",
-            test_timestamps.clone(),
-            vec![i64::MIN, -18000, -17999],
+            vec![i64::MIN, -28800, -28799, 0, 1],
         );
 
         // Test timezone offset +00:00 (e.g., UTC)
@@ -242,7 +200,7 @@ mod tests {
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00+00:00';",
             test_timestamps.clone(),
-            vec![i64::MIN, -18000, -17999],
+            vec![i64::MIN, -28800, -28799],
         );
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00+00:00';",
@@ -252,7 +210,7 @@ mod tests {
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00+00:00';",
             test_timestamps.clone(),
-            vec![i64::MIN, -18000, -17999, 0],
+            vec![i64::MIN, -28800, -28799, 0],
         );
     }
 

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -438,7 +438,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
                 PoSQLTimeUnit::Nanosecond,
                 PoSQLTimeZone::Utc,
                 [
-                    0,                         // Beginning of Unix time
+                    0, // Beginning of Unix time
                     444_972_800_000_000_000,
                     828_230_400_000_000_000,
                     1_231_006_505_000_000_000,

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -161,7 +161,6 @@ mod tests {
             test_timestamps.clone(),
             vec![i64::MIN, -1, 0],
         );
-
     }
 
     // This test simulates the following query:


### PR DESCRIPTION
# Rationale for this change

Quick PR to add support for inequality expressions between timestamps. Since theyre represented internally as i64, they can be easily compared against one another.

# What changes are included in this PR?

Adds support for statements with the following syntax:

```
SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00Z
SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00Z
SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00Z
SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00Z
```

# Are these changes tested?

yes
