### PR TITLE
feat: add `expression_evaluation.rs` and add arithmetic to `proof_of_sql_parser::utility`

### DIFF
--- a/crates/proof-of-sql-parser/src/utility.rs
+++ b/crates/proof-of-sql-parser/src/utility.rs
@@ -53,6 +53,42 @@ pub fn or(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
     })
 }
 
+/// Construct a new boxed `Expression` A + B
+pub fn add(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
+    Box::new(Expression::Binary {
+        op: BinaryOperator::Add,
+        left,
+        right,
+    })
+}
+
+/// Construct a new boxed `Expression` A - B
+pub fn sub(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
+    Box::new(Expression::Binary {
+        op: BinaryOperator::Subtract,
+        left,
+        right,
+    })
+}
+
+/// Construct a new boxed `Expression` A * B
+pub fn mul(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
+    Box::new(Expression::Binary {
+        op: BinaryOperator::Multiply,
+        left,
+        right,
+    })
+}
+
+/// Construct a new boxed `Expression` A / B
+pub fn div(left: Box<Expression>, right: Box<Expression>) -> Box<Expression> {
+    Box::new(Expression::Binary {
+        op: BinaryOperator::Division,
+        left,
+        right,
+    })
+}
+
 /// Get table from schema and name.
 ///
 /// If the schema is `None`, the table is assumed to be in the default schema.

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -1,0 +1,92 @@
+use super::{ExpressionEvaluationError, ExpressionEvaluationResult};
+use crate::base::{
+    database::{OwnedColumn, OwnedTable},
+    math::decimal::{try_into_to_scalar, Precision},
+    scalar::Scalar,
+};
+use proof_of_sql_parser::{
+    intermediate_ast::{BinaryOperator, Expression, Literal, UnaryOperator},
+    Identifier,
+};
+
+impl<S: Scalar> OwnedTable<S> {
+    /// Evaluate an expression on the table.
+    pub fn evaluate(&self, expr: &Expression) -> ExpressionEvaluationResult<OwnedColumn<S>> {
+        match expr {
+            Expression::Column(identifier) => self.evaluate_column(identifier),
+            Expression::Literal(lit) => self.evaluate_literal(lit),
+            Expression::Binary { op, left, right } => self.evaluate_binary_expr(*op, left, right),
+            Expression::Unary { op, expr } => self.evaluate_unary_expr(*op, expr),
+            _ => Err(ExpressionEvaluationError::Unsupported(format!(
+                "Expression {:?} is not supported yet",
+                expr
+            ))),
+        }
+    }
+
+    fn evaluate_column(
+        &self,
+        identifier: &Identifier,
+    ) -> ExpressionEvaluationResult<OwnedColumn<S>> {
+        Ok(self
+            .inner_table()
+            .get(identifier)
+            .ok_or(ExpressionEvaluationError::ColumnNotFound(
+                identifier.to_string(),
+            ))?
+            .clone())
+    }
+
+    fn evaluate_literal(&self, lit: &Literal) -> ExpressionEvaluationResult<OwnedColumn<S>> {
+        let len = self.num_rows();
+        match lit {
+            Literal::Boolean(b) => Ok(OwnedColumn::Boolean(vec![*b; len])),
+            Literal::BigInt(i) => Ok(OwnedColumn::BigInt(vec![*i; len])),
+            Literal::Int128(i) => Ok(OwnedColumn::Int128(vec![*i; len])),
+            Literal::Decimal(d) => {
+                let scale = d.scale();
+                let precision = Precision::new(d.precision())?;
+                let scalar = try_into_to_scalar(d, precision, scale)?;
+                Ok(OwnedColumn::Decimal75(precision, scale, vec![scalar; len]))
+            }
+            Literal::VarChar(s) => Ok(OwnedColumn::VarChar(vec![s.clone(); len])),
+            Literal::Timestamp(its) => Ok(OwnedColumn::TimestampTZ(
+                its.timeunit(),
+                its.timezone(),
+                vec![its.timestamp().timestamp(); len],
+            )),
+        }
+    }
+
+    fn evaluate_unary_expr(
+        &self,
+        op: UnaryOperator,
+        expr: &Expression,
+    ) -> ExpressionEvaluationResult<OwnedColumn<S>> {
+        let column = self.evaluate(expr)?;
+        match op {
+            UnaryOperator::Not => Ok(column.element_wise_not()?),
+        }
+    }
+
+    fn evaluate_binary_expr(
+        &self,
+        op: BinaryOperator,
+        left: &Expression,
+        right: &Expression,
+    ) -> ExpressionEvaluationResult<OwnedColumn<S>> {
+        let left = self.evaluate(left)?;
+        let right = self.evaluate(right)?;
+        match op {
+            BinaryOperator::And => Ok(left.element_wise_and(&right)?),
+            BinaryOperator::Or => Ok(left.element_wise_or(&right)?),
+            BinaryOperator::Equal => Ok(left.element_wise_eq(&right)?),
+            BinaryOperator::GreaterThanOrEqual => Ok(left.element_wise_ge(&right)?),
+            BinaryOperator::LessThanOrEqual => Ok(left.element_wise_le(&right)?),
+            BinaryOperator::Add => Ok((left + right)?),
+            BinaryOperator::Subtract => Ok((left - right)?),
+            BinaryOperator::Multiply => Ok((left * right)?),
+            BinaryOperator::Division => Ok((left / right)?),
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
@@ -1,0 +1,22 @@
+use crate::base::{database::ColumnOperationError, math::decimal::DecimalError};
+use thiserror::Error;
+
+/// Errors from evaluation of `Expression`s.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ExpressionEvaluationError {
+    /// Column not found
+    #[error("Column not found: {0}")]
+    ColumnNotFound(String),
+    /// Error in column operation
+    #[error(transparent)]
+    ColumnOperationError(#[from] ColumnOperationError),
+    /// Expression not yet supported
+    #[error("Expression {0} is not supported yet")]
+    Unsupported(String),
+    /// Error in decimal conversion
+    #[error(transparent)]
+    DecimalConversionError(#[from] DecimalError),
+}
+
+/// Result type for expression evaluation
+pub type ExpressionEvaluationResult<T> = std::result::Result<T, ExpressionEvaluationError>;

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
@@ -1,0 +1,250 @@
+use crate::base::{
+    database::{
+        owned_table_utility::*, ColumnOperationError, ExpressionEvaluationError, OwnedColumn,
+        OwnedTable,
+    },
+    math::decimal::Precision,
+    scalar::Curve25519Scalar,
+};
+use proof_of_sql_parser::{
+    intermediate_ast::Literal,
+    intermediate_decimal::IntermediateDecimal,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
+    utility::*,
+};
+
+#[test]
+fn we_can_evaluate_a_simple_literal() {
+    let table: OwnedTable<Curve25519Scalar> =
+        owned_table([varchar("languages", ["en", "es", "pt", "fr", "ht"])]);
+
+    // "Space and Time" in Hebrew
+    let expr = lit("מרחב וזמן".to_string());
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column = OwnedColumn::VarChar(vec!["מרחב וזמן".to_string(); 5]);
+    assert_eq!(actual_column, expected_column);
+
+    // Is Proof of SQL in production?
+    let expr = lit(true);
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column = OwnedColumn::Boolean(vec![true; 5]);
+    assert_eq!(actual_column, expected_column);
+
+    // When was Space and Time founded?
+    let timestamp = "2022-03-01T00:00:00Z";
+    let expr = lit(Literal::Timestamp(
+        PoSQLTimestamp::try_from(timestamp).unwrap(),
+    ));
+    let actual_column = table.evaluate(&expr).unwrap();
+    // UNIX timestamp for 2022-03-01T00:00:00Z
+    let actual_timestamp = 1646092800;
+    let expected_column = OwnedColumn::TimestampTZ(
+        PoSQLTimeUnit::Second,
+        PoSQLTimeZone::Utc,
+        vec![actual_timestamp; 5],
+    );
+    assert_eq!(actual_column, expected_column);
+
+    // A group of people has about 0.67 cats per person
+    let expr = lit("0.67".parse::<IntermediateDecimal>().unwrap());
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column = OwnedColumn::Decimal75(Precision::new(2).unwrap(), 2, vec![67.into(); 5]);
+    assert_eq!(actual_column, expected_column);
+}
+
+#[test]
+fn we_can_evaluate_a_simple_column() {
+    let table: OwnedTable<Curve25519Scalar> = owned_table([
+        bigint("bigints", [i64::MIN, -1, 0, 1, i64::MAX]),
+        varchar("language", ["en", "es", "pt", "fr", "ht"]),
+        varchar("john", ["John", "Juan", "João", "Jean", "Jean"]),
+    ]);
+    let expr = col("bigints");
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column = OwnedColumn::BigInt(vec![i64::MIN, -1, 0, 1, i64::MAX]);
+    assert_eq!(actual_column, expected_column);
+
+    let expr = col("john");
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column = OwnedColumn::VarChar(
+        ["John", "Juan", "João", "Jean", "Jean"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    );
+    assert_eq!(actual_column, expected_column);
+}
+
+#[test]
+fn we_can_not_evaluate_a_nonexisting_column() {
+    let table: OwnedTable<Curve25519Scalar> =
+        owned_table([varchar("cats", ["Chloe", "Margaret", "Prudence", "Lucy"])]);
+    // "not_a_column" is not a column in the table
+    let expr = col("not_a_column");
+    assert!(matches!(
+        table.evaluate(&expr),
+        Err(ExpressionEvaluationError::ColumnNotFound(_))
+    ));
+}
+
+#[test]
+fn we_can_evaluate_a_logical_expression() {
+    let table: OwnedTable<Curve25519Scalar> = owned_table([
+        varchar("en", ["Elizabeth", "John", "cat", "dog", "Munich"]),
+        varchar("pl", ["Elżbieta", "Jan", "kot", "pies", "Monachium"]),
+        varchar("cz", ["Alžběta", "Jan", "kočka", "pes", "Mnichov"]),
+        varchar("sk", ["Alžbeta", "Ján", "mačka", "pes", "Mníchov"]),
+        varchar("hr", ["Elizabeta", "Ivan", "mačka", "pas", "München"]),
+        varchar("sl", ["Elizabeta", "Janez", "mačka", "pes", "München"]),
+        boolean("is_proper_noun", [true, true, false, false, true]),
+    ]);
+
+    // Find words that are not proper nouns
+    let expr = not(col("is_proper_noun"));
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column = OwnedColumn::Boolean(vec![false, false, true, true, false]);
+    assert_eq!(actual_column, expected_column);
+
+    // Which Czech and Slovak words agree?
+    let expr = equal(col("cz"), col("sk"));
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column: OwnedColumn<Curve25519Scalar> =
+        OwnedColumn::Boolean(vec![false, false, false, true, false]);
+    assert_eq!(actual_column, expected_column);
+
+    // Find words shared among Slovak, Croatian and Slovenian
+    let expr = and(equal(col("sk"), col("hr")), equal(col("hr"), col("sl")));
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column: OwnedColumn<Curve25519Scalar> =
+        OwnedColumn::Boolean(vec![false, false, true, false, false]);
+    assert_eq!(actual_column, expected_column);
+
+    // Find words shared between Polish and Czech but not Slovenian
+    let expr = and(
+        equal(col("pl"), col("cz")),
+        not(equal(col("pl"), col("sl"))),
+    );
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column: OwnedColumn<Curve25519Scalar> =
+        OwnedColumn::Boolean(vec![false, true, false, false, false]);
+    assert_eq!(actual_column, expected_column);
+
+    // Proper nouns as well as words shared between Croatian and Slovenian
+    let expr = or(
+        col("is_proper_noun"),
+        and(equal(col("hr"), col("sl")), equal(col("hr"), col("sk"))),
+    );
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column: OwnedColumn<Curve25519Scalar> =
+        OwnedColumn::Boolean(vec![true, true, true, false, true]);
+    assert_eq!(actual_column, expected_column);
+}
+
+#[test]
+fn we_can_evaluate_an_arithmetic_expression() {
+    let table: OwnedTable<Curve25519Scalar> = owned_table([
+        smallint("smallints", [-2_i16, -1, 0, 1, 2]),
+        int("ints", [-4_i32, -2, 0, 2, 4]),
+        bigint("bigints", [-8_i64, -4, 0, 4, 8]),
+        int128("int128s", [-16_i128, -8, 0, 8, 16]),
+        decimal75("decimals", 2, 1, [0, 1, 2, 3, 4]),
+    ]);
+
+    // Subtract 1 from the bigints
+    let expr = sub(col("bigints"), lit(1));
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column = OwnedColumn::BigInt(vec![-9, -5, -1, 3, 7]);
+    assert_eq!(actual_column, expected_column);
+
+    // Add bigints to the smallints and multiply the sum by the ints
+    let expr = mul(add(col("bigints"), col("smallints")), col("ints"));
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_column = OwnedColumn::BigInt(vec![40, 10, 0, 10, 40]);
+    assert_eq!(actual_column, expected_column);
+
+    // Multiply decimals with 0.75 and add smallints to the product
+    let expr = add(
+        col("smallints"),
+        mul(
+            col("decimals"),
+            lit("0.75".parse::<IntermediateDecimal>().unwrap()),
+        ),
+    );
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_scalars = [-2000, -925, 150, 1225, 2300]
+        .iter()
+        .map(|&x| x.into())
+        .collect();
+    let expected_column = OwnedColumn::Decimal75(Precision::new(9).unwrap(), 3, expected_scalars);
+    assert_eq!(actual_column, expected_column);
+
+    // Decimals over 2.5 plus int128s
+    let expr = add(
+        div(
+            col("decimals"),
+            lit("2.5".parse::<IntermediateDecimal>().unwrap()),
+        ),
+        col("int128s"),
+    );
+    let actual_column = table.evaluate(&expr).unwrap();
+    let expected_scalars = [-16000000, -7960000, 80000, 8120000, 16160000]
+        .iter()
+        .map(|&x| x.into())
+        .collect();
+    let expected_column = OwnedColumn::Decimal75(Precision::new(46).unwrap(), 6, expected_scalars);
+    assert_eq!(actual_column, expected_column);
+}
+
+#[test]
+fn we_cannot_evaluate_expressions_if_column_operation_errors_out() {
+    let table: OwnedTable<Curve25519Scalar> = owned_table([
+        bigint("bigints", [i64::MIN, -1, 0, 1, i64::MAX]),
+        varchar("language", ["en", "es", "pt", "fr", "ht"]),
+        varchar("sarah", ["Sarah", "Sara", "Sara", "Sarah", "Sarah"]),
+    ]);
+
+    // NOT doesn't work on varchar
+    let expr = not(col("language"));
+    assert!(matches!(
+        table.evaluate(&expr),
+        Err(ExpressionEvaluationError::ColumnOperationError(
+            ColumnOperationError::UnaryOperationInvalidColumnType { .. }
+        ))
+    ));
+
+    // NOT doesn't work on bigint
+    let expr = not(col("bigints"));
+    assert!(matches!(
+        table.evaluate(&expr),
+        Err(ExpressionEvaluationError::ColumnOperationError(
+            ColumnOperationError::UnaryOperationInvalidColumnType { .. }
+        ))
+    ));
+
+    // + doesn't work on varchar
+    let expr = add(col("sarah"), col("bigints"));
+    assert!(matches!(
+        table.evaluate(&expr),
+        Err(ExpressionEvaluationError::ColumnOperationError(
+            ColumnOperationError::BinaryOperationInvalidColumnType { .. }
+        ))
+    ));
+
+    // i64::MIN - 1 overflows
+    let expr = sub(col("bigints"), lit(1));
+    assert!(matches!(
+        table.evaluate(&expr),
+        Err(ExpressionEvaluationError::ColumnOperationError(
+            ColumnOperationError::IntegerOverflow(_)
+        ))
+    ));
+
+    // We can't divide by zero
+    let expr = div(col("bigints"), lit(0));
+    assert!(matches!(
+        table.evaluate(&expr),
+        Err(ExpressionEvaluationError::ColumnOperationError(
+            ColumnOperationError::DivisionByZero
+        ))
+    ));
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -60,6 +60,12 @@ pub(crate) use owned_table::OwnedTableError;
 mod owned_table_test;
 pub mod owned_table_utility;
 
+pub(crate) mod expression_evaluation;
+mod expression_evaluation_error;
+#[cfg(test)]
+mod expression_evaluation_test;
+pub use expression_evaluation_error::{ExpressionEvaluationError, ExpressionEvaluationResult};
+
 mod owned_and_arrow_conversions;
 pub use owned_and_arrow_conversions::OwnedArrowConversionError;
 #[cfg(test)]


### PR DESCRIPTION
# Rationale for this change
This PR replaces #56 since we made substantial changes to evaluations in #70, #74, #76 and #78. Please review #87 first or look at the second commit.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- add `PostprocessingEvaluator`
- add arithmetic to `proof_of_sql_parser::utility`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
