### PR TITLE
fix: timestamp precision parsing

### DIFF
--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -214,7 +214,6 @@ mod tests {
         // Parse timestamps
         let before_leap_dt = PoSQLTimestamp::try_from(before_leap_second).unwrap();
         let leap_second_dt = PoSQLTimestamp::try_from(leap_second).unwrap();
-        dbg!(&leap_second_dt.timestamp.timestamp());
         let after_leap_dt = PoSQLTimestamp::try_from(after_leap_second).unwrap();
 
         // Ensure that "23:59:60Z" - 1 second is considered equivalent to "23:59:59Z"

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -50,6 +50,7 @@ impl PoSQLTimestamp {
         let offset_seconds = dt.offset().local_minus_utc();
         let timezone = PoSQLTimeZone::from_offset(offset_seconds);
         let nanoseconds = dt.timestamp_subsec_nanos();
+
         let timeunit = if nanoseconds % 1_000 != 0 {
             PoSQLTimeUnit::Nanosecond
         } else if nanoseconds % 1_000_000 != 0 {

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -50,7 +50,6 @@ impl PoSQLTimestamp {
         let offset_seconds = dt.offset().local_minus_utc();
         let timezone = PoSQLTimeZone::from_offset(offset_seconds);
         let nanoseconds = dt.timestamp_subsec_nanos();
-
         let timeunit = if nanoseconds % 1_000 != 0 {
             PoSQLTimeUnit::Nanosecond
         } else if nanoseconds % 1_000_000 != 0 {

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -16,6 +16,18 @@ pub enum PoSQLTimeUnit {
     Nanosecond,
 }
 
+impl PoSQLTimeUnit {
+    /// Get the number of digits needed to represent the precision of this time unit
+    pub fn get_scale(&self) -> i8 {
+        match self {
+            PoSQLTimeUnit::Second => 0,
+            PoSQLTimeUnit::Millisecond => 3,
+            PoSQLTimeUnit::Microsecond => 6,
+            PoSQLTimeUnit::Nanosecond => 9,
+        }
+    }
+}
+
 impl TryFrom<&str> for PoSQLTimeUnit {
     type Error = PoSQLTimestampError;
     fn try_from(value: &str) -> Result<Self, PoSQLTimestampError> {
@@ -100,6 +112,7 @@ mod time_unit_tests {
         let result = PoSQLTimestamp::try_from(input).unwrap();
         assert_eq!(result.timeunit, PoSQLTimeUnit::Millisecond);
         assert_eq!(result.timestamp, expected);
+        assert_eq!(expected.timestamp_millis(), 1687782896123);
     }
 
     #[test]
@@ -109,6 +122,7 @@ mod time_unit_tests {
         let result = PoSQLTimestamp::try_from(input).unwrap();
         assert_eq!(result.timeunit, PoSQLTimeUnit::Microsecond);
         assert_eq!(result.timestamp, expected);
+        assert_eq!(expected.timestamp_micros(), 1687782896123456);
     }
     #[test]
     fn test_rfc3339_timestamp_with_nanoseconds() {
@@ -117,5 +131,6 @@ mod time_unit_tests {
         let result = PoSQLTimestamp::try_from(input).unwrap();
         assert_eq!(result.timeunit, PoSQLTimeUnit::Nanosecond);
         assert_eq!(result.timestamp, expected);
+        assert_eq!(expected.timestamp_nanos_opt().unwrap(), 1687782896123456789);
     }
 }

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -16,18 +16,6 @@ pub enum PoSQLTimeUnit {
     Nanosecond,
 }
 
-impl PoSQLTimeUnit {
-    /// Get the number of digits needed to represent the precision of this time unit
-    pub fn get_scale(&self) -> i8 {
-        match self {
-            PoSQLTimeUnit::Second => 0,
-            PoSQLTimeUnit::Millisecond => 3,
-            PoSQLTimeUnit::Microsecond => 6,
-            PoSQLTimeUnit::Nanosecond => 9,
-        }
-    }
-}
-
 impl TryFrom<&str> for PoSQLTimeUnit {
     type Error = PoSQLTimestampError;
     fn try_from(value: &str) -> Result<Self, PoSQLTimestampError> {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -310,13 +310,14 @@ impl ColumnType {
     pub fn scale(&self) -> Option<i8> {
         match self {
             Self::Decimal75(_, scale) => Some(*scale),
-            Self::SmallInt
-            | Self::Int
-            | Self::BigInt
-            | Self::Int128
-            | Self::Scalar
-            | Self::TimestampTZ(_, _) => Some(0),
-            Self::Boolean | Self::VarChar => None,
+            Self::BigInt | Self::Int128 | Self::Scalar => Some(0),
+            Self::TimestampTZ(timeunit, _) => match timeunit {
+                PoSQLTimeUnit::Second => Some(0),
+                PoSQLTimeUnit::Millisecond => Some(3),
+                PoSQLTimeUnit::Microsecond => Some(6),
+                PoSQLTimeUnit::Nanosecond => Some(9),
+            },
+            _ => None,
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -311,6 +311,10 @@ impl ColumnType {
         match self {
             Self::Decimal75(_, scale) => Some(*scale),
             Self::BigInt | Self::Int128 | Self::Scalar => Some(0),
+            Self::TimestampTZ(PoSQLTimeUnit::Second, _) => Some(0),
+            Self::TimestampTZ(PoSQLTimeUnit::Millisecond, _) => Some(3),
+            Self::TimestampTZ(PoSQLTimeUnit::Microsecond, _) => Some(6),
+            Self::TimestampTZ(PoSQLTimeUnit::Nanosecond, _) => Some(9),
             _ => None,
         }
     }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -253,11 +253,6 @@ impl ColumnType {
         )
     }
 
-    /// Returns true if this column is a timestamp and false otherwise
-    pub fn is_timestamp(&self) -> bool {
-        matches!(self, ColumnType::TimestampTZ(_, _))
-    }
-
     /// Returns the number of bits in the integer type if it is an integer type. Otherwise, return None.
     fn to_integer_bits(self) -> Option<usize> {
         match self {
@@ -317,10 +312,6 @@ impl ColumnType {
         match self {
             Self::Decimal75(_, scale) => Some(*scale),
             Self::BigInt | Self::Int128 | Self::Scalar => Some(0),
-            Self::TimestampTZ(PoSQLTimeUnit::Second, _) => Some(0),
-            Self::TimestampTZ(PoSQLTimeUnit::Millisecond, _) => Some(3),
-            Self::TimestampTZ(PoSQLTimeUnit::Microsecond, _) => Some(6),
-            Self::TimestampTZ(PoSQLTimeUnit::Nanosecond, _) => Some(9),
             _ => None,
         }
     }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -306,7 +306,6 @@ impl ColumnType {
             _ => None,
         }
     }
-
     /// Returns scale of a ColumnType if it is convertible to a decimal wrapped in Some(). Otherwise return None.
     pub fn scale(&self) -> Option<i8> {
         match self {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -253,6 +253,11 @@ impl ColumnType {
         )
     }
 
+    /// Returns true if this column is a timestamp and false otherwise
+    pub fn is_timestamp(&self) -> bool {
+        matches!(self, ColumnType::TimestampTZ(_, _))
+    }
+
     /// Returns the number of bits in the integer type if it is an integer type. Otherwise, return None.
     fn to_integer_bits(self) -> Option<usize> {
         match self {
@@ -306,11 +311,16 @@ impl ColumnType {
             _ => None,
         }
     }
+
     /// Returns scale of a ColumnType if it is convertible to a decimal wrapped in Some(). Otherwise return None.
     pub fn scale(&self) -> Option<i8> {
         match self {
             Self::Decimal75(_, scale) => Some(*scale),
             Self::BigInt | Self::Int128 | Self::Scalar => Some(0),
+            Self::TimestampTZ(PoSQLTimeUnit::Second, _) => Some(0),
+            Self::TimestampTZ(PoSQLTimeUnit::Millisecond, _) => Some(3),
+            Self::TimestampTZ(PoSQLTimeUnit::Microsecond, _) => Some(6),
+            Self::TimestampTZ(PoSQLTimeUnit::Nanosecond, _) => Some(9),
             _ => None,
         }
     }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -47,7 +47,6 @@ pub use owned_table::OwnedTable;
 pub(crate) use owned_table::OwnedTableError;
 #[cfg(test)]
 mod owned_table_test;
-#[macro_use]
 pub mod owned_table_utility;
 
 mod owned_and_arrow_conversions;

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -47,6 +47,7 @@ pub use owned_table::OwnedTable;
 pub(crate) use owned_table::OwnedTableError;
 #[cfg(test)]
 mod owned_table_test;
+#[macro_use]
 pub mod owned_table_utility;
 
 mod owned_and_arrow_conversions;

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -59,7 +59,7 @@ fn we_can_create_an_owned_table_with_data() {
             "boolean",
             [true, false, true, false, true, false, true, false, true],
         ),
-        timestamptz(
+        timestamptz_epoch(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -126,7 +126,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
         int128("b", [0; 0]),
         varchar("c", ["0"; 0]),
         boolean("d", [false; 0]),
-        timestamptz(
+        timestamptz_epoch(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -138,7 +138,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
         int128("b", [0; 0]),
         bigint("a", [0; 0]),
         varchar("c", ["0"; 0]),
-        timestamptz(
+        timestamptz_epoch(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -154,7 +154,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
         int128("b", [0]),
         varchar("c", ["0"]),
         boolean("d", [true]),
-        timestamptz(
+        timestamptz_epoch(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -166,7 +166,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
         int128("b", [0]),
         varchar("c", ["0"]),
         boolean("d", [true]),
-        timestamptz(
+        timestamptz_epoch(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -59,10 +59,9 @@ fn we_can_create_an_owned_table_with_data() {
             "boolean",
             [true, false, true, false, true, false, true, false, true],
         ),
-        timestamptz_epoch(
+        timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::Utc,
             [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
         ),
     ]);
@@ -126,24 +125,14 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
         int128("b", [0; 0]),
         varchar("c", ["0"; 0]),
         boolean("d", [false; 0]),
-        timestamptz_epoch(
-            "time_stamp",
-            PoSQLTimeUnit::Second,
-            PoSQLTimeZone::Utc,
-            [0; 0],
-        ),
+        timestamptz("time_stamp", PoSQLTimeUnit::Second, [0; 0]),
     ]);
     let owned_table_b: OwnedTable<Curve25519Scalar> = owned_table([
         boolean("d", [false; 0]),
         int128("b", [0; 0]),
         bigint("a", [0; 0]),
         varchar("c", ["0"; 0]),
-        timestamptz_epoch(
-            "time_stamp",
-            PoSQLTimeUnit::Second,
-            PoSQLTimeZone::Utc,
-            [0; 0],
-        ),
+        timestamptz("time_stamp", PoSQLTimeUnit::Second, [0; 0]),
     ]);
     assert_ne!(owned_table_a, owned_table_b);
 }
@@ -154,24 +143,14 @@ fn we_get_inequality_between_tables_with_differing_data() {
         int128("b", [0]),
         varchar("c", ["0"]),
         boolean("d", [true]),
-        timestamptz_epoch(
-            "time_stamp",
-            PoSQLTimeUnit::Second,
-            PoSQLTimeZone::Utc,
-            [1625072400],
-        ),
+        timestamptz("time_stamp", PoSQLTimeUnit::Second, [1625072400]),
     ]);
     let owned_table_b: OwnedTable<DoryScalar> = owned_table([
         bigint("a", [1]),
         int128("b", [0]),
         varchar("c", ["0"]),
         boolean("d", [true]),
-        timestamptz_epoch(
-            "time_stamp",
-            PoSQLTimeUnit::Second,
-            PoSQLTimeZone::Utc,
-            [1625076000],
-        ),
+        timestamptz("time_stamp", PoSQLTimeUnit::Second, [1625076000]),
     ]);
     assert_ne!(owned_table_a, owned_table_b);
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -49,12 +49,7 @@ fn we_can_access_the_columns_of_a_table() {
         varchar("varchar", ["a", "bc", "d", "e"]),
         scalar("scalar", [1, 2, 3, 4]),
         boolean("boolean", [true, false, true, false]),
-        timestamptz_epoch(
-            "time",
-            PoSQLTimeUnit::Second,
-            PoSQLTimeZone::Utc,
-            [4, 5, 6, 5],
-        ),
+        timestamptz("time", PoSQLTimeUnit::Second, [4, 5, 6, 5]),
     ]);
     accessor.add_table(table_ref_2, data2, 0_usize);
 

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -49,7 +49,7 @@ fn we_can_access_the_columns_of_a_table() {
         varchar("varchar", ["a", "bc", "d", "e"]),
         scalar("scalar", [1, 2, 3, 4]),
         boolean("boolean", [true, false, true, false]),
-        timestamptz(
+        timestamptz_epoch(
             "time",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -230,14 +230,10 @@ pub fn timestamptz_epoch<S: Scalar>(
     timezone: PoSQLTimeZone,
     data: impl IntoIterator<Item = i64>,
 ) -> (Identifier, OwnedColumn<S>) {
-    let result = (
+    (
         name.parse().unwrap(),
         OwnedColumn::TimestampTZ(time_unit, timezone, data.into_iter().collect()),
-    );
-
-    dbg!(result.clone().1);
-
-    result
+    )
 }
 
 /// Creates a (Identifier, OwnedColumn) pair for a timestamp column.
@@ -281,7 +277,6 @@ pub fn timestamptz<S: Scalar>(
     let result = (
         name.parse().unwrap(),
         OwnedColumn::TimestampTZ(
-            // We assume all timestamps have the same time unit, so take the unit from the first timestamp.
             parsed_data
                 .first()
                 .expect("No timestamps provided")
@@ -300,12 +295,4 @@ pub fn timestamptz<S: Scalar>(
     );
 
     result
-}
-
-#[macro_export]
-/// Macro to convert a given Unix timestamp in seconds into an RFC 3339 formatted string.
-macro_rules! epoch_to_rfc3339 {
-    ($x:expr) => {
-        Utc.timestamp_opt($x, 0).unwrap().to_rfc3339()
-    };
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -254,11 +254,13 @@ pub fn timestamptz_epoch<S: Scalar>(
 ///    posql_time::{PoSQLTimeZone, PoSQLTimeUnit}};
 ///
 /// let result = owned_table::<Curve25519Scalar>([
-///        timestamptz("event_time", vec![
-///            "1969-12-31T23:59:59Z", // One second before the Unix epoch
-///            "1970-01-01T00:00:00Z", // The Unix epoch
-///            "1970-01-01T00:00:01Z", // One second after the Unix epoch
-///        ].iter().map(|s| s.to_string())),
+///         timestamptz("event_time",
+///         PoSQLTimeUnit::Second,
+///         vec![
+///             "1969-12-31T23:59:59Z", // One second before the Unix epoch
+///             "1970-01-01T00:00:00Z", // The Unix epoch
+///             "1970-01-01T00:00:01Z", // One second after the Unix epoch
+///         ].iter().map(|s| s.to_string())),
 /// ]);
 /// ```
 pub fn timestamptz<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/mod.rs
+++ b/crates/proof-of-sql/src/sql/mod.rs
@@ -4,3 +4,7 @@ pub mod parse;
 pub mod postprocessing;
 pub mod proof;
 pub mod transform;
+/// Contains testing machinery shared between different
+/// modules.
+#[cfg(feature = "test")]
+pub mod utils;

--- a/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use proof_of_sql_parser::{
     intermediate_ast::{AggregationOperator, BinaryOperator, Expression, Literal, UnaryOperator},
+    posql_time::{PoSQLTimeUnit, PoSQLTimestampError},
     Identifier,
 };
 use std::collections::HashMap;
@@ -100,9 +101,27 @@ impl ProvableExprPlanBuilder<'_> {
                 s.clone(),
                 s.into(),
             )))),
-            Literal::Timestamp(its) => Ok(ProvableExprPlan::new_literal(
-                LiteralValue::TimeStampTZ(its.timeunit, its.timezone, its.timestamp.timestamp()),
-            )),
+            Literal::Timestamp(its) => {
+                let timestamp = match its.timeunit {
+                    PoSQLTimeUnit::Nanosecond => {
+                        its.timestamp.timestamp_nanos_opt().ok_or_else(|| {
+                                PoSQLTimestampError::UnsupportedPrecision("Timestamp out of range: 
+                                Valid nanosecond timestamps must be between 1677-09-21T00:12:43.145224192 
+                                and 2262-04-11T23:47:16.854775807.".to_owned()
+                            )
+                        })?
+                    }
+                    PoSQLTimeUnit::Microsecond => its.timestamp.timestamp_micros(),
+                    PoSQLTimeUnit::Millisecond => its.timestamp.timestamp_millis(),
+                    PoSQLTimeUnit::Second => its.timestamp.timestamp(),
+                };
+
+                Ok(ProvableExprPlan::new_literal(LiteralValue::TimeStampTZ(
+                    its.timeunit,
+                    its.timezone,
+                    timestamp,
+                )))
+            }
         }
     }
 

--- a/crates/proof-of-sql/src/sql/utils.rs
+++ b/crates/proof-of-sql/src/sql/utils.rs
@@ -1,0 +1,78 @@
+use crate::{
+    base::database::{
+        owned_table_utility::{convert_timestamps_to_epochs, *},
+        OwnedTableTestAccessor, TestAccessor,
+    },
+    sql::{parse::QueryExpr, proof::VerifiableQueryResult},
+    to_epochs,
+};
+use blitzar::proof::InnerProductProof;
+use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimestamp};
+
+/// Functions to convert arbitrary-type slices into unix epoch slices
+pub trait TimestampData {
+    /// Convert supported sliced types into slices of unix epochs with
+    /// a given precision
+    fn to_timestamps(&self, timeunit: PoSQLTimeUnit) -> Vec<i64>;
+}
+
+impl TimestampData for Vec<i64> {
+    fn to_timestamps(&self, timeunit: PoSQLTimeUnit) -> Vec<i64> {
+        self.iter()
+            .map(|&s| {
+                let ts = PoSQLTimestamp::to_timestamp(s).unwrap();
+                match timeunit {
+                    PoSQLTimeUnit::Second => ts.timestamp.timestamp(),
+                    PoSQLTimeUnit::Millisecond => ts.timestamp.timestamp_millis(),
+                    PoSQLTimeUnit::Microsecond => ts.timestamp.timestamp_micros(),
+                    PoSQLTimeUnit::Nanosecond => ts.timestamp.timestamp_nanos_opt().unwrap(),
+                }
+            })
+            .collect()
+    }
+}
+
+impl TimestampData for Vec<&str> {
+    fn to_timestamps(&self, time_unit: PoSQLTimeUnit) -> Vec<i64> {
+        to_epochs!(&self, time_unit)
+    }
+}
+
+/// Given either a slice of i64 unix epochs, or a slice of rfc3339 strings,
+/// this function abstracts away the process of carrying out query against
+/// an owned table.
+pub fn run_timestamp_query_test<T: TimestampData, U: TimestampData>(
+    query_str: &str,
+    test_timestamps: &T,
+    test_timeunit: PoSQLTimeUnit,
+    expected_timestamps: &U,
+    expected_timeunit: PoSQLTimeUnit,
+) {
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+
+    let test_ts_vec = test_timestamps.to_timestamps(test_timeunit);
+    let expected_ts_vec = expected_timestamps.to_timestamps(expected_timeunit);
+
+    accessor.add_table(
+        "sxt.table".parse().unwrap(),
+        owned_table([timestamptz("times", test_timeunit, test_ts_vec)]),
+        0,
+    );
+
+    let query = QueryExpr::try_new(
+        query_str.parse().unwrap(),
+        "sxt".parse().unwrap(),
+        &accessor,
+    )
+    .unwrap();
+
+    let proof = VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+
+    let owned_table_result = proof
+        .verify(query.proof_expr(), &accessor, &())
+        .unwrap()
+        .table;
+    let expected_result = owned_table([timestamptz("times", expected_timeunit, expected_ts_vec)]);
+
+    assert_eq!(owned_table_result, expected_result);
+}

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -1,22 +1,19 @@
 #![cfg(feature = "test")]
-#[cfg(feature = "blitzar")]
-use proof_of_sql::base::commitment::InnerProductProof;
 use proof_of_sql::{
     base::database::{owned_table_utility::*, OwnedTableTestAccessor, TestAccessor},
     proof_primitive::dory::{
-        test_rng, DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup,
-        DoryVerifierPublicSetup, ProverSetup, PublicParameters, VerifierSetup,
+        test_rng, DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup,
+        PublicParameters, VerifierSetup,
     },
-    sql::{
-        parse::QueryExpr,
-        proof::{QueryProof, VerifiableQueryResult},
-    },
+    sql::{parse::QueryExpr, proof::QueryProof},
 };
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
+    use proof_of_sql_parser::posql_time::PoSQLTimestamp;
+
     let public_parameters = PublicParameters::rand(4, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
@@ -36,12 +33,12 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
                 "times",
                 PoSQLTimeUnit::Second,
                 [
-                    "1969-12-31T23:59:59Z", // One second before the Unix epoch
-                    "1970-01-01T00:00:00Z", // The Unix epoch
-                    "1970-01-01T00:00:01Z", // One second after the Unix epoch
+                    "1969-12-31T23:59:59Z", // -1
+                    "1970-01-01T00:00:00Z", // 0
+                    "1970-01-01T00:00:01Z", // 1
                 ]
                 .iter()
-                .map(|s| s.to_string()),
+                .map(|s| PoSQLTimestamp::try_from(s).unwrap().timestamp.timestamp()),
             ),
         ]),
         0,
@@ -68,679 +65,17 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
     let expected_result = owned_table([timestamptz(
         "times",
         PoSQLTimeUnit::Second,
-        ["1970-01-01T00:00:00Z".to_string()],
+        ["1970-01-01T00:00:00Z"]
+            .iter()
+            .map(|s| PoSQLTimestamp::try_from(s).unwrap().timestamp.timestamp()),
     )]);
     assert_eq!(owned_table_result, expected_result);
-}
-
-/// Runs a timestamp query test with unix epochs as input.
-#[cfg(feature = "blitzar")]
-fn run_timestamp_epoch_query_test(
-    query_str: &str,
-    test_timestamps: &[i64], // Input timestamps for the test
-    test_timeunit: PoSQLTimeUnit,
-    expected_timestamps: &[i64], // Expected timestamps to match the query result
-    expected_timeunit: PoSQLTimeUnit,
-) {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-
-    // Setting up a table specifically for timestamps
-    accessor.add_table(
-        "sxt.table".parse().unwrap(),
-        owned_table([timestamptz_epoch(
-            "times",
-            test_timeunit,
-            PoSQLTimeZone::Utc,
-            test_timestamps.to_owned(),
-        )]),
-        0,
-    );
-
-    // Parse and execute the query
-    let query = QueryExpr::try_new(
-        query_str.parse().unwrap(),
-        "sxt".parse().unwrap(),
-        &accessor,
-    )
-    .unwrap();
-
-    let proof = VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-
-    // Verify the results
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &())
-        .unwrap()
-        .table;
-    let expected_result = owned_table([timestamptz_epoch(
-        "times",
-        expected_timeunit,
-        PoSQLTimeZone::Utc,
-        expected_timestamps.to_owned(),
-    )]);
-
-    // Check if the results match the expected results
-    assert_eq!(owned_table_result, expected_result);
-}
-
-/// Runs a timestamp query test with unix epochs as input.
-#[cfg(feature = "blitzar")]
-fn run_timestamp_query_test(
-    query_str: &str,
-    test_timestamps: &[&str], // Input timestamps for the test
-    test_timeunit: PoSQLTimeUnit,
-    expected_timestamps: &[&str], // Expected timestamps to match the query
-    expected_timeunit: PoSQLTimeUnit,
-) {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-
-    // Setting up a table specifically for timestamps
-    accessor.add_table(
-        "sxt.table".parse().unwrap(),
-        owned_table([timestamptz(
-            "times",
-            test_timeunit,
-            test_timestamps.iter().map(|s| s.to_string()),
-        )]),
-        0,
-    );
-
-    // Parse and execute the query
-    let query = QueryExpr::try_new(
-        query_str.parse().unwrap(),
-        "sxt".parse().unwrap(),
-        &accessor,
-    )
-    .unwrap();
-
-    let proof = VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-
-    // Verify the results
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &())
-        .unwrap()
-        .table;
-    let expected_result = owned_table([timestamptz(
-        "times",
-        expected_timeunit,
-        expected_timestamps.iter().map(|s| s.to_string()),
-    )]);
-
-    // Check if the results match the expected results
-    assert_eq!(owned_table_result, expected_result);
-}
-
-#[cfg(feature = "blitzar")]
-#[cfg(feature = "test")]
-mod tests {
-
-    use crate::{run_timestamp_epoch_query_test, run_timestamp_query_test};
-    use chrono::DateTime;
-    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
-
-    #[test]
-    fn test_basic_timestamp_query() {
-        let test_timestamps = &[1609459200, 1612137600, 1614556800];
-        let expected_timestamps = &[1609459200_i64];
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2021-01-01T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[should_panic] //these should pass once the scaling bug is resolved
-    #[test]
-    fn test_precision_and_rounding() {
-        // Testing timestamps near rounding thresholds in milliseconds
-        let test_timestamps = &["2009-01-03T18:15:05.999Z"];
-        let expected_timestamps = &["2009-01-03T18:15:05.999Z"];
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05.999Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-
-        // test microseconds
-        let test_timestamps = &["2009-01-03T18:15:05.999999Z"];
-        let expected_timestamps = &["2009-01-03T18:15:05.999999Z"];
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05.999999Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-
-        // test nanoseconds
-        let test_timestamps = &["2009-01-03T18:15:05.999999999Z"];
-        let expected_timestamps = &["2009-01-03T18:15:05.999999999Z"];
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05.999999999Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-
-        // test nanoseconds
-        let test_timestamps = &["2009-01-03T18:15:05.999Z", "2009-01-03T18:15:05.000Z"];
-        let expected_timestamps = &["2009-01-03T18:15:05.000Z"];
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[should_panic] //these should pass once the scaling bug is resolved
-    #[test]
-    fn test_precision_and_rounding_with_differing_precisions() {
-        // Testing timestamps near rounding thresholds in milliseconds
-        let test_timestamps = &[
-            "2009-01-03T18:15:05.999999999Z",
-            "2009-01-03T18:15:05.000000000Z",
-        ];
-        let expected_timestamps = &["2009-01-03T18:15:05.000000000Z"];
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Nanosecond,
-            expected_timestamps,
-            PoSQLTimeUnit::Nanosecond,
-        );
-
-        // // Testing timestamps near rounding thresholds in milliseconds
-        // let test_timestamps = &["2009-01-03T18:15:05.999999Z", "2009-01-03T18:15:05.000000Z"];
-        // let expected_timestamps = &["2009-01-03T18:15:05.000000Z"];
-        // run_timestamp_query_test(
-        //     "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
-        //     test_timestamps,
-        //     expected_timestamps,
-        // );
-
-        // // Testing timestamps near rounding thresholds in milliseconds
-        // let test_timestamps = &["2009-01-03T18:15:05.999Z", "2009-01-03T18:15:05.000Z"];
-        // let expected_timestamps = &["2009-01-03T18:15:05.000Z"];
-        // run_timestamp_query_test(
-        //     "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
-        //     test_timestamps,
-        //     expected_timestamps,
-        // );
-
-        // // Test scaling a query literal to match a variety of timestamp precisions
-        // let test_timestamps = &[
-        //     "2009-01-03T18:15:05.0Z",
-        //     "2009-01-03T18:15:05.00Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.0000Z",
-        //     "2009-01-03T18:15:05.00000Z",
-        //     "2009-01-03T18:15:05.000000Z",
-        //     "2009-01-03T18:15:05.0000000Z",
-        //     "2009-01-03T18:15:05.00000000Z",
-        //     "2009-01-03T18:15:05.000000000Z",
-        //     "2009-01-03T18:15:05Z",
-        //     "2009-01-03T18:15:05.1Z",
-        //     "2009-01-03T18:15:05.12Z",
-        //     "2009-01-03T18:15:05.123Z",
-        //     "2009-01-03T18:15:05.1234Z",
-        //     "2009-01-03T18:15:05.12345Z",
-        //     "2009-01-03T18:15:05.123456Z",
-        //     "2009-01-03T18:15:05.1234567Z",
-        //     "2009-01-03T18:15:05.1234568Z",
-        //     "2009-01-03T18:15:05.12345689Z",
-        // ];
-        // let expected_timestamps = &[
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        //     "2009-01-03T18:15:05.000Z",
-        // ];
-        // run_timestamp_query_test(
-        //     "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
-        //     test_timestamps,
-        //     expected_timestamps,
-        // );
-        // run_timestamp_query_test(
-        //     "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05.123456Z';",
-        //     test_timestamps,
-        //     &["2009-01-03T18:15:05.123456Z"],
-        // );
-        // run_timestamp_query_test(
-        //     "SELECT * FROM table WHERE times > timestamp '2009-01-03T18:15:05.123456Z';",
-        //     test_timestamps,
-        //     &[
-        //         "2009-01-03T18:15:05.1234567Z",
-        //         "2009-01-03T18:15:05.1234568Z",
-        //         "2009-01-03T18:15:05.12345689Z",
-        //     ],
-        // );
-        // run_timestamp_query_test(
-        //     "SELECT * FROM table WHERE times < timestamp '2009-01-03T18:15:05.123456Z';",
-        //     test_timestamps,
-        //     &[
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05.000Z",
-        //         "2009-01-03T18:15:05Z",
-        //         "2009-01-03T18:15:05.1Z",
-        //         "2009-01-03T18:15:05.12Z",
-        //         "2009-01-03T18:15:05.123Z",
-        //         "2009-01-03T18:15:05.1234Z",
-        //         "2009-01-03T18:15:05.12345Z",
-        //     ],
-        // );
-    }
-
-    #[test]
-    fn test_equality_with_variety_of_rfc3339_timestamps() {
-        // Testing timestamps near rounding thresholds
-        let test_timestamps = &[
-            "2009-01-03T18:15:05Z", // Bitcoin genesis block time
-            "1970-01-01T00:00:00Z", // Unix epoch
-            "1969-07-20T20:17:40Z", // Apollo 11 moon landing
-            "1993-04-30T00:00:00Z", // World Wide Web goes live
-            "1927-03-07T00:00:00Z", // Discovery of Penicillin
-            "2004-02-04T00:00:00Z", // Founding of Facebook
-            "2011-11-26T05:17:57Z", // Curiosity Rover lands on Mars
-        ];
-        let expected_timestamps = &["2009-01-03T18:15:05Z"];
-
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times >= timestamp '1993-04-30T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[
-                "2009-01-03T18:15:05Z",
-                "1993-04-30T00:00:00Z",
-                "2004-02-04T00:00:00Z",
-                "2011-11-26T05:17:57Z",
-            ],
-            PoSQLTimeUnit::Second,
-        );
-
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times > timestamp '1993-04-30T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[
-                "2009-01-03T18:15:05Z",
-                "2004-02-04T00:00:00Z",
-                "2011-11-26T05:17:57Z",
-            ],
-            PoSQLTimeUnit::Second,
-        );
-
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times <= timestamp '1993-04-30T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[
-                "1970-01-01T00:00:00Z",
-                "1969-07-20T20:17:40Z",
-                "1993-04-30T00:00:00Z",
-                "1927-03-07T00:00:00Z",
-            ],
-            PoSQLTimeUnit::Second,
-        );
-
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times < timestamp '1993-04-30T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[
-                "1970-01-01T00:00:00Z",
-                "1969-07-20T20:17:40Z",
-                "1927-03-07T00:00:00Z",
-            ],
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_basic_timestamp_inequality_query() {
-        let test_timestamps = &[i64::MIN, -1, 0, 1, i64::MAX];
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[i64::MIN, -1],
-            PoSQLTimeUnit::Second,
-        );
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[1, i64::MAX],
-            PoSQLTimeUnit::Second,
-        );
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[0, 1, i64::MAX],
-            PoSQLTimeUnit::Second,
-        );
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[i64::MIN, -1, 0],
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_timestamp_inequality_queries_with_timezone_offsets() {
-        // Test with a range of timestamps around the Unix epoch
-        // 60 * 60 = 3600 * 8 (PST offset) = 28800
-        let test_timestamps = &[28800, 28799, -1, 0, 1];
-
-        // Test timezone offset -08:00 (e.g., Pacific Standard Time)
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00-08:00';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[],
-            PoSQLTimeUnit::Second,
-        );
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00-08:00';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[28799, -1, 0, 1],
-            PoSQLTimeUnit::Second,
-        );
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00-08:00';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[28800],
-            PoSQLTimeUnit::Second,
-        );
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00-08:00';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[28800, 28799, -1, 0, 1],
-            PoSQLTimeUnit::Second,
-        );
-
-        // Test timezone offset +00:00 (e.g., UTC)
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00+00:00';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[28800, 28799, 1],
-            PoSQLTimeUnit::Second,
-        );
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00+00:00';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[-1],
-            PoSQLTimeUnit::Second,
-        );
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00+00:00';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[28800, 28799, 0, 1],
-            PoSQLTimeUnit::Second,
-        );
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00+00:00';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[-1, 0],
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    // This test simulates the following query:
-    //
-    // 1. Creating a table:
-    //    CREATE TABLE test_table(name VARCHAR, mytime TIMESTAMP);
-    //
-    // 2. Inserting values into the table:
-    //    INSERT INTO test_table(name, mytime) VALUES
-    //    ('a', '2009-01-03T18:15:05+03:00'),
-    //    ('b', '2009-01-03T18:15:05+04:00'),
-    //    ('c', '2009-01-03T19:15:05+03:00'),
-    //    ('d', '2009-01-03T19:15:05+04:00');
-    //
-    // 3. Selecting entries where the timestamp matches a specific value:
-    //    SELECT * FROM test_table WHERE mytime = '2009-01-03T19:15:05+04:00';
-    //
-    // This test confirms that timestamp parsing matches that of both postgresql
-    // and the gateway.
-    #[test]
-    fn test_timestamp_queries_match_postgresql_and_gateway() {
-        let test_timestamps = &[1230995705, 1230992105, 1230999305, 1230995705];
-        let expected_timestamps = &[1230995705, 1230995705];
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2009-01-03T19:15:05+04:00'",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_leap_seconds_parsing() {
-        // Unix time for 1998-12-31T23:59:59 UTC is 915148799
-        // Assuming leap second at 1998-12-31T23:59:60 UTC is recognized, it would be 915148799
-        // Unix time for 1999-01-01T00:00:00 UTC is 915148800
-        let test_timestamps = &[915148799, 915148800, 915148801];
-        let expected_timestamps = [915148799, 915148800, 915148801]; // Expect the leap second to be parsed and matched
-
-        // Test the query to select the leap second
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = timestamp '1998-12-31T23:59:60Z'",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &[915148799],
-            PoSQLTimeUnit::Second,
-        );
-
-        // Test the query to select the leap second
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = timestamp '1999-01-01T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            &expected_timestamps[1..2],
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_new_years_eve_boundary() {
-        let test_timestamps = &[
-            DateTime::parse_from_rfc3339("2023-12-31T23:59:59Z")
-                .unwrap()
-                .timestamp(),
-            DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
-                .unwrap()
-                .timestamp(),
-        ];
-        let expected_timestamps = &[test_timestamps[1]]; // Expect only the new year start
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2024-01-01T00:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[should_panic] //these should pass once the scaling bug is resolved
-    #[test]
-    fn test_fractional_seconds_handling() {
-        let test_timestamps = &[
-            "2023-07-01T12:00:00.999Z", /* "2023-07-01T12:00:01.000Z"*/
-        ];
-        let expected_timestamps = &["2023-07-01T12:00:00.999Z"];
-
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2023-07-01T12:00:00.999Z'",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_february_29_leap_year() {
-        // Test year 2024 which is a leap year
-        let test_timestamps = &[
-            DateTime::parse_from_rfc3339("2024-02-29T12:00:00Z")
-                .unwrap()
-                .timestamp(),
-            DateTime::parse_from_rfc3339("2024-03-01T12:00:00Z")
-                .unwrap()
-                .timestamp(),
-        ];
-        let expected_timestamps = &[test_timestamps[0]]; // Expect the leap day
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2024-02-29T12:00:00Z';",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_time_zone_crossings() {
-        // Checking how the same absolute moment is handled in different time zones
-        let test_timestamps = &[
-            DateTime::parse_from_rfc3339("2023-08-15T15:00:00-05:00")
-                .unwrap()
-                .timestamp(), // Central Time
-            DateTime::parse_from_rfc3339("2023-08-15T16:00:00-04:00")
-                .unwrap()
-                .timestamp(), // Eastern Time, same moment
-        ];
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2023-08-15T20:00:00Z'", // UTC time
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_basic_unix_epoch() {
-        // Parse the RFC 3339 formatted string to Unix timestamps directly
-        let test_timestamps = &[
-            DateTime::parse_from_rfc3339("2009-01-03T18:15:05Z")
-                .unwrap()
-                .timestamp(), // The test timestamp from RFC 3339 string
-        ];
-
-        let expected_timestamps = &[
-            DateTime::parse_from_rfc3339("2009-01-03T18:15:05Z")
-                .unwrap()
-                .timestamp(), // The expected timestamp, same as test
-        ];
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = to_timestamp(1231006505);",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_unix_epoch_daylight_saving() {
-        // Timestamps just before and after DST change in spring
-        let test_timestamps = &[1583651999, 1583652000]; // Spring forward at 2 AM
-        let expected_timestamps = &[1583651999]; // Only the time before the DST jump should match
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = to_timestamp(1583651999)",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_unix_epoch_leap_year() {
-        let test_timestamps = &[1582934400]; // 2020-02-29T00:00:00Z
-        let expected_timestamps = &[1582934400];
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = to_timestamp(1582934400);",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
-
-    #[test]
-    fn test_unix_epoch_time_zone_handling() {
-        let test_timestamps = &[
-            1603587600, // 2020-10-25T01:00:00Z in UTC, corresponds to 2 AM in UTC+1 before DST ends
-            1603591200, // Corresponds to 2 AM in UTC+1 after DST ends (1 hour later)
-        ];
-        let expected_timestamps = &[1603587600];
-
-        run_timestamp_epoch_query_test(
-            "SELECT * FROM table WHERE times = to_timestamp(1603587600)",
-            test_timestamps,
-            PoSQLTimeUnit::Second,
-            expected_timestamps,
-            PoSQLTimeUnit::Second,
-        );
-    }
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
-    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+    use proof_of_sql::{proof_primitive::dory::DoryCommitment, sql::utils::TimestampData};
 
     let public_parameters = PublicParameters::rand(4, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
@@ -755,7 +90,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
             timestamptz(
                 "a",
                 PoSQLTimeUnit::Second,
-                [
+                vec![
                     "2009-01-03T18:15:05Z", // Bitcoin genesis block time
                     "1961-04-12T06:07:00Z", // First human spaceflight by Yuri Gagarin
                     "1969-07-20T20:17:40Z", // Apollo 11 moon landing
@@ -764,13 +99,12 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
                     "2004-02-04T00:00:00Z", // Founding of Facebook
                     "1964-05-20T00:00:00Z", // Cosmic Microwave Background Radiation discovered
                 ]
-                .iter()
-                .map(|s| s.to_string()),
+                .to_timestamps(PoSQLTimeUnit::Second),
             ),
             timestamptz(
                 "b",
                 PoSQLTimeUnit::Second,
-                [
+                vec![
                     "1953-02-28T00:00:00Z", // Publication of DNA's double helix structure
                     "1970-01-01T00:00:00Z", // Unix epoch
                     "1954-12-23T00:00:00Z", // First successful kidney transplant
@@ -779,8 +113,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
                     "2003-04-14T00:00:00Z", // Completion of the first draft of the human genome
                     "2011-11-26T05:17:57Z", // Curiosity Rover lands on Mars
                 ]
-                .iter()
-                .map(|s| s.to_string()),
+                .to_timestamps(PoSQLTimeUnit::Second),
             ),
         ]),
         0,
@@ -808,26 +141,181 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         timestamptz(
             "a",
             PoSQLTimeUnit::Second,
-            [
+            vec![
                 "1961-04-12T06:07:00Z",
                 "1983-01-01T00:00:00Z",
                 "1964-05-20T00:00:00Z",
             ]
-            .iter()
-            .map(|s| s.to_string()),
+            .to_timestamps(PoSQLTimeUnit::Second),
         ),
         timestamptz(
             "b",
             PoSQLTimeUnit::Second,
-            [
+            vec![
                 "1970-01-01T00:00:00Z",
                 "1993-04-30T00:00:00Z",
                 "2011-11-26T05:17:57Z",
             ]
-            .iter()
-            .map(|s| s.to_string()),
+            .to_timestamps(PoSQLTimeUnit::Second),
         ),
         boolean("res", [true, true, true]),
     ]);
     assert_eq!(owned_table_result, expected_result);
+}
+
+#[cfg(feature = "blitzar")]
+#[cfg(feature = "test")]
+mod tests {
+
+    use proof_of_sql::sql::utils::run_timestamp_query_test;
+    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+
+    #[test]
+    fn test_basic_timestamp_query() {
+        let test_timestamps: Vec<i64> = vec![1609459200, 1612137600, 1614556800]; // example timestamps
+        let expected_timestamps: Vec<i64> = vec![1609459200];
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2021-01-01T00:00:00Z';",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &expected_timestamps,
+            PoSQLTimeUnit::Second,
+        );
+    }
+
+    #[test]
+    fn test_leap_seconds_parsing() {
+        // Unix time for 1998-12-31T23:59:59 UTC is 915148799
+        // Assuming leap second at 1998-12-31T23:59:60 UTC is recognized, it would be 915148799
+        // Unix time for 1999-01-01T00:00:00 UTC is 915148800
+        let test_timestamps = vec![915148799, 915148800, 915148801];
+
+        // Test the query to select the leap second
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '1998-12-31T23:59:60Z'",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &vec![915148799],
+            PoSQLTimeUnit::Second,
+        );
+
+        // Test the query to select the leap second
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '1999-01-01T00:00:00Z';",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &vec![915148800],
+            PoSQLTimeUnit::Second,
+        );
+    }
+
+    #[test]
+    fn test_new_years_eve_boundary() {
+        let test_timestamps = vec!["2023-12-31T23:59:59Z", "2024-01-01T00:00:00Z"];
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2024-01-01T00:00:00Z';",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &vec![test_timestamps[1]],
+            PoSQLTimeUnit::Second,
+        );
+    }
+
+    #[test]
+    fn test_february_29_leap_year() {
+        // Test year 2024 which is a leap year
+        let test_timestamps = vec!["2024-02-29T12:00:00Z", "2024-03-01T12:00:00Z"];
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2024-02-29T12:00:00Z';",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &vec![test_timestamps[0]],
+            PoSQLTimeUnit::Second,
+        );
+    }
+
+    #[test]
+    fn test_time_zone_crossings() {
+        // Checking how the same absolute moment is handled in different time zones
+        let test_timestamps = vec![
+            "2023-08-15T15:00:00-05:00", // Central Time
+            "2023-08-15T16:00:00-04:00", // Eastern Time, same moment
+        ];
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2023-08-15T20:00:00Z'", // UTC time
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+        );
+    }
+
+    #[test]
+    fn test_basic_unix_epoch() {
+        // Parse the RFC 3339 formatted string to Unix timestamps directly
+        let test_timestamps = vec![
+            "2009-01-03T18:15:05Z", // The test timestamp from RFC 3339 string
+        ];
+
+        let expected_timestamps = vec![
+            "2009-01-03T18:15:05Z", // The expected timestamp, same as test
+        ];
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = to_timestamp(1231006505);",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &expected_timestamps,
+            PoSQLTimeUnit::Second,
+        );
+    }
+
+    #[test]
+    fn test_unix_epoch_daylight_saving() {
+        // Timestamps just before and after DST change in spring
+        let test_timestamps = vec![1583651999, 1583652000]; // Spring forward at 2 AM
+        let expected_timestamps = vec![1583651999]; // Only the time before the DST jump should match
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = to_timestamp(1583651999)",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &expected_timestamps,
+            PoSQLTimeUnit::Second,
+        );
+    }
+
+    #[test]
+    fn test_unix_epoch_leap_year() {
+        let test_timestamps = vec![1582934400]; // 2020-02-29T00:00:00Z
+        let expected_timestamps = vec![1582934400];
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = to_timestamp(1582934400);",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &expected_timestamps,
+            PoSQLTimeUnit::Second,
+        );
+    }
+
+    #[test]
+    fn test_unix_epoch_time_zone_handling() {
+        let test_timestamps = vec![
+            1603587600, // 2020-10-25T01:00:00Z in UTC, corresponds to 2 AM in UTC+1 before DST ends
+            1603591200, // Corresponds to 2 AM in UTC+1 after DST ends (1 hour later)
+        ];
+        let expected_timestamps = vec![1603587600];
+
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = to_timestamp(1603587600)",
+            &test_timestamps,
+            PoSQLTimeUnit::Second,
+            &expected_timestamps,
+            PoSQLTimeUnit::Second,
+        );
+    }
 }

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -595,26 +595,30 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
             timestamptz(
                 "a",
                 PoSQLTimeUnit::Nanosecond,
-                ["2009-01-03T18:15:05Z", // Bitcoin genesis block time
+                [
+                    "2009-01-03T18:15:05Z", // Bitcoin genesis block time
                     "1961-04-12T06:07:00Z", // First human spaceflight by Yuri Gagarin
                     "1969-07-20T20:17:40Z", // Apollo 11 moon landing
                     "1983-01-01T00:00:00Z", // Official start of the Internet (TCP/IP)
                     "1927-03-07T00:00:00Z", // Discovery of Penicillin
                     "2004-02-04T00:00:00Z", // Founding of Facebook
-                    "1964-05-20T00:00:00Z"]
+                    "1964-05-20T00:00:00Z",
+                ]
                 .iter()
                 .map(|s| s.to_string()),
             ),
             timestamptz(
                 "b",
                 PoSQLTimeUnit::Nanosecond,
-                ["1953-02-28T00:00:00Z", // Publication of DNA's double helix structure
+                [
+                    "1953-02-28T00:00:00Z", // Publication of DNA's double helix structure
                     "1970-01-01T00:00:00Z", // Unix epoch
                     "1954-12-23T00:00:00Z", // First successful kidney transplant
                     "1993-04-30T00:00:00Z", // World Wide Web goes live
                     "1905-11-21T00:00:00Z", // Einstein's paper on mass-energy equivalence, E=mc²
                     "2003-04-14T00:00:00Z", // Completion of the first draft of the human genome
-                    "2011-11-26T05:17:57Z"]
+                    "2011-11-26T05:17:57Z",
+                ]
                 .iter()
                 .map(|s| s.to_string()),
             ),
@@ -644,18 +648,22 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         timestamptz(
             "a",
             PoSQLTimeUnit::Nanosecond,
-            ["1961-04-12T06:07:00Z",
+            [
+                "1961-04-12T06:07:00Z",
                 "1983-01-01T00:00:00Z",
-                "1964-05-20T00:00:00Z"]
+                "1964-05-20T00:00:00Z",
+            ]
             .iter()
             .map(|s| s.to_string()),
         ),
         timestamptz(
             "b",
             PoSQLTimeUnit::Nanosecond,
-            ["1970-01-01T00:00:00Z",
+            [
+                "1970-01-01T00:00:00Z",
                 "1993-04-30T00:00:00Z",
-                "2011-11-26T05:17:57Z"]
+                "2011-11-26T05:17:57Z",
+            ]
             .iter()
             .map(|s| s.to_string()),
         ),

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -602,7 +602,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
                     "1983-01-01T00:00:00Z", // Official start of the Internet (TCP/IP)
                     "1927-03-07T00:00:00Z", // Discovery of Penicillin
                     "2004-02-04T00:00:00Z", // Founding of Facebook
-                    "1964-05-20T00:00:00Z",
+                    "1964-05-20T00:00:00Z", // Cosmic Microwave Background Radiation discovered
                 ]
                 .iter()
                 .map(|s| s.to_string()),
@@ -617,7 +617,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
                     "1993-04-30T00:00:00Z", // World Wide Web goes live
                     "1905-11-21T00:00:00Z", // Einstein's paper on mass-energy equivalence, E=mc²
                     "2003-04-14T00:00:00Z", // Completion of the first draft of the human genome
-                    "2011-11-26T05:17:57Z",
+                    "2011-11-26T05:17:57Z", // Curiosity Rover lands on Mars
                 ]
                 .iter()
                 .map(|s| s.to_string()),

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -219,6 +219,16 @@ mod tests {
             test_timestamps,
             expected_timestamps,
         );
+
+        // test nanoseconds
+        let test_timestamps = vec!["2009-01-03T18:15:05.999Z", "2009-01-03T18:15:05.000Z"];
+        let expected_timestamps = vec!["2009-01-03T18:15:05.000Z"];
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
+            PoSQLTimeUnit::Millisecond,
+            test_timestamps,
+            expected_timestamps,
+        );
     }
 
     #[test]

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -77,9 +77,8 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
 #[cfg(feature = "blitzar")]
 fn run_timestamp_epoch_query_test(
     query_str: &str,
-    test_timestamps: Vec<i64>,     // Input timestamps for the test
-    expected_timestamps: Vec<i64>, // Expected timestamps to match the query result
-    expected_timeunit: PoSQLTimeUnit,
+    test_timestamps: &[i64],     // Input timestamps for the test
+    expected_timestamps: &[i64], // Expected timestamps to match the query result
 ) {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
 
@@ -88,9 +87,9 @@ fn run_timestamp_epoch_query_test(
         "sxt.table".parse().unwrap(),
         owned_table([timestamptz_epoch(
             "times",
-            expected_timeunit,
+            PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
-            test_timestamps,
+            test_timestamps.to_owned(),
         )]),
         0,
     );
@@ -112,9 +111,9 @@ fn run_timestamp_epoch_query_test(
         .table;
     let expected_result = owned_table([timestamptz_epoch(
         "times",
-        expected_timeunit,
+        PoSQLTimeUnit::Second,
         PoSQLTimeZone::Utc,
-        expected_timestamps,
+        expected_timestamps.to_owned(),
     )]);
 
     // Check if the results match the expected results
@@ -125,9 +124,8 @@ fn run_timestamp_epoch_query_test(
 #[cfg(feature = "blitzar")]
 fn run_timestamp_query_test(
     query_str: &str,
-    test_timeunit: PoSQLTimeUnit,
-    test_timestamps: Vec<&str>,     // Input timestamps for the test
-    expected_timestamps: Vec<&str>, // Expected timestamps to match the query
+    test_timestamps: &[&str],     // Input timestamps for the test
+    expected_timestamps: &[&str], // Expected timestamps to match the query
 ) {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
 
@@ -136,7 +134,7 @@ fn run_timestamp_query_test(
         "sxt.table".parse().unwrap(),
         owned_table([timestamptz(
             "times",
-            test_timeunit,
+            PoSQLTimeUnit::Second,
             test_timestamps.iter().map(|s| s.to_string()),
         )]),
         0,
@@ -159,7 +157,7 @@ fn run_timestamp_query_test(
         .table;
     let expected_result = owned_table([timestamptz(
         "times",
-        test_timeunit,
+        PoSQLTimeUnit::Second,
         expected_timestamps.iter().map(|s| s.to_string()),
     )]);
 
@@ -173,68 +171,174 @@ mod tests {
 
     use crate::{run_timestamp_epoch_query_test, run_timestamp_query_test};
     use chrono::DateTime;
-    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 
     #[test]
     fn test_basic_timestamp_query() {
-        let test_timestamps = vec![1609459200, 1612137600, 1614556800];
-        let expected_timestamps = vec![1609459200];
+        let test_timestamps = &[
+            1609459200000000000,
+            1612137600000000000,
+            1614556800000000000,
+        ];
+        let expected_timestamps = &[1609459200000000000_i64];
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = timestamp '2021-01-01T00:00:00Z';",
             test_timestamps,
             expected_timestamps,
-            PoSQLTimeUnit::Second,
         );
     }
 
     #[test]
     fn test_precision_and_rounding() {
         // Testing timestamps near rounding thresholds in milliseconds
-        let test_timestamps = vec!["2009-01-03T18:15:05.999Z"];
-        let expected_timestamps = vec!["2009-01-03T18:15:05.999Z"];
+        let test_timestamps = &["2009-01-03T18:15:05.999Z"];
+        let expected_timestamps = &["2009-01-03T18:15:05.999Z"];
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05.999Z';",
-            PoSQLTimeUnit::Millisecond,
             test_timestamps,
             expected_timestamps,
         );
 
         // test microseconds
-        let test_timestamps = vec!["2009-01-03T18:15:05.999999Z"];
-        let expected_timestamps = vec!["2009-01-03T18:15:05.999999Z"];
+        let test_timestamps = &["2009-01-03T18:15:05.999999Z"];
+        let expected_timestamps = &["2009-01-03T18:15:05.999999Z"];
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05.999999Z';",
-            PoSQLTimeUnit::Microsecond,
             test_timestamps,
             expected_timestamps,
         );
 
         // test nanoseconds
-        let test_timestamps = vec!["2009-01-03T18:15:05.999999999Z"];
-        let expected_timestamps = vec!["2009-01-03T18:15:05.999999999Z"];
+        let test_timestamps = &["2009-01-03T18:15:05.999999999Z"];
+        let expected_timestamps = &["2009-01-03T18:15:05.999999999Z"];
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05.999999999Z';",
-            PoSQLTimeUnit::Nanosecond,
             test_timestamps,
             expected_timestamps,
         );
 
         // test nanoseconds
-        let test_timestamps = vec!["2009-01-03T18:15:05.999Z", "2009-01-03T18:15:05.000Z"];
-        let expected_timestamps = vec!["2009-01-03T18:15:05.000Z"];
+        let test_timestamps = &["2009-01-03T18:15:05.999Z", "2009-01-03T18:15:05.000Z"];
+        let expected_timestamps = &["2009-01-03T18:15:05.000Z"];
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
-            PoSQLTimeUnit::Millisecond,
             test_timestamps,
             expected_timestamps,
         );
     }
 
     #[test]
+    fn test_precision_and_rounding_with_differing_precisions() {
+        // Testing timestamps near rounding thresholds in milliseconds
+        let test_timestamps = &[
+            "2009-01-03T18:15:05.999999999Z",
+            "2009-01-03T18:15:05.000000000Z",
+        ];
+        let expected_timestamps = &["2009-01-03T18:15:05.000000000Z"];
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
+            test_timestamps,
+            expected_timestamps,
+        );
+
+        // Testing timestamps near rounding thresholds in milliseconds
+        let test_timestamps = &["2009-01-03T18:15:05.999999Z", "2009-01-03T18:15:05.000000Z"];
+        let expected_timestamps = &["2009-01-03T18:15:05.000000Z"];
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
+            test_timestamps,
+            expected_timestamps,
+        );
+
+        // Testing timestamps near rounding thresholds in milliseconds
+        let test_timestamps = &["2009-01-03T18:15:05.999Z", "2009-01-03T18:15:05.000Z"];
+        let expected_timestamps = &["2009-01-03T18:15:05.000Z"];
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
+            test_timestamps,
+            expected_timestamps,
+        );
+
+        // Test scaling a query literal to match a variety of timestamp precisions
+        let test_timestamps = &[
+            "2009-01-03T18:15:05.0Z",
+            "2009-01-03T18:15:05.00Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.0000Z",
+            "2009-01-03T18:15:05.00000Z",
+            "2009-01-03T18:15:05.000000Z",
+            "2009-01-03T18:15:05.0000000Z",
+            "2009-01-03T18:15:05.00000000Z",
+            "2009-01-03T18:15:05.000000000Z",
+            "2009-01-03T18:15:05Z",
+            "2009-01-03T18:15:05.1Z",
+            "2009-01-03T18:15:05.12Z",
+            "2009-01-03T18:15:05.123Z",
+            "2009-01-03T18:15:05.1234Z",
+            "2009-01-03T18:15:05.12345Z",
+            "2009-01-03T18:15:05.123456Z",
+            "2009-01-03T18:15:05.1234567Z",
+            "2009-01-03T18:15:05.1234568Z",
+            "2009-01-03T18:15:05.12345689Z",
+        ];
+        let expected_timestamps = &[
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+            "2009-01-03T18:15:05.000Z",
+        ];
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
+            test_timestamps,
+            expected_timestamps,
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05.123456Z';",
+            test_timestamps,
+            &["2009-01-03T18:15:05.123456Z"],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times > timestamp '2009-01-03T18:15:05.123456Z';",
+            test_timestamps,
+            &[
+                "2009-01-03T18:15:05.1234567Z",
+                "2009-01-03T18:15:05.1234568Z",
+                "2009-01-03T18:15:05.12345689Z",
+            ],
+        );
+        run_timestamp_query_test(
+            "SELECT * FROM table WHERE times < timestamp '2009-01-03T18:15:05.123456Z';",
+            test_timestamps,
+            &[
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05.000Z",
+                "2009-01-03T18:15:05Z",
+                "2009-01-03T18:15:05.1Z",
+                "2009-01-03T18:15:05.12Z",
+                "2009-01-03T18:15:05.123Z",
+                "2009-01-03T18:15:05.1234Z",
+                "2009-01-03T18:15:05.12345Z",
+            ],
+        );
+    }
+
+    #[test]
     fn test_equality_with_variety_of_rfc3339_timestamps() {
         // Testing timestamps near rounding thresholds
-        let test_timestamps = vec![
+        let test_timestamps = &[
             "2009-01-03T18:15:05Z", // Bitcoin genesis block time
             "1970-01-01T00:00:00Z", // Unix epoch
             "1969-07-20T20:17:40Z", // Apollo 11 moon landing
@@ -243,20 +347,18 @@ mod tests {
             "2004-02-04T00:00:00Z", // Founding of Facebook
             "2011-11-26T05:17:57Z", // Curiosity Rover lands on Mars
         ];
-        let expected_timestamps = vec!["2009-01-03T18:15:05Z"];
+        let expected_timestamps = &["2009-01-03T18:15:05Z"];
 
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times = timestamp '2009-01-03T18:15:05Z';",
-            PoSQLTimeUnit::Second,
-            test_timestamps.clone(),
-            expected_timestamps.clone(),
+            test_timestamps,
+            expected_timestamps,
         );
 
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times >= timestamp '1993-04-30T00:00:00Z';",
-            PoSQLTimeUnit::Second,
-            test_timestamps.clone(),
-            vec![
+            test_timestamps,
+            &[
                 "2009-01-03T18:15:05Z",
                 "1993-04-30T00:00:00Z",
                 "2004-02-04T00:00:00Z",
@@ -266,9 +368,8 @@ mod tests {
 
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times > timestamp '1993-04-30T00:00:00Z';",
-            PoSQLTimeUnit::Second,
-            test_timestamps.clone(),
-            vec![
+            test_timestamps,
+            &[
                 "2009-01-03T18:15:05Z",
                 "2004-02-04T00:00:00Z",
                 "2011-11-26T05:17:57Z",
@@ -277,9 +378,8 @@ mod tests {
 
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times <= timestamp '1993-04-30T00:00:00Z';",
-            PoSQLTimeUnit::Second,
-            test_timestamps.clone(),
-            vec![
+            test_timestamps,
+            &[
                 "1970-01-01T00:00:00Z",
                 "1969-07-20T20:17:40Z",
                 "1993-04-30T00:00:00Z",
@@ -289,9 +389,8 @@ mod tests {
 
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times < timestamp '1993-04-30T00:00:00Z';",
-            PoSQLTimeUnit::Second,
-            test_timestamps.clone(),
-            vec![
+            test_timestamps,
+            &[
                 "1970-01-01T00:00:00Z",
                 "1969-07-20T20:17:40Z",
                 "1927-03-07T00:00:00Z",
@@ -301,34 +400,30 @@ mod tests {
 
     #[test]
     fn test_basic_timestamp_inequality_query() {
-        let test_timestamps = vec![i64::MIN, -1, 0, 1, i64::MAX];
+        let test_timestamps = &[i64::MIN, -1, 0, 1, i64::MAX];
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00Z';",
-            test_timestamps.clone(),
-            vec![i64::MIN, -1],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[i64::MIN, -1],
         );
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00Z';",
-            test_timestamps.clone(),
-            vec![1, i64::MAX],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[1, i64::MAX],
         );
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00Z';",
-            test_timestamps.clone(),
-            vec![0, 1, i64::MAX],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[0, 1, i64::MAX],
         );
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00Z';",
-            test_timestamps.clone(),
-            vec![i64::MIN, -1, 0],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[i64::MIN, -1, 0],
         );
     }
 
@@ -336,58 +431,50 @@ mod tests {
     fn test_timestamp_inequality_queries_with_timezone_offsets() {
         // Test with a range of timestamps around the Unix epoch
         // 60 * 60 = 3600 * 8 (PST offset) = 28800
-        let test_timestamps = vec![i64::MIN, 28800, 28799, 0, 1, i64::MAX];
+        let test_timestamps = &[28800, 28799, -1, 0, 1];
 
         // Test timezone offset -08:00 (e.g., Pacific Standard Time)
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00-08:00';",
-            test_timestamps.clone(),
-            vec![i64::MAX],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[],
         );
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00-08:00';",
-            test_timestamps.clone(),
-            vec![i64::MIN, 28799, 0, 1],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[28800, 28799, -1, 0, 1],
         );
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00-08:00';",
-            test_timestamps.clone(),
-            vec![28800, i64::MAX],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[],
         );
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00-08:00';",
-            test_timestamps.clone(),
-            vec![i64::MIN, 28800, 28799, 0, 1],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[28800, 28799, -1, 0, 1],
         );
 
         // Test timezone offset +00:00 (e.g., UTC)
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times > timestamp '1970-01-01T00:00:00+00:00';",
-            test_timestamps.clone(),
-            vec![28800, 28799, 1, i64::MAX],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[28800, 28799, 1],
         );
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00+00:00';",
-            test_timestamps.clone(),
-            vec![i64::MIN],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[-1],
         );
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times >= timestamp '1970-01-01T00:00:00+00:00';",
-            test_timestamps.clone(),
-            vec![28800, 28799, 0, 1, i64::MAX],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[28800, 28799, 0, 1],
         );
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times <= timestamp '1970-01-01T00:00:00+00:00';",
-            test_timestamps.clone(),
-            vec![i64::MIN, 0],
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[-1, 0],
         );
     }
 
@@ -410,14 +497,18 @@ mod tests {
     // and the gateway.
     #[test]
     fn test_timestamp_queries_match_postgresql_and_gateway() {
-        let test_timestamps = vec![1230995705, 1230992105, 1230999305, 1230995705];
-        let expected_timestamps = vec![1230995705, 1230995705];
+        let test_timestamps = &[
+            1230995705000000000,
+            1230992105000000000,
+            1230999305000000000,
+            1230995705000000000,
+        ];
+        let expected_timestamps = &[1230995705000000000, 1230995705000000000];
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = timestamp '2009-01-03T19:15:05+04:00'",
             test_timestamps,
             expected_timestamps,
-            PoSQLTimeUnit::Second,
         );
     }
 
@@ -426,56 +517,54 @@ mod tests {
         // Unix time for 1998-12-31T23:59:59 UTC is 915148799
         // Assuming leap second at 1998-12-31T23:59:60 UTC is recognized, it would be 915148799
         // Unix time for 1999-01-01T00:00:00 UTC is 915148800
-        let test_timestamps = vec![915148799, 915148800, 915148801];
-        let expected_timestamps = [915148799, 915148800, 915148801]; // Expect the leap second to be parsed and matched
+        let test_timestamps = &[915148799000000000, 915148800000000000, 915148801000000000];
+        let expected_timestamps = [915148799000000000, 915148800000000000, 915148801000000000]; // Expect the leap second to be parsed and matched
 
         // Test the query to select the leap second
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = timestamp '1998-12-31T23:59:60Z'",
-            test_timestamps.clone(),
-            expected_timestamps[0..1].to_vec(),
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &[915148800000000000],
         );
 
         // Test the query to select the leap second
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = timestamp '1999-01-01T00:00:00Z';",
-            test_timestamps.clone(),
-            expected_timestamps[1..2].to_vec(),
-            PoSQLTimeUnit::Second,
+            test_timestamps,
+            &expected_timestamps[1..2],
         );
     }
 
     #[test]
     fn test_new_years_eve_boundary() {
-        let test_timestamps = vec![
+        let test_timestamps = &[
             DateTime::parse_from_rfc3339("2023-12-31T23:59:59Z")
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
         ];
-        let expected_timestamps = vec![test_timestamps[1]]; // Expect only the new year start
+        let expected_timestamps = &[test_timestamps[1]]; // Expect only the new year start
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = timestamp '2024-01-01T00:00:00Z';",
             test_timestamps,
             expected_timestamps,
-            PoSQLTimeUnit::Second,
         );
     }
 
     #[test]
     fn test_fractional_seconds_handling() {
-        let test_timestamps = vec![
+        let test_timestamps = &[
             "2023-07-01T12:00:00.999Z", /* "2023-07-01T12:00:01.000Z"*/
         ];
-        let expected_timestamps = vec!["2023-07-01T12:00:00.999Z"];
+        let expected_timestamps = &["2023-07-01T12:00:00.999Z"];
 
         run_timestamp_query_test(
             "SELECT * FROM table WHERE times = timestamp '2023-07-01T12:00:00.999Z'",
-            PoSQLTimeUnit::Millisecond,
             test_timestamps,
             expected_timestamps,
         );
@@ -484,107 +573,107 @@ mod tests {
     #[test]
     fn test_february_29_leap_year() {
         // Test year 2024 which is a leap year
-        let test_timestamps = vec![
+        let test_timestamps = &[
             DateTime::parse_from_rfc3339("2024-02-29T12:00:00Z")
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
             DateTime::parse_from_rfc3339("2024-03-01T12:00:00Z")
                 .unwrap()
-                .timestamp(),
+                .timestamp_nanos_opt()
+                .unwrap(),
         ];
-        let expected_timestamps = vec![test_timestamps[0]]; // Expect the leap day
+        let expected_timestamps = &[test_timestamps[0]]; // Expect the leap day
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = timestamp '2024-02-29T12:00:00Z';",
             test_timestamps,
             expected_timestamps,
-            PoSQLTimeUnit::Second,
         );
     }
 
     #[test]
     fn test_time_zone_crossings() {
         // Checking how the same absolute moment is handled in different time zones
-        let test_timestamps = vec![
+        let test_timestamps = &[
             DateTime::parse_from_rfc3339("2023-08-15T15:00:00-05:00")
                 .unwrap()
-                .timestamp(), // Central Time
+                .timestamp_nanos_opt()
+                .unwrap(), // Central Time
             DateTime::parse_from_rfc3339("2023-08-15T16:00:00-04:00")
                 .unwrap()
-                .timestamp(), // Eastern Time, same moment
+                .timestamp_nanos_opt()
+                .unwrap(), // Eastern Time, same moment
         ];
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = timestamp '2023-08-15T20:00:00Z'", // UTC time
-            test_timestamps.clone(),
             test_timestamps,
-            PoSQLTimeUnit::Second,
+            test_timestamps,
         );
     }
 
     #[test]
     fn test_basic_unix_epoch() {
         // Parse the RFC 3339 formatted string to Unix timestamps directly
-        let test_timestamps = vec![
+        let test_timestamps = &[
             DateTime::parse_from_rfc3339("2009-01-03T18:15:05Z")
                 .unwrap()
-                .timestamp(), // The test timestamp from RFC 3339 string
+                .timestamp_nanos_opt()
+                .unwrap(), // The test timestamp from RFC 3339 string
         ];
 
-        let expected_timestamps = vec![
+        let expected_timestamps = &[
             DateTime::parse_from_rfc3339("2009-01-03T18:15:05Z")
                 .unwrap()
-                .timestamp(), // The expected timestamp, same as test
+                .timestamp_nanos_opt()
+                .unwrap(), // The expected timestamp, same as test
         ];
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = to_timestamp(1231006505);",
             test_timestamps,
             expected_timestamps,
-            PoSQLTimeUnit::Second,
         );
     }
 
     #[test]
     fn test_unix_epoch_daylight_saving() {
         // Timestamps just before and after DST change in spring
-        let test_timestamps = vec![1583651999, 1583652000]; // Spring forward at 2 AM
-        let expected_timestamps = vec![1583651999]; // Only the time before the DST jump should match
+        let test_timestamps = &[1583651999000000000, 1583652000000000000]; // Spring forward at 2 AM
+        let expected_timestamps = &[1583651999000000000]; // Only the time before the DST jump should match
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = to_timestamp(1583651999)",
             test_timestamps,
             expected_timestamps,
-            PoSQLTimeUnit::Second,
         );
     }
 
     #[test]
     fn test_unix_epoch_leap_year() {
-        let test_timestamps = vec![1582934400]; // 2020-02-29T00:00:00Z
-        let expected_timestamps = vec![1582934400];
+        let test_timestamps = &[1582934400000000000]; // 2020-02-29T00:00:00Z
+        let expected_timestamps = &[1582934400000000000];
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = to_timestamp(1582934400);",
             test_timestamps,
             expected_timestamps,
-            PoSQLTimeUnit::Second,
         );
     }
 
     #[test]
     fn test_unix_epoch_time_zone_handling() {
-        let test_timestamps = vec![
-            1603587600, // 2020-10-25T01:00:00Z in UTC, corresponds to 2 AM in UTC+1 before DST ends
-            1603591200, // Corresponds to 2 AM in UTC+1 after DST ends (1 hour later)
+        let test_timestamps = &[
+            1603587600000000000, // 2020-10-25T01:00:00Z in UTC, corresponds to 2 AM in UTC+1 before DST ends
+            1603591200000000000, // Corresponds to 2 AM in UTC+1 after DST ends (1 hour later)
         ];
-        let expected_timestamps = vec![1603587600];
+        let expected_timestamps = &[1603587600000000000];
 
         run_timestamp_epoch_query_test(
             "SELECT * FROM table WHERE times = to_timestamp(1603587600)",
             test_timestamps,
             expected_timestamps,
-            PoSQLTimeUnit::Second,
         );
     }
 }
@@ -592,6 +681,8 @@ mod tests {
 #[test]
 #[cfg(feature = "blitzar")]
 fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
+    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+
     let public_parameters = PublicParameters::rand(4, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let verifier_setup = VerifierSetup::from(&public_parameters);
@@ -604,7 +695,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         owned_table([
             timestamptz(
                 "a",
-                PoSQLTimeUnit::Nanosecond,
+                PoSQLTimeUnit::Second,
                 [
                     "2009-01-03T18:15:05Z", // Bitcoin genesis block time
                     "1961-04-12T06:07:00Z", // First human spaceflight by Yuri Gagarin
@@ -619,7 +710,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
             ),
             timestamptz(
                 "b",
-                PoSQLTimeUnit::Nanosecond,
+                PoSQLTimeUnit::Second,
                 [
                     "1953-02-28T00:00:00Z", // Publication of DNA's double helix structure
                     "1970-01-01T00:00:00Z", // Unix epoch
@@ -657,7 +748,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
     let expected_result = owned_table([
         timestamptz(
             "a",
-            PoSQLTimeUnit::Nanosecond,
+            PoSQLTimeUnit::Second,
             [
                 "1961-04-12T06:07:00Z",
                 "1983-01-01T00:00:00Z",
@@ -668,7 +759,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         ),
         timestamptz(
             "b",
-            PoSQLTimeUnit::Nanosecond,
+            PoSQLTimeUnit::Second,
             [
                 "1970-01-01T00:00:00Z",
                 "1993-04-30T00:00:00Z",


### PR DESCRIPTION
# Rationale for this change

Timestamp literals were parsed in seconds despite containing up to nanosecond precision. This caused a situation where equality and inequality queries would fail across the board. This PR updates timestamp literal parsing to use the correct time unit precision corresponding to whatever data is inserted in the table..

# What changes are included in this PR?

- [x] cover precision match in literal conversion
- [x] update tests to parse rfc3339 strings in addition to epochs

# Are these changes tested?

- [x] test inequality support between strings of differing precision
- [x] test complex query and filter
- [x] cover edge cases with string parsing in addition to epoch parsing
- [x] cover differing timezone tests with string parsing
- [x] cover differing timezone and precision tests with string parsing
- [x] test that timestamps in differing precisions and scales can match appropriately
- [ ] reorganize tests to appropriate modules
