### PR TITLE
refactor: simplify `proof-of-sql-parser`

### DIFF
--- a/crates/proof-of-sql-parser/Cargo.toml
+++ b/crates/proof-of-sql-parser/Cargo.toml
@@ -23,6 +23,9 @@ lalrpop-util = { workspace = true, features = ["lexer", "unicode"] }
 serde = { workspace = true, features = ["serde_derive"] }
 thiserror = { workspace = true }
 
+[features]
+parser-test-utility = []
+
 [build-dependencies]
 lalrpop = { version = "0.20.0" }
 

--- a/crates/proof-of-sql-parser/src/error.rs
+++ b/crates/proof-of-sql-parser/src/error.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Errors encountered during the parsing process
@@ -18,46 +17,3 @@ pub enum ParseError {
 /// General parsing error that may occur, for example if the provided schema/object_name strings
 /// aren't valid postgres-style identifiers (excluding dollar signs).
 pub type ParseResult<T> = std::result::Result<T, ParseError>;
-
-/// Errors related to time operations, including timezone and timestamp conversions.s
-#[derive(Error, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum PoSQLTimestampError {
-    /// Error when the timezone string provided cannot be parsed into a valid timezone.
-    #[error("invalid timezone string: {0}")]
-    InvalidTimezone(String),
-
-    /// Error indicating an invalid timezone offset was provided.
-    #[error("invalid timezone offset")]
-    InvalidTimezoneOffset,
-
-    /// Indicates a failure to convert between different representations of time units.
-    #[error("Invalid time unit")]
-    InvalidTimeUnit(String),
-
-    /// The local time does not exist because there is a gap in the local time.
-    /// This variant may also be returned if there was an error while resolving the local time,
-    /// caused by for example missing time zone data files, an error in an OS API, or overflow.
-    #[error("Local time does not exist because there is a gap in the local time")]
-    LocalTimeDoesNotExist,
-
-    /// The local time is ambiguous because there is a fold in the local time.
-    /// This variant contains the two possible results, in the order (earliest, latest).
-    #[error("Unix timestamp is ambiguous because there is a fold in the local time.")]
-    Ambiguous(String),
-
-    /// Represents a catch-all for parsing errors not specifically covered by other variants.
-    #[error("Timestamp parsing error: {0}")]
-    ParsingError(String),
-
-    /// Represents a failure to parse a provided time unit precision value, PoSQL supports
-    /// Seconds, Milliseconds, Microseconds, and Nanoseconds
-    #[error("Timestamp parsing error: {0}")]
-    UnsupportedPrecision(String),
-}
-
-// This exists because TryFrom<DataType> for ColumnType error is String
-impl From<PoSQLTimestampError> for String {
-    fn from(error: PoSQLTimestampError) -> Self {
-        error.to_string()
-    }
-}

--- a/crates/proof-of-sql-parser/src/intermediate_ast.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast.rs
@@ -4,9 +4,7 @@
 * https://docs.rs/vervolg/latest/vervolg/ast/enum.Statement.html
 ***/
 
-use crate::{
-    intermediate_decimal::IntermediateDecimal, posql_time::timestamp::PoSQLTimestamp, Identifier,
-};
+use crate::{intermediate_decimal::IntermediateDecimal, posql_time::PoSQLTimestamp, Identifier};
 use serde::{Deserialize, Serialize};
 
 /// Representation of a SetExpression, a collection of rows, each having one or more columns.

--- a/crates/proof-of-sql-parser/src/lib.rs
+++ b/crates/proof-of-sql-parser/src/lib.rs
@@ -9,11 +9,12 @@ extern crate lalrpop_util;
 
 pub mod intermediate_ast;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "parser-test-utility"))]
 mod intermediate_ast_tests;
 
-#[cfg(test)]
-pub(crate) mod test_utility;
+#[cfg(feature = "parser-test-utility")]
+/// Shortcuts to construct intermediate AST nodes.
+pub mod test_utility;
 
 pub(crate) mod select_statement;
 pub use select_statement::SelectStatement;

--- a/crates/proof-of-sql-parser/src/posql_time/error.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/error.rs
@@ -1,0 +1,45 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors related to time operations, including timezone and timestamp conversions.s
+#[derive(Error, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum PoSQLTimestampError {
+    /// Error when the timezone string provided cannot be parsed into a valid timezone.
+    #[error("invalid timezone string: {0}")]
+    InvalidTimezone(String),
+
+    /// Error indicating an invalid timezone offset was provided.
+    #[error("invalid timezone offset")]
+    InvalidTimezoneOffset,
+
+    /// Indicates a failure to convert between different representations of time units.
+    #[error("Invalid time unit")]
+    InvalidTimeUnit(String),
+
+    /// The local time does not exist because there is a gap in the local time.
+    /// This variant may also be returned if there was an error while resolving the local time,
+    /// caused by for example missing time zone data files, an error in an OS API, or overflow.
+    #[error("Local time does not exist because there is a gap in the local time")]
+    LocalTimeDoesNotExist,
+
+    /// The local time is ambiguous because there is a fold in the local time.
+    /// This variant contains the two possible results, in the order (earliest, latest).
+    #[error("Unix timestamp is ambiguous because there is a fold in the local time.")]
+    Ambiguous(String),
+
+    /// Represents a catch-all for parsing errors not specifically covered by other variants.
+    #[error("Timestamp parsing error: {0}")]
+    ParsingError(String),
+
+    /// Represents a failure to parse a provided time unit precision value, PoSQL supports
+    /// Seconds, Milliseconds, Microseconds, and Nanoseconds
+    #[error("Timestamp parsing error: {0}")]
+    UnsupportedPrecision(String),
+}
+
+// This exists because TryFrom<DataType> for ColumnType error is String
+impl From<PoSQLTimestampError> for String {
+    fn from(error: PoSQLTimestampError) -> Self {
+        error.to_string()
+    }
+}

--- a/crates/proof-of-sql-parser/src/posql_time/mod.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/mod.rs
@@ -1,6 +1,12 @@
+mod error;
+/// Errors related to time operations, including timezone and timestamp conversions.
+pub use error::PoSQLTimestampError;
+mod timestamp;
 /// Defines an RFC3339-formatted timestamp
-pub mod timestamp;
+pub use timestamp::PoSQLTimestamp;
+mod timezone;
 /// Defines a timezone as count of seconds offset from UTC
-pub mod timezone;
+pub use timezone::PoSQLTimeZone;
+mod unit;
 /// Defines the precision of the timestamp
-pub mod unit;
+pub use unit::PoSQLTimeUnit;

--- a/crates/proof-of-sql-parser/src/posql_time/timezone.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timezone.rs
@@ -1,4 +1,4 @@
-use crate::error::PoSQLTimestampError;
+use super::PoSQLTimestampError;
 use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -1,4 +1,4 @@
-use crate::error::PoSQLTimestampError;
+use super::PoSQLTimestampError;
 use arrow::datatypes::TimeUnit as ArrowTimeUnit;
 use core::fmt;
 use serde::{Deserialize, Serialize};
@@ -68,7 +68,7 @@ impl fmt::Display for PoSQLTimeUnit {
 #[allow(deprecated)]
 mod time_unit_tests {
     use super::*;
-    use crate::{error::PoSQLTimestampError, posql_time::timestamp::PoSQLTimestamp};
+    use crate::posql_time::{PoSQLTimestamp, PoSQLTimestampError};
     use chrono::{TimeZone, Utc};
 
     #[test]

--- a/crates/proof-of-sql-parser/src/sql.lalrpop
+++ b/crates/proof-of-sql-parser/src/sql.lalrpop
@@ -2,7 +2,7 @@ use crate::intermediate_ast;
 use crate::select_statement;
 use crate::identifier;
 use lalrpop_util::ParseError::User;
-use crate::{intermediate_decimal::IntermediateDecimal, posql_time::timestamp::PoSQLTimestamp};
+use crate::{intermediate_decimal::IntermediateDecimal, posql_time::PoSQLTimestamp};
 
 grammar;
 

--- a/crates/proof-of-sql-parser/src/test_utility.rs
+++ b/crates/proof-of-sql-parser/src/test_utility.rs
@@ -1,5 +1,6 @@
 use crate::{intermediate_ast::*, Identifier, SelectStatement};
 
+/// A == B
 pub fn equal(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     Box::new(Expression::Binary {
         op: BinaryOperator::Equal,
@@ -8,6 +9,7 @@ pub fn equal(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     })
 }
 
+/// A >= B
 pub fn ge(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     Box::new(Expression::Binary {
         op: BinaryOperator::GreaterThanOrEqual,
@@ -16,6 +18,7 @@ pub fn ge(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     })
 }
 
+/// A <= B
 pub fn le(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     Box::new(Expression::Binary {
         op: BinaryOperator::LessThanOrEqual,
@@ -24,6 +27,7 @@ pub fn le(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     })
 }
 
+/// NOT P
 pub fn not(expr: Box<Expression>) -> Box<Expression> {
     Box::new(Expression::Unary {
         op: UnaryOperator::Not,
@@ -31,6 +35,7 @@ pub fn not(expr: Box<Expression>) -> Box<Expression> {
     })
 }
 
+/// P AND Q
 pub fn and(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     Box::new(Expression::Binary {
         op: BinaryOperator::And,
@@ -39,6 +44,7 @@ pub fn and(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     })
 }
 
+/// P OR Q
 pub fn or(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     Box::new(Expression::Binary {
         op: BinaryOperator::Or,
@@ -47,6 +53,7 @@ pub fn or(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     })
 }
 
+/// Get table from schema and name
 pub fn tab(schema: Option<&str>, name: &str) -> Box<TableExpression> {
     Box::new(TableExpression::Named {
         table: name.parse().unwrap(),
@@ -54,18 +61,22 @@ pub fn tab(schema: Option<&str>, name: &str) -> Box<TableExpression> {
     })
 }
 
+/// Get column from name
 pub fn col(name: &str) -> Box<Expression> {
     Box::new(Expression::Column(name.parse().unwrap()))
 }
 
+/// Get literal from value
 pub fn lit<L: Into<Literal>>(literal: L) -> Box<Expression> {
     Box::new(Expression::Literal(literal.into()))
 }
 
+/// SELECT *
 pub fn col_res_all() -> SelectResultExpr {
     SelectResultExpr::ALL
 }
 
+/// SELECT COL AS ALIAS
 pub fn col_res(col_val: Box<Expression>, alias: &str) -> SelectResultExpr {
     SelectResultExpr::AliasedResultExpr(AliasedResultExpr {
         expr: col_val,
@@ -73,10 +84,12 @@ pub fn col_res(col_val: Box<Expression>, alias: &str) -> SelectResultExpr {
     })
 }
 
+/// SELECT COL1, COL2, ...
 pub fn cols_res(names: &[&str]) -> Vec<SelectResultExpr> {
     names.iter().map(|name| col_res(col(name), name)).collect()
 }
 
+/// SELECT MIN(EXPR) AS ALIAS
 pub fn min_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
     SelectResultExpr::AliasedResultExpr(AliasedResultExpr {
         expr: Box::new(Expression::Aggregation {
@@ -87,6 +100,7 @@ pub fn min_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
     })
 }
 
+/// SELECT MAX(EXPR) AS ALIAS
 pub fn max_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
     SelectResultExpr::AliasedResultExpr(AliasedResultExpr {
         expr: Expression::Aggregation {
@@ -98,6 +112,7 @@ pub fn max_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
     })
 }
 
+/// SELECT SUM(EXPR) AS ALIAS
 pub fn sum_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
     SelectResultExpr::AliasedResultExpr(AliasedResultExpr {
         expr: Expression::Aggregation {
@@ -109,6 +124,7 @@ pub fn sum_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
     })
 }
 
+/// SELECT COUNT(EXPR) AS ALIAS
 pub fn count_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
     SelectResultExpr::AliasedResultExpr(AliasedResultExpr {
         expr: Expression::Aggregation {
@@ -120,6 +136,7 @@ pub fn count_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
     })
 }
 
+/// SELECT COUNT(*) AS ALIAS
 pub fn count_all_res(alias: &str) -> SelectResultExpr {
     SelectResultExpr::AliasedResultExpr(AliasedResultExpr {
         expr: Expression::Aggregation {
@@ -131,6 +148,7 @@ pub fn count_all_res(alias: &str) -> SelectResultExpr {
     })
 }
 
+/// SELECT COL1, COL2, ... FROM TAB WHERE EXPR GROUP BY ...
 pub fn query(
     result_exprs: Vec<SelectResultExpr>,
     tab: Box<TableExpression>,
@@ -145,6 +163,7 @@ pub fn query(
     })
 }
 
+/// SELECT COL1, COL2, ... FROM TAB GROUP BY ...
 pub fn query_all(
     result_exprs: Vec<SelectResultExpr>,
     tab: Box<TableExpression>,
@@ -158,6 +177,7 @@ pub fn query_all(
     })
 }
 
+/// SELECT ... ORDER BY ... [LIMIT ... OFFSET ...]
 pub fn select(
     expr: Box<SetExpression>,
     order_by: Vec<OrderBy>,
@@ -170,6 +190,7 @@ pub fn select(
     }
 }
 
+/// ORDER BY ID [ASC|DESC]
 pub fn order(id: &str, direction: OrderByDirection) -> Vec<OrderBy> {
     vec![OrderBy {
         expr: id.parse().unwrap(),
@@ -177,6 +198,7 @@ pub fn order(id: &str, direction: OrderByDirection) -> Vec<OrderBy> {
     }]
 }
 
+/// ORDER BY ID0 [ASC|DESC], ID1 [ASC|DESC], ...
 pub fn orders(ids: &[&str], directions: &[OrderByDirection]) -> Vec<OrderBy> {
     ids.iter()
         .zip(directions.iter())
@@ -187,6 +209,7 @@ pub fn orders(ids: &[&str], directions: &[OrderByDirection]) -> Vec<OrderBy> {
         .collect::<Vec<_>>()
 }
 
+/// LIMIT N OFFSET M
 pub fn slice(number_rows: u64, offset_value: i64) -> Option<Slice> {
     Some(Slice {
         number_rows,
@@ -194,6 +217,7 @@ pub fn slice(number_rows: u64, offset_value: i64) -> Option<Slice> {
     })
 }
 
+/// GROUP BY ID0, ID1, ...
 pub fn group_by(ids: &[&str]) -> Vec<Identifier> {
     ids.iter().map(|id| id.parse().unwrap()).collect()
 }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -290,7 +290,7 @@ mod tests {
     use super::*;
     use crate::base::{database::OwnedColumn, math::decimal::Precision, scalar::Curve25519Scalar};
     use itertools::Itertools;
-    use proof_of_sql_parser::posql_time::{timezone, unit::PoSQLTimeUnit};
+    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
     #[test]
     fn we_can_construct_bounds_by_method() {
@@ -533,7 +533,7 @@ mod tests {
 
         let timestamp_column = OwnedColumn::<Curve25519Scalar>::TimestampTZ(
             PoSQLTimeUnit::Second,
-            timezone::PoSQLTimeZone::Utc,
+            PoSQLTimeZone::Utc,
             vec![1_i64, 2, 3, 4],
         );
         let committable_timestamp_column = CommittableColumn::from(&timestamp_column);

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -169,10 +169,7 @@ mod tests {
         commitment::column_bounds::Bounds, database::OwnedColumn, math::decimal::Precision,
         scalar::Curve25519Scalar,
     };
-    use proof_of_sql_parser::posql_time::{
-        timezone::{self, PoSQLTimeZone},
-        unit::PoSQLTimeUnit,
-    };
+    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
     #[test]
     fn we_can_construct_metadata() {
@@ -374,7 +371,7 @@ mod tests {
         let timestamp_column: OwnedColumn<Curve25519Scalar> =
             OwnedColumn::<Curve25519Scalar>::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                timezone::PoSQLTimeZone::Utc,
+                PoSQLTimeZone::Utc,
                 [1i64, 2, 3, 4, 5].to_vec(),
             );
         let committable_timestamp_column = CommittableColumn::from(&timestamp_column);
@@ -536,7 +533,7 @@ mod tests {
             1_625_072_400,
             1_625_065_000,
         ];
-        let timezone = timezone::PoSQLTimeZone::Utc;
+        let timezone = PoSQLTimeZone::Utc;
         let timeunit = PoSQLTimeUnit::Second;
         let timestamp_column_a = CommittableColumn::TimestampTZ(timeunit, timezone, &times[..2]);
         let timestamp_metadata_a = ColumnCommitmentMetadata::from_column(&timestamp_column_a);
@@ -562,7 +559,7 @@ mod tests {
             1_625_072_400,
             1_625_065_000,
         ];
-        let timezone = timezone::PoSQLTimeZone::Utc;
+        let timezone = PoSQLTimeZone::Utc;
         let timeunit = PoSQLTimeUnit::Second;
 
         let timestamp_column_a = CommittableColumn::TimestampTZ(timeunit, timezone, &times[..2]);
@@ -859,18 +856,12 @@ mod tests {
             .is_err());
 
         let timestamp_tz_metadata_a = ColumnCommitmentMetadata {
-            column_type: ColumnType::TimestampTZ(
-                PoSQLTimeUnit::Second,
-                timezone::PoSQLTimeZone::Utc,
-            ),
+            column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
             bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
         };
 
         let timestamp_tz_metadata_b = ColumnCommitmentMetadata {
-            column_type: ColumnType::TimestampTZ(
-                PoSQLTimeUnit::Millisecond,
-                timezone::PoSQLTimeZone::Utc,
-            ),
+            column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
             bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
         };
 

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -6,7 +6,7 @@ use crate::base::{
 };
 #[cfg(feature = "blitzar")]
 use blitzar::sequence::Sequence;
-use proof_of_sql_parser::posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit};
+use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
 /// Column data in "committable form".
 ///

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -12,10 +12,7 @@ use arrow::{
     datatypes::{i256, DataType, TimeUnit as ArrowTimeUnit},
 };
 use bumpalo::Bump;
-use proof_of_sql_parser::{
-    error::PoSQLTimestampError,
-    posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit},
-};
+use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError};
 use std::ops::Range;
 use thiserror::Error;
 

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -6,7 +6,7 @@ use crate::base::{
 use arrow::datatypes::{DataType, Field, TimeUnit as ArrowTimeUnit};
 use bumpalo::Bump;
 use proof_of_sql_parser::{
-    posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit},
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     Identifier,
 };
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,5 +1,5 @@
 use crate::base::{database::ColumnType, math::decimal::Precision, scalar::Scalar};
-use proof_of_sql_parser::posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit};
+use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use serde::{Deserialize, Serialize};
 
 /// Represents a literal value.

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -33,8 +33,7 @@ use arrow::{
 };
 use indexmap::IndexMap;
 use proof_of_sql_parser::{
-    error::PoSQLTimestampError,
-    posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit},
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError},
     Identifier, ParseError,
 };
 use std::sync::Arc;

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -13,7 +13,7 @@ use crate::base::{
 use core::cmp::Ordering;
 use proof_of_sql_parser::{
     intermediate_ast::OrderByDirection,
-    posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit},
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
 };
 
 #[derive(Debug, PartialEq, Clone, Eq)]

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use indexmap::IndexMap;
 use proof_of_sql_parser::{
-    posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit},
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     Identifier,
 };
 

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -7,7 +7,7 @@ use crate::base::{
     scalar::{compute_commitment_for_testing, Curve25519Scalar},
 };
 use blitzar::proof::InnerProductProof;
-use proof_of_sql_parser::posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit};
+use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
 #[test]
 fn we_can_query_the_length_of_a_table() {

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -17,7 +17,7 @@ use super::{OwnedColumn, OwnedTable};
 use crate::base::scalar::Scalar;
 use core::ops::Deref;
 use proof_of_sql_parser::{
-    posql_time::{timezone, unit::PoSQLTimeUnit},
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     Identifier,
 };
 
@@ -214,7 +214,7 @@ pub fn decimal75<S: Scalar>(
 ///     scalar::Curve25519Scalar,
 /// };
 /// use proof_of_sql_parser::{
-///    posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit}};
+///    posql_time::{PoSQLTimeZone, PoSQLTimeUnit}};
 ///
 /// let result = owned_table::<Curve25519Scalar>([
 ///     timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, vec![1625072400, 1625076000, 1625079600]),
@@ -223,7 +223,7 @@ pub fn decimal75<S: Scalar>(
 pub fn timestamptz<S: Scalar>(
     name: impl Deref<Target = str>,
     time_unit: PoSQLTimeUnit,
-    timezone: timezone::PoSQLTimeZone,
+    timezone: PoSQLTimeZone,
     data: impl IntoIterator<Item = i64>,
 ) -> (Identifier, OwnedColumn<S>) {
     (

--- a/crates/proof-of-sql/src/base/database/record_batch_utility.rs
+++ b/crates/proof-of-sql/src/base/database/record_batch_utility.rs
@@ -2,7 +2,7 @@ use arrow::array::{
     TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
     TimestampSecondArray,
 };
-use proof_of_sql_parser::posql_time::unit::PoSQLTimeUnit;
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use std::sync::Arc;
 
 /// Extension trait for Vec<T> to convert it to an Arrow array

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -8,7 +8,7 @@ use arrow::{
     datatypes::{i256, DataType, Field, Schema},
     record_batch::RecordBatch,
 };
-use proof_of_sql_parser::posql_time::unit::PoSQLTimeUnit;
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use rand::{
     distributions::{Distribution, Uniform},
     rngs::StdRng,

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -1,5 +1,5 @@
 use crate::base::{database::ColumnType, math::decimal::DecimalError};
-use proof_of_sql_parser::{error::PoSQLTimestampError, Identifier, ResourceId};
+use proof_of_sql_parser::{posql_time::PoSQLTimestampError, Identifier, ResourceId};
 use thiserror::Error;
 
 /// Errors from converting an intermediate AST into a provable AST.

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -12,7 +12,7 @@ use proof_of_sql::{
         proof::{QueryProof, VerifiableQueryResult},
     },
 };
-use proof_of_sql_parser::posql_time::{timezone::PoSQLTimeZone, unit::PoSQLTimeUnit};
+use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
 #[test]
 fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {


### PR DESCRIPTION
# Rationale for this change
For intermediate AST -> Provable AST and intermediate AST postprocessing evaluation tests in `proof-of-sql` it is a good idea to be able to use shortcuts in `proof_of_sql_parser::test_utility`. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- put `test_utility.rs` in parser behind a feature flag and allow it to be used by the other crate
- prevent `posql_time` from being unnecessarily convoluted
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
