### PR TITLE
fix: timestamp precision

### DIFF
--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -16,10 +16,9 @@ pub struct PoSQLTimestamp {
 }
 
 impl PoSQLTimestamp {
-    /// Returns the number of non-leap seconds since
-    /// January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
-    pub fn timestamp(&self) -> i64 {
-        self.timestamp.timestamp()
+    /// Returns the combined date and time with time zone.
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
     }
 
     /// Returns the [PoSQLTimeUnit] for this timestamp

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -6,16 +6,32 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PoSQLTimestamp {
     /// The datetime representation in UTC.
-    pub timestamp: DateTime<Utc>,
+    timestamp: DateTime<Utc>,
 
     /// The precision of the datetime value, e.g., seconds, milliseconds.
-    pub timeunit: PoSQLTimeUnit,
+    timeunit: PoSQLTimeUnit,
 
     /// The timezone of the datetime, either UTC or a fixed offset from UTC.
-    pub timezone: PoSQLTimeZone,
+    timezone: PoSQLTimeZone,
 }
 
 impl PoSQLTimestamp {
+    /// Returns the number of non-leap seconds since
+    /// January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
+    pub fn timestamp(&self) -> i64 {
+        self.timestamp.timestamp()
+    }
+
+    /// Returns the [PoSQLTimeUnit] for this timestamp
+    pub fn timeunit(&self) -> PoSQLTimeUnit {
+        self.timeunit
+    }
+
+    /// Returns the [PoSQLTimeZone] for this timestamp
+    pub fn timezone(&self) -> PoSQLTimeZone {
+        self.timezone
+    }
+
     /// Attempts to parse a timestamp string into an [PoSQLTimestamp] structure.
     /// This function supports two primary formats:
     ///

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -51,12 +51,12 @@ impl PoSQLTimestamp {
     /// // Parsing an RFC 3339 timestamp without a timezone:
     /// let timestamp_str = "2009-01-03T18:15:05Z";
     /// let intermediate_timestamp = PoSQLTimestamp::try_from(timestamp_str).unwrap();
-    /// assert_eq!(intermediate_timestamp.timezone, PoSQLTimeZone::Utc);
+    /// assert_eq!(intermediate_timestamp.timezone(), PoSQLTimeZone::Utc);
     ///
     /// // Parsing an RFC 3339 timestamp with a positive timezone offset:
     /// let timestamp_str_with_tz = "2009-01-03T18:15:05+03:00";
     /// let intermediate_timestamp = PoSQLTimestamp::try_from(timestamp_str_with_tz).unwrap();
-    /// assert_eq!(intermediate_timestamp.timezone, PoSQLTimeZone::FixedOffset(10800)); // 3 hours in seconds
+    /// assert_eq!(intermediate_timestamp.timezone(), PoSQLTimeZone::FixedOffset(10800)); // 3 hours in seconds
     /// ```
     pub fn try_from(timestamp_str: &str) -> Result<Self, PoSQLTimestampError> {
         let dt = DateTime::parse_from_rfc3339(timestamp_str)
@@ -97,7 +97,7 @@ impl PoSQLTimestamp {
     /// // Parsing a Unix epoch timestamp (assumed to be seconds and UTC):
     /// let unix_time = 1231006505;
     /// let intermediate_timestamp = PoSQLTimestamp::to_timestamp(unix_time).unwrap();
-    /// assert_eq!(intermediate_timestamp.timezone, PoSQLTimeZone::Utc);
+    /// assert_eq!(intermediate_timestamp.timezone(), PoSQLTimeZone::Utc);
     /// ```
     pub fn to_timestamp(epoch: i64) -> Result<Self, PoSQLTimestampError> {
         match Utc.timestamp_opt(epoch, 0) {

--- a/crates/proof-of-sql-parser/src/posql_time/timezone.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timezone.rs
@@ -104,7 +104,7 @@ mod timezone_offset_tests {
         let input = "2023-06-26T12:34:56Z";
         let expected_timezone = timezone::PoSQLTimeZone::Utc;
         let result = PoSQLTimestamp::try_from(input).unwrap();
-        assert_eq!(result.timezone, expected_timezone);
+        assert_eq!(result.timezone(), expected_timezone);
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod timezone_offset_tests {
         let input = "2023-06-26T12:34:56+03:30";
         let expected_timezone = timezone::PoSQLTimeZone::from_offset(12600); // 3 hours and 30 minutes in seconds
         let result = PoSQLTimestamp::try_from(input).unwrap();
-        assert_eq!(result.timezone, expected_timezone);
+        assert_eq!(result.timezone(), expected_timezone);
     }
 
     #[test]
@@ -120,7 +120,7 @@ mod timezone_offset_tests {
         let input = "2023-06-26T12:34:56-04:00";
         let expected_timezone = timezone::PoSQLTimeZone::from_offset(-14400); // -4 hours in seconds
         let result = PoSQLTimestamp::try_from(input).unwrap();
-        assert_eq!(result.timezone, expected_timezone);
+        assert_eq!(result.timezone(), expected_timezone);
     }
 
     #[test]
@@ -128,6 +128,6 @@ mod timezone_offset_tests {
         let input = "2023-06-26T12:34:56+00:00";
         let expected_timezone = timezone::PoSQLTimeZone::Utc; // Zero offset defaults to UTC
         let result = PoSQLTimestamp::try_from(input).unwrap();
-        assert_eq!(result.timezone, expected_timezone);
+        assert_eq!(result.timezone(), expected_timezone);
     }
 }

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -98,8 +98,8 @@ mod time_unit_tests {
         let input = "2023-06-26T12:34:56.123Z";
         let expected = Utc.ymd(2023, 6, 26).and_hms_milli(12, 34, 56, 123);
         let result = PoSQLTimestamp::try_from(input).unwrap();
-        assert_eq!(result.timeunit, PoSQLTimeUnit::Millisecond);
-        assert_eq!(result.timestamp, expected);
+        assert_eq!(result.timeunit(), PoSQLTimeUnit::Millisecond);
+        assert_eq!(result.timestamp(), expected.timestamp_millis());
     }
 
     #[test]
@@ -107,15 +107,15 @@ mod time_unit_tests {
         let input = "2023-06-26T12:34:56.123456Z";
         let expected = Utc.ymd(2023, 6, 26).and_hms_micro(12, 34, 56, 123456);
         let result = PoSQLTimestamp::try_from(input).unwrap();
-        assert_eq!(result.timeunit, PoSQLTimeUnit::Microsecond);
-        assert_eq!(result.timestamp, expected);
+        assert_eq!(result.timeunit(), PoSQLTimeUnit::Microsecond);
+        assert_eq!(result.timestamp(), expected.timestamp_micros());
     }
     #[test]
     fn test_rfc3339_timestamp_with_nanoseconds() {
         let input = "2023-06-26T12:34:56.123456789Z";
         let expected = Utc.ymd(2023, 6, 26).and_hms_nano(12, 34, 56, 123456789);
         let result = PoSQLTimestamp::try_from(input).unwrap();
-        assert_eq!(result.timeunit, PoSQLTimeUnit::Nanosecond);
-        assert_eq!(result.timestamp, expected);
+        assert_eq!(result.timeunit(), PoSQLTimeUnit::Nanosecond);
+        assert_eq!(result.timestamp(), expected.timestamp_nanos_opt().unwrap());
     }
 }

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -99,7 +99,10 @@ mod time_unit_tests {
         let expected = Utc.ymd(2023, 6, 26).and_hms_milli(12, 34, 56, 123);
         let result = PoSQLTimestamp::try_from(input).unwrap();
         assert_eq!(result.timeunit(), PoSQLTimeUnit::Millisecond);
-        assert_eq!(result.timestamp(), expected.timestamp_millis());
+        assert_eq!(
+            result.timestamp().timestamp_millis(),
+            expected.timestamp_millis()
+        );
     }
 
     #[test]
@@ -108,7 +111,10 @@ mod time_unit_tests {
         let expected = Utc.ymd(2023, 6, 26).and_hms_micro(12, 34, 56, 123456);
         let result = PoSQLTimestamp::try_from(input).unwrap();
         assert_eq!(result.timeunit(), PoSQLTimeUnit::Microsecond);
-        assert_eq!(result.timestamp(), expected.timestamp_micros());
+        assert_eq!(
+            result.timestamp().timestamp_micros(),
+            expected.timestamp_micros()
+        );
     }
     #[test]
     fn test_rfc3339_timestamp_with_nanoseconds() {
@@ -116,6 +122,9 @@ mod time_unit_tests {
         let expected = Utc.ymd(2023, 6, 26).and_hms_nano(12, 34, 56, 123456789);
         let result = PoSQLTimestamp::try_from(input).unwrap();
         assert_eq!(result.timeunit(), PoSQLTimeUnit::Nanosecond);
-        assert_eq!(result.timestamp(), expected.timestamp_nanos_opt().unwrap());
+        assert_eq!(
+            result.timestamp().timestamp_nanos_opt().unwrap(),
+            expected.timestamp_nanos_opt().unwrap()
+        );
     }
 }

--- a/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
@@ -101,7 +101,7 @@ impl ProvableExprPlanBuilder<'_> {
                 s.into(),
             )))),
             Literal::Timestamp(its) => Ok(ProvableExprPlan::new_literal(
-                LiteralValue::TimeStampTZ(its.timeunit, its.timezone, its.timestamp.timestamp()),
+                LiteralValue::TimeStampTZ(its.timeunit(), its.timezone(), its.timestamp()),
             )),
         }
     }

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -249,7 +249,7 @@ impl<'a> QueryContextBuilder<'a> {
                 let precision = Precision::new(d.precision())?;
                 Ok(ColumnType::Decimal75(precision, d.scale()))
             }
-            Literal::Timestamp(its) => Ok(ColumnType::TimestampTZ(its.timeunit, its.timezone)),
+            Literal::Timestamp(its) => Ok(ColumnType::TimestampTZ(its.timeunit(), its.timezone())),
         }
     }
 

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -349,7 +349,7 @@ mod tests {
         let test_timestamps = vec![
             DateTime::parse_from_rfc3339("2023-10-10T12:34:56.789Z")
                 .unwrap()
-                .timestamp(), // Close to rounding up
+                .timestamp_millis(), // Close to rounding up
         ];
         let expected_timestamps = vec![test_timestamps[0]];
 

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -290,10 +290,10 @@ mod tests {
         let test_timestamps = vec![
             DateTime::parse_from_rfc3339("2023-07-01T12:00:00.999Z")
                 .unwrap()
-                .timestamp(),
+                .timestamp_millis(),
             DateTime::parse_from_rfc3339("2023-07-01T12:00:01.000Z")
                 .unwrap()
-                .timestamp(),
+                .timestamp_millis(),
         ];
         let expected_timestamps = vec![test_timestamps[0]]; // Expect the fractional second just before the full second
 


### PR DESCRIPTION
# Rationale for this change

Timestamp literals were parsed in seconds despite containing up to nanosecond precision. This caused a situation where equality and inequality queries would fail across the board. This is the first small PR to address this issue. Timestamps of varying, user supplied precisions are now parsed correctly.

# What changes are included in this PR?

- [x] cover precision match in literal conversion
- [x] add accessor methods for timestamp  
- [x] update test expectations

# Are these changes tested?

yes. next PR is to refactor existing timestamp tests into appropriate ast tests.