### PR TITLE
refactor: simplify `QueryProof::new`

### DIFF
--- a/crates/proof-of-sql/src/sql/ast/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/inequality_expr_test.rs
@@ -1,30 +1,21 @@
 use crate::{
     base::{
-        bit::BitDistribution,
         commitment::InnerProductProof,
         database::{
             owned_table_utility::*, Column, OwnedTable, OwnedTableTestAccessor, TestAccessor,
         },
         math::decimal::scale_scalar,
-        proof::{MessageLabel, TranscriptProtocol},
         scalar::{Curve25519Scalar, Scalar},
     },
     sql::{
-        ast::{
-            prover_evaluate_equals_zero, prover_evaluate_or, test_utility::*, ProvableExpr,
-            ProvableExprPlan,
-        },
+        ast::{test_utility::*, ProofPlan, ProvableExpr, ProvableExprPlan},
         parse::ConversionError,
-        proof::{
-            exercise_verification, make_transcript, Indexes, ProofBuilder, ProofExpr, QueryProof,
-            ResultBuilder, VerifiableQueryResult,
-        },
+        proof::{exercise_verification, VerifiableQueryResult},
     },
 };
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use itertools::{multizip, MultiUnzip};
-use num_traits::Zero;
 use rand::{
     distributions::{Distribution, Uniform},
     rngs::StdRng,
@@ -390,48 +381,19 @@ fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
     let data = owned_table([bigint("a", [0_i64, 0, 0]), bigint("b", [1_i64, 2, 3])]);
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
-    let ast = filter(
+    let mut ast = filter(
         cols_result(t, &["b"], &accessor),
         tab(t),
         lte(column(t, "a", &accessor), const_bigint(0)),
     );
-    let table_length = ast.get_length(&accessor);
-    let generator_offset = ast.get_offset(&accessor);
-    let alloc = Bump::new();
-
-    let mut result_builder = ResultBuilder::new(3);
-    result_builder.set_result_indexes(Indexes::Sparse(vec![0, 1, 2]));
-    let result_cols = cols_result(t, &["b"], &accessor);
-    result_cols[0].result_evaluate(&mut result_builder, &accessor);
-
-    let provable_result = result_builder.make_provable_query_result();
-    let mut transcript = make_transcript(&ast, &provable_result, table_length, generator_offset);
-    transcript.challenge_scalars::<Curve25519Scalar>(&mut [], MessageLabel::PostResultChallenges);
-
-    let mut builder = ProofBuilder::new(3, 2, Vec::new());
-
-    let lhs = [Curve25519Scalar::zero(); 3];
-    builder.produce_anchored_mle(&lhs);
-    let equals_zero = prover_evaluate_equals_zero(&mut builder, &alloc, &lhs);
-
-    let mut bit_distribution = BitDistribution {
-        or_all: [0; 4],
-        vary_mask: [0; 4],
-    };
-    bit_distribution.or_all[3] = 1 << 63;
-    assert!(bit_distribution.sign_bit());
-    builder.produce_bit_distribution(bit_distribution);
-    let sign = [true; 3];
-    prover_evaluate_or(&mut builder, &alloc, equals_zero, &sign);
-
-    let selection = [true; 3];
-    result_cols[0].prover_evaluate(&mut builder, &alloc, &accessor, &selection);
-
-    let proof = QueryProof::<InnerProductProof>::new_from_builder(builder, 0, transcript, &());
-    let res = proof
-        .verify(&ast, &accessor, &provable_result, &())
-        .unwrap()
-        .table;
+    if let ProofPlan::Filter(filter) = &mut ast {
+        if let ProvableExprPlan::Inequality(lte) = &mut filter.where_clause {
+            lte.treat_column_of_zeros_as_negative = true
+        }
+    }
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected);
 }

--- a/crates/proof-of-sql/src/sql/ast/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/sign_expr.rs
@@ -76,10 +76,19 @@ pub fn prover_evaluate_sign<'a, S: Scalar>(
     builder: &mut ProofBuilder<'a, S>,
     alloc: &'a Bump,
     expr: &'a [S],
+    #[cfg(test)] treat_column_of_zeros_as_negative: bool,
 ) -> &'a [bool] {
     let table_length = expr.len();
     // bit_distribution
     let dist = BitDistribution::new::<S, _>(expr);
+    #[cfg(test)]
+    let dist = {
+        let mut dist = dist;
+        if treat_column_of_zeros_as_negative && dist.vary_mask == [0; 4] {
+            dist.or_all[3] = 1 << 63;
+        }
+        dist
+    };
     builder.produce_bit_distribution(dist.clone());
 
     // handle the constant case

--- a/crates/proof-of-sql/src/sql/ast/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/sign_expr_test.rs
@@ -20,7 +20,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_constant_column() {
     let alloc = Bump::new();
     let data: Vec<Curve25519Scalar> = data.into_iter().map(Curve25519Scalar::from).collect();
     let mut builder = ProofBuilder::new(3, 2, Vec::new());
-    let sign = prover_evaluate_sign(&mut builder, &alloc, &data);
+    let sign = prover_evaluate_sign(&mut builder, &alloc, &data, false);
     assert_eq!(sign, [false; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
 }
@@ -32,7 +32,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_negative_constant_colum
     let alloc = Bump::new();
     let data: Vec<Curve25519Scalar> = data.into_iter().map(Curve25519Scalar::from).collect();
     let mut builder = ProofBuilder::new(3, 2, Vec::new());
-    let sign = prover_evaluate_sign(&mut builder, &alloc, &data);
+    let sign = prover_evaluate_sign(&mut builder, &alloc, &data, false);
     assert_eq!(sign, [true; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
 }

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -41,8 +41,6 @@ pub use proof_exprs::ProofExpr;
 pub(crate) use proof_exprs::{HonestProver, ProverEvaluate, ProverHonestyMarker};
 
 mod query_proof;
-#[cfg(test)]
-pub(crate) use query_proof::make_transcript;
 #[cfg(not(feature = "test"))]
 pub(crate) use query_proof::QueryProof;
 #[cfg(feature = "test")]

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -77,16 +77,6 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             ProofBuilder::new(table_length, num_sumcheck_variables, post_result_challenges);
         expr.prover_evaluate(&mut builder, &alloc, accessor);
 
-        let proof = QueryProof::new_from_builder(builder, generator_offset, transcript, setup);
-        (proof, provable_result)
-    }
-
-    pub(crate) fn new_from_builder(
-        builder: ProofBuilder<CP::Scalar>,
-        generator_offset: usize,
-        mut transcript: Transcript,
-        setup: &CP::ProverPublicSetup<'_>,
-    ) -> Self {
         let num_sumcheck_variables = builder.num_sumcheck_variables();
         let table_length = builder.table_length();
 
@@ -146,7 +136,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             pre_result_mle_evaluations,
             evaluation_proof,
         };
-        proof
+        (proof, provable_result)
     }
 
     #[tracing::instrument(name = "QueryProof::verify", level = "debug", skip_all, err)]
@@ -330,7 +320,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 /// This function returns a `merlin::Transcript`. The transcript is a record
 /// of all the operations and data involved in creating a proof.
 /// ```
-pub fn make_transcript<C: Commitment>(
+fn make_transcript<C: Commitment>(
     expr: &(impl ProofExpr<C> + Serialize),
     result: &ProvableQueryResult,
     table_length: usize,


### PR DESCRIPTION
# Rationale for this change

The `QueryProof::new_from_builder` method is only used in one place: a test. It adds non-trivial complexity to modifying `QueryProof`.


# What changes are included in this PR?

* This commit refactors the offending test by allowing `sign_expr` to, optionally, allow a column of zeros to be considered negative.
* `QueryProof::new_from_builder` is inlined into `QueryProof::new`.

# Are these changes tested?

Yes