### PR TITLE
refactor: clean up `where_expr_builder_test.rs`

### DIFF
--- a/crates/proof-of-sql/src/sql/parse/mod.rs
+++ b/crates/proof-of-sql/src/sql/parse/mod.rs
@@ -1,6 +1,6 @@
 //! This module contains conversion of intermediate AST to provable AST and a non-provable component if necessary.
 mod error;
-mod where_expr_builder_tests;
+
 pub use error::ConversionError;
 pub(crate) use error::ConversionResult;
 
@@ -30,3 +30,5 @@ pub(crate) use provable_expr_plan_builder::ProvableExprPlanBuilder;
 
 mod where_expr_builder;
 pub(crate) use where_expr_builder::WhereExprBuilder;
+#[cfg(all(test, feature = "blitzar"))]
+mod where_expr_builder_tests;

--- a/crates/proof-of-sql/src/sql/parse/mod.rs
+++ b/crates/proof-of-sql/src/sql/parse/mod.rs
@@ -30,5 +30,5 @@ pub(crate) use provable_expr_plan_builder::ProvableExprPlanBuilder;
 
 mod where_expr_builder;
 pub(crate) use where_expr_builder::WhereExprBuilder;
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(test)]
 mod where_expr_builder_tests;

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -19,6 +19,7 @@ use proof_of_sql_parser::{
 };
 use std::str::FromStr;
 
+#[inline]
 fn run_test_case(column_mapping: &IndexMap<Identifier, ColumnRef>, expr: Expression) {
     let builder = WhereExprBuilder::new(column_mapping);
     let result = builder.build::<RistrettoPoint>(Some(Box::new(expr)));

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -1,372 +1,370 @@
-mod tests {
-    use crate::{
-        base::{
-            database::{ColumnRef, ColumnType, LiteralValue, TestSchemaAccessor},
-            math::decimal::Precision,
-        },
-        sql::{
-            ast::{ColumnExpr, LiteralExpr, ProvableExprPlan},
-            parse::{ConversionError, QueryExpr, WhereExprBuilder},
-        },
-    };
-    use curve25519_dalek::RistrettoPoint;
-    use indexmap::{indexmap, IndexMap};
-    use proof_of_sql_parser::{
-        intermediate_ast::Expression,
-        intermediate_decimal::IntermediateDecimal,
-        posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
-        utility::*,
-        Identifier, SelectStatement,
-    };
-    use std::str::FromStr;
+use crate::{
+    base::{
+        database::{ColumnRef, ColumnType, LiteralValue, TestSchemaAccessor},
+        math::decimal::Precision,
+    },
+    sql::{
+        ast::{ColumnExpr, LiteralExpr, ProvableExprPlan},
+        parse::{ConversionError, QueryExpr, WhereExprBuilder},
+    },
+};
+use curve25519_dalek::RistrettoPoint;
+use indexmap::{indexmap, IndexMap};
+use proof_of_sql_parser::{
+    intermediate_ast::Expression,
+    intermediate_decimal::IntermediateDecimal,
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
+    utility::*,
+    Identifier, SelectStatement,
+};
+use std::str::FromStr;
 
-    fn run_test_case(column_mapping: &IndexMap<Identifier, ColumnRef>, expr: Expression) {
-        let builder = WhereExprBuilder::new(column_mapping);
-        let result = builder.build::<RistrettoPoint>(Some(Box::new(expr)));
-        assert!(result.is_ok(), "Test case should succeed without panic.");
-    }
+fn run_test_case(column_mapping: &IndexMap<Identifier, ColumnRef>, expr: Expression) {
+    let builder = WhereExprBuilder::new(column_mapping);
+    let result = builder.build::<RistrettoPoint>(Some(Box::new(expr)));
+    assert!(result.is_ok(), "Test case should succeed without panic.");
+}
 
-    fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
-        let tab_ref = "sxt.sxt_tab".parse().unwrap();
-        let mut column_mapping = IndexMap::new();
-        // Setup column mapping
-        column_mapping.insert(
-            ident("boolean_column"),
-            ColumnRef::new(tab_ref, ident("boolean_column"), ColumnType::Boolean),
-        );
-        column_mapping.insert(
+fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
+    let tab_ref = "sxt.sxt_tab".parse().unwrap();
+    let mut column_mapping = IndexMap::new();
+    // Setup column mapping
+    column_mapping.insert(
+        ident("boolean_column"),
+        ColumnRef::new(tab_ref, ident("boolean_column"), ColumnType::Boolean),
+    );
+    column_mapping.insert(
+        ident("decimal_column"),
+        ColumnRef::new(
+            tab_ref,
             ident("decimal_column"),
-            ColumnRef::new(
-                tab_ref,
-                ident("decimal_column"),
-                ColumnType::Decimal75(Precision::new(7).unwrap(), 2),
-            ),
-        );
-        column_mapping.insert(
-            ident("int128_column"),
-            ColumnRef::new(tab_ref, ident("int128_column"), ColumnType::Int128),
-        );
-        column_mapping.insert(
-            ident("bigint_column"),
-            ColumnRef::new(tab_ref, ident("bigint_column"), ColumnType::BigInt),
-        );
+            ColumnType::Decimal75(Precision::new(7).unwrap(), 2),
+        ),
+    );
+    column_mapping.insert(
+        ident("int128_column"),
+        ColumnRef::new(tab_ref, ident("int128_column"), ColumnType::Int128),
+    );
+    column_mapping.insert(
+        ident("bigint_column"),
+        ColumnRef::new(tab_ref, ident("bigint_column"), ColumnType::BigInt),
+    );
 
-        column_mapping.insert(
-            ident("varchar_column"),
-            ColumnRef::new(tab_ref, ident("varchar_column"), ColumnType::VarChar),
-        );
-        column_mapping.insert(
+    column_mapping.insert(
+        ident("varchar_column"),
+        ColumnRef::new(tab_ref, ident("varchar_column"), ColumnType::VarChar),
+    );
+    column_mapping.insert(
+        ident("timestamp_second_column"),
+        ColumnRef::new(
+            tab_ref,
             ident("timestamp_second_column"),
-            ColumnRef::new(
-                tab_ref,
-                ident("timestamp_second_column"),
-                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
-            ),
-        );
-        column_mapping.insert(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
+        ),
+    );
+    column_mapping.insert(
+        ident("timestamp_millisecond_column"),
+        ColumnRef::new(
+            tab_ref,
             ident("timestamp_millisecond_column"),
-            ColumnRef::new(
-                tab_ref,
-                ident("timestamp_millisecond_column"),
-                ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
-            ),
-        );
-        column_mapping.insert(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::Utc),
+        ),
+    );
+    column_mapping.insert(
+        ident("timestamp_microsecond_column"),
+        ColumnRef::new(
+            tab_ref,
             ident("timestamp_microsecond_column"),
-            ColumnRef::new(
-                tab_ref,
-                ident("timestamp_microsecond_column"),
-                ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::Utc),
-            ),
-        );
-        column_mapping.insert(
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::Utc),
+        ),
+    );
+    column_mapping.insert(
+        ident("timestamp_nanosecond_column"),
+        ColumnRef::new(
+            tab_ref,
             ident("timestamp_nanosecond_column"),
-            ColumnRef::new(
-                tab_ref,
-                ident("timestamp_nanosecond_column"),
-                ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::Utc),
-            ),
-        );
-        column_mapping
-    }
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::Utc),
+        ),
+    );
+    column_mapping
+}
 
-    #[test]
-    fn we_can_directly_check_whether_boolean_column_is_true() {
-        let column_mapping = get_column_mappings_for_testing();
-        let builder = WhereExprBuilder::new(&column_mapping);
-        let expr_boolean = col("boolean_column");
-        assert!(builder.build::<RistrettoPoint>(Some(expr_boolean)).is_ok());
-    }
+#[test]
+fn we_can_directly_check_whether_boolean_column_is_true() {
+    let column_mapping = get_column_mappings_for_testing();
+    let builder = WhereExprBuilder::new(&column_mapping);
+    let expr_boolean = col("boolean_column");
+    assert!(builder.build::<RistrettoPoint>(Some(expr_boolean)).is_ok());
+}
 
-    #[test]
-    fn we_can_directly_check_whether_boolean_literal_is_true() {
-        let column_mapping = get_column_mappings_for_testing();
-        let builder = WhereExprBuilder::new(&column_mapping);
-        let expr_boolean = lit(false);
-        assert!(builder.build::<RistrettoPoint>(Some(expr_boolean)).is_ok());
-    }
+#[test]
+fn we_can_directly_check_whether_boolean_literal_is_true() {
+    let column_mapping = get_column_mappings_for_testing();
+    let builder = WhereExprBuilder::new(&column_mapping);
+    let expr_boolean = lit(false);
+    assert!(builder.build::<RistrettoPoint>(Some(expr_boolean)).is_ok());
+}
 
-    #[test]
-    fn we_can_directly_check_nested_eq() {
-        let column_mapping = get_column_mappings_for_testing();
-        let builder = WhereExprBuilder::new(&column_mapping);
-        let expr_nested = equal(
-            col("boolean_column"),
-            equal(col("bigint_column"), col("int128_column")),
-        );
-        assert!(builder.build::<RistrettoPoint>(Some(expr_nested)).is_ok());
-    }
+#[test]
+fn we_can_directly_check_nested_eq() {
+    let column_mapping = get_column_mappings_for_testing();
+    let builder = WhereExprBuilder::new(&column_mapping);
+    let expr_nested = equal(
+        col("boolean_column"),
+        equal(col("bigint_column"), col("int128_column")),
+    );
+    assert!(builder.build::<RistrettoPoint>(Some(expr_nested)).is_ok());
+}
 
-    #[test]
-    fn we_can_directly_check_whether_boolean_columns_eq_boolean() {
-        let column_mapping = get_column_mappings_for_testing();
-        let builder = WhereExprBuilder::new(&column_mapping);
-        let expr_boolean_to_boolean = equal(col("boolean_column"), lit(false));
-        assert!(builder
-            .build::<RistrettoPoint>(Some(expr_boolean_to_boolean))
-            .is_ok());
-    }
+#[test]
+fn we_can_directly_check_whether_boolean_columns_eq_boolean() {
+    let column_mapping = get_column_mappings_for_testing();
+    let builder = WhereExprBuilder::new(&column_mapping);
+    let expr_boolean_to_boolean = equal(col("boolean_column"), lit(false));
+    assert!(builder
+        .build::<RistrettoPoint>(Some(expr_boolean_to_boolean))
+        .is_ok());
+}
 
-    #[test]
-    fn we_can_directly_check_whether_integer_columns_eq_integer() {
-        let column_mapping = get_column_mappings_for_testing();
-        let builder = WhereExprBuilder::new(&column_mapping);
-        let expr_integer_to_integer = equal(col("int128_column"), lit(12345_i128));
-        assert!(builder
-            .build::<RistrettoPoint>(Some(expr_integer_to_integer))
-            .is_ok());
-    }
+#[test]
+fn we_can_directly_check_whether_integer_columns_eq_integer() {
+    let column_mapping = get_column_mappings_for_testing();
+    let builder = WhereExprBuilder::new(&column_mapping);
+    let expr_integer_to_integer = equal(col("int128_column"), lit(12345_i128));
+    assert!(builder
+        .build::<RistrettoPoint>(Some(expr_integer_to_integer))
+        .is_ok());
+}
 
-    #[test]
-    fn we_can_directly_check_whether_bigint_columns_ge_int128() {
-        let column_mapping = get_column_mappings_for_testing();
-        let builder = WhereExprBuilder::new(&column_mapping);
-        let expr_integer_to_integer = ge(col("bigint_column"), lit(-12345_i128));
-        let actual = builder
-            .build::<RistrettoPoint>(Some(expr_integer_to_integer))
-            .unwrap()
-            .unwrap();
-        let expected = ProvableExprPlan::try_new_inequality(
-            ProvableExprPlan::Column(ColumnExpr::new(ColumnRef::new(
-                "sxt.sxt_tab".parse().unwrap(),
-                ident("bigint_column"),
-                ColumnType::BigInt,
-            ))),
-            ProvableExprPlan::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
-            false,
-        )
+#[test]
+fn we_can_directly_check_whether_bigint_columns_ge_int128() {
+    let column_mapping = get_column_mappings_for_testing();
+    let builder = WhereExprBuilder::new(&column_mapping);
+    let expr_integer_to_integer = ge(col("bigint_column"), lit(-12345_i128));
+    let actual = builder
+        .build::<RistrettoPoint>(Some(expr_integer_to_integer))
+        .unwrap()
         .unwrap();
-        assert_eq!(actual, expected);
-    }
+    let expected = ProvableExprPlan::try_new_inequality(
+        ProvableExprPlan::Column(ColumnExpr::new(ColumnRef::new(
+            "sxt.sxt_tab".parse().unwrap(),
+            ident("bigint_column"),
+            ColumnType::BigInt,
+        ))),
+        ProvableExprPlan::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
+        false,
+    )
+    .unwrap();
+    assert_eq!(actual, expected);
+}
 
-    #[test]
-    fn we_can_directly_check_whether_bigint_columns_le_int128() {
-        let column_mapping = get_column_mappings_for_testing();
-        let builder = WhereExprBuilder::new(&column_mapping);
-        let expr_integer_to_integer = le(col("bigint_column"), lit(-12345_i128));
-        let actual = builder
-            .build::<RistrettoPoint>(Some(expr_integer_to_integer))
-            .unwrap()
-            .unwrap();
-        let expected = ProvableExprPlan::try_new_inequality(
-            ProvableExprPlan::Column(ColumnExpr::new(ColumnRef::new(
-                "sxt.sxt_tab".parse().unwrap(),
-                ident("bigint_column"),
-                ColumnType::BigInt,
-            ))),
-            ProvableExprPlan::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
-            true,
-        )
+#[test]
+fn we_can_directly_check_whether_bigint_columns_le_int128() {
+    let column_mapping = get_column_mappings_for_testing();
+    let builder = WhereExprBuilder::new(&column_mapping);
+    let expr_integer_to_integer = le(col("bigint_column"), lit(-12345_i128));
+    let actual = builder
+        .build::<RistrettoPoint>(Some(expr_integer_to_integer))
+        .unwrap()
         .unwrap();
-        assert_eq!(actual, expected);
-    }
+    let expected = ProvableExprPlan::try_new_inequality(
+        ProvableExprPlan::Column(ColumnExpr::new(ColumnRef::new(
+            "sxt.sxt_tab".parse().unwrap(),
+            ident("bigint_column"),
+            ColumnType::BigInt,
+        ))),
+        ProvableExprPlan::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
+        true,
+    )
+    .unwrap();
+    assert_eq!(actual, expected);
+}
 
-    #[test]
-    fn we_can_directly_check_whether_varchar_columns_eq_varchar() {
-        let column_mapping = get_column_mappings_for_testing();
-        // VarChar column with VarChar literal
-        let expr_varchar_to_varchar = equal(col("varchar_column"), lit("test_string"));
-        run_test_case(&column_mapping, *expr_varchar_to_varchar);
-    }
+#[test]
+fn we_can_directly_check_whether_varchar_columns_eq_varchar() {
+    let column_mapping = get_column_mappings_for_testing();
+    // VarChar column with VarChar literal
+    let expr_varchar_to_varchar = equal(col("varchar_column"), lit("test_string"));
+    run_test_case(&column_mapping, *expr_varchar_to_varchar);
+}
 
-    #[test]
-    fn we_can_check_non_decimal_columns_eq_integer_literals() {
-        let column_mapping = get_column_mappings_for_testing();
+#[test]
+fn we_can_check_non_decimal_columns_eq_integer_literals() {
+    let column_mapping = get_column_mappings_for_testing();
 
-        // Non-decimal column with integer literal
-        let expr_integer_to_integer = equal(col("bigint_column"), lit(12345_i64));
-        run_test_case(&column_mapping, *expr_integer_to_integer);
-    }
+    // Non-decimal column with integer literal
+    let expr_integer_to_integer = equal(col("bigint_column"), lit(12345_i64));
+    run_test_case(&column_mapping, *expr_integer_to_integer);
+}
 
-    #[test]
-    fn we_can_check_scaled_integers_eq_correctly() {
-        let column_mapping = get_column_mappings_for_testing();
+#[test]
+fn we_can_check_scaled_integers_eq_correctly() {
+    let column_mapping = get_column_mappings_for_testing();
 
-        // Decimal column with integer literal that can be appropriately scaled
-        let expr_integer_to_decimal = equal(col("decimal_column"), lit(12345_i128));
-        run_test_case(&column_mapping, *expr_integer_to_decimal);
-    }
+    // Decimal column with integer literal that can be appropriately scaled
+    let expr_integer_to_decimal = equal(col("decimal_column"), lit(12345_i128));
+    run_test_case(&column_mapping, *expr_integer_to_decimal);
+}
 
-    #[test]
-    fn we_can_check_exact_scale_and_precision_eq() {
-        let column_mapping = get_column_mappings_for_testing();
+#[test]
+fn we_can_check_exact_scale_and_precision_eq() {
+    let column_mapping = get_column_mappings_for_testing();
 
-        // Decimal column with matching scale decimal literal
-        let expr_decimal = equal(
-            col("decimal_column"),
-            lit(IntermediateDecimal::try_from("123.45").unwrap()),
-        );
-        run_test_case(&column_mapping, *expr_decimal);
-    }
+    // Decimal column with matching scale decimal literal
+    let expr_decimal = equal(
+        col("decimal_column"),
+        lit(IntermediateDecimal::try_from("123.45").unwrap()),
+    );
+    run_test_case(&column_mapping, *expr_decimal);
+}
 
-    #[test]
-    fn we_can_check_varying_precision_eq_for_timestamp() {
-        let column_mapping = get_column_mappings_for_testing();
+#[test]
+fn we_can_check_varying_precision_eq_for_timestamp() {
+    let column_mapping = get_column_mappings_for_testing();
 
-        run_test_case(
-            &column_mapping,
-            *equal(
-                col("timestamp_nanosecond_column"),
-                lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456789Z").unwrap()),
-            ),
-        );
+    run_test_case(
+        &column_mapping,
+        *equal(
+            col("timestamp_nanosecond_column"),
+            lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456789Z").unwrap()),
+        ),
+    );
 
-        run_test_case(
-            &column_mapping,
-            *equal(
-                col("timestamp_microsecond_column"),
-                lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456Z").unwrap()),
-            ),
-        );
+    run_test_case(
+        &column_mapping,
+        *equal(
+            col("timestamp_microsecond_column"),
+            lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456Z").unwrap()),
+        ),
+    );
 
-        run_test_case(
-            &column_mapping,
-            *equal(
-                col("timestamp_millisecond_column"),
-                lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap()),
-            ),
-        );
+    run_test_case(
+        &column_mapping,
+        *equal(
+            col("timestamp_millisecond_column"),
+            lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap()),
+        ),
+    );
 
-        run_test_case(
-            &column_mapping,
-            *equal(
-                col("timestamp_second_column"),
-                lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap()),
-            ),
-        );
-    }
+    run_test_case(
+        &column_mapping,
+        *equal(
+            col("timestamp_second_column"),
+            lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap()),
+        ),
+    );
+}
 
-    #[test]
-    fn we_can_not_have_missing_column_as_where_clause() {
-        let column_mapping = get_column_mappings_for_testing();
+#[test]
+fn we_can_not_have_missing_column_as_where_clause() {
+    let column_mapping = get_column_mappings_for_testing();
 
-        let builder = WhereExprBuilder::new(&column_mapping);
+    let builder = WhereExprBuilder::new(&column_mapping);
 
-        let expr_missing = col("not_a_column");
-        let res = builder.build::<RistrettoPoint>(Some(expr_missing));
-        assert!(matches!(
-            res,
-            Result::Err(ConversionError::MissingColumnWithoutTable(_))
-        ));
-    }
+    let expr_missing = col("not_a_column");
+    let res = builder.build::<RistrettoPoint>(Some(expr_missing));
+    assert!(matches!(
+        res,
+        Result::Err(ConversionError::MissingColumnWithoutTable(_))
+    ));
+}
 
-    #[test]
-    fn we_can_not_have_non_boolean_column_as_where_clause() {
-        let column_mapping = get_column_mappings_for_testing();
+#[test]
+fn we_can_not_have_non_boolean_column_as_where_clause() {
+    let column_mapping = get_column_mappings_for_testing();
 
-        let builder = WhereExprBuilder::new(&column_mapping);
+    let builder = WhereExprBuilder::new(&column_mapping);
 
-        let expr_non_boolean = col("varchar_column");
-        let res = builder.build::<RistrettoPoint>(Some(expr_non_boolean));
-        assert!(matches!(
-            res,
-            Result::Err(ConversionError::NonbooleanWhereClause(_))
-        ));
-    }
+    let expr_non_boolean = col("varchar_column");
+    let res = builder.build::<RistrettoPoint>(Some(expr_non_boolean));
+    assert!(matches!(
+        res,
+        Result::Err(ConversionError::NonbooleanWhereClause(_))
+    ));
+}
 
-    #[test]
-    fn we_can_not_have_non_boolean_literal_as_where_clause() {
-        let column_mapping = IndexMap::new();
+#[test]
+fn we_can_not_have_non_boolean_literal_as_where_clause() {
+    let column_mapping = IndexMap::new();
 
-        let builder = WhereExprBuilder::new(&column_mapping);
+    let builder = WhereExprBuilder::new(&column_mapping);
 
-        let expr_non_boolean = lit(123_i128);
-        let res = builder.build::<RistrettoPoint>(Some(expr_non_boolean));
-        assert!(matches!(
-            res,
-            Result::Err(ConversionError::NonbooleanWhereClause(_))
-        ));
-    }
+    let expr_non_boolean = lit(123_i128);
+    let res = builder.build::<RistrettoPoint>(Some(expr_non_boolean));
+    assert!(matches!(
+        res,
+        Result::Err(ConversionError::NonbooleanWhereClause(_))
+    ));
+}
 
-    #[test]
-    fn we_expect_an_error_while_trying_to_check_varchar_column_eq_decimal() {
-        let t = "sxt.sxt_tab".parse().unwrap();
-        let accessor = TestSchemaAccessor::new(indexmap! {
-            t => indexmap! {
-                "b".parse().unwrap() => ColumnType::VarChar,
-            },
-        });
+#[test]
+fn we_expect_an_error_while_trying_to_check_varchar_column_eq_decimal() {
+    let t = "sxt.sxt_tab".parse().unwrap();
+    let accessor = TestSchemaAccessor::new(indexmap! {
+        t => indexmap! {
+            "b".parse().unwrap() => ColumnType::VarChar,
+        },
+    });
 
-        assert!(matches!(
-            QueryExpr::<RistrettoPoint>::try_new(
-                SelectStatement::from_str("select * from sxt_tab where b = 123").unwrap(),
-                t.schema_id(),
-                &accessor,
-            ),
-            Err(ConversionError::DataTypeMismatch(_, _))
-        ));
-    }
-
-    #[test]
-    fn we_expect_an_error_while_trying_to_check_varchar_column_ge_decimal() {
-        let t = "sxt.sxt_tab".parse().unwrap();
-        let accessor = TestSchemaAccessor::new(indexmap! {
-            t => indexmap! {
-                "b".parse().unwrap() => ColumnType::VarChar,
-            },
-        });
-
-        assert!(matches!(
-            QueryExpr::<RistrettoPoint>::try_new(
-                SelectStatement::from_str("select * from sxt_tab where b >= 123").unwrap(),
-                t.schema_id(),
-                &accessor,
-            ),
-            Err(ConversionError::DataTypeMismatch(_, _))
-        ));
-    }
-
-    #[test]
-    fn we_do_not_expect_an_error_while_trying_to_check_int128_column_eq_decimal_with_zero_scale() {
-        let t = "sxt.sxt_tab".parse().unwrap();
-        let accessor = TestSchemaAccessor::new(indexmap! {
-            t => indexmap! {
-                "b".parse().unwrap() => ColumnType::Int128,
-            },
-        });
-
-        assert!(QueryExpr::<RistrettoPoint>::try_new(
-            SelectStatement::from_str("select * from sxt_tab where b = 123.000").unwrap(),
+    assert!(matches!(
+        QueryExpr::<RistrettoPoint>::try_new(
+            SelectStatement::from_str("select * from sxt_tab where b = 123").unwrap(),
             t.schema_id(),
             &accessor,
-        )
-        .is_ok());
-    }
+        ),
+        Err(ConversionError::DataTypeMismatch(_, _))
+    ));
+}
 
-    #[test]
-    fn we_do_not_expect_an_error_while_trying_to_check_bigint_column_eq_decimal_with_zero_scale() {
-        let t = "sxt.sxt_tab".parse().unwrap();
-        let accessor = TestSchemaAccessor::new(indexmap! {
-            t => indexmap! {
-                "b".parse().unwrap() => ColumnType::BigInt,
-            },
-        });
+#[test]
+fn we_expect_an_error_while_trying_to_check_varchar_column_ge_decimal() {
+    let t = "sxt.sxt_tab".parse().unwrap();
+    let accessor = TestSchemaAccessor::new(indexmap! {
+        t => indexmap! {
+            "b".parse().unwrap() => ColumnType::VarChar,
+        },
+    });
 
-        assert!(QueryExpr::<RistrettoPoint>::try_new(
-            SelectStatement::from_str("select * from sxt_tab where b = 123.000").unwrap(),
+    assert!(matches!(
+        QueryExpr::<RistrettoPoint>::try_new(
+            SelectStatement::from_str("select * from sxt_tab where b >= 123").unwrap(),
             t.schema_id(),
             &accessor,
-        )
-        .is_ok());
-    }
+        ),
+        Err(ConversionError::DataTypeMismatch(_, _))
+    ));
+}
+
+#[test]
+fn we_do_not_expect_an_error_while_trying_to_check_int128_column_eq_decimal_with_zero_scale() {
+    let t = "sxt.sxt_tab".parse().unwrap();
+    let accessor = TestSchemaAccessor::new(indexmap! {
+        t => indexmap! {
+            "b".parse().unwrap() => ColumnType::Int128,
+        },
+    });
+
+    assert!(QueryExpr::<RistrettoPoint>::try_new(
+        SelectStatement::from_str("select * from sxt_tab where b = 123.000").unwrap(),
+        t.schema_id(),
+        &accessor,
+    )
+    .is_ok());
+}
+
+#[test]
+fn we_do_not_expect_an_error_while_trying_to_check_bigint_column_eq_decimal_with_zero_scale() {
+    let t = "sxt.sxt_tab".parse().unwrap();
+    let accessor = TestSchemaAccessor::new(indexmap! {
+        t => indexmap! {
+            "b".parse().unwrap() => ColumnType::BigInt,
+        },
+    });
+
+    assert!(QueryExpr::<RistrettoPoint>::try_new(
+        SelectStatement::from_str("select * from sxt_tab where b = 123.000").unwrap(),
+        t.schema_id(),
+        &accessor,
+    )
+    .is_ok());
 }


### PR DESCRIPTION
# Rationale for this change
This PR cleans up `where_expr_builder_test.rs` by using `proof_of_sql_parser::utility`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- clean up `where_expr_builder_test.rs`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
We changed tests exclusively.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
