### PR TITLE
build!: revert "build: upgrade to arrow 51"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ ark-poly = { version = "0.4.0", features = [ "parallel" ] }
 ark-serialize = { version = "0.4.0" }
 ark-std = { version = "0.4.0", features = [ "parallel" ] }
 arrayvec = { version = "0.7" }
-arrow = { version = "51.0" }
-arrow-csv = { version = "51.0" }
+arrow = { version = "45.0" }
+arrow-csv = { version = "45.0" }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", features = ["serde"] }
 blake3 = { version = "1.3.3" }

--- a/crates/proof-of-sql/examples/posql_db/csv_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/csv_accessor.rs
@@ -22,14 +22,14 @@ pub fn read_record_batch_from_csv(
     path: &Path,
 ) -> Result<RecordBatch, Box<dyn Error>> {
     let mut csv = ReaderBuilder::new(Arc::new(schema))
-        .with_header(true)
+        .has_header(true)
         .build(File::open(path)?)?;
     let batch = csv.next().ok_or("Empty table.")??;
     Ok(batch)
 }
 fn append_record_batch_to_csv(batch: &RecordBatch, path: &Path) -> Result<(), Box<dyn Error>> {
     let mut writer = WriterBuilder::new()
-        .with_header(false)
+        .has_headers(false)
         .build(OpenOptions::new().append(true).open(path)?);
     writer.write(batch)?;
     Ok(())


### PR DESCRIPTION
Temporarily reverts spaceandtimelabs/sxt-proof-of-sql#60 since we should have bumped Rust version in services before bumping Arrow version in dependencies.