### PR TITLE
refactor: move `dense_filter_util` and `group_by_util` to `base::database`

### DIFF
--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -1,4 +1,4 @@
-use crate::base::{database::Column, polynomial::MultilinearExtension, scalar::Scalar};
+use crate::base::{database::Column, scalar::Scalar};
 use bumpalo::Bump;
 
 /// This function takes a selection vector and a set of columns and returns a
@@ -71,38 +71,4 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
         ),
     }
-}
-
-/// This function takes a set of columns and fold it into a slice of scalars.
-///
-/// The result `res` is updated with
-/// `res[i] += mul * sum (beta^j * columns[j][i]) for j in 0..columns.len()`
-/// where each column is padded with 0s as needed.
-///
-/// This is similar to adding `mul * fold_vals(beta,...)` on each row.
-
-pub fn fold_columns<S: Scalar>(
-    res: &mut [S],
-    mul: S,
-    beta: S,
-    columns: &[impl MultilinearExtension<S>],
-) {
-    for (m, col) in powers(mul, beta).zip(columns) {
-        col.mul_add(res, &m);
-    }
-}
-
-/// This function takes a set of values and returns a scalar that is the
-/// result of folding the values.
-///
-/// The result is
-/// `sum (beta^j * vals[j]) for j in 0..vals.len()`
-pub fn fold_vals<S: Scalar>(beta: S, vals: &[S]) -> S {
-    let beta_powers = powers(S::one(), beta);
-    beta_powers.zip(vals).map(|(pow, &val)| pow * val).sum()
-}
-
-/// Returns an iterator for the lazily evaluated sequence `init, init * base, init * base^2, ...`
-fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
-    core::iter::successors(Some(init), move |&m| Some(m * base))
 }

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,0 +1,91 @@
+use crate::base::{
+    database::{filter_util::*, Column},
+    math::decimal::Precision,
+    scalar::Curve25519Scalar,
+};
+use bumpalo::Bump;
+
+#[test]
+fn we_can_filter_columns() {
+    let selection = vec![true, false, true, false, true];
+    let str_scalars: [Curve25519Scalar; 5] =
+        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
+    let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
+    let columns = vec![
+        Column::BigInt(&[1, 2, 3, 4, 5]),
+        Column::Int128(&[1, 2, 3, 4, 5]),
+        Column::VarChar((&["1", "2", "3", "4", "5"], &str_scalars)),
+        Column::Scalar(&scalars),
+        Column::Decimal75(Precision::new(75).unwrap(), 0, &decimals),
+    ];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 3);
+    assert_eq!(
+        result,
+        vec![
+            Column::BigInt(&[1, 3, 5]),
+            Column::Int128(&[1, 3, 5]),
+            Column::VarChar((&["1", "3", "5"], &["1".into(), "3".into(), "5".into()])),
+            Column::Scalar(&[1.into(), 3.into(), 5.into()]),
+            Column::Decimal75(
+                Precision::new(75).unwrap(),
+                0,
+                &[1.into(), 3.into(), 5.into()]
+            )
+        ]
+    );
+}
+#[test]
+fn we_can_filter_columns_with_empty_result() {
+    let selection = vec![false, false, false, false, false];
+    let str_scalars: [Curve25519Scalar; 5] =
+        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
+    let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
+    let columns = vec![
+        Column::BigInt(&[1, 2, 3, 4, 5]),
+        Column::Int128(&[1, 2, 3, 4, 5]),
+        Column::VarChar((&["1", "2", "3", "4", "5"], &str_scalars)),
+        Column::Scalar(&scalars),
+        Column::Decimal75(Precision::new(75).unwrap(), -1, &decimals),
+    ];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 0);
+    assert_eq!(
+        result,
+        vec![
+            Column::BigInt(&[]),
+            Column::Int128(&[]),
+            Column::VarChar((&[], &[])),
+            Column::Scalar(&[]),
+            Column::Decimal75(Precision::new(75).unwrap(), -1, &[])
+        ]
+    );
+}
+#[test]
+fn we_can_filter_empty_columns() {
+    let selection = vec![];
+    let columns = vec![
+        Column::<Curve25519Scalar>::BigInt(&[]),
+        Column::Int128(&[]),
+        Column::VarChar((&[], &[])),
+        Column::Scalar(&[]),
+        Column::Decimal75(Precision::new(75).unwrap(), -1, &[]),
+    ];
+    let alloc = Bump::new();
+    let (result, len) = filter_columns(&alloc, &columns, &selection);
+    assert_eq!(len, 0);
+    assert_eq!(
+        result,
+        vec![
+            Column::BigInt(&[]),
+            Column::Int128(&[]),
+            Column::VarChar((&[], &[])),
+            Column::Scalar(&[]),
+            Column::Decimal75(Precision::new(75).unwrap(), -1, &[])
+        ]
+    );
+}

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -1,8 +1,7 @@
 //! Contains the utility functions for the `GroupByExpr` node.
 
-use super::filter_column_by_index;
 use crate::base::{
-    database::{Column, OwnedColumn},
+    database::{filter_util::filter_column_by_index, Column, OwnedColumn},
     scalar::Scalar,
 };
 use bumpalo::Bump;
@@ -100,7 +99,7 @@ pub fn aggregate_columns<'a, S: Scalar>(
 /// contains the indexes of the elements in `column`.
 ///
 /// See [`sum_aggregate_slice_by_index_counts`] for an example. This is a helper wrapper around that function.
-pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
+pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
     alloc: &'a Bump,
     column: &Column<S>,
     counts: &[usize],
@@ -142,7 +141,7 @@ pub(super) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
 /// let result = sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
 /// assert_eq!(result, expected);
 /// ```
-pub(super) fn sum_aggregate_slice_by_index_counts<'a, S, T>(
+pub(crate) fn sum_aggregate_slice_by_index_counts<'a, S, T>(
     alloc: &'a Bump,
     slice: &[T],
     counts: &[usize],
@@ -164,7 +163,7 @@ where
 
 /// Compares the tuples (group_by[0][i], group_by[1][i], ...) and
 /// (group_by[0][j], group_by[1][j], ...) in lexicographic order.
-pub(super) fn compare_indexes_by_columns<S: Scalar>(
+pub(crate) fn compare_indexes_by_columns<S: Scalar>(
     group_by: &[Column<S>],
     i: usize,
     j: usize,
@@ -190,7 +189,7 @@ pub(super) fn compare_indexes_by_columns<S: Scalar>(
 /// (group_by[0][j], group_by[1][j], ...) in lexicographic order.
 ///
 /// Identical in functionality to [compare_indexes_by_columns]
-pub(super) fn compare_indexes_by_owned_columns<S: Scalar>(
+pub(crate) fn compare_indexes_by_owned_columns<S: Scalar>(
     group_by: &[&OwnedColumn<S>],
     i: usize,
     j: usize,

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,17 +1,9 @@
-use super::{
-    aggregate_columns,
-    group_by_util::{
-        compare_indexes_by_columns, sum_aggregate_column_by_index_counts,
-        sum_aggregate_slice_by_index_counts,
-    },
-};
 use crate::{
     base::{
-        database::{Column, OwnedColumn},
+        database::{group_by_util::*, Column, OwnedColumn},
         scalar::Curve25519Scalar,
     },
     proof_primitive::dory::DoryScalar,
-    sql::ast::group_by_util::compare_indexes_by_owned_columns,
 };
 use bumpalo::Bump;
 use core::cmp::Ordering;

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -87,3 +87,11 @@ pub use owned_table_test_accessor::OwnedTableTestAccessor;
 mod owned_table_test_accessor_test;
 /// Contains traits for scalar <-> i256 conversions
 pub mod scalar_and_i256_conversions;
+
+pub(crate) mod filter_util;
+#[cfg(test)]
+mod filter_util_test;
+
+pub(crate) mod group_by_util;
+#[cfg(test)]
+mod group_by_util_test;

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_expr.rs
@@ -1,13 +1,12 @@
 use super::{
-    dense_filter_util::{fold_columns, fold_vals},
-    filter_columns, AliasedProvableExprPlan, ProvableExpr, ProvableExprPlan, TableExpr,
+    fold_columns, fold_vals, AliasedProvableExprPlan, ProvableExpr, ProvableExprPlan, TableExpr,
 };
 use crate::{
     base::{
         commitment::Commitment,
         database::{
-            Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
-            OwnedTable,
+            filter_util::filter_columns, Column, ColumnField, ColumnRef, CommitmentAccessor,
+            DataAccessor, MetadataAccessor, OwnedTable,
         },
         proof::ProofError,
         scalar::Scalar,

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test_dishonest_prover.rs
@@ -1,10 +1,8 @@
-use super::{
-    dense_filter_expr::prove_filter, filter_columns, OstensibleDenseFilterExpr, ProvableExpr,
-};
+use super::{dense_filter_expr::prove_filter, OstensibleDenseFilterExpr, ProvableExpr};
 use crate::base::database::owned_table_utility::*;
 use crate::{
     base::{
-        database::{Column, DataAccessor, OwnedTableTestAccessor, TestAccessor},
+        database::{filter_util::*, Column, DataAccessor, OwnedTableTestAccessor, TestAccessor},
         proof::ProofError,
         scalar::Curve25519Scalar,
     },

--- a/crates/proof-of-sql/src/sql/ast/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/ast/fold_util.rs
@@ -1,0 +1,35 @@
+use crate::base::{polynomial::MultilinearExtension, scalar::Scalar};
+
+/// This function takes a set of columns and fold it into a slice of scalars.
+///
+/// The result `res` is updated with
+/// `res[i] += mul * sum (beta^j * columns[j][i]) for j in 0..columns.len()`
+/// where each column is padded with 0s as needed.
+///
+/// This is similar to adding `mul * fold_vals(beta,...)` on each row.
+
+pub fn fold_columns<S: Scalar>(
+    res: &mut [S],
+    mul: S,
+    beta: S,
+    columns: &[impl MultilinearExtension<S>],
+) {
+    for (m, col) in powers(mul, beta).zip(columns) {
+        col.mul_add(res, &m);
+    }
+}
+
+/// This function takes a set of values and returns a scalar that is the
+/// result of folding the values.
+///
+/// The result is
+/// `sum (beta^j * vals[j]) for j in 0..vals.len()`
+pub fn fold_vals<S: Scalar>(beta: S, vals: &[S]) -> S {
+    let beta_powers = powers(S::one(), beta);
+    beta_powers.zip(vals).map(|(pow, &val)| pow * val).sum()
+}
+
+/// Returns an iterator for the lazily evaluated sequence `init, init * base, init * base^2, ...`
+fn powers<S: Scalar>(init: S, base: S) -> impl Iterator<Item = S> {
+    core::iter::successors(Some(init), move |&m| Some(m * base))
+}

--- a/crates/proof-of-sql/src/sql/ast/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/fold_util_test.rs
@@ -1,95 +1,9 @@
-use super::{filter_columns, fold_vals};
 use crate::{
     base::{database::Column, math::decimal::Precision, scalar::Curve25519Scalar},
-    sql::ast::dense_filter_util::fold_columns,
+    sql::ast::{fold_columns, fold_vals},
 };
 use bumpalo::Bump;
 use num_traits::Zero;
-
-#[test]
-fn we_can_filter_columns() {
-    let selection = vec![true, false, true, false, true];
-    let str_scalars: [Curve25519Scalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
-    let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
-    let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
-    let columns = vec![
-        Column::BigInt(&[1, 2, 3, 4, 5]),
-        Column::Int128(&[1, 2, 3, 4, 5]),
-        Column::VarChar((&["1", "2", "3", "4", "5"], &str_scalars)),
-        Column::Scalar(&scalars),
-        Column::Decimal75(Precision::new(75).unwrap(), 0, &decimals),
-    ];
-    let alloc = Bump::new();
-    let (result, len) = filter_columns(&alloc, &columns, &selection);
-    assert_eq!(len, 3);
-    assert_eq!(
-        result,
-        vec![
-            Column::BigInt(&[1, 3, 5]),
-            Column::Int128(&[1, 3, 5]),
-            Column::VarChar((&["1", "3", "5"], &["1".into(), "3".into(), "5".into()])),
-            Column::Scalar(&[1.into(), 3.into(), 5.into()]),
-            Column::Decimal75(
-                Precision::new(75).unwrap(),
-                0,
-                &[1.into(), 3.into(), 5.into()]
-            )
-        ]
-    );
-}
-#[test]
-fn we_can_filter_columns_with_empty_result() {
-    let selection = vec![false, false, false, false, false];
-    let str_scalars: [Curve25519Scalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
-    let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
-    let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
-    let columns = vec![
-        Column::BigInt(&[1, 2, 3, 4, 5]),
-        Column::Int128(&[1, 2, 3, 4, 5]),
-        Column::VarChar((&["1", "2", "3", "4", "5"], &str_scalars)),
-        Column::Scalar(&scalars),
-        Column::Decimal75(Precision::new(75).unwrap(), -1, &decimals),
-    ];
-    let alloc = Bump::new();
-    let (result, len) = filter_columns(&alloc, &columns, &selection);
-    assert_eq!(len, 0);
-    assert_eq!(
-        result,
-        vec![
-            Column::BigInt(&[]),
-            Column::Int128(&[]),
-            Column::VarChar((&[], &[])),
-            Column::Scalar(&[]),
-            Column::Decimal75(Precision::new(75).unwrap(), -1, &[])
-        ]
-    );
-}
-#[test]
-fn we_can_filter_empty_columns() {
-    let selection = vec![];
-    let columns = vec![
-        Column::<Curve25519Scalar>::BigInt(&[]),
-        Column::Int128(&[]),
-        Column::VarChar((&[], &[])),
-        Column::Scalar(&[]),
-        Column::Decimal75(Precision::new(75).unwrap(), -1, &[]),
-    ];
-    let alloc = Bump::new();
-    let (result, len) = filter_columns(&alloc, &columns, &selection);
-    assert_eq!(len, 0);
-    assert_eq!(
-        result,
-        vec![
-            Column::BigInt(&[]),
-            Column::Int128(&[]),
-            Column::VarChar((&[], &[])),
-            Column::Scalar(&[]),
-            Column::Decimal75(Precision::new(75).unwrap(), -1, &[])
-        ]
-    );
-}
 
 #[test]
 fn we_can_fold_columns_with_scalars() {

--- a/crates/proof-of-sql/src/sql/ast/group_by_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_expr.rs
@@ -1,12 +1,14 @@
 use super::{
-    aggregate_columns, fold_columns, fold_vals,
-    group_by_util::{compare_indexes_by_owned_columns, AggregatedColumns},
-    AliasedProvableExprPlan, ColumnExpr, ProvableExpr, ProvableExprPlan, TableExpr,
+    fold_columns, fold_vals, AliasedProvableExprPlan, ColumnExpr, ProvableExpr, ProvableExprPlan,
+    TableExpr,
 };
 use crate::{
     base::{
         commitment::Commitment,
         database::{
+            group_by_util::{
+                aggregate_columns, compare_indexes_by_owned_columns, AggregatedColumns,
+            },
             Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
             MetadataAccessor, OwnedTable,
         },

--- a/crates/proof-of-sql/src/sql/ast/mod.rs
+++ b/crates/proof-of-sql/src/sql/ast/mod.rs
@@ -108,23 +108,16 @@ mod dense_filter_expr_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod dense_filter_expr_test_dishonest_prover;
 
-mod dense_filter_util;
-pub(crate) use dense_filter_util::{
-    filter_column_by_index, filter_columns, fold_columns, fold_vals,
-};
+mod fold_util;
+pub(crate) use fold_util::{fold_columns, fold_vals};
 #[cfg(test)]
-mod dense_filter_util_test;
+mod fold_util_test;
 
 mod group_by_expr;
 pub(crate) use group_by_expr::GroupByExpr;
 
 #[cfg(all(test, feature = "blitzar"))]
 mod group_by_expr_test;
-
-mod group_by_util;
-use group_by_util::aggregate_columns;
-#[cfg(test)]
-mod group_by_util_test;
 
 mod proof_plan;
 pub use proof_plan::ProofPlan;


### PR DESCRIPTION
# Rationale for this change
In order to reuse these utils for both proof generation and postprocessing we need to move them into `base::database`
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- move most of `dense_filter_util` and all of `group_by_util` to `base::database`
- rename the remaining file to `fold_util` & the moved one to `filter_util`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
