### PR TITLE
fix: timezone display

### DIFF
--- a/crates/proof-of-sql-parser/src/posql_time/timezone.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timezone.rs
@@ -57,7 +57,7 @@ impl fmt::Display for PoSQLTimeZone {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             PoSQLTimeZone::Utc => {
-                write!(f, "00:00")
+                write!(f, "+00:00")
             }
             PoSQLTimeZone::FixedOffset(seconds) => {
                 let hours = seconds / 3600;
@@ -91,7 +91,7 @@ mod timezone_parsing_tests {
     #[test]
     fn test_display_utc() {
         let timezone = timezone::PoSQLTimeZone::Utc;
-        assert_eq!(format!("{}", timezone), "00:00");
+        assert_eq!(format!("{}", timezone), "+00:00");
     }
 }
 


### PR DESCRIPTION
# Rationale for this change

Arrow displays inconsistent behavior when instantiating timestamp record columns which include timezones. It is observed that "00:00" is interpreted as a valid timezone string by arrow, but "+00:00" is. 

# What changes are included in this PR?

This PR simply updates the display impl for timezone to match this expectation. 

# Are these changes tested?

yes
