### PR TITLE
refactor: exclusively use `DecimalError` for `proof-of-sql` decimal-related errors

### DIFF
--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -1,8 +1,5 @@
 use super::scalar_and_i256_conversions::convert_i256_to_scalar;
-use crate::{
-    base::{database::Column, math::decimal::Precision, scalar::Scalar},
-    sql::parse::ConversionError,
-};
+use crate::base::{database::Column, math::decimal::Precision, scalar::Scalar};
 use arrow::{
     array::{
         Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
@@ -25,15 +22,15 @@ pub enum ArrowArrayToColumnConversionError {
     /// This error occurs when trying to convert from an unsupported arrow type.
     #[error("unsupported type: attempted conversion from ArrayRef of type {0} to OwnedColumn")]
     UnsupportedType(DataType),
+    /// Variant for decimal errors
+    #[error(transparent)]
+    DecimalError(#[from] crate::base::math::decimal::DecimalError),
     /// This error occurs when trying to convert from an i256 to a Scalar.
     #[error("decimal conversion failed: {0}")]
     DecimalConversionFailed(i256),
     /// This error occurs when the specified range is out of the bounds of the array.
     #[error("index out of bounds: the len is {0} but the index is {1}")]
     IndexOutOfBounds(usize, usize),
-    /// Variant for conversion errors
-    #[error("conversion error: {0}")]
-    ConversionError(#[from] ConversionError),
     /// Using TimeError to handle all time-related errors
     #[error(transparent)]
     TimestampConversionError(#[from] PoSQLTimestampError),

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -4,7 +4,6 @@ pub use error::ScalarConversionError;
 mod mont_scalar;
 #[cfg(test)]
 mod mont_scalar_test;
-use crate::sql::parse::ConversionError;
 use core::{cmp::Ordering, ops::Sub};
 pub use mont_scalar::Curve25519Scalar;
 pub(crate) use mont_scalar::MontScalar;
@@ -68,7 +67,7 @@ pub trait Scalar:
     + std::convert::From<i32>
     + std::convert::From<i16>
     + std::convert::From<bool>
-    + TryFrom<BigInt, Error = ConversionError>
+    + TryFrom<BigInt, Error = ScalarConversionError>
 {
     /// The value (p - 1) / 2. This is "mid-point" of the field - the "six" on the clock.
     /// It is the largest signed value that can be represented in the field with the natural embedding.

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -1,11 +1,5 @@
 use super::{scalar_conversion_to_int, Scalar, ScalarConversionError};
-use crate::{
-    base::{
-        math::decimal::{DecimalError, MAX_SUPPORTED_PRECISION},
-        scalar::mont_scalar::DecimalError::InvalidDecimal,
-    },
-    sql::parse::{ConversionError, ConversionError::DecimalConversionError},
-};
+use crate::base::math::decimal::MAX_SUPPORTED_PRECISION;
 use ark_ff::{BigInteger, Field, Fp, Fp256, MontBackend, MontConfig, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bytemuck::TransparentWrapper;
@@ -157,8 +151,8 @@ impl<T: MontConfig<4>> MontScalar<T> {
     }
 }
 
-impl<T: MontConfig<4>> TryFrom<num_bigint::BigInt> for MontScalar<T> {
-    type Error = ConversionError;
+impl<T: MontConfig<4>> TryFrom<BigInt> for MontScalar<T> {
+    type Error = ScalarConversionError;
 
     fn try_from(value: BigInt) -> Result<Self, Self::Error> {
         // Obtain the absolute value to ignore the sign when counting digits
@@ -169,11 +163,11 @@ impl<T: MontConfig<4>> TryFrom<num_bigint::BigInt> for MontScalar<T> {
 
         // Check if the number of digits exceeds the maximum precision allowed
         if digits.len() > MAX_SUPPORTED_PRECISION.into() {
-            return Err(DecimalConversionError(InvalidDecimal(format!(
+            return Err(ScalarConversionError::Overflow(format!(
                 "Attempted to parse a number with {} digits, which exceeds the max supported precision of {}",
                 digits.len(),
                 MAX_SUPPORTED_PRECISION
-            ))));
+            )));
         }
 
         // Continue with the previous logic

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -1,5 +1,8 @@
 use crate::base::{database::ColumnType, math::decimal::DecimalError};
-use proof_of_sql_parser::{posql_time::PoSQLTimestampError, Identifier, ResourceId};
+use proof_of_sql_parser::{
+    intermediate_decimal::IntermediateDecimalError, posql_time::PoSQLTimestampError, Identifier,
+    ResourceId,
+};
 use thiserror::Error;
 
 /// Errors from converting an intermediate AST into a provable AST.
@@ -76,6 +79,14 @@ impl From<String> for ConversionError {
 impl From<ConversionError> for String {
     fn from(error: ConversionError) -> Self {
         error.to_string()
+    }
+}
+
+impl From<IntermediateDecimalError> for ConversionError {
+    fn from(err: IntermediateDecimalError) -> ConversionError {
+        ConversionError::DecimalConversionError(DecimalError::IntermediateDecimalConversionError(
+            err,
+        ))
     }
 }
 


### PR DESCRIPTION
# Rationale for this change
This PR was split from #56. For evaluation to work it is good if decimal-related errors remain `DecimalError`s as opposed to requiring `ConversionError`. It also lowers the possibility of circular dependencies.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- eliminate any dependency of `proof-of-sql::base` on `proof-of-sql::sql` including references to `sql::parse::ConversionError`
- remove all references to `sql::parse::ParseError` from `decimal.rs`
- refactor `Scalar` def so that `TryFrom<BigInt>` now has `ScalarConversionError`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
