### PR TITLE
refactor: simplify commitment trait

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -72,9 +72,6 @@ pub trait Commitment:
         offset: usize,
         setup: &Self::PublicSetup<'_>,
     );
-
-    /// Compute a linear combination of the given commitments: `sum commitment[i] * multiplier[i]`.
-    fn fold_commitments(commitments: &[Self], multipliers: &[Self::Scalar]) -> Self;
 }
 
 impl Commitment for RistrettoPoint {
@@ -111,17 +108,6 @@ impl Commitment for RistrettoPoint {
         _setup: &Self::PublicSetup<'_>,
     ) {
         unimplemented!()
-    }
-
-    fn fold_commitments(commitments: &[Self], multipliers: &[Self::Scalar]) -> Self {
-        commitments
-            .iter()
-            .zip(multipliers.iter())
-            .map(|(c, m)| *m * c)
-            .fold(Default::default(), |mut a, c| {
-                a += c;
-                a
-            })
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -30,7 +30,6 @@ use crate::base::{
 };
 use ark_ec::pairing::PairingOutput;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use bytemuck::TransparentWrapper;
 use core::ops::Mul;
 use derive_more::{AddAssign, Neg, Sub, SubAssign};
 use num_traits::One;
@@ -60,10 +59,8 @@ impl Scalar for DoryScalar {
     SubAssign,
     CanonicalSerialize,
     CanonicalDeserialize,
-    TransparentWrapper,
 )]
 /// The Dory commitment type.
-#[repr(transparent)]
 pub struct DoryCommitment(pub(super) GT);
 
 /// The default for GT is the the additive identity, but should be the multiplicative identity.

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -28,7 +28,7 @@ use crate::base::{
     impl_serde_for_ark_serde_checked,
     scalar::{scalar_conversion_to_int, MontScalar, Scalar, ScalarConversionError},
 };
-use ark_ec::{pairing::PairingOutput, VariableBaseMSM};
+use ark_ec::pairing::PairingOutput;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bytemuck::TransparentWrapper;
 use core::ops::Mul;
@@ -100,13 +100,6 @@ impl Commitment for DoryCommitment {
         assert_eq!(commitments.len(), committable_columns.len());
         let c = super::compute_dory_commitments(committable_columns, offset, setup);
         commitments.copy_from_slice(&c);
-    }
-
-    fn fold_commitments(commitments: &[Self], multipliers: &[Self::Scalar]) -> Self {
-        Self(VariableBaseMSM::msm_unchecked(
-            TransparentWrapper::peel_slice(commitments),
-            TransparentWrapper::peel_slice(multipliers),
-        ))
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
@@ -6,7 +6,6 @@ use super::{
 };
 use crate::base::commitment::CommitmentEvaluationProof;
 use merlin::Transcript;
-use num_traits::One;
 use thiserror::Error;
 
 /// The `CommitmentEvaluationProof` for the Dory PCS.
@@ -63,28 +62,11 @@ impl CommitmentEvaluationProof for DoryEvaluationProof {
         messages
     }
 
-    #[tracing::instrument(name = "DoryEvaluationProof::verify_proof", level = "debug", skip_all)]
-    fn verify_proof(
-        &self,
-        transcript: &mut Transcript,
-        a_commit: &Self::Commitment,
-        product: &Self::Scalar,
-        b_point: &[Self::Scalar],
-        generators_offset: u64,
-        _table_length: usize,
-        setup: &Self::VerifierPublicSetup<'_>,
-    ) -> Result<(), Self::Error> {
-        self.verify_batched_proof(
-            transcript,
-            &[*a_commit],
-            &[DoryScalar::one()],
-            product,
-            b_point,
-            generators_offset,
-            _table_length,
-            setup,
-        )
-    }
+    #[tracing::instrument(
+        name = "DoryEvaluationProof::verify_batched_proof",
+        level = "debug",
+        skip_all
+    )]
     fn verify_batched_proof(
         &self,
         transcript: &mut Transcript,


### PR DESCRIPTION
# Rationale for this change

The `Commitment` trait has a `fold_commitments` which is only used internally to the `CommitmentEvaluationProof`, and as a result, is somewhat superfluous, making adding new commitment schemes more complex.

# What changes are included in this PR?

* `Commitment::fold_commitments` is removed.
* `CommitmentEvaluationProof::verify_batched_proof` is no longer a provided method. Instead, `CommitmentEvaluationProof::verify_proof` is a provided method, and implementers must implement `verify_batched_proof` instead.

# Are these changes tested?

By existing tests.