### PR TITLE
feat: add division to `column_operation` and `Div` to `OwnedColumn`

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -24,6 +24,10 @@ pub enum ColumnOperationError {
     #[error("Overflow in integer operation: {0}")]
     IntegerOverflow(String),
 
+    /// Division by zero
+    #[error("Division by zero")]
+    DivisionByZero,
+
     /// Errors related to decimal operations
     #[error(transparent)]
     DecimalConversionError(#[from] DecimalError),

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -8,7 +8,9 @@ mod column;
 pub use column::{Column, ColumnField, ColumnRef, ColumnType};
 
 mod column_operation;
-pub use column_operation::{try_add_subtract_column_types, try_multiply_column_types};
+pub use column_operation::{
+    try_add_subtract_column_types, try_divide_column_types, try_multiply_column_types,
+};
 
 mod column_operation_error;
 pub use column_operation_error::{ColumnOperationError, ColumnOperationResult};

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -3,7 +3,7 @@ use crate::base::{
     database::{column_operation::*, OwnedColumn},
     scalar::Scalar,
 };
-use core::ops::{Add, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 
 impl<S: Scalar> Add for OwnedColumn<S> {
@@ -443,6 +443,153 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
     }
 }
 
+impl<S: Scalar> Div for OwnedColumn<S> {
+    type Output = ColumnOperationResult<Self>;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        if self.len() != rhs.len() {
+            return Err(ColumnOperationError::DifferentColumnLength(
+                self.len(),
+                rhs.len(),
+            ));
+        }
+        match (&self, &rhs) {
+            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => {
+                Ok(Self::SmallInt(try_divide_slices(lhs, rhs)?))
+            }
+            (Self::SmallInt(lhs), Self::Int(rhs)) => {
+                Ok(Self::Int(try_divide_slices_left_upcast(lhs, rhs)?))
+            }
+            (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
+                Ok(Self::BigInt(try_divide_slices_left_upcast(lhs, rhs)?))
+            }
+            (Self::SmallInt(lhs), Self::Int128(rhs)) => {
+                Ok(Self::Int128(try_divide_slices_left_upcast(lhs, rhs)?))
+            }
+            (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            (Self::Int(lhs), Self::SmallInt(rhs)) => {
+                Ok(Self::Int(try_divide_slices_right_upcast(lhs, rhs)?))
+            }
+            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Int(try_divide_slices(lhs, rhs)?)),
+            (Self::Int(lhs), Self::BigInt(rhs)) => {
+                Ok(Self::BigInt(try_divide_slices_left_upcast(lhs, rhs)?))
+            }
+            (Self::Int(lhs), Self::Int128(rhs)) => {
+                Ok(Self::Int128(try_divide_slices_left_upcast(lhs, rhs)?))
+            }
+            (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
+                Ok(Self::BigInt(try_divide_slices_right_upcast(lhs, rhs)?))
+            }
+            (Self::BigInt(lhs), Self::Int(rhs)) => {
+                Ok(Self::BigInt(try_divide_slices_right_upcast(lhs, rhs)?))
+            }
+            (Self::BigInt(lhs), Self::BigInt(rhs)) => {
+                Ok(Self::BigInt(try_divide_slices(lhs, rhs)?))
+            }
+            (Self::BigInt(lhs), Self::Int128(rhs)) => {
+                Ok(Self::Int128(try_divide_slices_left_upcast(lhs, rhs)?))
+            }
+            (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            (Self::Int128(lhs), Self::SmallInt(rhs)) => {
+                Ok(Self::Int128(try_divide_slices_right_upcast(lhs, rhs)?))
+            }
+            (Self::Int128(lhs), Self::Int(rhs)) => {
+                Ok(Self::Int128(try_divide_slices_right_upcast(lhs, rhs)?))
+            }
+            (Self::Int128(lhs), Self::BigInt(rhs)) => {
+                Ok(Self::Int128(try_divide_slices_right_upcast(lhs, rhs)?))
+            }
+            (Self::Int128(lhs), Self::Int128(rhs)) => {
+                Ok(Self::Int128(try_divide_slices(lhs, rhs)?))
+            }
+            (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
+                let (new_precision, new_scale, new_values) = try_divide_decimal_columns(
+                    lhs_values,
+                    rhs_values,
+                    self.column_type(),
+                    rhs.column_type(),
+                )?;
+                Ok(Self::Decimal75(new_precision, new_scale, new_values))
+            }
+            _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
+                operator: BinaryOperator::Division,
+                left_type: self.column_type(),
+                right_type: rhs.column_type(),
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -464,7 +611,13 @@ mod test {
             Err(ColumnOperationError::DifferentColumnLength(_, _))
         ));
 
-        let result = lhs * rhs;
+        let result = lhs.clone() * rhs.clone();
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::DifferentColumnLength(_, _))
+        ));
+
+        let result = lhs / rhs;
         assert!(matches!(
             result,
             Err(ColumnOperationError::DifferentColumnLength(_, _))
@@ -496,7 +649,13 @@ mod test {
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
-        let result = lhs * rhs;
+        let result = lhs.clone() * rhs.clone();
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
+        ));
+
+        let result = lhs / rhs;
         assert!(matches!(
             result,
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
@@ -708,6 +867,70 @@ mod test {
             OwnedColumn::<Curve25519Scalar>::Decimal75(
                 Precision::new(16).unwrap(),
                 2,
+                expected_scalars
+            )
+        );
+    }
+
+    #[test]
+    fn we_can_try_divide_integer_columns() {
+        // lhs and rhs have the same precision
+        let lhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 5, -2]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::BigInt(vec![1_i64, 2, 3]);
+        let result = lhs / rhs;
+        assert_eq!(
+            result,
+            Ok(OwnedColumn::<Curve25519Scalar>::BigInt(vec![4_i64, 2, 0]))
+        );
+
+        // lhs and rhs have different precisions
+        let lhs = OwnedColumn::<Curve25519Scalar>::Int(vec![3_i32, 2, 3]);
+        let rhs = OwnedColumn::<Curve25519Scalar>::Int128(vec![1_i128, 2, 5]);
+        let result = lhs / rhs;
+        assert_eq!(
+            result,
+            Ok(OwnedColumn::<Curve25519Scalar>::Int128(vec![3_i128, 1, 0]))
+        );
+    }
+
+    #[test]
+    fn we_can_try_divide_decimal_columns() {
+        // lhs and rhs are both decimals
+        let lhs_scalars = [4, 5, 3].iter().map(Curve25519Scalar::from).collect();
+        let lhs =
+            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, lhs_scalars);
+        let rhs_scalars = [-1, 2, 4].iter().map(Curve25519Scalar::from).collect();
+        let rhs =
+            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(5).unwrap(), 2, rhs_scalars);
+        let result = (lhs / rhs).unwrap();
+        let expected_scalars = [-400000000_i128, 250000000, 75000000]
+            .iter()
+            .map(Curve25519Scalar::from)
+            .collect();
+        assert_eq!(
+            result,
+            OwnedColumn::<Curve25519Scalar>::Decimal75(
+                Precision::new(13).unwrap(),
+                8,
+                expected_scalars
+            )
+        );
+
+        // lhs is integer and rhs is decimal
+        let lhs = OwnedColumn::<Curve25519Scalar>::SmallInt(vec![4, 5, 3]);
+        let rhs_scalars = [-1, 2, 3].iter().map(Curve25519Scalar::from).collect();
+        let rhs =
+            OwnedColumn::<Curve25519Scalar>::Decimal75(Precision::new(3).unwrap(), 2, rhs_scalars);
+        let result = (lhs / rhs).unwrap();
+        let expected_scalars = [-400000000, 250000000, 100000000]
+            .iter()
+            .map(Curve25519Scalar::from)
+            .collect();
+        assert_eq!(
+            result,
+            OwnedColumn::<Curve25519Scalar>::Decimal75(
+                Precision::new(13).unwrap(),
+                6,
                 expected_scalars
             )
         );


### PR DESCRIPTION
# Rationale for this change
Division is needed in postprocessing hence we need to add it. Please merge #70 before reviewing this PR or alternatively look at the latest commit.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- add division to `column_operation`
- implement `Div` for `OwnedColumn`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
