### PR TITLE
refactor!: remove `DecompressedCommitment` from `VecCommitmentExt`

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -1,6 +1,6 @@
 use super::{
     committable_column::CommittableColumn, ColumnCommitmentMetadata, ColumnCommitmentMetadataMap,
-    ColumnCommitmentMetadataMapExt, ColumnCommitmentsMismatch, VecCommitmentExt,
+    ColumnCommitmentMetadataMapExt, ColumnCommitmentsMismatch, Commitment, VecCommitmentExt,
 };
 use crate::base::database::{ColumnField, ColumnRef, CommitmentAccessor, TableRef};
 use proof_of_sql_parser::Identifier;
@@ -28,40 +28,23 @@ pub enum AppendColumnCommitmentsError {
 ///
 /// These columns do not need to belong to the same table, and can have differing lengths.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ColumnCommitments<C>
-where
-    Vec<C>: VecCommitmentExt,
-{
+pub struct ColumnCommitments<C> {
     commitments: Vec<C>,
     column_metadata: ColumnCommitmentMetadataMap,
 }
 
-/// Private convenience aliases.
-type Decompressed<C> = <Vec<C> as VecCommitmentExt>::DecompressedCommitment;
-type Setup<'a, C> = <Vec<C> as VecCommitmentExt>::CommitmentPublicSetup<'a>;
-
-impl<C> ColumnCommitments<C>
-where
-    Vec<C>: VecCommitmentExt,
-{
+impl<C: Commitment> ColumnCommitments<C> {
     /// Create a new [`ColumnCommitments`] for a table from a commitment accessor.
     pub fn from_accessor_with_max_bounds(
         table: TableRef,
         columns: &[ColumnField],
-        accessor: &impl CommitmentAccessor<Decompressed<C>>,
-    ) -> Self
-    where
-        Decompressed<C>: Into<C>,
-    {
+        accessor: &impl CommitmentAccessor<C>,
+    ) -> Self {
         let column_metadata =
             ColumnCommitmentMetadataMap::from_column_fields_with_max_bounds(columns);
         let commitments = columns
             .iter()
-            .map(|c| {
-                accessor
-                    .get_commitment(ColumnRef::new(table, c.name(), c.data_type()))
-                    .into()
-            })
+            .map(|c| accessor.get_commitment(ColumnRef::new(table, c.name(), c.data_type())))
             .collect();
         ColumnCommitments {
             commitments,
@@ -95,10 +78,10 @@ where
     }
 
     /// Returns the commitment with the given identifier.
-    pub fn get_commitment(&self, identifier: &Identifier) -> Option<Decompressed<C>> {
+    pub fn get_commitment(&self, identifier: &Identifier) -> Option<C> {
         self.column_metadata
             .get_index_of(identifier)
-            .map(|index| self.commitments.get_decompressed_commitment(index).unwrap())
+            .map(|index| self.commitments[index])
     }
 
     /// Returns the metadata for the commitment with the given identifier.
@@ -115,7 +98,7 @@ where
     pub fn try_from_columns_with_offset<'a, COL>(
         columns: impl IntoIterator<Item = (&'a Identifier, COL)>,
         offset: usize,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<ColumnCommitments<C>, DuplicateIdentifiers>
     where
         COL: Into<CommittableColumn<'a>>,
@@ -165,7 +148,7 @@ where
         &mut self,
         columns: impl IntoIterator<Item = (&'a Identifier, COL)>,
         offset: usize,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<(), AppendColumnCommitmentsError>
     where
         COL: Into<CommittableColumn<'a>>,
@@ -210,7 +193,7 @@ where
         &mut self,
         columns: impl IntoIterator<Item = (&'a Identifier, COL)>,
         offset: usize,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<(), DuplicateIdentifiers>
     where
         COL: Into<CommittableColumn<'a>>,
@@ -235,7 +218,7 @@ where
 
         // this constructor will check for duplicates among the new columns
         let new_column_commitments =
-            ColumnCommitments::try_from_columns_with_offset(unique_columns, offset, setup)?;
+            ColumnCommitments::<C>::try_from_columns_with_offset(unique_columns, offset, setup)?;
 
         self.commitments.extend(new_column_commitments.commitments);
         self.column_metadata
@@ -291,10 +274,7 @@ pub type IntoIter<C> = std::iter::Map<
     fn(((Identifier, ColumnCommitmentMetadata), C)) -> (Identifier, ColumnCommitmentMetadata, C),
 >;
 
-impl<C> IntoIterator for ColumnCommitments<C>
-where
-    Vec<C>: VecCommitmentExt,
-{
+impl<C> IntoIterator for ColumnCommitments<C> {
     type Item = (Identifier, ColumnCommitmentMetadata, C);
     type IntoIter = IntoIter<C>;
     fn into_iter(self) -> Self::IntoIter {
@@ -316,10 +296,7 @@ pub type Iter<'a, C> = std::iter::Map<
     ) -> (&'a Identifier, &'a ColumnCommitmentMetadata, &'a C),
 >;
 
-impl<'a, C> IntoIterator for &'a ColumnCommitments<C>
-where
-    Vec<C>: VecCommitmentExt,
-{
+impl<'a, C> IntoIterator for &'a ColumnCommitments<C> {
     type Item = (&'a Identifier, &'a ColumnCommitmentMetadata, &'a C);
     type IntoIter = Iter<'a, C>;
     fn into_iter(self) -> Self::IntoIter {
@@ -330,10 +307,7 @@ where
     }
 }
 
-impl<C> FromIterator<(Identifier, ColumnCommitmentMetadata, C)> for ColumnCommitments<C>
-where
-    Vec<C>: VecCommitmentExt,
-{
+impl<C> FromIterator<(Identifier, ColumnCommitmentMetadata, C)> for ColumnCommitments<C> {
     fn from_iter<T: IntoIterator<Item = (Identifier, ColumnCommitmentMetadata, C)>>(
         iter: T,
     ) -> Self {

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
@@ -26,9 +26,7 @@ pub fn test_simple_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
         ])],
         0,
         prover_setup,
-    )
-    .to_decompressed()
-    .unwrap();
+    );
 
     let mut transcript = Transcript::new(b"evaluation_proof");
     let r = proof.verify_proof(
@@ -52,9 +50,7 @@ pub fn test_commitment_evaluation_proof_with_length_1<CP: CommitmentEvaluationPr
     let mut transcript = Transcript::new(b"evaluation_proof");
     let proof = CP::new(&mut transcript, &[r], &[], 0, prover_setup);
 
-    let commits = Vec::from_columns_with_offset(&[Column::Scalar(&[r])], 0, prover_setup)
-        .to_decompressed()
-        .unwrap();
+    let commits = Vec::from_columns_with_offset(&[Column::Scalar(&[r])], 0, prover_setup);
 
     let mut transcript = Transcript::new(b"evaluation_proof");
     let r = proof.verify_proof(&mut transcript, &commits[0], &r, &[], 0, 1, verifier_setup);
@@ -82,9 +78,7 @@ pub fn test_random_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
     let mut transcript = Transcript::new(b"evaluation_proof");
     let proof = CP::new(&mut transcript, &a, &b_point, offset as u64, prover_setup);
 
-    let commits = Vec::from_columns_with_offset(&[Column::Scalar(&a)], offset, prover_setup)
-        .to_decompressed()
-        .unwrap();
+    let commits = Vec::from_columns_with_offset(&[Column::Scalar(&a)], offset, prover_setup);
 
     let mut b = vec![CP::Scalar::zero(); a.len()];
     crate::base::polynomial::compute_evaluation_vector(&mut b, &b_point);

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -1,6 +1,6 @@
 use super::{
     committable_column::CommittableColumn, AppendColumnCommitmentsError, ColumnCommitments,
-    ColumnCommitmentsMismatch, Commitment, DuplicateIdentifiers, VecCommitmentExt,
+    ColumnCommitmentsMismatch, Commitment, DuplicateIdentifiers,
 };
 use crate::base::{
     database::{
@@ -90,29 +90,19 @@ pub enum AppendRecordBatchTableCommitmentError {
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TableCommitment<C>
 where
-    Vec<C>: VecCommitmentExt,
+    C: Commitment,
 {
     column_commitments: ColumnCommitments<C>,
     range: Range<usize>,
 }
 
-/// Private convenience alias.
-type Setup<'a, C> = <Vec<C> as VecCommitmentExt>::CommitmentPublicSetup<'a>;
-type Decompressed<C> = <Vec<C> as VecCommitmentExt>::DecompressedCommitment;
-
-impl<C> TableCommitment<C>
-where
-    Vec<C>: VecCommitmentExt,
-{
+impl<C: Commitment> TableCommitment<C> {
     /// Create a new [`TableCommitment`] for a table from a commitment accessor.
-    pub fn from_accessor_with_max_bounds<A: CommitmentAccessor<Decompressed<C>>>(
+    pub fn from_accessor_with_max_bounds(
         table_ref: TableRef,
         columns: &[ColumnField],
-        accessor: &A,
-    ) -> Self
-    where
-        Decompressed<C>: Into<C>,
-    {
+        accessor: &impl CommitmentAccessor<C>,
+    ) -> Self {
         let length = accessor.get_length(table_ref);
         let offset = accessor.get_offset(table_ref);
         Self::try_new(
@@ -170,7 +160,7 @@ where
     pub fn try_from_columns_with_offset<'a, COL>(
         columns: impl IntoIterator<Item = (&'a Identifier, COL)>,
         offset: usize,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<TableCommitment<C>, TableCommitmentFromColumnsError>
     where
         COL: Into<CommittableColumn<'a>>,
@@ -199,7 +189,7 @@ where
     pub fn from_owned_table_with_offset<S>(
         owned_table: &OwnedTable<S>,
         offset: usize,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> TableCommitment<C>
     where
         S: Scalar,
@@ -216,7 +206,7 @@ where
     pub fn try_append_rows<'a, COL>(
         &mut self,
         columns: impl IntoIterator<Item = (&'a Identifier, COL)>,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<(), AppendTableCommitmentError>
     where
         COL: Into<CommittableColumn<'a>>,
@@ -246,7 +236,7 @@ where
     pub fn append_owned_table<S>(
         &mut self,
         owned_table: &OwnedTable<S>,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<(), ColumnCommitmentsMismatch>
     where
         S: Scalar,
@@ -271,7 +261,7 @@ where
     pub fn try_extend_columns<'a, COL>(
         &mut self,
         columns: impl IntoIterator<Item = (&'a Identifier, COL)>,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<(), TableCommitmentFromColumnsError>
     where
         COL: Into<CommittableColumn<'a>>,
@@ -367,10 +357,10 @@ where
     pub fn try_append_record_batch(
         &mut self,
         batch: &RecordBatch,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<(), AppendRecordBatchTableCommitmentError> {
         match self.try_append_rows(
-            batch_to_columns::<<Decompressed<C> as Commitment>::Scalar>(batch, &Bump::new())?
+            batch_to_columns::<C::Scalar>(batch, &Bump::new())?
                 .iter()
                 .map(|(a, b)| (a, b)),
             setup,
@@ -392,7 +382,7 @@ where
     /// Returns a [`TableCommitment`] to the provided arrow [`RecordBatch`].
     pub fn try_from_record_batch(
         batch: &RecordBatch,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<TableCommitment<C>, RecordBatchToColumnsError> {
         Self::try_from_record_batch_with_offset(batch, 0, setup)
     }
@@ -401,10 +391,10 @@ where
     pub fn try_from_record_batch_with_offset(
         batch: &RecordBatch,
         offset: usize,
-        setup: &Setup<C>,
+        setup: &C::PublicSetup<'_>,
     ) -> Result<TableCommitment<C>, RecordBatchToColumnsError> {
         match Self::try_from_columns_with_offset(
-            batch_to_columns::<<Decompressed<C> as Commitment>::Scalar>(batch, &Bump::new())?
+            batch_to_columns::<C::Scalar>(batch, &Bump::new())?
                 .iter()
                 .map(|(a, b)| (a, b)),
             offset,

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -67,17 +67,6 @@ pub trait VecCommitmentExt {
 
     /// Returns the number of commitments in the collection.
     fn num_commitments(&self) -> usize;
-
-    /// The decompressed commitment type.
-    type DecompressedCommitment: Commitment;
-
-    /// Decompresses the commitments in the collection.
-    ///
-    /// Note: this _could_ be made to return an iterator, but the usage does not currently require it.
-    fn to_decompressed(&self) -> Option<Vec<Self::DecompressedCommitment>>;
-
-    /// Decompresses a single commitment in the collection.
-    fn get_decompressed_commitment(&self, i: usize) -> Option<Self::DecompressedCommitment>;
 }
 
 fn unsafe_add_assign<C: Commitment>(a: &mut [C], b: &[C]) {
@@ -182,16 +171,6 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
 
     fn num_commitments(&self) -> usize {
         self.len()
-    }
-
-    type DecompressedCommitment = C;
-
-    fn to_decompressed(&self) -> Option<Vec<Self::DecompressedCommitment>> {
-        Some(self.to_vec())
-    }
-
-    fn get_decompressed_commitment(&self, i: usize) -> Option<Self::DecompressedCommitment> {
-        Some(self[i])
     }
 }
 

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -101,9 +101,7 @@ impl<CP: CommitmentEvaluationProof> CommitmentAccessor<CP::Commitment>
     fn get_commitment(&self, column: ColumnRef) -> CP::Commitment {
         let (table, offset) = self.tables.get(&column.table_ref()).unwrap();
         let owned_column = table.inner_table().get(&column.column_id()).unwrap();
-        Vec::from_columns_with_offset([owned_column], *offset, self.setup.as_ref().unwrap())
-            .to_decompressed()
-            .unwrap()[0]
+        Vec::from_columns_with_offset([owned_column], *offset, self.setup.as_ref().unwrap())[0]
     }
 }
 impl<CP: CommitmentEvaluationProof> MetadataAccessor for OwnedTableTestAccessor<'_, CP> {

--- a/crates/proof-of-sql/src/sql/proof/proof_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::base::{
     bit::BitDistribution,
-    commitment::{CommittableColumn, VecCommitmentExt},
+    commitment::{Commitment, CommittableColumn},
     polynomial::{CompositePolynomial, MultilinearExtension},
     scalar::Scalar,
 };
@@ -99,16 +99,19 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
         level = "debug",
         skip_all
     )]
-    pub fn commit_intermediate_mles<V: VecCommitmentExt>(
+    pub fn commit_intermediate_mles<C: Commitment>(
         &self,
         offset_generators: usize,
-        setup: &V::CommitmentPublicSetup<'_>,
-    ) -> V {
-        V::from_commitable_columns_with_offset(
+        setup: &C::PublicSetup<'_>,
+    ) -> Vec<C> {
+        let mut commitments = vec![C::default(); self.commitment_descriptor.len()];
+        C::compute_commitments(
+            &mut commitments,
             &self.commitment_descriptor,
             offset_generators,
             setup,
-        )
+        );
+        commitments
     }
 
     /// Given random multipliers, construct an aggregatated sumcheck polynomial from all

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     base::{
         bit::BitDistribution,
-        commitment::{Commitment, CommitmentEvaluationProof, VecCommitmentExt},
+        commitment::{Commitment, CommitmentEvaluationProof},
         database::{CommitmentAccessor, DataAccessor},
         math::log2_up,
         polynomial::{compute_evaluation_vector, CompositePolynomialInfo},
@@ -182,13 +182,6 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             Err(ProofError::VerificationError("invalid proof size"))?;
         }
 
-        let commitments =
-            self.commitments
-                .to_decompressed()
-                .ok_or(ProofError::VerificationError(
-                    "commitment failed to decompress",
-                ))?;
-
         // construct a transcript for the proof
         let mut transcript = make_transcript(expr, result, table_length, generator_offset);
 
@@ -263,7 +256,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             generator_offset,
             sumcheck_evaluations,
             &self.bit_distributions,
-            &commitments,
+            &self.commitments,
             sumcheck_random_scalars.subpolynomial_multipliers,
             &evaluation_random_scalars,
             post_result_challenges,
@@ -308,7 +301,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
     fn validate_sizes(&self, counts: &ProofCounts, result: &ProvableQueryResult) -> bool {
         result.num_columns() == counts.result_columns
-            && self.commitments.num_commitments() == counts.intermediate_mles
+            && self.commitments.len() == counts.intermediate_mles
             && self.pre_result_mle_evaluations.len()
                 == counts.intermediate_mles + counts.anchored_mles
     }


### PR DESCRIPTION
# Rationale for this change

In the process of allowing for single table commitments, there is some refactoring needed of the commitment API. This PR simplifies it a bit to ease future PR complexity.

# What changes are included in this PR?

`DecompressedCommitment` was made redundant because every commitment is "decompressed" in the sense that there is no concept of compression in the traits.

This commit simply removes it, which consequently allows for a decent simplification of many of the commitment structures.

# Are these changes tested?

By existing tests