### PR TITLE
feat!: use `sql::postprocessing` instead of `sql::transform` in `QueryExpr`

### DIFF
--- a/crates/proof-of-sql-parser/src/utility.rs
+++ b/crates/proof-of-sql-parser/src/utility.rs
@@ -146,6 +146,11 @@ pub fn count(expr: Box<Expression>) -> Box<Expression> {
     })
 }
 
+/// Count the rows
+pub fn count_all() -> Box<Expression> {
+    count(Box::new(Expression::Wildcard))
+}
+
 /// An expression with an alias i.e. EXPR AS ALIAS
 pub fn aliased_expr(expr: Box<Expression>, alias: &str) -> AliasedResultExpr {
     AliasedResultExpr {

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -72,6 +72,10 @@ pub enum ConversionError {
     #[error(transparent)]
     ColumnOperationError(#[from] ColumnOperationError),
 
+    /// Errors related to postprocessing
+    #[error(transparent)]
+    PostprocessingError(#[from] crate::sql::postprocessing::PostprocessingError),
+
     #[error("Query not provable because: {0}")]
     /// Query requires unprovable feature
     Unprovable(String),

--- a/crates/proof-of-sql/src/sql/parse/mod.rs
+++ b/crates/proof-of-sql/src/sql/parse/mod.rs
@@ -13,9 +13,6 @@ mod query_expr_tests;
 mod query_expr;
 pub use query_expr::QueryExpr;
 
-mod result_expr_builder;
-pub(crate) use result_expr_builder::ResultExprBuilder;
-
 mod filter_expr_builder;
 pub(crate) use filter_expr_builder::FilterExprBuilder;
 

--- a/crates/proof-of-sql/src/sql/postprocessing/owned_table_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/owned_table_postprocessing.rs
@@ -3,9 +3,10 @@ use super::{
     SelectPostprocessing, SlicePostprocessing,
 };
 use crate::base::{database::OwnedTable, scalar::Scalar};
+use serde::{Deserialize, Serialize};
 
 /// An enum for nodes that can apply postprocessing to a `OwnedTable`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum OwnedTablePostprocessing {
     /// Slice the `OwnedTable` with the given `SlicePostprocessing`.
     Slice(SlicePostprocessing),

--- a/crates/proof-of-sql/tests/decimal_integration_tests.rs
+++ b/crates/proof-of-sql/tests/decimal_integration_tests.rs
@@ -3,6 +3,7 @@
 use blitzar::proof::InnerProductProof;
 #[cfg(feature = "blitzar")]
 use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar as S};
+use proof_of_sql::sql::postprocessing::apply_postprocessing_steps;
 
 #[cfg(feature = "blitzar")]
 fn run_query(
@@ -38,12 +39,8 @@ fn run_query(
         .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
-    let owned_table_result: OwnedTable<_> = query
-        .result()
-        .transform_results(owned_table_result.try_into().unwrap())
-        .unwrap()
-        .try_into()
-        .unwrap();
+    let owned_table_result: OwnedTable<_> =
+        apply_postprocessing_steps(owned_table_result, query.postprocessing()).unwrap();
 
     // Adjust expected result based on the precision and scale provided
     let expected_result = owned_table::<S>([


### PR DESCRIPTION
# Rationale for this change
Please review #86 first. Otherwise please look at the second commit.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- switch from `sql::transform` to `sql::postprocessing`
- remove `sql::parser::ResultExprBuilder`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
