### PR TITLE
refactor!: replace `HashSet` and `HashMap` with `IndexSet` and `IndexMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ curve25519-dalek = { version = "4", features = ["rand_core"] }
 derive_more = { version = "0.99" }
 dyn_partial_eq = { version = "0.1.2" }
 flexbuffers = { version = "2.0.0" }
-hashbrown = { version = "0.14.0" }
 indexmap = { version = "2.1" }
 itertools = { version = "0.13.0" }
 lalrpop-util = { version = "0.20.0" }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -33,7 +33,6 @@ curve25519-dalek = { workspace = true, features = ["serde"] }
 chrono = {workspace = true, features = ["serde"]}
 derive_more = { workspace = true }
 dyn_partial_eq = { workspace = true }
-hashbrown = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }

--- a/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
+++ b/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use proof_of_sql::base::{
     commitment::Commitment,
     database::{
@@ -6,15 +7,14 @@ use proof_of_sql::base::{
     },
 };
 use proof_of_sql_parser::Identifier;
-use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct BenchmarkAccessor<'a, C: Commitment> {
-    columns: HashMap<ColumnRef, Column<'a, C::Scalar>>,
-    lengths: HashMap<TableRef, usize>,
-    commitments: HashMap<ColumnRef, C>,
-    column_types: HashMap<(TableRef, Identifier), ColumnType>,
-    table_schemas: HashMap<TableRef, Vec<(Identifier, ColumnType)>>,
+    columns: IndexMap<ColumnRef, Column<'a, C::Scalar>>,
+    lengths: IndexMap<TableRef, usize>,
+    commitments: IndexMap<ColumnRef, C>,
+    column_types: IndexMap<(TableRef, Identifier), ColumnType>,
+    table_schemas: IndexMap<TableRef, Vec<(Identifier, ColumnType)>>,
 }
 
 impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {

--- a/crates/proof-of-sql/examples/posql_db/record_batch_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/record_batch_accessor.rs
@@ -1,5 +1,6 @@
 use arrow::record_batch::RecordBatch;
 use bumpalo::Bump;
+use indexmap::IndexMap;
 use proof_of_sql::base::{
     database::{
         ArrayRefExt, Column, ColumnRef, ColumnType, DataAccessor, MetadataAccessor, SchemaAccessor,
@@ -8,7 +9,6 @@ use proof_of_sql::base::{
     scalar::Scalar,
 };
 use proof_of_sql_parser::Identifier;
-use std::collections::HashMap;
 
 #[derive(Default)]
 /// An implementation of a data accessor that uses a record batch as the underlying data source.
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 /// This type implements the `DataAccessor`, `MetadataAccessor`, and `SchemaAccessor` traits.
 pub struct RecordBatchAccessor {
     alloc: Bump,
-    tables: HashMap<TableRef, RecordBatch>,
+    tables: IndexMap<TableRef, RecordBatch>,
 }
 impl RecordBatchAccessor {
     /// Inserts a new table into the accessor.

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -3,9 +3,9 @@ use super::{
     ColumnCommitmentMetadataMapExt, ColumnCommitmentsMismatch, Commitment, VecCommitmentExt,
 };
 use crate::base::database::{ColumnField, ColumnRef, CommitmentAccessor, TableRef};
+use indexmap::IndexSet;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use thiserror::Error;
 
 /// Cannot create commitments with duplicate identifier.
@@ -104,7 +104,7 @@ impl<C: Commitment> ColumnCommitments<C> {
         COL: Into<CommittableColumn<'a>>,
     {
         // Check for duplicate identifiers
-        let mut unique_identifiers = HashSet::new();
+        let mut unique_identifiers = IndexSet::new();
         let unique_columns = columns
             .into_iter()
             .map(|(identifier, column)| {
@@ -154,7 +154,7 @@ impl<C: Commitment> ColumnCommitments<C> {
         COL: Into<CommittableColumn<'a>>,
     {
         // Check for duplicate identifiers.
-        let mut unique_identifiers = HashSet::new();
+        let mut unique_identifiers = IndexSet::new();
         let unique_columns = columns
             .into_iter()
             .map(|(identifier, column)| {

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -51,8 +51,8 @@ pub trait Commitment:
     + Eq
     + core::ops::Sub<Output = Self>
     + core::fmt::Debug
-    + std::marker::Sync
-    + std::marker::Send
+    + core::marker::Sync
+    + core::marker::Send
 {
     /// The associated scalar that the commitment is for.
     /// There are multiple possible commitment schemes for a scalar, but only one scalar for any commitment.

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -3,8 +3,8 @@ use crate::base::database::{
     ColumnField, ColumnRef, ColumnType, CommitmentAccessor, MetadataAccessor, SchemaAccessor,
     TableRef,
 };
+use indexmap::IndexMap;
 use proof_of_sql_parser::Identifier;
-use std::collections::HashMap;
 
 /// The commitments for all of the tables in a query.
 ///
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 /// - [`MetadataAccessor`]
 /// - [`CommitmentAccessor`]
 /// - [`SchemaAccessor`]
-pub type QueryCommitments<C> = HashMap<TableRef, TableCommitment<C>>;
+pub type QueryCommitments<C> = IndexMap<TableRef, TableCommitment<C>>;
 
 /// A trait for extending the functionality of the [`QueryCommitments`] alias.
 pub trait QueryCommitmentsExt<C>
@@ -33,7 +33,7 @@ impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
     ) -> Self {
         columns
             .into_iter()
-            .fold(HashMap::<_, Vec<_>>::new(), |mut table_columns, column| {
+            .fold(IndexMap::<_, Vec<_>>::new(), |mut table_columns, column| {
                 table_columns
                     .entry(column.table_ref())
                     .or_default()

--- a/crates/proof-of-sql/src/base/database/record_batch_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/record_batch_test_accessor.rs
@@ -10,7 +10,6 @@ use curve25519_dalek::ristretto::RistrettoPoint;
 use indexmap::IndexMap;
 use polars::prelude::DataFrame;
 use proof_of_sql_parser::Identifier;
-use std::collections::HashMap;
 
 /// TestTable is used to simulate an in-memory table and commitment tracking table.
 #[derive(Clone)]
@@ -24,7 +23,7 @@ struct TestAccessorTable {
 /// TestAccessor is used to simulate an in-memory databasefor proof testing.
 pub struct RecordBatchTestAccessor {
     alloc: Bump,
-    tables: HashMap<TableRef, TestAccessorTable>,
+    tables: IndexMap<TableRef, TestAccessorTable>,
 }
 
 impl Clone for RecordBatchTestAccessor {
@@ -48,7 +47,7 @@ impl TestAccessor<RistrettoPoint> for RecordBatchTestAccessor {
     fn new_empty() -> Self {
         Self {
             alloc: Bump::new(),
-            tables: HashMap::new(),
+            tables: IndexMap::new(),
         }
     }
     fn add_table(&mut self, table_ref: TableRef, data: RecordBatch, table_offset: usize) {

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -1,5 +1,5 @@
 use crate::base::scalar::Scalar;
-use hashbrown::HashMap;
+use indexmap::IndexMap;
 /**
  * Adopted from arkworks
  *
@@ -32,7 +32,7 @@ pub struct CompositePolynomial<S: Scalar> {
     pub products: Vec<(S, Vec<usize>)>,
     /// Stores multilinear extensions in which product multiplicand can refer to.
     pub flattened_ml_extensions: Vec<Rc<Vec<S>>>,
-    raw_pointers_lookup_table: HashMap<*const Vec<S>, usize>,
+    raw_pointers_lookup_table: IndexMap<*const Vec<S>, usize>,
 }
 
 /// Stores the number of variables and max number of multiplicands of the added polynomial used by the prover.
@@ -53,7 +53,7 @@ impl<S: Scalar> CompositePolynomial<S> {
             num_variables,
             products: Vec::new(),
             flattened_ml_extensions: Vec::new(),
-            raw_pointers_lookup_table: HashMap::new(),
+            raw_pointers_lookup_table: IndexMap::new(),
         }
     }
 

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
@@ -1,6 +1,7 @@
 use crate::base::scalar::{Curve25519Scalar, Scalar};
 use byte_slice_cast::AsByteSlice;
 use core::cmp::Ordering;
+use indexmap::IndexSet;
 use num_traits::{One, Zero};
 use rand::{
     distributions::{Distribution, Uniform},
@@ -8,7 +9,6 @@ use rand::{
     Rng,
 };
 use rand_core::SeedableRng;
-use std::collections::HashSet;
 
 #[test]
 fn the_zero_integer_maps_to_the_zero_scalar() {
@@ -119,7 +119,7 @@ fn byte_arrays_with_the_same_content_but_different_types_map_to_different_scalar
 
 #[test]
 fn strings_of_arbitrary_size_map_to_different_scalars() {
-    let mut prev_scalars = HashSet::new();
+    let mut prev_scalars = IndexSet::new();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let dist = Uniform::new(1, 100);
 
@@ -136,7 +136,7 @@ fn strings_of_arbitrary_size_map_to_different_scalars() {
 
 #[test]
 fn byte_arrays_of_arbitrary_size_map_to_different_scalars() {
-    let mut prev_scalars = HashSet::new();
+    let mut prev_scalars = IndexSet::new();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let dist = Uniform::new(1, 100);
 
@@ -156,7 +156,7 @@ fn the_string_hash_implementation_uses_the_full_range_of_bits() {
 
     for i in 0..252 {
         let mut curr_iters = 0;
-        let mut bset = HashSet::new();
+        let mut bset = IndexSet::new();
 
         loop {
             let s: Curve25519Scalar = dist.sample(&mut rng).to_string().as_str().into();
@@ -166,7 +166,7 @@ fn the_string_hash_implementation_uses_the_full_range_of_bits() {
 
             bset.insert(is_ith_bit_set);
 
-            if bset == HashSet::from([false, true]) {
+            if bset == IndexSet::from([false, true]) {
                 break;
             }
 

--- a/crates/proof-of-sql/src/sql/ast/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/add_subtract_expr.rs
@@ -11,9 +11,9 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable numerical `+` / `-` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -112,7 +112,7 @@ impl<C: Commitment> ProvableExpr<C> for AddSubtractExpr<C> {
         Ok(res)
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/ast/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/aggregate_expr.rs
@@ -8,9 +8,9 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable aggregate expression
 ///
@@ -69,7 +69,7 @@ impl<C: Commitment> ProvableExpr<C> for AggregateExpr<C> {
         self.expr.verifier_evaluate(builder, accessor)
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.expr.get_column_references(columns)
     }
 }

--- a/crates/proof-of-sql/src/sql/ast/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/and_expr.rs
@@ -8,9 +8,9 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable logical AND expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -104,7 +104,7 @@ impl<C: Commitment> ProvableExpr<C> for AndExpr<C> {
         Ok(lhs_and_rhs)
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/ast/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/column_expr.rs
@@ -8,9 +8,10 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
+use core::marker::PhantomData;
+use indexmap::IndexSet;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, marker::PhantomData};
 /// Provable expression for a column
 ///
 /// Note: this is currently limited to named column expressions.
@@ -94,10 +95,10 @@ impl<C: Commitment> ProvableExpr<C> for ColumnExpr<C> {
         Ok(builder.consume_anchored_mle(col_commit))
     }
 
-    /// Insert in the HashSet `columns` all the column
+    /// Insert in the IndexSet `columns` all the column
     /// references in the BoolExpr or forwards the call to some
     /// subsequent bool_expr
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         columns.insert(self.column_ref);
     }
 }

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_expr.rs
@@ -18,10 +18,10 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use core::iter::repeat_with;
+use core::{iter::repeat_with, marker::PhantomData};
+use indexmap::IndexSet;
 use num_traits::{One, Zero};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, marker::PhantomData};
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -128,8 +128,8 @@ where
             .collect()
     }
 
-    fn get_column_references(&self) -> HashSet<ColumnRef> {
-        let mut columns = HashSet::new();
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        let mut columns = IndexSet::new();
 
         for aliased_expr in self.aliased_results.iter() {
             aliased_expr.expr.get_column_references(&mut columns);

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test.rs
@@ -20,9 +20,9 @@ use arrow::datatypes::{Field, Schema};
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{Identifier, ResourceId};
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -138,7 +138,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
 
     assert_eq!(
         ref_columns,
-        HashSet::from([
+        IndexSet::from([
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("a").unwrap(),

--- a/crates/proof-of-sql/src/sql/ast/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/equals_expr.rs
@@ -10,8 +10,8 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable AST expression for an equals expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -84,7 +84,7 @@ impl<C: Commitment> ProvableExpr<C> for EqualsExpr<C> {
         Ok(verifier_evaluate_equals_zero(builder, res))
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/ast/filter_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/filter_expr.rs
@@ -14,8 +14,9 @@ use crate::{
     },
 };
 use bumpalo::Bump;
+use core::marker::PhantomData;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, marker::PhantomData};
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -95,8 +96,8 @@ where
         columns
     }
 
-    fn get_column_references(&self) -> HashSet<ColumnRef> {
-        let mut columns = HashSet::new();
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        let mut columns = IndexSet::new();
 
         for col in self.results.iter() {
             columns.insert(col.get_column_reference());

--- a/crates/proof-of-sql/src/sql/ast/filter_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/filter_expr_test.rs
@@ -22,9 +22,9 @@ use arrow::datatypes::{Field, Schema};
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{Identifier, ResourceId};
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -124,7 +124,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
 
     assert_eq!(
         ref_columns,
-        HashSet::from([
+        IndexSet::from([
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("a").unwrap(),

--- a/crates/proof-of-sql/src/sql/ast/group_by_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/group_by_expr.rs
@@ -23,10 +23,10 @@ use crate::{
 };
 use bumpalo::Bump;
 use core::iter::repeat_with;
+use indexmap::IndexSet;
 use num_traits::One;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -183,8 +183,8 @@ impl<C: Commitment> ProofExpr<C> for GroupByExpr<C> {
             .collect()
     }
 
-    fn get_column_references(&self) -> HashSet<ColumnRef> {
-        let mut columns = HashSet::new();
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        let mut columns = IndexSet::new();
 
         for col in self.group_by_exprs.iter() {
             columns.insert(col.get_column_reference());

--- a/crates/proof-of-sql/src/sql/ast/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/inequality_expr.rs
@@ -13,8 +13,8 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable AST expression for an inequality expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -129,7 +129,7 @@ impl<C: Commitment> ProvableExpr<C> for InequalityExpr<C> {
         Ok(verifier_evaluate_or(builder, &equals_zero, &sign))
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/ast/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/literal_expr.rs
@@ -9,8 +9,8 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable CONST expression
 ///
@@ -75,5 +75,5 @@ impl<C: Commitment> ProvableExpr<C> for LiteralExpr<C::Scalar> {
         Ok(commitment)
     }
 
-    fn get_column_references(&self, _columns: &mut HashSet<ColumnRef>) {}
+    fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {}
 }

--- a/crates/proof-of-sql/src/sql/ast/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/multiply_expr.rs
@@ -14,9 +14,9 @@ use crate::{
     },
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable numerical * expression
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -112,7 +112,7 @@ impl<C: Commitment> ProvableExpr<C> for MultiplyExpr<C> {
         Ok(lhs_times_rhs)
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/ast/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/not_expr.rs
@@ -8,8 +8,8 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable logical NOT expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -68,7 +68,7 @@ impl<C: Commitment> ProvableExpr<C> for NotExpr<C> {
         Ok(builder.mle_evaluations.one_evaluation - eval)
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.expr.get_column_references(columns);
     }
 }

--- a/crates/proof-of-sql/src/sql/ast/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/or_expr.rs
@@ -9,8 +9,8 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable logical OR expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -79,7 +79,7 @@ impl<C: Commitment> ProvableExpr<C> for OrExpr<C> {
         Ok(verifier_evaluate_or(builder, &lhs, &rhs))
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         self.lhs.get_column_references(columns);
         self.rhs.get_column_references(columns);
     }

--- a/crates/proof-of-sql/src/sql/ast/projection_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/projection_expr.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 use bumpalo::Bump;
 use core::iter::repeat_with;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 /// Provable expressions for queries of the form
 /// ```ignore
@@ -82,8 +82,8 @@ impl<C: Commitment> ProofExpr<C> for ProjectionExpr<C> {
             .collect()
     }
 
-    fn get_column_references(&self) -> HashSet<ColumnRef> {
-        let mut columns = HashSet::new();
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        let mut columns = IndexSet::new();
         self.aliased_results.iter().for_each(|aliased_expr| {
             aliased_expr.expr.get_column_references(&mut columns);
         });

--- a/crates/proof-of-sql/src/sql/ast/projection_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/projection_expr_test.rs
@@ -20,8 +20,7 @@ use arrow::datatypes::{Field, Schema};
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
-use indexmap::IndexMap;
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{Identifier, ResourceId};
 use std::sync::Arc;
 

--- a/crates/proof-of-sql/src/sql/ast/projection_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/projection_expr_test.rs
@@ -21,8 +21,9 @@ use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use indexmap::IndexMap;
+use indexmap::IndexSet;
 use proof_of_sql_parser::{Identifier, ResourceId};
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -98,7 +99,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
 
     assert_eq!(
         ref_columns,
-        HashSet::from([
+        IndexSet::from([
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("a").unwrap(),

--- a/crates/proof-of-sql/src/sql/ast/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/ast/proof_plan.rs
@@ -91,7 +91,7 @@ impl<C: Commitment> ProofExpr<C> for ProofPlan<C> {
         }
     }
 
-    fn get_column_references(&self) -> std::collections::HashSet<crate::base::database::ColumnRef> {
+    fn get_column_references(&self) -> indexmap::IndexSet<crate::base::database::ColumnRef> {
         match self {
             ProofPlan::Projection(expr) => expr.get_column_references(),
             ProofPlan::Filter(expr) => expr.get_column_references(),

--- a/crates/proof-of-sql/src/sql/ast/provable_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/provable_expr.rs
@@ -7,7 +7,8 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
-use std::{collections::HashSet, fmt::Debug};
+use indexmap::IndexSet;
+use std::fmt::Debug;
 
 /// Provable AST column expression that evaluates to a `Column`
 pub trait ProvableExpr<C: Commitment>: Debug + Send + Sync {
@@ -45,8 +46,8 @@ pub trait ProvableExpr<C: Commitment>: Debug + Send + Sync {
         accessor: &dyn CommitmentAccessor<C>,
     ) -> Result<C::Scalar, ProofError>;
 
-    /// Insert in the HashSet `columns` all the column
+    /// Insert in the IndexSet `columns` all the column
     /// references in the BoolExpr or forwards the call to some
     /// subsequent bool_expr
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>);
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>);
 }

--- a/crates/proof-of-sql/src/sql/ast/provable_expr_plan.rs
+++ b/crates/proof-of-sql/src/sql/ast/provable_expr_plan.rs
@@ -14,9 +14,10 @@ use crate::{
     },
 };
 use bumpalo::Bump;
+use indexmap::IndexSet;
 use proof_of_sql_parser::intermediate_ast::{AggregationOperator, BinaryOperator};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, fmt::Debug};
+use std::fmt::Debug;
 
 /// Enum of AST column expression types that implement `ProvableExpr`. Is itself a `ProvableExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -328,7 +329,7 @@ impl<C: Commitment> ProvableExpr<C> for ProvableExprPlan<C> {
         }
     }
 
-    fn get_column_references(&self, columns: &mut HashSet<ColumnRef>) {
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         match self {
             ProvableExprPlan::Column(expr) => {
                 ProvableExpr::<C>::get_column_references(expr, columns)

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -3,11 +3,11 @@ use crate::{
     base::{commitment::Commitment, database::ColumnRef},
     sql::ast::ProvableExprPlan,
 };
+use indexmap::IndexMap;
 use proof_of_sql_parser::{
     intermediate_ast::{AliasedResultExpr, Expression},
     Identifier,
 };
-use std::collections::HashMap;
 /// Enriched expression
 ///
 /// An enriched expression consists of an `proof_of_sql_parser::intermediate_ast::AliasedResultExpr`
@@ -28,7 +28,7 @@ impl<C: Commitment> EnrichedExpr<C> {
     /// and the `residue_expression` will contain the remaining expression.
     pub fn new(
         expression: AliasedResultExpr,
-        column_mapping: HashMap<Identifier, ColumnRef>,
+        column_mapping: IndexMap<Identifier, ColumnRef>,
     ) -> Self {
         // TODO: Using new_agg (ironically) disables aggregations in `QueryExpr` for now.
         // Re-enable aggregations when we add `GroupByExpr` generalizations.

--- a/crates/proof-of-sql/src/sql/parse/filter_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/filter_expr_builder.rs
@@ -6,20 +6,20 @@ use crate::{
     },
     sql::ast::{AliasedProvableExprPlan, DenseFilterExpr, ProvableExprPlan, TableExpr},
 };
+use indexmap::IndexMap;
 use itertools::Itertools;
 use proof_of_sql_parser::{intermediate_ast::Expression, Identifier};
-use std::collections::HashMap;
 
 pub struct FilterExprBuilder<C: Commitment> {
     table_expr: Option<TableExpr>,
     where_expr: Option<ProvableExprPlan<C>>,
     filter_result_expr_list: Vec<AliasedProvableExprPlan<C>>,
-    column_mapping: HashMap<Identifier, ColumnRef>,
+    column_mapping: IndexMap<Identifier, ColumnRef>,
 }
 
 // Public interface
 impl<C: Commitment> FilterExprBuilder<C> {
-    pub fn new(column_mapping: HashMap<Identifier, ColumnRef>) -> Self {
+    pub fn new(column_mapping: IndexMap<Identifier, ColumnRef>) -> Self {
         Self {
             table_expr: None,
             where_expr: None,

--- a/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/provable_expr_plan_builder.rs
@@ -10,30 +10,30 @@ use crate::{
         parse::ConversionError::DecimalConversionError,
     },
 };
+use indexmap::IndexMap;
 use proof_of_sql_parser::{
     intermediate_ast::{AggregationOperator, BinaryOperator, Expression, Literal, UnaryOperator},
     posql_time::{PoSQLTimeUnit, PoSQLTimestampError},
     Identifier,
 };
-use std::collections::HashMap;
 
 /// Builder that enables building a `proofs::sql::ast::ProvableExprPlan` from
 /// a `proof_of_sql_parser::intermediate_ast::Expression`.
 pub struct ProvableExprPlanBuilder<'a> {
-    column_mapping: &'a HashMap<Identifier, ColumnRef>,
+    column_mapping: &'a IndexMap<Identifier, ColumnRef>,
     in_agg_scope: bool,
 }
 
 impl<'a> ProvableExprPlanBuilder<'a> {
     /// Creates a new `ProvableExprPlanBuilder` with the given column mapping.
-    pub fn new(column_mapping: &'a HashMap<Identifier, ColumnRef>) -> Self {
+    pub fn new(column_mapping: &'a IndexMap<Identifier, ColumnRef>) -> Self {
         Self {
             column_mapping,
             in_agg_scope: false,
         }
     }
     /// Creates a new `ProvableExprPlanBuilder` with the given column mapping and within aggregation scope.
-    pub(crate) fn new_agg(column_mapping: &'a HashMap<Identifier, ColumnRef>) -> Self {
+    pub(crate) fn new_agg(column_mapping: &'a IndexMap<Identifier, ColumnRef>) -> Self {
         Self {
             column_mapping,
             in_agg_scope: true,

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -8,12 +8,11 @@ use crate::{
         parse::{ConversionError, ConversionResult, ProvableExprPlanBuilder, WhereExprBuilder},
     },
 };
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{
     intermediate_ast::{AggregationOperator, AliasedResultExpr, Expression, OrderBy, Slice},
     Identifier,
 };
-use std::collections::HashMap;
 
 #[derive(Default, Debug)]
 pub struct QueryContext {
@@ -29,7 +28,7 @@ pub struct QueryContext {
     where_expr: Option<Box<Expression>>,
     result_column_set: IndexSet<Identifier>,
     res_aliased_exprs: Vec<AliasedResultExpr>,
-    column_mapping: HashMap<Identifier, ColumnRef>,
+    column_mapping: IndexMap<Identifier, ColumnRef>,
     first_result_col_out_agg_scope: Option<Identifier>,
 }
 
@@ -138,7 +137,7 @@ impl QueryContext {
         let mut columns = self.result_column_set.iter().collect::<Vec<_>>();
         columns.sort();
         columns.first().map(|c| {
-            let column = self.column_mapping[c];
+            let column = self.column_mapping[*c];
             (column.column_id(), *column.column_type())
         })
     }
@@ -212,7 +211,7 @@ impl QueryContext {
         self.result_column_set.clone()
     }
 
-    pub fn get_column_mapping(&self) -> HashMap<Identifier, ColumnRef> {
+    pub fn get_column_mapping(&self) -> IndexMap<Identifier, ColumnRef> {
         self.column_mapping.clone()
     }
 }

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -8,11 +8,12 @@ use crate::{
         parse::{ConversionError, ConversionResult, ProvableExprPlanBuilder, WhereExprBuilder},
     },
 };
+use indexmap::IndexSet;
 use proof_of_sql_parser::{
     intermediate_ast::{AggregationOperator, AliasedResultExpr, Expression, OrderBy, Slice},
     Identifier,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 #[derive(Default, Debug)]
 pub struct QueryContext {
@@ -26,7 +27,7 @@ pub struct QueryContext {
     order_by_exprs: Vec<OrderBy>,
     group_by_exprs: Vec<Identifier>,
     where_expr: Option<Box<Expression>>,
-    result_column_set: HashSet<Identifier>,
+    result_column_set: IndexSet<Identifier>,
     res_aliased_exprs: Vec<AliasedResultExpr>,
     column_mapping: HashMap<Identifier, ColumnRef>,
     first_result_col_out_agg_scope: Option<Identifier>,
@@ -207,7 +208,7 @@ impl QueryContext {
         &self.group_by_exprs
     }
 
-    pub fn get_result_column_set(&self) -> HashSet<Identifier> {
+    pub fn get_result_column_set(&self) -> IndexSet<Identifier> {
         self.result_column_set.clone()
     }
 

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     sql::ast::{ProvableExpr, ProvableExprPlan},
 };
+use indexmap::IndexMap;
 use proof_of_sql_parser::{intermediate_ast::Expression, Identifier};
-use std::collections::HashMap;
 
 /// Builder that enables building a `proof_of_sql::sql::ast::ProvableExprPlan` from a `proof_of_sql_parser::intermediate_ast::Expression` that is
 /// intended to be used as the where clause in a filter expression or group by expression.
@@ -16,7 +16,7 @@ pub struct WhereExprBuilder<'a> {
 }
 impl<'a> WhereExprBuilder<'a> {
     /// Creates a new `WhereExprBuilder` with the given column mapping.
-    pub fn new(column_mapping: &'a HashMap<Identifier, ColumnRef>) -> Self {
+    pub fn new(column_mapping: &'a IndexMap<Identifier, ColumnRef>) -> Self {
         Self {
             builder: ProvableExprPlanBuilder::new(column_mapping),
         }

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -15,6 +15,7 @@ mod tests {
         },
     };
     use curve25519_dalek::RistrettoPoint;
+    use indexmap::IndexMap;
     use proof_of_sql_parser::{
         intermediate_ast::{BinaryOperator, Expression, Literal},
         intermediate_decimal::IntermediateDecimal,
@@ -22,16 +23,16 @@ mod tests {
         utility::{col, equal, lit},
         Identifier, SelectStatement,
     };
-    use std::{collections::HashMap, str::FromStr};
+    use std::str::FromStr;
 
-    fn run_test_case(column_mapping: &HashMap<Identifier, ColumnRef>, expr: Expression) {
+    fn run_test_case(column_mapping: &IndexMap<Identifier, ColumnRef>, expr: Expression) {
         let builder = WhereExprBuilder::new(column_mapping);
         let result = builder.build::<RistrettoPoint>(Some(Box::new(expr)));
         assert!(result.is_ok(), "Test case should succeed without panic.");
     }
 
-    fn get_column_mappings_for_testing() -> HashMap<Identifier, ColumnRef> {
-        let mut column_mapping = HashMap::new();
+    fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
+        let mut column_mapping = IndexMap::new();
         // Setup column mapping
         column_mapping.insert(
             Identifier::try_new("boolean_column").unwrap(),
@@ -373,7 +374,7 @@ mod tests {
 
     #[test]
     fn we_can_not_have_non_boolean_literal_as_where_clause() {
-        let column_mapping = HashMap::new();
+        let column_mapping = IndexMap::new();
 
         let builder = WhereExprBuilder::new(&column_mapping);
 

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -3,9 +3,10 @@ use crate::base::{
     scalar::Scalar,
     slice_ops,
 };
+use indexmap::IndexMap;
 use num_traits::{One, Zero};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
-use std::{collections::HashMap, ffi::c_void, rc::Rc};
+use std::{ffi::c_void, rc::Rc};
 
 // Build up a composite polynomial from individual MLE expressions
 pub struct CompositePolynomialBuilder<S: Scalar> {
@@ -14,7 +15,7 @@ pub struct CompositePolynomialBuilder<S: Scalar> {
     fr_multiplicands_rest: Vec<(S, Vec<Rc<Vec<S>>>)>,
     zerosum_multiplicands: Vec<(S, Vec<Rc<Vec<S>>>)>,
     fr: Rc<Vec<S>>,
-    mles: HashMap<*const c_void, Rc<Vec<S>>>,
+    mles: IndexMap<*const c_void, Rc<Vec<S>>>,
 }
 
 impl<S: Scalar> CompositePolynomialBuilder<S> {
@@ -26,7 +27,7 @@ impl<S: Scalar> CompositePolynomialBuilder<S> {
             fr_multiplicands_rest: vec![],
             zerosum_multiplicands: vec![],
             fr: fr.to_sumcheck_term(num_sumcheck_variables),
-            mles: HashMap::new(),
+            mles: IndexMap::new(),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof/proof_exprs.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_exprs.rs
@@ -8,7 +8,8 @@ use crate::base::{
     scalar::Scalar,
 };
 use bumpalo::Bump;
-use std::{collections::HashSet, fmt::Debug};
+use indexmap::IndexSet;
+use std::fmt::Debug;
 
 /// Provable nodes in the provable AST.
 pub trait ProofExpr<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scalar> {
@@ -42,7 +43,7 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
     fn get_column_result_fields(&self) -> Vec<ColumnField>;
 
     /// Return all the columns referenced in the Query
-    fn get_column_references(&self) -> HashSet<ColumnRef>;
+    fn get_column_references(&self) -> IndexSet<ColumnRef>;
 }
 
 pub trait ProverEvaluate<S: Scalar> {

--- a/crates/proof-of-sql/src/sql/proof/test_query_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof/test_query_expr.rs
@@ -13,8 +13,9 @@ use crate::base::{
 use bumpalo::Bump;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use dyn_partial_eq::DynPartialEq;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, fmt, fmt::Debug};
+use std::{fmt, fmt::Debug};
 
 type ResultFn = Box<
     dyn for<'a> Fn(&mut ResultBuilder<'a>, &'a Bump, &'a dyn DataAccessor<Curve25519Scalar>)
@@ -100,7 +101,7 @@ impl ProofExpr<RistrettoPoint> for TestQueryExpr {
         columns
     }
 
-    fn get_column_references(&self) -> HashSet<ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")
     }
 }

--- a/crates/proof-of-sql/src/sql/transform/group_by_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/transform/group_by_expr_test.rs
@@ -350,14 +350,14 @@ fn validate_group_by_map_i128_to_utf8(s: Vec<i128>) {
     // no collision happens
     assert_eq!(
         expected_len,
-        s.iter().collect::<std::collections::HashSet<_>>().len()
+        s.iter().collect::<indexmap::IndexSet<_>>().len()
     );
 
     assert_eq!(
         expected_len,
         s.into_iter()
             .map(group_by_map_i128_to_utf8)
-            .collect::<std::collections::HashSet<_>>()
+            .collect::<indexmap::IndexSet<_>>()
             .len(),
     );
 }

--- a/crates/proof-of-sql/src/sql/transform/order_by_exprs_test.rs
+++ b/crates/proof-of-sql/src/sql/transform/order_by_exprs_test.rs
@@ -195,13 +195,10 @@ fn validate_order_by_map_i128_to_utf8_with_array(s: Vec<i128>) {
 
     // no collision happens
     assert_eq!(
-        sorted_s
-            .iter()
-            .collect::<std::collections::HashSet<_>>()
-            .len(),
+        sorted_s.iter().collect::<indexmap::IndexSet<_>>().len(),
         utf8_sorted_s
             .iter()
-            .collect::<std::collections::HashSet<_>>()
+            .collect::<indexmap::IndexSet<_>>()
             .len(),
     );
 }


### PR DESCRIPTION
# Rationale for this change

There are several locations where a well-defined order is very important. We should be using the more predictable `IndexMap` over a `HashMap`.

# What changes are included in this PR?

See rationale. This is technically a breaking change.

# Are these changes tested?

Yes
