### PR TITLE
fix!: timestamp scaling

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -310,13 +310,14 @@ impl ColumnType {
     pub fn scale(&self) -> Option<i8> {
         match self {
             Self::Decimal75(_, scale) => Some(*scale),
-            Self::SmallInt
-            | Self::Int
-            | Self::BigInt
-            | Self::Int128
-            | Self::Scalar
-            | Self::TimestampTZ(_, _) => Some(0),
+            Self::SmallInt | Self::Int | Self::BigInt | Self::Int128 | Self::Scalar => Some(0),
             Self::Boolean | Self::VarChar => None,
+            Self::TimestampTZ(tu, _) => match tu {
+                PoSQLTimeUnit::Second => Some(0),
+                PoSQLTimeUnit::Millisecond => Some(3),
+                PoSQLTimeUnit::Microsecond => Some(6),
+                PoSQLTimeUnit::Nanosecond => Some(9),
+            },
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -18,6 +18,7 @@ mod tests {
     use proof_of_sql_parser::{
         intermediate_ast::{BinaryOperator, Expression, Literal},
         intermediate_decimal::IntermediateDecimal,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
         Identifier, SelectStatement,
     };
     use std::{collections::HashMap, str::FromStr};
@@ -70,6 +71,38 @@ mod tests {
                 "sxt.sxt_tab".parse().unwrap(),
                 Identifier::try_new("varchar_column").unwrap(),
                 ColumnType::VarChar,
+            ),
+        );
+        column_mapping.insert(
+            Identifier::try_new("timestamp_column").unwrap(),
+            ColumnRef::new(
+                "sxt.sxt_tab".parse().unwrap(),
+                Identifier::try_new("timestamp_column").unwrap(),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
+            ),
+        );
+        column_mapping.insert(
+            Identifier::try_new("timestamp_column").unwrap(),
+            ColumnRef::new(
+                "sxt.sxt_tab".parse().unwrap(),
+                Identifier::try_new("timestamp_column").unwrap(),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
+            ),
+        );
+        column_mapping.insert(
+            Identifier::try_new("timestamp_column").unwrap(),
+            ColumnRef::new(
+                "sxt.sxt_tab".parse().unwrap(),
+                Identifier::try_new("timestamp_column").unwrap(),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::Utc),
+            ),
+        );
+        column_mapping.insert(
+            Identifier::try_new("timestamp_column").unwrap(),
+            ColumnRef::new(
+                "sxt.sxt_tab".parse().unwrap(),
+                Identifier::try_new("timestamp_column").unwrap(),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::Utc),
             ),
         );
         column_mapping
@@ -267,6 +300,55 @@ mod tests {
             )),
             right: Box::new(Expression::Literal(Literal::Decimal(
                 IntermediateDecimal::try_from("123.45").unwrap(),
+            ))),
+        };
+        run_test_case(&column_mapping, expr_decimal);
+    }
+
+    #[test]
+    fn we_can_check_varying_precision_eq_for_timestamp() {
+        let column_mapping = get_column_mappings_for_testing();
+
+        let expr_decimal = Expression::Binary {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::Column(
+                Identifier::try_new("timestamp_column").unwrap(),
+            )),
+            right: Box::new(Expression::Literal(Literal::Timestamp(
+                PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456789Z").unwrap(),
+            ))),
+        };
+        run_test_case(&column_mapping, expr_decimal);
+
+        let expr_decimal = Expression::Binary {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::Column(
+                Identifier::try_new("timestamp_column").unwrap(),
+            )),
+            right: Box::new(Expression::Literal(Literal::Timestamp(
+                PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456Z").unwrap(),
+            ))),
+        };
+        run_test_case(&column_mapping, expr_decimal);
+
+        let expr_decimal = Expression::Binary {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::Column(
+                Identifier::try_new("timestamp_column").unwrap(),
+            )),
+            right: Box::new(Expression::Literal(Literal::Timestamp(
+                PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap(),
+            ))),
+        };
+        run_test_case(&column_mapping, expr_decimal);
+
+        let expr_decimal = Expression::Binary {
+            op: BinaryOperator::Equal,
+            left: Box::new(Expression::Column(
+                Identifier::try_new("timestamp_column").unwrap(),
+            )),
+            right: Box::new(Expression::Literal(Literal::Timestamp(
+                PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap(),
             ))),
         };
         run_test_case(&column_mapping, expr_decimal);

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -19,6 +19,7 @@ mod tests {
         intermediate_ast::{BinaryOperator, Expression, Literal},
         intermediate_decimal::IntermediateDecimal,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
+        utility::equal,
         Identifier, SelectStatement,
     };
     use std::{collections::HashMap, str::FromStr};
@@ -74,7 +75,7 @@ mod tests {
             ),
         );
         column_mapping.insert(
-            Identifier::try_new("timestamp_column").unwrap(),
+            Identifier::try_new("timestamp_second_column").unwrap(),
             ColumnRef::new(
                 "sxt.sxt_tab".parse().unwrap(),
                 Identifier::try_new("timestamp_column").unwrap(),
@@ -82,7 +83,7 @@ mod tests {
             ),
         );
         column_mapping.insert(
-            Identifier::try_new("timestamp_column").unwrap(),
+            Identifier::try_new("timestamp_millisecond_column").unwrap(),
             ColumnRef::new(
                 "sxt.sxt_tab".parse().unwrap(),
                 Identifier::try_new("timestamp_column").unwrap(),
@@ -90,7 +91,7 @@ mod tests {
             ),
         );
         column_mapping.insert(
-            Identifier::try_new("timestamp_column").unwrap(),
+            Identifier::try_new("timestamp__microsecond_column").unwrap(),
             ColumnRef::new(
                 "sxt.sxt_tab".parse().unwrap(),
                 Identifier::try_new("timestamp_column").unwrap(),
@@ -101,7 +102,7 @@ mod tests {
             Identifier::try_new("timestamp_column").unwrap(),
             ColumnRef::new(
                 "sxt.sxt_tab".parse().unwrap(),
-                Identifier::try_new("timestamp_column").unwrap(),
+                Identifier::try_new("timestamp_nanosecond_column").unwrap(),
                 ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::Utc),
             ),
         );
@@ -309,49 +310,49 @@ mod tests {
     fn we_can_check_varying_precision_eq_for_timestamp() {
         let column_mapping = get_column_mappings_for_testing();
 
-        let expr_decimal = Expression::Binary {
-            op: BinaryOperator::Equal,
-            left: Box::new(Expression::Column(
+        let expr = equal(
+            Box::new(Expression::Column(
                 Identifier::try_new("timestamp_column").unwrap(),
             )),
-            right: Box::new(Expression::Literal(Literal::Timestamp(
-                PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456789Z").unwrap(),
-            ))),
-        };
-        run_test_case(&column_mapping, expr_decimal);
+            Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
+                Literal::Timestamp(
+                    PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456789Z").unwrap(),
+                ),
+            )),
+        );
+        run_test_case(&column_mapping, *expr);
 
-        let expr_decimal = Expression::Binary {
-            op: BinaryOperator::Equal,
-            left: Box::new(Expression::Column(
+        let expr = equal(
+            Box::new(Expression::Column(
                 Identifier::try_new("timestamp_column").unwrap(),
             )),
-            right: Box::new(Expression::Literal(Literal::Timestamp(
-                PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456Z").unwrap(),
-            ))),
-        };
-        run_test_case(&column_mapping, expr_decimal);
+            Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
+                Literal::Timestamp(
+                    PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456Z").unwrap(),
+                ),
+            )),
+        );
+        run_test_case(&column_mapping, *expr);
 
-        let expr_decimal = Expression::Binary {
-            op: BinaryOperator::Equal,
-            left: Box::new(Expression::Column(
+        let expr = equal(
+            Box::new(Expression::Column(
                 Identifier::try_new("timestamp_column").unwrap(),
             )),
-            right: Box::new(Expression::Literal(Literal::Timestamp(
-                PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap(),
-            ))),
-        };
-        run_test_case(&column_mapping, expr_decimal);
+            Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
+                Literal::Timestamp(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap()),
+            )),
+        );
+        run_test_case(&column_mapping, *expr);
 
-        let expr_decimal = Expression::Binary {
-            op: BinaryOperator::Equal,
-            left: Box::new(Expression::Column(
+        let expr = equal(
+            Box::new(Expression::Column(
                 Identifier::try_new("timestamp_column").unwrap(),
             )),
-            right: Box::new(Expression::Literal(Literal::Timestamp(
-                PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap(),
-            ))),
-        };
-        run_test_case(&column_mapping, expr_decimal);
+            Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
+                Literal::Timestamp(PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap()),
+            )),
+        );
+        run_test_case(&column_mapping, *expr);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -19,7 +19,7 @@ mod tests {
         intermediate_ast::{BinaryOperator, Expression, Literal},
         intermediate_decimal::IntermediateDecimal,
         posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
-        utility::equal,
+        utility::{col, equal, lit},
         Identifier, SelectStatement,
     };
     use std::{collections::HashMap, str::FromStr};
@@ -78,7 +78,7 @@ mod tests {
             Identifier::try_new("timestamp_second_column").unwrap(),
             ColumnRef::new(
                 "sxt.sxt_tab".parse().unwrap(),
-                Identifier::try_new("timestamp_column").unwrap(),
+                Identifier::try_new("timestamp_second_column").unwrap(),
                 ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
             ),
         );
@@ -86,20 +86,20 @@ mod tests {
             Identifier::try_new("timestamp_millisecond_column").unwrap(),
             ColumnRef::new(
                 "sxt.sxt_tab".parse().unwrap(),
-                Identifier::try_new("timestamp_column").unwrap(),
+                Identifier::try_new("timestamp_millisecond_column").unwrap(),
                 ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
             ),
         );
         column_mapping.insert(
-            Identifier::try_new("timestamp__microsecond_column").unwrap(),
+            Identifier::try_new("timestamp_microsecond_column").unwrap(),
             ColumnRef::new(
                 "sxt.sxt_tab".parse().unwrap(),
-                Identifier::try_new("timestamp_column").unwrap(),
+                Identifier::try_new("timestamp_microsecond_column").unwrap(),
                 ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::Utc),
             ),
         );
         column_mapping.insert(
-            Identifier::try_new("timestamp_column").unwrap(),
+            Identifier::try_new("timestamp_nanosecond_column").unwrap(),
             ColumnRef::new(
                 "sxt.sxt_tab".parse().unwrap(),
                 Identifier::try_new("timestamp_nanosecond_column").unwrap(),
@@ -310,49 +310,37 @@ mod tests {
     fn we_can_check_varying_precision_eq_for_timestamp() {
         let column_mapping = get_column_mappings_for_testing();
 
-        let expr = equal(
-            Box::new(Expression::Column(
-                Identifier::try_new("timestamp_nanoseconds_column").unwrap(),
-            )),
-            Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
-                Literal::Timestamp(
-                    PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456789Z").unwrap(),
-                ),
-            )),
+        run_test_case(
+            &column_mapping,
+            *equal(
+                col("timestamp_nanosecond_column"),
+                lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456789Z").unwrap()),
+            ),
         );
-        run_test_case(&column_mapping, *expr);
 
-        let expr = equal(
-            Box::new(Expression::Column(
-                Identifier::try_new("timestamp_microseconds_column").unwrap(),
-            )),
-            Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
-                Literal::Timestamp(
-                    PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456Z").unwrap(),
-                ),
-            )),
+        run_test_case(
+            &column_mapping,
+            *equal(
+                col("timestamp_microsecond_column"),
+                lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456Z").unwrap()),
+            ),
         );
-        run_test_case(&column_mapping, *expr);
 
-        let expr = equal(
-            Box::new(Expression::Column(
-                Identifier::try_new("timestamp_milliseconds_column").unwrap(),
-            )),
-            Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
-                Literal::Timestamp(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap()),
-            )),
+        run_test_case(
+            &column_mapping,
+            *equal(
+                col("timestamp_millisecond_column"),
+                lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap()),
+            ),
         );
-        run_test_case(&column_mapping, *expr);
 
-        let expr = equal(
-            Box::new(Expression::Column(
-                Identifier::try_new("timestamp_seconds_column").unwrap(),
-            )),
-            Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
-                Literal::Timestamp(PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap()),
-            )),
+        run_test_case(
+            &column_mapping,
+            *equal(
+                col("timestamp_second_column"),
+                lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap()),
+            ),
         );
-        run_test_case(&column_mapping, *expr);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -312,7 +312,7 @@ mod tests {
 
         let expr = equal(
             Box::new(Expression::Column(
-                Identifier::try_new("timestamp_column").unwrap(),
+                Identifier::try_new("timestamp_nanoseconds_column").unwrap(),
             )),
             Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
                 Literal::Timestamp(
@@ -324,7 +324,7 @@ mod tests {
 
         let expr = equal(
             Box::new(Expression::Column(
-                Identifier::try_new("timestamp_column").unwrap(),
+                Identifier::try_new("timestamp_microseconds_column").unwrap(),
             )),
             Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
                 Literal::Timestamp(
@@ -336,7 +336,7 @@ mod tests {
 
         let expr = equal(
             Box::new(Expression::Column(
-                Identifier::try_new("timestamp_column").unwrap(),
+                Identifier::try_new("timestamp_milliseconds_column").unwrap(),
             )),
             Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
                 Literal::Timestamp(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap()),
@@ -346,7 +346,7 @@ mod tests {
 
         let expr = equal(
             Box::new(Expression::Column(
-                Identifier::try_new("timestamp_column").unwrap(),
+                Identifier::try_new("timestamp_seconds_column").unwrap(),
             )),
             Box::new(proof_of_sql_parser::intermediate_ast::Expression::Literal(
                 Literal::Timestamp(PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap()),

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -286,25 +286,6 @@ mod tests {
     }
 
     #[test]
-    fn test_fractional_seconds_handling() {
-        let test_timestamps = vec![
-            DateTime::parse_from_rfc3339("2023-07-01T12:00:00.999Z")
-                .unwrap()
-                .timestamp_millis(),
-            DateTime::parse_from_rfc3339("2023-07-01T12:00:01.000Z")
-                .unwrap()
-                .timestamp_millis(),
-        ];
-        let expected_timestamps = vec![test_timestamps[0]]; // Expect the fractional second just before the full second
-
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2023-07-01T12:00:00.999Z'",
-            test_timestamps,
-            expected_timestamps,
-        );
-    }
-
-    #[test]
     fn test_february_29_leap_year() {
         // Test year 2024 which is a leap year
         let test_timestamps = vec![
@@ -340,23 +321,6 @@ mod tests {
             "SELECT * FROM table WHERE times = timestamp '2023-08-15T20:00:00Z'", // UTC time
             test_timestamps.clone(),
             test_timestamps,
-        );
-    }
-
-    #[test]
-    fn test_precision_and_rounding() {
-        // Testing timestamps near rounding thresholds
-        let test_timestamps = vec![
-            DateTime::parse_from_rfc3339("2023-10-10T12:34:56.789Z")
-                .unwrap()
-                .timestamp_millis(), // Close to rounding up
-        ];
-        let expected_timestamps = vec![test_timestamps[0]];
-
-        run_timestamp_query_test(
-            "SELECT * FROM table WHERE times = timestamp '2023-10-10T12:34:56.789Z';",
-            test_timestamps,
-            expected_timestamps,
         );
     }
 


### PR DESCRIPTION
# Rationale for this change

This is the second small PR that corrects the scaling of differing timestamp precisions for operations such as inequality or equality comparisons.

# What changes are included in this PR?

- [x] corrects the scaling of timestamptz precision
- [x] removes incorrect unit tests for handling of timestamp precision

# Are these changes tested?

existing tests pass, incorrect tests are removed. The next PR will contain a large refactor of existing timestamptz tests.
