### PR TITLE
refactor: add flexibility for dory verifier folding

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
@@ -1,8 +1,9 @@
 use super::{
     build_vmv_prover_state, build_vmv_verifier_state, compute_T_vec_prime, compute_nu,
     eval_vmv_re_prove, eval_vmv_re_verify, extended_dory_inner_product_prove,
-    extended_dory_inner_product_verify, DeferredGT, DoryCommitment, DoryMessages,
-    DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup, F,
+    extended_dory_inner_product_verify,
+    extended_dory_reduce_helper::extended_dory_reduce_verify_fold_s_vecs, DeferredGT,
+    DoryCommitment, DoryMessages, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup, F,
 };
 use crate::base::commitment::CommitmentEvaluationProof;
 use merlin::Transcript;
@@ -101,6 +102,7 @@ impl CommitmentEvaluationProof for DoryEvaluationProof {
             transcript,
             extended_state,
             verifier_setup,
+            extended_dory_reduce_verify_fold_s_vecs,
         ) {
             Err(DoryError::VerificationError)?;
         }

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product.rs
@@ -1,6 +1,6 @@
 use super::{
     scalar_product_prove, scalar_product_verify, DoryMessages, ExtendedProverState,
-    ExtendedVerifierState, ProverSetup, VerifierSetup,
+    ExtendedVerifierState, ProverSetup, VerifierSetup, F,
 };
 use crate::proof_primitive::dory::{
     extended_dory_reduce_prove, extended_dory_reduce_verify, fold_scalars_0_prove,
@@ -34,6 +34,7 @@ pub fn extended_dory_inner_product_verify(
     transcript: &mut Transcript,
     mut state: ExtendedVerifierState,
     setup: &VerifierSetup,
+    fold_s_tensors_verify: impl Fn(&ExtendedVerifierState) -> (F, F),
 ) -> bool {
     let nu = state.base_state.nu;
     assert!(setup.max_nu >= nu);
@@ -42,6 +43,7 @@ pub fn extended_dory_inner_product_verify(
             return false;
         }
     }
-    let base_state = fold_scalars_0_verify(messages, transcript, state, setup);
+    let base_state =
+        fold_scalars_0_verify(messages, transcript, state, setup, fold_s_tensors_verify);
     scalar_product_verify(messages, transcript, base_state, setup)
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product_test.rs
@@ -1,5 +1,6 @@
 use super::{
-    extended_dory_inner_product_prove, extended_dory_inner_product_verify, rand_F_tensors,
+    extended_dory_inner_product_prove, extended_dory_inner_product_verify,
+    extended_dory_reduce_helper::extended_dory_reduce_verify_fold_s_vecs, rand_F_tensors,
     rand_G_vecs, test_rng, DoryMessages, ExtendedProverState, G1Affine, PublicParameters, GT,
 };
 use ark_std::UniformRand;
@@ -26,7 +27,8 @@ fn we_can_prove_and_verify_an_extended_dory_inner_product() {
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -58,7 +60,8 @@ fn we_can_prove_and_verify_an_extended_dory_inner_product_for_multiple_nu_values
             &mut messages,
             &mut transcript,
             verifier_state,
-            &verifier_setup
+            &verifier_setup,
+            extended_dory_reduce_verify_fold_s_vecs
         ));
     }
 }
@@ -86,7 +89,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_a_message_is_modified()
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -113,7 +117,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_few_GT_me
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -140,7 +145,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_many_GT_m
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -167,7 +173,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_few_G1_me
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -194,7 +201,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_there_are_too_many_G1_m
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -219,7 +227,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_the_transcripts_differ(
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -247,7 +256,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_the_setups_differ() {
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -274,7 +284,8 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_the_base_commitment_is_
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }
 
@@ -301,6 +312,7 @@ fn we_fail_to_verify_an_extended_dory_inner_product_when_a_scalar_commitment_is_
         &mut messages,
         &mut transcript,
         verifier_state,
-        &verifier_setup
+        &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs
     ));
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
@@ -91,7 +91,8 @@ pub fn extended_dory_reduce_verify(
         alphas,
         betas,
     );
-    extended_dory_reduce_verify_fold_s_vecs(state, alphas);
+    state.alphas[state.base_state.nu - 1] = alphas.0;
+    state.alpha_invs[state.base_state.nu - 1] = alphas.1;
     state.base_state.nu -= 1;
     true
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce_helper.rs
@@ -104,12 +104,19 @@ pub fn extended_dory_reduce_verify_update_Es(
 /// `s1_tensor[nu-1] <- s1_tensor[nu-1] * (1- alpha) + alpha`
 ///
 /// and taking the product in [fold_scalars_0_verify](super::fold_scalars_0_verify).
-pub fn extended_dory_reduce_verify_fold_s_vecs(
-    state: &mut ExtendedVerifierState,
-    (alpha, alpha_inv): (F, F),
-) {
-    state.s1_tensor[state.base_state.nu - 1] *= F::ONE - alpha;
-    state.s1_tensor[state.base_state.nu - 1] += alpha;
-    state.s2_tensor[state.base_state.nu - 1] *= F::ONE - alpha_inv;
-    state.s2_tensor[state.base_state.nu - 1] += alpha_inv;
+pub fn extended_dory_reduce_verify_fold_s_vecs(state: &ExtendedVerifierState) -> (F, F) {
+    (
+        state
+            .s1_tensor
+            .iter()
+            .zip(state.alphas.iter())
+            .map(|(s, a)| (F::ONE - s) * a + s)
+            .product(),
+        state
+            .s2_tensor
+            .iter()
+            .zip(state.alpha_invs.iter())
+            .map(|(s, a)| (F::ONE - s) * a + s)
+            .product(),
+    )
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs
@@ -79,6 +79,8 @@ impl ExtendedProverState {
             E_2: E_2.into(),
             s1_tensor: self.s1_tensor.clone(),
             s2_tensor: self.s2_tensor.clone(),
+            alphas: vec![Default::default(); self.base_state.nu],
+            alpha_invs: vec![Default::default(); self.base_state.nu],
         }
     }
 }
@@ -95,10 +97,14 @@ pub struct ExtendedVerifierState {
     pub(super) E_1: DeferredG1,
     /// The "commitment" to s2. This should be <s1,v2>. This will be mutated during the proof verification.
     pub(super) E_2: DeferredG2,
-    /// The first tensor of F elements in the witness. This will be mutated during the proof verification.
+    /// The first tensor of F elements in the witness. This will NOT be mutated during the proof verification.
     pub(super) s1_tensor: Vec<F>,
-    /// The second tensor of F elements in the witness. This will be mutated during the proof verification.
+    /// The second tensor of F elements in the witness. This will NOT be mutated during the proof verification.
     pub(super) s2_tensor: Vec<F>,
+    /// The folding factors for the s1_tensors. This will be populated during the proof verification.
+    pub(super) alphas: Vec<F>,
+    /// The folding factors for the s2_tensors. This will be populated during the proof verification.
+    pub(super) alpha_invs: Vec<F>,
 }
 
 impl ExtendedVerifierState {
@@ -120,6 +126,8 @@ impl ExtendedVerifierState {
             E_2,
             s1_tensor,
             s2_tensor,
+            alphas: vec![Default::default(); nu],
+            alpha_invs: vec![Default::default(); nu],
         }
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars.rs
@@ -1,7 +1,7 @@
 use super::{
     extended_state::{ExtendedProverState, ExtendedVerifierState},
     pairings, DeferredGT, DoryMessages, G1Projective, G2Projective, ProverSetup, ProverState,
-    VerifierSetup, VerifierState,
+    VerifierSetup, VerifierState, F,
 };
 use merlin::Transcript;
 
@@ -33,11 +33,11 @@ pub fn fold_scalars_0_verify(
     transcript: &mut Transcript,
     mut state: ExtendedVerifierState,
     setup: &VerifierSetup,
+    fold_s_tensors_verify: impl Fn(&ExtendedVerifierState) -> (F, F),
 ) -> VerifierState {
     assert_eq!(state.base_state.nu, 0);
     let (gamma, gamma_inv) = messages.verifier_F_message(transcript);
-    let s1_folded = state.s1_tensor.iter().product();
-    let s2_folded = state.s2_tensor.iter().product();
+    let (s1_folded, s2_folded) = fold_s_tensors_verify(&state);
     state.base_state.C += DeferredGT::from(setup.H_T) * s1_folded * s2_folded
         + DeferredGT::from(pairings::pairing(
             setup.H_1,

--- a/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars_test.rs
@@ -1,6 +1,7 @@
 use super::{
-    fold_scalars_0_prove, fold_scalars_0_verify, rand_F_tensors, rand_G_vecs, test_rng,
-    DoryMessages, ExtendedProverState, PublicParameters,
+    extended_dory_reduce_helper::extended_dory_reduce_verify_fold_s_vecs, fold_scalars_0_prove,
+    fold_scalars_0_verify, rand_F_tensors, rand_G_vecs, test_rng, DoryMessages,
+    ExtendedProverState, PublicParameters,
 };
 use merlin::Transcript;
 
@@ -27,6 +28,7 @@ fn we_can_fold_scalars() {
         &mut transcript,
         verifier_state,
         &verifier_setup,
+        extended_dory_reduce_verify_fold_s_vecs,
     );
     assert_eq!(
         prover_folded_state.calculate_verifier_state(&prover_setup),


### PR DESCRIPTION
# Rationale for this change

We need to add the Dynamic Dory commitment scheme. In order to make the existing methods work with the dynamic dory commitment scheme, the method that folds the s tensors within the verify methods needs to be modified. In particular, it needs to have access to all the folding factors at a time in order to fold properly.

# What changes are included in this PR?

The folding of the s tensor is now done once within the `fold_scalars_0_verify` rather than accumulating within each round.
There are 2 main changes to accomplish this:
* During each round/call of `extended_dory_reduce_verify`, instead of mutating the s tensors, the `alpha` folding factors are added to the `state`.
* `fold_s_tensors_verify` is added as a parameter to `extended_dory_inner_product_verify` and `fold_scalars_0_verify`

# Are these changes tested?

Existing tests pass.