### PR TITLE
feat: add relevant conversions for group by

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -51,6 +51,9 @@ mod owned_column;
 pub(crate) use owned_column::compare_indexes_by_owned_columns_with_direction;
 pub use owned_column::OwnedColumn;
 
+mod owned_column_error;
+pub use owned_column_error::{OwnedColumnError, OwnedColumnResult};
+
 pub(crate) mod owned_column_operation;
 
 mod owned_table;

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -2,7 +2,7 @@
 /// This is primarily used as an internal result that is used before
 /// converting to the final result in either Arrow format or JSON.
 /// This is the analog of an arrow Array.
-use super::{Column, ColumnType};
+use super::{Column, ColumnType, OwnedColumnError, OwnedColumnResult};
 use crate::base::{
     math::{
         decimal::Precision,
@@ -123,6 +123,103 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             OwnedColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
+    }
+
+    /// Convert a slice of scalars to a vec of owned columns
+    pub fn try_from_scalars(scalars: &[S], column_type: ColumnType) -> OwnedColumnResult<Self> {
+        match column_type {
+            ColumnType::Boolean => Ok(OwnedColumn::Boolean(
+                scalars
+                    .iter()
+                    .map(|s| -> Result<bool, _> { TryInto::<bool>::try_into(*s) })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| {
+                        OwnedColumnError::ScalarConversionError(
+                            "Overflow in scalar conversions".to_string(),
+                        )
+                    })?,
+            )),
+            ColumnType::SmallInt => Ok(OwnedColumn::SmallInt(
+                scalars
+                    .iter()
+                    .map(|s| -> Result<i16, _> { TryInto::<i16>::try_into(*s) })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| {
+                        OwnedColumnError::ScalarConversionError(
+                            "Overflow in scalar conversions".to_string(),
+                        )
+                    })?,
+            )),
+            ColumnType::Int => Ok(OwnedColumn::Int(
+                scalars
+                    .iter()
+                    .map(|s| -> Result<i32, _> { TryInto::<i32>::try_into(*s) })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| {
+                        OwnedColumnError::ScalarConversionError(
+                            "Overflow in scalar conversions".to_string(),
+                        )
+                    })?,
+            )),
+            ColumnType::BigInt => Ok(OwnedColumn::BigInt(
+                scalars
+                    .iter()
+                    .map(|s| -> Result<i64, _> { TryInto::<i64>::try_into(*s) })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| {
+                        OwnedColumnError::ScalarConversionError(
+                            "Overflow in scalar conversions".to_string(),
+                        )
+                    })?,
+            )),
+            ColumnType::Int128 => Ok(OwnedColumn::Int128(
+                scalars
+                    .iter()
+                    .map(|s| -> Result<i128, _> { TryInto::<i128>::try_into(*s) })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| {
+                        OwnedColumnError::ScalarConversionError(
+                            "Overflow in scalar conversions".to_string(),
+                        )
+                    })?,
+            )),
+            ColumnType::Scalar => Ok(OwnedColumn::Scalar(scalars.to_vec())),
+            ColumnType::Decimal75(precision, scale) => {
+                Ok(OwnedColumn::Decimal75(precision, scale, scalars.to_vec()))
+            }
+            ColumnType::TimestampTZ(tu, tz) => {
+                let raw_values: Vec<i64> = scalars
+                    .iter()
+                    .map(|s| -> Result<i64, _> { TryInto::<i64>::try_into(*s) })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| {
+                        OwnedColumnError::ScalarConversionError(
+                            "Overflow in scalar conversions".to_string(),
+                        )
+                    })?;
+                Ok(OwnedColumn::TimestampTZ(tu, tz, raw_values))
+            }
+            // Can not convert scalars to VarChar
+            ColumnType::VarChar => Err(OwnedColumnError::TypeCastError {
+                from_type: ColumnType::Scalar,
+                to_type: ColumnType::VarChar,
+            }),
+        }
+    }
+
+    /// Convert a slice of option scalars to a vec of owned columns
+    pub fn try_from_option_scalars(
+        option_scalars: &[Option<S>],
+        column_type: ColumnType,
+    ) -> OwnedColumnResult<Self> {
+        let scalars = option_scalars
+            .iter()
+            .copied()
+            .collect::<Option<Vec<_>>>()
+            .ok_or(OwnedColumnError::Unsupported(
+                "NULL is not supported yet".to_string(),
+            ))?;
+        Self::try_from_scalars(&scalars, column_type)
     }
 
     #[cfg(test)]
@@ -361,5 +458,190 @@ mod test {
         );
         let new_col = Column::<Curve25519Scalar>::from_owned_column(&owned_col, &alloc);
         assert_eq!(col, new_col);
+    }
+
+    #[test]
+    fn we_can_convert_scalars_to_owned_columns() {
+        // Int
+        let scalars = [1, 2, 3, 4, 5]
+            .iter()
+            .map(Curve25519Scalar::from)
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Int128;
+        let owned_col = OwnedColumn::try_from_scalars(&scalars, column_type).unwrap();
+        assert_eq!(owned_col, OwnedColumn::Int128(vec![1, 2, 3, 4, 5]));
+
+        // Boolean
+        let scalars = [true, false, true, false, true]
+            .iter()
+            .map(Curve25519Scalar::from)
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Boolean;
+        let owned_col = OwnedColumn::try_from_scalars(&scalars, column_type).unwrap();
+        assert_eq!(
+            owned_col,
+            OwnedColumn::Boolean(vec![true, false, true, false, true])
+        );
+
+        // Decimal
+        let scalars = [1, 2, 3, 4, 5]
+            .iter()
+            .map(Curve25519Scalar::from)
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Decimal75(Precision::new(75).unwrap(), -128);
+        let owned_col = OwnedColumn::try_from_scalars(&scalars, column_type).unwrap();
+        assert_eq!(
+            owned_col,
+            OwnedColumn::Decimal75(Precision::new(75).unwrap(), -128, scalars)
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_scalars_to_owned_columns_if_varchar() {
+        let scalars = ["a", "b", "c", "d", "e"]
+            .iter()
+            .map(Curve25519Scalar::from)
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::VarChar;
+        let res = OwnedColumn::try_from_scalars(&scalars, column_type);
+        assert!(matches!(res, Err(OwnedColumnError::TypeCastError { .. })));
+    }
+
+    #[test]
+    fn we_cannot_convert_scalars_to_owned_columns_if_overflow() {
+        // Int
+        let scalars = [i128::MAX, i128::MAX, i128::MAX, i128::MAX, i128::MAX]
+            .iter()
+            .map(Curve25519Scalar::from)
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::BigInt;
+        let res = OwnedColumn::try_from_scalars(&scalars, column_type);
+        assert!(matches!(
+            res,
+            Err(OwnedColumnError::ScalarConversionError(_))
+        ));
+
+        // Boolean
+        let scalars = [i128::MAX, i128::MAX, i128::MAX, i128::MAX, i128::MAX]
+            .iter()
+            .map(Curve25519Scalar::from)
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Boolean;
+        let res = OwnedColumn::try_from_scalars(&scalars, column_type);
+        assert!(matches!(
+            res,
+            Err(OwnedColumnError::ScalarConversionError(_))
+        ));
+    }
+
+    #[test]
+    fn we_can_convert_option_scalars_to_owned_columns() {
+        // Int
+        let option_scalars = [Some(1), Some(2), Some(3), Some(4), Some(5)]
+            .iter()
+            .map(|s| s.map(Curve25519Scalar::from))
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Int128;
+        let owned_col = OwnedColumn::try_from_option_scalars(&option_scalars, column_type).unwrap();
+        assert_eq!(owned_col, OwnedColumn::Int128(vec![1, 2, 3, 4, 5]));
+
+        // Boolean
+        let option_scalars = [Some(true), Some(false), Some(true), Some(false), Some(true)]
+            .iter()
+            .map(|s| s.map(Curve25519Scalar::from))
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Boolean;
+        let owned_col = OwnedColumn::try_from_option_scalars(&option_scalars, column_type).unwrap();
+        assert_eq!(
+            owned_col,
+            OwnedColumn::Boolean(vec![true, false, true, false, true])
+        );
+
+        // Decimal
+        let option_scalars = [Some(1), Some(2), Some(3), Some(4), Some(5)]
+            .iter()
+            .map(|s| s.map(Curve25519Scalar::from))
+            .collect::<Vec<_>>();
+        let scalars = [1, 2, 3, 4, 5]
+            .iter()
+            .map(|&i| Curve25519Scalar::from(i))
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Decimal75(Precision::new(75).unwrap(), 127);
+        let owned_col = OwnedColumn::try_from_option_scalars(&option_scalars, column_type).unwrap();
+        assert_eq!(
+            owned_col,
+            OwnedColumn::Decimal75(Precision::new(75).unwrap(), 127, scalars)
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_option_scalars_to_owned_columns_if_varchar() {
+        let option_scalars = ["a", "b", "c", "d", "e"]
+            .iter()
+            .map(|s| Some(Curve25519Scalar::from(*s)))
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::VarChar;
+        let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
+        assert!(matches!(res, Err(OwnedColumnError::TypeCastError { .. })));
+    }
+
+    #[test]
+    fn we_cannot_convert_option_scalars_to_owned_columns_if_overflow() {
+        // Int
+        let option_scalars = [
+            Some(i128::MAX),
+            Some(i128::MAX),
+            Some(i128::MAX),
+            Some(i128::MAX),
+            Some(i128::MAX),
+        ]
+        .iter()
+        .map(|s| s.map(Curve25519Scalar::from))
+        .collect::<Vec<_>>();
+        let column_type = ColumnType::BigInt;
+        let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
+        assert!(matches!(
+            res,
+            Err(OwnedColumnError::ScalarConversionError(_))
+        ));
+
+        // Boolean
+        let option_scalars = [
+            Some(i128::MAX),
+            Some(i128::MAX),
+            Some(i128::MAX),
+            Some(i128::MAX),
+            Some(i128::MAX),
+        ]
+        .iter()
+        .map(|s| s.map(Curve25519Scalar::from))
+        .collect::<Vec<_>>();
+        let column_type = ColumnType::Boolean;
+        let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
+        assert!(matches!(
+            res,
+            Err(OwnedColumnError::ScalarConversionError(_))
+        ));
+    }
+
+    #[test]
+    fn we_cannot_convert_option_scalars_to_owned_columns_if_none() {
+        // Int
+        let option_scalars = [Some(1), Some(2), None, Some(4), Some(5)]
+            .iter()
+            .map(|s| s.map(Curve25519Scalar::from))
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Int128;
+        let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
+        assert!(matches!(res, Err(OwnedColumnError::Unsupported(_))));
+
+        // Boolean
+        let option_scalars = [Some(true), Some(false), None, Some(false), Some(true)]
+            .iter()
+            .map(|s| s.map(Curve25519Scalar::from))
+            .collect::<Vec<_>>();
+        let column_type = ColumnType::Boolean;
+        let res = OwnedColumn::try_from_option_scalars(&option_scalars, column_type);
+        assert!(matches!(res, Err(OwnedColumnError::Unsupported(_))));
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -1,0 +1,24 @@
+use crate::base::database::ColumnType;
+use thiserror::Error;
+
+/// Errors from operations related to `OwnedColumn`s.
+#[derive(Error, Debug)]
+pub enum OwnedColumnError {
+    /// Can not perform type casting.
+    #[error("Can not perform type casting from {from_type:?} to {to_type:?}")]
+    TypeCastError {
+        /// The type from which we are trying to cast.
+        from_type: ColumnType,
+        /// The type to which we are trying to cast.
+        to_type: ColumnType,
+    },
+    /// Error in converting scalars to a given column type.
+    #[error("Error in converting scalars to a given column type: {0}")]
+    ScalarConversionError(String),
+    /// Unsupported operation.
+    #[error("Unsupported operation: {0}")]
+    Unsupported(String),
+}
+
+/// Result type for operations related to `OwnedColumn`s.
+pub type OwnedColumnResult<T> = core::result::Result<T, OwnedColumnError>;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -104,6 +104,28 @@ fn test_curve25519_scalar_mid() {
 }
 
 #[test]
+fn test_curve25519_scalar_to_bool() {
+    assert!(!bool::try_from(Curve25519Scalar::ZERO).unwrap());
+    assert!(bool::try_from(Curve25519Scalar::ONE).unwrap());
+}
+
+#[test]
+fn test_curve25519_scalar_to_bool_overflow() {
+    matches!(
+        bool::try_from(Curve25519Scalar::from(2)),
+        Err(ScalarConversionError::Overflow(_))
+    );
+    matches!(
+        bool::try_from(Curve25519Scalar::from(-1)),
+        Err(ScalarConversionError::Overflow(_))
+    );
+    matches!(
+        bool::try_from(Curve25519Scalar::from(-2)),
+        Err(ScalarConversionError::Overflow(_))
+    );
+}
+
+#[test]
 fn test_curve25519_scalar_to_i8() {
     assert_eq!(i8::try_from(Curve25519Scalar::from(0)).unwrap(), 0);
     assert_eq!(i8::try_from(Curve25519Scalar::ONE).unwrap(), 1);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
@@ -4,6 +4,28 @@ use core::cmp::Ordering;
 use num_bigint::BigInt;
 
 #[test]
+fn test_dory_scalar_to_bool() {
+    assert!(!bool::try_from(DoryScalar::ZERO).unwrap());
+    assert!(bool::try_from(DoryScalar::ONE).unwrap());
+}
+
+#[test]
+fn test_dory_scalar_to_bool_overflow() {
+    matches!(
+        bool::try_from(DoryScalar::from(2)),
+        Err(ScalarConversionError::Overflow(_))
+    );
+    matches!(
+        bool::try_from(DoryScalar::from(-1)),
+        Err(ScalarConversionError::Overflow(_))
+    );
+    matches!(
+        bool::try_from(DoryScalar::from(-2)),
+        Err(ScalarConversionError::Overflow(_))
+    );
+}
+
+#[test]
 fn test_dory_scalar_to_i8() {
     assert_eq!(i8::try_from(DoryScalar::from(0)).unwrap(), 0);
     assert_eq!(i8::try_from(DoryScalar::ONE).unwrap(), 1);


### PR DESCRIPTION
# Rationale for this change
We need to be able to convert from scalars back to respective types after doing aggregations.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- add `try_from_scalars` and `try_from_option_scalars` to `OwnedColumn`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
