### PR TITLE
feat: add `MAX` and `MIN` to `AggregateColumns`

### DIFF
--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -18,7 +18,7 @@ fn we_can_aggregate_empty_columns() {
     let sum_columns = &[column_c.clone(), column_d.clone()];
     let selection = &[];
     let alloc = Bump::new();
-    let aggregate_result = aggregate_columns(&alloc, group_by, sum_columns, selection)
+    let aggregate_result = aggregate_columns(&alloc, group_by, sum_columns, &[], &[], selection)
         .expect("Aggregation should succeed");
     assert_eq!(
         aggregate_result.group_by_columns,
@@ -26,6 +26,89 @@ fn we_can_aggregate_empty_columns() {
     );
     assert_eq!(aggregate_result.sum_columns, vec![&[], &[]]);
     assert_eq!(aggregate_result.count_column, &[0i64; 0]);
+}
+
+#[test]
+fn we_can_aggregate_columns_with_empty_group_by_and_no_rows_selected() {
+    let slice_c = &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
+    let slice_d = &[200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211];
+    let selection = &[false; 12];
+    let scals_d: Vec<Curve25519Scalar> = slice_d.iter().map(|s| s.into()).collect();
+    let column_c = Column::Int128(slice_c);
+    let column_d = Column::Scalar(&scals_d);
+    let group_by = &[];
+    let sum_columns = &[column_c.clone(), column_d.clone()];
+    let max_columns = &[column_c.clone(), column_d.clone()];
+    let min_columns = &[column_c.clone(), column_d.clone()];
+    let alloc = Bump::new();
+    let aggregate_result = aggregate_columns(
+        &alloc,
+        group_by,
+        sum_columns,
+        min_columns,
+        max_columns,
+        selection,
+    )
+    .expect("Aggregation should succeed");
+    let expected_group_by_result = &[];
+    let expected_sum_result = &[&[], &[]];
+    let expected_max_result = &[&[], &[]];
+    let expected_min_result = &[&[], &[]];
+    let expected_count_result: &[i64] = &[];
+    assert_eq!(aggregate_result.group_by_columns, expected_group_by_result);
+    assert_eq!(aggregate_result.sum_columns, expected_sum_result);
+    assert_eq!(aggregate_result.count_column, expected_count_result);
+    assert_eq!(aggregate_result.max_columns, expected_max_result);
+    assert_eq!(aggregate_result.min_columns, expected_min_result);
+}
+
+#[test]
+fn we_can_aggregate_columns_with_empty_group_by() {
+    let slice_c = &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
+    let slice_d = &[200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211];
+    let selection = &[
+        false, true, true, true, true, true, true, true, true, true, true, true,
+    ];
+    let scals_d: Vec<Curve25519Scalar> = slice_d.iter().map(|s| s.into()).collect();
+    let column_c = Column::Int128(slice_c);
+    let column_d = Column::Scalar(&scals_d);
+    let group_by = &[];
+    let sum_columns = &[column_c.clone(), column_d.clone()];
+    let max_columns = &[column_c.clone(), column_d.clone()];
+    let min_columns = &[column_c.clone(), column_d.clone()];
+    let alloc = Bump::new();
+    let aggregate_result = aggregate_columns(
+        &alloc,
+        group_by,
+        sum_columns,
+        min_columns,
+        max_columns,
+        selection,
+    )
+    .expect("Aggregation should succeed");
+    let expected_group_by_result = &[];
+    let expected_sum_result = &[
+        &[Curve25519Scalar::from(
+            101 + 102 + 103 + 104 + 105 + 106 + 107 + 108 + 109 + 110 + 111,
+        )],
+        &[Curve25519Scalar::from(
+            201 + 202 + 203 + 204 + 205 + 206 + 207 + 208 + 209 + 210 + 211,
+        )],
+    ];
+    let expected_max_result = &[
+        &[Some(Curve25519Scalar::from(111))],
+        &[Some(Curve25519Scalar::from(211))],
+    ];
+    let expected_min_result = &[
+        &[Some(Curve25519Scalar::from(101))],
+        &[Some(Curve25519Scalar::from(201))],
+    ];
+    let expected_count_result = &[11];
+    assert_eq!(aggregate_result.group_by_columns, expected_group_by_result);
+    assert_eq!(aggregate_result.sum_columns, expected_sum_result);
+    assert_eq!(aggregate_result.count_column, expected_count_result);
+    assert_eq!(aggregate_result.max_columns, expected_max_result);
+    assert_eq!(aggregate_result.min_columns, expected_min_result);
 }
 
 #[test]
@@ -47,9 +130,18 @@ fn we_can_aggregate_columns() {
     let column_d = Column::Scalar(&scals_d);
     let group_by = &[column_a.clone(), column_b.clone()];
     let sum_columns = &[column_c.clone(), column_d.clone()];
+    let max_columns = &[column_c.clone(), column_d.clone()];
+    let min_columns = &[column_c.clone(), column_d.clone()];
     let alloc = Bump::new();
-    let aggregate_result = aggregate_columns(&alloc, group_by, sum_columns, selection)
-        .expect("Aggregation should succeed");
+    let aggregate_result = aggregate_columns(
+        &alloc,
+        group_by,
+        sum_columns,
+        min_columns,
+        max_columns,
+        selection,
+    )
+    .expect("Aggregation should succeed");
     let scals_res = [
         Curve25519Scalar::from("Cat"),
         Curve25519Scalar::from("Dog"),
@@ -80,10 +172,48 @@ fn we_can_aggregate_columns() {
             Curve25519Scalar::from(202 + 210),
         ],
     ];
+    let expected_max_result = &[
+        &[
+            Some(Curve25519Scalar::from(105)),
+            Some(Curve25519Scalar::from(106)),
+            Some(Curve25519Scalar::from(107)),
+            Some(Curve25519Scalar::from(108)),
+            Some(Curve25519Scalar::from(111)),
+            Some(Curve25519Scalar::from(110)),
+        ],
+        &[
+            Some(Curve25519Scalar::from(205)),
+            Some(Curve25519Scalar::from(206)),
+            Some(Curve25519Scalar::from(207)),
+            Some(Curve25519Scalar::from(208)),
+            Some(Curve25519Scalar::from(211)),
+            Some(Curve25519Scalar::from(210)),
+        ],
+    ];
+    let expected_min_result = &[
+        &[
+            Some(Curve25519Scalar::from(105)),
+            Some(Curve25519Scalar::from(106)),
+            Some(Curve25519Scalar::from(103)),
+            Some(Curve25519Scalar::from(104)),
+            Some(Curve25519Scalar::from(101)),
+            Some(Curve25519Scalar::from(102)),
+        ],
+        &[
+            Some(Curve25519Scalar::from(205)),
+            Some(Curve25519Scalar::from(206)),
+            Some(Curve25519Scalar::from(203)),
+            Some(Curve25519Scalar::from(204)),
+            Some(Curve25519Scalar::from(201)),
+            Some(Curve25519Scalar::from(202)),
+        ],
+    ];
     let expected_count_result = &[1, 1, 2, 2, 3, 2];
     assert_eq!(aggregate_result.group_by_columns, expected_group_by_result);
     assert_eq!(aggregate_result.sum_columns, expected_sum_result);
     assert_eq!(aggregate_result.count_column, expected_count_result);
+    assert_eq!(aggregate_result.max_columns, expected_max_result);
+    assert_eq!(aggregate_result.min_columns, expected_min_result);
 }
 
 #[test]
@@ -264,6 +394,7 @@ fn we_can_compare_indexes_by_columns_for_scalar_columns() {
     assert_eq!(compare_indexes_by_columns(columns, 6, 9), Ordering::Equal);
 }
 
+// SUM slices
 #[test]
 fn we_can_sum_aggregate_slice_by_counts_for_empty_slice() {
     let slice_a: &[i64; 0] = &[];
@@ -289,7 +420,39 @@ fn we_can_sum_aggregate_slice_by_counts_with_empty_result() {
 }
 
 #[test]
-fn we_can_sum_aggregate_slice_by_counts() {
+fn we_can_sum_aggregate_slice_by_counts_with_all_empty_groups() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let indexes = &[];
+    let counts = &[0, 0, 0];
+    let expected = &[Curve25519Scalar::from(0); 3];
+    let alloc = Bump::new();
+    let result: &[Curve25519Scalar] =
+        sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_sum_aggregate_slice_by_counts_with_some_empty_group() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let indexes = &[12, 11, 1, 10, 2, 3, 4];
+    let counts = &[3, 4, 0];
+    let expected = &[
+        Curve25519Scalar::from(112 + 111 + 101),
+        Curve25519Scalar::from(110 + 102 + 103 + 104),
+        Curve25519Scalar::from(0),
+    ];
+    let alloc = Bump::new();
+    let result: &[Curve25519Scalar] =
+        sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_sum_aggregate_slice_by_counts_without_empty_groups() {
     let slice_a = &[
         100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
     ];
@@ -347,5 +510,245 @@ fn we_can_sum_aggregate_columns_by_counts() {
     let result = sum_aggregate_column_by_index_counts(&alloc, &columns_b, counts, indexes);
     assert_eq!(result, expected);
     let result = sum_aggregate_column_by_index_counts(&alloc, &columns_c, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+// MAX slices
+#[test]
+fn we_can_max_aggregate_slice_by_counts_for_empty_slice() {
+    let slice_a: &[i64; 0] = &[];
+    let indexes = &[];
+    let counts = &[];
+    let expected: &[Option<DoryScalar>; 0] = &[];
+    let alloc = Bump::new();
+    let result: &[Option<DoryScalar>] =
+        max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_max_aggregate_slice_by_counts_with_empty_result() {
+    let slice_a = &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109];
+    let indexes = &[];
+    let counts = &[];
+    let expected: &[Option<DoryScalar>; 0] = &[];
+    let alloc = Bump::new();
+    let result: &[Option<DoryScalar>] =
+        max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_max_aggregate_slice_by_counts_with_all_empty_groups() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let indexes = &[];
+    let counts = &[0, 0, 0];
+    let expected = &[None; 3];
+    let alloc = Bump::new();
+    let result: &[Option<Curve25519Scalar>] =
+        max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_max_aggregate_slice_by_counts_with_some_empty_group() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let indexes = &[12, 11, 1, 10, 2, 3, 4];
+    let counts = &[3, 4, 0];
+    let expected = &[
+        Some(Curve25519Scalar::from(112)),
+        Some(Curve25519Scalar::from(110)),
+        None,
+    ];
+    let alloc = Bump::new();
+    let result: &[Option<Curve25519Scalar>] =
+        max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_max_aggregate_slice_by_counts_without_empty_groups() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
+    let counts = &[3, 3, 4];
+    let expected = &[
+        Some(Curve25519Scalar::from(112)),
+        Some(Curve25519Scalar::from(110)),
+        Some(Curve25519Scalar::from(114)),
+    ];
+    let alloc = Bump::new();
+    let result: &[Option<Curve25519Scalar>] =
+        max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_max_aggregate_columns_by_counts_for_empty_column() {
+    let slice_a: &[i64; 0] = &[];
+    let column_a = Column::BigInt::<DoryScalar>(slice_a);
+    let indexes = &[];
+    let counts = &[];
+    let expected: &[Option<DoryScalar>; 0] = &[];
+    let alloc = Bump::new();
+    let result: &[Option<DoryScalar>] =
+        max_aggregate_column_by_index_counts(&alloc, &column_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_max_aggregate_columns_by_counts() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let slice_b = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let slice_c = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let scals_c: Vec<Curve25519Scalar> = slice_c.iter().map(|s| s.into()).collect();
+    let column_a = Column::BigInt::<Curve25519Scalar>(slice_a);
+    let columns_b = Column::Int128::<Curve25519Scalar>(slice_b);
+    let columns_c = Column::Scalar(&scals_c);
+    let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
+    let counts = &[3, 3, 4, 0];
+    let expected = &[
+        Some(Curve25519Scalar::from(112)),
+        Some(Curve25519Scalar::from(110)),
+        Some(Curve25519Scalar::from(114)),
+        None,
+    ];
+    let alloc = Bump::new();
+    let result = max_aggregate_column_by_index_counts(&alloc, &column_a, counts, indexes);
+    assert_eq!(result, expected);
+    let result = max_aggregate_column_by_index_counts(&alloc, &columns_b, counts, indexes);
+    assert_eq!(result, expected);
+    let result = max_aggregate_column_by_index_counts(&alloc, &columns_c, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+// MIN slices
+#[test]
+fn we_can_min_aggregate_slice_by_counts_for_empty_slice() {
+    let slice_a: &[i64; 0] = &[];
+    let indexes = &[];
+    let counts = &[];
+    let expected: &[Option<DoryScalar>; 0] = &[];
+    let alloc = Bump::new();
+    let result: &[Option<DoryScalar>] =
+        min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_min_aggregate_slice_by_counts_with_empty_result() {
+    let slice_a = &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109];
+    let indexes = &[];
+    let counts = &[];
+    let expected: &[Option<DoryScalar>; 0] = &[];
+    let alloc = Bump::new();
+    let result: &[Option<DoryScalar>] =
+        min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_min_aggregate_slice_by_counts_with_all_empty_groups() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let indexes = &[];
+    let counts = &[0, 0, 0];
+    let expected = &[None; 3];
+    let alloc = Bump::new();
+    let result: &[Option<Curve25519Scalar>] =
+        min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_min_aggregate_slice_by_counts_with_some_empty_group() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let indexes = &[12, 11, 1, 10, 2, 3, 4];
+    let counts = &[3, 4, 0];
+    let expected = &[
+        Some(Curve25519Scalar::from(101)),
+        Some(Curve25519Scalar::from(102)),
+        None,
+    ];
+    let alloc = Bump::new();
+    let result: &[Option<Curve25519Scalar>] =
+        min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_min_aggregate_slice_by_counts_without_empty_groups() {
+    let slice_a = &[
+        100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
+    ];
+    let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
+    let counts = &[3, 3, 4];
+    let expected = &[
+        Some(Curve25519Scalar::from(101)),
+        Some(Curve25519Scalar::from(102)),
+        Some(Curve25519Scalar::from(106)),
+    ];
+    let alloc = Bump::new();
+    let result: &[Option<Curve25519Scalar>] =
+        min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_min_aggregate_columns_by_counts_for_empty_column() {
+    let slice_a: &[i64; 0] = &[];
+    let column_a = Column::BigInt::<DoryScalar>(slice_a);
+    let indexes = &[];
+    let counts = &[];
+    let expected: &[Option<DoryScalar>; 0] = &[];
+    let alloc = Bump::new();
+    let result: &[Option<DoryScalar>] =
+        min_aggregate_column_by_index_counts(&alloc, &column_a, counts, indexes);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn we_can_min_aggregate_columns_by_counts() {
+    let slice_a = &[
+        100, -101, 102, -103, 104, -105, 106, -107, 108, -109, 110, -111, 112, -113, 114, -115,
+    ];
+    let slice_b = &[
+        100, -101, 102, -103, 104, -105, 106, -107, 108, -109, 110, -111, 112, -113, 114, -115,
+    ];
+    let slice_c = &[
+        100, -101, 102, -103, 104, -105, 106, -107, 108, -109, 110, -111, 112, -113, 114, -115,
+    ];
+    let scals_c: Vec<Curve25519Scalar> = slice_c.iter().map(|s| s.into()).collect();
+    let column_a = Column::BigInt::<Curve25519Scalar>(slice_a);
+    let columns_b = Column::Int128::<Curve25519Scalar>(slice_b);
+    let columns_c = Column::Scalar(&scals_c);
+    let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
+    let counts = &[3, 3, 4, 0];
+    let expected = &[
+        Some(Curve25519Scalar::from(-111)),
+        Some(Curve25519Scalar::from(-103)),
+        Some(Curve25519Scalar::from(-113)),
+        None,
+    ];
+    let alloc = Bump::new();
+    let result = min_aggregate_column_by_index_counts(&alloc, &column_a, counts, indexes);
+    assert_eq!(result, expected);
+    let result = min_aggregate_column_by_index_counts(&alloc, &columns_b, counts, indexes);
+    assert_eq!(result, expected);
+    let result = min_aggregate_column_by_index_counts(&alloc, &columns_c, counts, indexes);
     assert_eq!(result, expected);
 }

--- a/crates/proof-of-sql/src/sql/ast/group_by_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_expr.rs
@@ -232,7 +232,8 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExpr<C> {
             group_by_columns: group_by_result_columns,
             sum_columns: sum_result_columns,
             count_column,
-        } = aggregate_columns(alloc, &group_by_columns, &sum_columns, selection)
+            ..
+        } = aggregate_columns(alloc, &group_by_columns, &sum_columns, &[], &[], selection)
             .expect("columns should be aggregatable");
         // 3. set indexes
         builder.set_result_indexes(Indexes::Dense(0..(count_column.len() as u64)));
@@ -278,7 +279,8 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExpr<C> {
             group_by_columns: group_by_result_columns,
             sum_columns: sum_result_columns,
             count_column,
-        } = aggregate_columns(alloc, &group_by_columns, &sum_columns, selection)
+            ..
+        } = aggregate_columns(alloc, &group_by_columns, &sum_columns, &[], &[], selection)
             .expect("columns should be aggregatable");
 
         let alpha = builder.consume_post_result_challenge();


### PR DESCRIPTION
# Rationale for this change
We need to add `max` and `min` to `AggregateColumns` for postprocessing even though we don't make them provable just yet.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- add max and min to `AggregateColumns`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
