### PR TITLE
refactor!: remove `OwnedTable::apply_polars_filter`

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -67,37 +67,6 @@ impl<S: Scalar> OwnedTable<S> {
     pub fn column_names(&self) -> impl Iterator<Item = &Identifier> {
         self.table.keys()
     }
-
-    /// Applies a filter to this table via polars, returning a new table. This is useful for testing that a filter is executed correctly.
-    #[cfg(test)]
-    pub fn apply_polars_filter(
-        &self,
-        results: &[&str],
-        predicate: polars::prelude::Expr,
-    ) -> OwnedTable<S> {
-        OwnedTable::try_from(
-            super::dataframe_to_record_batch(
-                polars::prelude::IntoLazy::lazy(
-                    super::record_batch_to_dataframe(
-                        arrow::record_batch::RecordBatch::try_from(self.clone()).unwrap(),
-                    )
-                    .unwrap(),
-                )
-                .filter(predicate)
-                .select(
-                    results
-                        .iter()
-                        .map(|v| polars::prelude::col(v))
-                        .collect::<Vec<_>>()
-                        .as_slice(),
-                )
-                .collect()
-                .unwrap(),
-            )
-            .unwrap(),
-        )
-        .unwrap()
-    }
 }
 
 // Note: we modify the default PartialEq for IndexMap to also check for column ordering.


### PR DESCRIPTION
# Rationale for this change
This PR continues our removal of `polars`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- remove `OwnedTable::apply_polars_filter`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
