### PR TITLE
refactor: explicitly mention all enum variants in `ColumnType::precision_value` and `ColumnType::scale`

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -303,15 +303,20 @@ impl ColumnType {
             // Scalars are not in database & are only used for typeless comparisons for testing so we return 0
             // so that they do not cause errors when used in comparisons.
             Self::Scalar => Some(0_u8),
-            _ => None,
+            Self::Boolean | Self::VarChar => None,
         }
     }
     /// Returns scale of a ColumnType if it is convertible to a decimal wrapped in Some(). Otherwise return None.
     pub fn scale(&self) -> Option<i8> {
         match self {
             Self::Decimal75(_, scale) => Some(*scale),
-            Self::BigInt | Self::Int128 | Self::Scalar => Some(0),
-            _ => None,
+            Self::SmallInt
+            | Self::Int
+            | Self::BigInt
+            | Self::Int128
+            | Self::Scalar
+            | Self::TimestampTZ(_, _) => Some(0),
+            Self::Boolean | Self::VarChar => None,
         }
     }
 }


### PR DESCRIPTION
# Rationale for this change
This is a clean and explicit solution. Note that for all timestamp types we have `scale = 0` since in #75 time unit is removed anyway. Also this is a refactoring since it doesn't affect functionality.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

- Explicitly mention all enum variants in `ColumnType::precision_value` and `ColumnType::scale`

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
