### PR TITLE
perf: Dory commitments should be done with Blitzar's packed_msm function (PROOF-895)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ arrow-csv = { version = "51.0" }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", features = ["serde"] }
 blake3 = { version = "1.3.3" }
-blitzar = { version = "3.0.2" }
+blitzar = { version = "3.1.0" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
 byte-slice-cast = { version = "1.2.1" }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -26,14 +26,11 @@ fn compute_dory_commitments_packed_impl(
     let offset = offset % num_columns;
 
     // Get the number of sub-commits per full commit
-    let num_sub_commits_per_full_commit = pack_scalars::get_num_of_sub_commits_per_full_commit(
-        committable_columns,
-        offset,
-        num_columns,
-    );
+    let num_sub_commits_per_full_commit =
+        pack_scalars::num_of_sub_commits_per_full_commit(committable_columns, offset, num_columns);
 
     // Get the bit table and packed scalars for the packed msm
-    let (bit_table, packed_scalars) = pack_scalars::get_bit_table_and_scalars_for_packed_msm(
+    let (bit_table, packed_scalars) = pack_scalars::bit_table_and_scalars_for_packed_msm(
         committable_columns,
         offset,
         num_columns,

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -25,16 +25,16 @@ fn compute_dory_commitments_packed_impl(
     let gamma_2_offset = offset / num_columns;
     let offset = offset % num_columns;
 
-    // Get the number of sub-commits per full commit
-    let num_sub_commits_per_full_commit =
-        pack_scalars::num_of_sub_commits_per_full_commit(committable_columns, offset, num_columns);
+    // Get the number of sub-commits for each full commit
+    let num_matrix_commitment_columns =
+        pack_scalars::num_matrix_commitment_columns(committable_columns, offset, num_columns);
 
     // Get the bit table and packed scalars for the packed msm
     let (bit_table, packed_scalars) = pack_scalars::bit_table_and_scalars_for_packed_msm(
         committable_columns,
         offset,
         num_columns,
-        num_sub_commits_per_full_commit,
+        num_matrix_commitment_columns,
     );
 
     let mut sub_commits_from_blitzar =
@@ -59,16 +59,16 @@ fn compute_dory_commitments_packed_impl(
     let modified_sub_commits = pack_scalars::modify_commits(
         &all_sub_commits,
         committable_columns,
-        num_sub_commits_per_full_commit,
+        num_matrix_commitment_columns,
     );
 
     let gamma_2_slice = &setup.prover_setup().Gamma_2.last().unwrap()
-        [gamma_2_offset..gamma_2_offset + num_sub_commits_per_full_commit];
+        [gamma_2_offset..gamma_2_offset + num_matrix_commitment_columns];
 
     // Compute the Dory commitments using multi pairing of sub-commits
     let span = span!(Level::INFO, "multi_pairing").entered();
     let dc = modified_sub_commits
-        .par_chunks_exact(num_sub_commits_per_full_commit)
+        .par_chunks_exact(num_matrix_commitment_columns)
         .map(|sub_commits| DoryCommitment(pairings::multi_pairing(sub_commits, gamma_2_slice)))
         .collect();
     span.exit();

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -63,7 +63,6 @@ fn compute_dory_commitments_packed_impl(
     let modified_sub_commits = pack_scalars::modify_commits(
         &all_sub_commits,
         committable_columns,
-        num_full_commits,
         num_sub_commits_per_full_commit,
     );
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -1,162 +1,90 @@
-use super::{pairings, transpose, DoryCommitment, DoryProverPublicSetup, DoryScalar, G1Affine};
-use crate::{
-    base::commitment::CommittableColumn, proof_primitive::dory::offset_to_bytes::OffsetToBytes,
-};
-use ark_bls12_381::Fr;
-use ark_ec::CurveGroup;
-use ark_std::ops::Mul;
-use blitzar::{compute::ElementP2, sequence::Sequence};
+use super::{pack_scalars, pairings, DoryCommitment, DoryProverPublicSetup, G1Affine};
+use crate::base::commitment::CommittableColumn;
+use blitzar::compute::ElementP2;
 use rayon::prelude::*;
+use tracing::{span, Level};
 
-#[tracing::instrument(name = "get_offset_commits (gpu)", level = "debug", skip_all)]
-fn get_offset_commits(
-    column_len: usize,
+#[tracing::instrument(
+    name = "compute_dory_commitments_packed_impl (gpu)",
+    level = "debug",
+    skip_all
+)]
+fn compute_dory_commitments_packed_impl(
+    committable_columns: &[CommittableColumn],
     offset: usize,
-    num_columns: usize,
-    num_of_commits: usize,
-    scalar: Fr,
     setup: &DoryProverPublicSetup,
-) -> Vec<G1Affine> {
-    let first_row_offset = offset % num_columns;
-    let first_row_len = column_len.min(num_columns - first_row_offset);
-    let num_zero_commits = offset / num_columns;
-    let data_size = 1;
-
-    let ones = vec![1_u8; column_len];
-    let (first_row, remaining_elements) = ones.split_at(first_row_len);
-
-    let mut ones_blitzar_commits =
-        vec![ElementP2::<ark_bls12_381::g1::Config>::default(); num_of_commits];
-
-    if num_zero_commits < num_of_commits {
-        // Get the commit of the first non-zero row
-        let first_row_offset = offset - (num_zero_commits * num_columns);
-        let first_row_transpose = transpose::transpose_for_fixed_msm(
-            first_row,
-            first_row_offset,
-            1,
-            num_columns,
-            data_size,
-        );
-
-        setup.prover_setup().blitzar_msm(
-            &mut ones_blitzar_commits[num_zero_commits..num_zero_commits + 1],
-            data_size as u32,
-            first_row_transpose.as_slice(),
-        );
-
-        // If there are more rows, get the commits of the middle row and duplicate them
-        let mut chunks = remaining_elements.chunks(num_columns);
-        if chunks.len() > 1 {
-            if let Some(middle_row) = chunks.next() {
-                let middle_row_transpose =
-                    transpose::transpose_for_fixed_msm(middle_row, 0, 1, num_columns, data_size);
-                let mut middle_row_blitzar_commit =
-                    vec![ElementP2::<ark_bls12_381::g1::Config>::default(); 1];
-
-                setup.prover_setup().blitzar_msm(
-                    &mut middle_row_blitzar_commit,
-                    data_size as u32,
-                    middle_row_transpose.as_slice(),
-                );
-
-                ones_blitzar_commits[num_zero_commits + 1..num_of_commits - 1]
-                    .par_iter_mut()
-                    .for_each(|commit| *commit = middle_row_blitzar_commit[0].clone());
-            }
-        }
-
-        // Get the commit of the last row to handle an zero padding at the end of the column
-        if let Some(last_row) = remaining_elements.chunks(num_columns).last() {
-            let last_row_transpose =
-                transpose::transpose_for_fixed_msm(last_row, 0, 1, num_columns, data_size);
-
-            setup.prover_setup().blitzar_msm(
-                &mut ones_blitzar_commits[num_of_commits - 1..num_of_commits],
-                data_size as u32,
-                last_row_transpose.as_slice(),
-            );
-        }
+) -> Vec<DoryCommitment> {
+    if committable_columns.is_empty() {
+        return vec![];
     }
 
-    ones_blitzar_commits
-        .par_iter()
-        .map(Into::into)
-        .map(|commit: G1Affine| commit.mul(scalar).into_affine())
-        .collect()
-}
-
-#[tracing::instrument(name = "compute_dory_commitment_impl (gpu)", level = "debug", skip_all)]
-fn compute_dory_commitment_impl<'a, T>(
-    column: &'a [T],
-    offset: usize,
-    setup: &DoryProverPublicSetup,
-) -> DoryCommitment
-where
-    &'a T: Into<DoryScalar>,
-    &'a [T]: Into<Sequence<'a>>,
-    T: OffsetToBytes,
-{
     let num_columns = 1 << setup.sigma();
-    let data_size = std::mem::size_of::<T>();
+    let num_full_commits = committable_columns.len();
 
-    // Format column to match column major data layout required by blitzar's msm
-    let num_of_commits = ((column.len() + offset) + num_columns - 1) / num_columns;
-    let column_transpose =
-        transpose::transpose_for_fixed_msm(column, offset, num_of_commits, num_columns, data_size);
-    let gamma_2_slice = &setup.prover_setup().Gamma_2.last().unwrap()[0..num_of_commits];
+    // If the offset is larger than the number of columns, we compute an
+    // offset for the gamma_2 table to avoid finding sub-commits of zero.
+    let gamma_2_offset = offset / num_columns;
+    let offset = offset % num_columns;
 
-    // Compute the commitment for the entire data set
-    let mut blitzar_commits =
-        vec![ElementP2::<ark_bls12_381::g1::Config>::default(); num_of_commits];
-    setup.prover_setup().blitzar_msm(
-        &mut blitzar_commits,
-        data_size as u32,
-        column_transpose.as_slice(),
+    // Get the number of sub-commits per full commit
+    let num_sub_commits_per_full_commit = pack_scalars::get_num_of_sub_commits_per_full_commit(
+        committable_columns,
+        offset,
+        num_columns,
     );
 
-    let commits: Vec<G1Affine> = blitzar_commits.par_iter().map(Into::into).collect();
+    // Get the bit table and packed scalars for the packed msm
+    let (bit_table, packed_scalars) = pack_scalars::get_bit_table_and_scalars_for_packed_msm(
+        committable_columns,
+        offset,
+        num_columns,
+        num_sub_commits_per_full_commit,
+    );
 
-    // Signed data requires offset commitments
-    if T::IS_SIGNED {
-        let offset_commits = get_offset_commits(
-            column.len(),
-            offset,
-            num_columns,
-            num_of_commits,
-            T::min_as_fr(),
-            setup,
+    let mut sub_commits_from_blitzar =
+        vec![ElementP2::<ark_bls12_381::g1::Config>::default(); bit_table.len()];
+
+    // Compute packed msm
+    if !bit_table.is_empty() {
+        setup.prover_setup().blitzar_packed_msm(
+            &mut sub_commits_from_blitzar,
+            &bit_table,
+            packed_scalars.as_slice(),
         );
-
-        DoryCommitment(
-            pairings::multi_pairing(commits, gamma_2_slice)
-                + pairings::multi_pairing(offset_commits, gamma_2_slice),
-        )
-    } else {
-        DoryCommitment(pairings::multi_pairing(commits, gamma_2_slice))
     }
-}
 
-fn compute_dory_commitment(
-    committable_column: &CommittableColumn,
-    offset: usize,
-    setup: &DoryProverPublicSetup,
-) -> DoryCommitment {
-    match committable_column {
-        CommittableColumn::SmallInt(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::BigInt(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Int128(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Decimal75(_, _, column) => {
-            compute_dory_commitment_impl(column, offset, setup)
-        }
-        CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::TimestampTZ(_, _, column) => {
-            compute_dory_commitment_impl(column, offset, setup)
-        }
-    }
+    // Convert the sub-commits to G1Affine
+    let all_sub_commits: Vec<G1Affine> = sub_commits_from_blitzar
+        .par_iter()
+        .map(Into::into)
+        .collect();
+
+    // Modify the signed sub-commits by adding the offset
+    let modified_sub_commits = pack_scalars::modify_commits(
+        &all_sub_commits,
+        committable_columns,
+        num_full_commits,
+        num_sub_commits_per_full_commit,
+    );
+
+    let gamma_2_slice = &setup.prover_setup().Gamma_2.last().unwrap()
+        [gamma_2_offset..gamma_2_offset + num_sub_commits_per_full_commit];
+
+    // Compute the Dory commitments using multi pairing of sub-commits
+    let span = span!(Level::INFO, "multi_pairing").entered();
+    let dc: Vec<DoryCommitment> = (0..num_full_commits)
+        .into_par_iter()
+        .map(|i| {
+            let idx = i * num_sub_commits_per_full_commit;
+            let sub_commits: Vec<G1Affine> =
+                modified_sub_commits[idx..idx + num_sub_commits_per_full_commit].to_vec();
+
+            DoryCommitment(pairings::multi_pairing(sub_commits, gamma_2_slice))
+        })
+        .collect::<Vec<_>>();
+    span.exit();
+
+    dc
 }
 
 pub(super) fn compute_dory_commitments(
@@ -164,8 +92,5 @@ pub(super) fn compute_dory_commitments(
     offset: usize,
     setup: &DoryProverPublicSetup,
 ) -> Vec<DoryCommitment> {
-    committable_columns
-        .iter()
-        .map(|column| compute_dory_commitment(column, offset, setup))
-        .collect()
+    compute_dory_commitments_packed_impl(committable_columns, offset, setup)
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -139,6 +139,7 @@ type DeferredG1 = deferred_msm::DeferredMSM<G1Affine, F>;
 type DeferredG2 = deferred_msm::DeferredMSM<G2Affine, F>;
 
 mod offset_to_bytes;
+mod pack_scalars;
 mod pairings;
 mod transpose;
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -1,18 +1,12 @@
-use super::F;
 use zerocopy::AsBytes;
 
 pub trait OffsetToBytes {
     const IS_SIGNED: bool;
-    fn min_as_fr() -> F;
     fn offset_to_bytes(&self) -> Vec<u8>;
 }
 
 impl OffsetToBytes for u8 {
     const IS_SIGNED: bool = false;
-
-    fn min_as_fr() -> F {
-        F::from(0)
-    }
 
     fn offset_to_bytes(&self) -> Vec<u8> {
         vec![*self]
@@ -21,10 +15,6 @@ impl OffsetToBytes for u8 {
 
 impl OffsetToBytes for i16 {
     const IS_SIGNED: bool = true;
-
-    fn min_as_fr() -> F {
-        F::from(i16::MIN)
-    }
 
     fn offset_to_bytes(&self) -> Vec<u8> {
         let shifted = self.wrapping_sub(i16::MIN);
@@ -35,10 +25,6 @@ impl OffsetToBytes for i16 {
 impl OffsetToBytes for i32 {
     const IS_SIGNED: bool = true;
 
-    fn min_as_fr() -> F {
-        F::from(i32::MIN)
-    }
-
     fn offset_to_bytes(&self) -> Vec<u8> {
         let shifted = self.wrapping_sub(i32::MIN);
         shifted.to_le_bytes().to_vec()
@@ -47,10 +33,6 @@ impl OffsetToBytes for i32 {
 
 impl OffsetToBytes for i64 {
     const IS_SIGNED: bool = true;
-
-    fn min_as_fr() -> F {
-        F::from(i64::MIN)
-    }
 
     fn offset_to_bytes(&self) -> Vec<u8> {
         let shifted = self.wrapping_sub(i64::MIN);
@@ -61,10 +43,6 @@ impl OffsetToBytes for i64 {
 impl OffsetToBytes for i128 {
     const IS_SIGNED: bool = true;
 
-    fn min_as_fr() -> F {
-        F::from(i128::MIN)
-    }
-
     fn offset_to_bytes(&self) -> Vec<u8> {
         let shifted = self.wrapping_sub(i128::MIN);
         shifted.to_le_bytes().to_vec()
@@ -74,10 +52,6 @@ impl OffsetToBytes for i128 {
 impl OffsetToBytes for bool {
     const IS_SIGNED: bool = false;
 
-    fn min_as_fr() -> F {
-        F::from(false)
-    }
-
     fn offset_to_bytes(&self) -> Vec<u8> {
         vec![*self as u8]
     }
@@ -85,10 +59,6 @@ impl OffsetToBytes for bool {
 
 impl OffsetToBytes for u64 {
     const IS_SIGNED: bool = false;
-
-    fn min_as_fr() -> F {
-        F::from(0)
-    }
 
     fn offset_to_bytes(&self) -> Vec<u8> {
         let bytes = self.to_le_bytes();
@@ -98,10 +68,6 @@ impl OffsetToBytes for u64 {
 
 impl OffsetToBytes for [u64; 4] {
     const IS_SIGNED: bool = false;
-
-    fn min_as_fr() -> F {
-        F::from(0)
-    }
 
     fn offset_to_bytes(&self) -> Vec<u8> {
         let slice = self.as_bytes();

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -1,0 +1,926 @@
+use super::{G1Affine, F};
+use crate::{
+    base::commitment::CommittableColumn, proof_primitive::dory::offset_to_bytes::OffsetToBytes,
+};
+use ark_ec::CurveGroup;
+use ark_std::ops::Mul;
+use rayon::prelude::*;
+
+const BYTE_SIZE: usize = 8;
+
+/// Returns the byte size of a committable column.
+///
+/// # Arguments
+///
+/// * `column` - A reference to the committable column.
+fn get_byte_size(column: &CommittableColumn) -> usize {
+    match column {
+        CommittableColumn::SmallInt(_) => std::mem::size_of::<i16>(),
+        CommittableColumn::Int(_) => std::mem::size_of::<i32>(),
+        CommittableColumn::BigInt(_) => std::mem::size_of::<i64>(),
+        CommittableColumn::Int128(_) => std::mem::size_of::<i128>(),
+        CommittableColumn::Decimal75(_, _, _) => std::mem::size_of::<[u64; 4]>(),
+        CommittableColumn::Scalar(_) => std::mem::size_of::<[u64; 4]>(),
+        CommittableColumn::VarChar(_) => std::mem::size_of::<[u64; 4]>(),
+        CommittableColumn::Boolean(_) => std::mem::size_of::<bool>(),
+        CommittableColumn::TimestampTZ(_, _, _) => std::mem::size_of::<i64>(),
+    }
+}
+
+/// Returns the bit size of a committable column.
+///
+/// # Arguments
+///
+/// * `column` - A reference to the committable column.
+fn get_bit_size(column: &CommittableColumn) -> usize {
+    get_byte_size(column) * BYTE_SIZE
+}
+
+/// Returns a bit table vector related to each of the committable columns data size.
+///
+/// # Arguments
+///
+/// * `committable_columns` - A reference to the committable columns.
+pub fn get_output_bit_table(committable_columns: &[CommittableColumn]) -> Vec<u32> {
+    committable_columns
+        .iter()
+        .map(|column| get_bit_size(column) as u32)
+        .collect()
+}
+
+/// Returns the size of the largest committable column.
+///
+/// # Arguments
+///
+/// * `committable_columns` - A reference to the committable columns.
+fn get_max_committable_column_length(committable_columns: &[CommittableColumn]) -> usize {
+    committable_columns
+        .iter()
+        .map(|column| column.len())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Returns the minimum value of a column as an Fr.
+///
+/// # Arguments
+///
+/// * `column` - A reference to the committable column.
+pub fn get_min_as_fr(column: &CommittableColumn) -> F {
+    match column {
+        CommittableColumn::SmallInt(_) => i16::min_as_fr(),
+        CommittableColumn::Int(_) => i32::min_as_fr(),
+        CommittableColumn::BigInt(_) => i64::min_as_fr(),
+        CommittableColumn::Int128(_) => i128::min_as_fr(),
+        CommittableColumn::Decimal75(_, _, _) => <[u64; 4]>::min_as_fr(),
+        CommittableColumn::Scalar(_) => <[u64; 4]>::min_as_fr(),
+        CommittableColumn::VarChar(_) => <[u64; 4]>::min_as_fr(),
+        CommittableColumn::Boolean(_) => <[u64; 4]>::min_as_fr(),
+        CommittableColumn::TimestampTZ(_, _, _) => i64::min_as_fr(),
+    }
+}
+
+/// Returns a repeated bit table vector that duplicated the
+/// bit table for each element by the num_sub_commits.
+///
+/// # Arguments
+///
+/// * `bit_table` - A reference to the bit table.
+/// * `num_sub_commits` - The number of sub commits.
+fn get_repeated_bit_table(bit_table: &[u32], num_sub_commits: usize) -> Vec<u32> {
+    bit_table
+        .iter()
+        .flat_map(|&value| std::iter::repeat(value).take(num_sub_commits))
+        .collect()
+}
+
+/// Returns the number of commits needed for the packed_msm function.
+///
+/// # Arguments
+///
+/// * `committable_columns` - A reference to the committable columns.
+/// * `offset` - The offset to the data.
+/// * `num_columns` - The number of generators used for msm.
+pub fn get_num_of_sub_commits_per_full_commit(
+    committable_columns: &[CommittableColumn],
+    offset: usize,
+    num_columns: usize,
+) -> usize {
+    // Committable columns may be different sizes, get the max size and add offset.
+    let max_column_length = get_max_committable_column_length(committable_columns) + offset;
+
+    // Number of scalar vectors that the size of the generators n.
+    // Each scalar will be used to call the packed_msm function.
+    (max_column_length + num_columns - 1) / num_columns
+}
+
+/// Modifies the signed sub-commits by adding the offset to the sub-commits.
+///
+/// # Arguments
+///
+/// * `commits` - A reference to the signed sub-commits.
+/// * `committable_columns` - A reference to the committable columns.
+/// * `num_full_commits` - The number of full commits.
+/// * `num_sub_commits_per_full_commit` - The number of sub commits needed for each full commit for the packed_msm function.
+#[tracing::instrument(name = "pack_scalars::modify_commits (gpu)", level = "debug", skip_all)]
+pub fn modify_commits(
+    commits: &[G1Affine],
+    committable_columns: &[CommittableColumn],
+    num_full_commits: usize,
+    num_sub_commits_per_full_commit: usize,
+) -> Vec<G1Affine> {
+    // Currently, the packed_scalars doubles the number of commits to deal with
+    // signed sub-commits. Commit i is offset by commit at i + num_sub_commits_per_full_commit.
+    // Spit the commits into signed sub-commits and offset sub-commits.
+    let num_signed_sub_commits = num_full_commits * num_sub_commits_per_full_commit;
+    let (signed_sub_commits, offset_sub_commits) = commits.split_at(num_signed_sub_commits);
+
+    // Ensure the packed_scalars were split correctly
+    if signed_sub_commits.len() != offset_sub_commits.len() {
+        return vec![];
+    }
+
+    // Add the offset sub-commits multiplied by the min value to the signed sub-commits
+    signed_sub_commits
+        .par_iter()
+        .zip(offset_sub_commits.par_iter())
+        .enumerate()
+        .map(|(index, (first, second))| {
+            let min = get_min_as_fr(&committable_columns[index / num_sub_commits_per_full_commit]);
+            let modified_second = second.mul(min).into_affine();
+            *first + modified_second
+        })
+        .map(|point| point.into_affine())
+        .collect::<Vec<_>>()
+}
+
+/// Packs bits of a committable column into the packed scalars array.
+/// Will offset signed values by the minimum of the data type.
+///
+/// # Arguments
+///
+/// * `column` - A reference to the committable column to be packed.
+/// * `packed_scalars` - A mutable reference to the array where the packed scalars will be stored.
+/// * `current_bit_table_sum` - The current sum of the bit table up to the current sub commit.
+/// * `offset` - The offset to the data.
+/// * `current_byte_size` - The current byte size of the column.
+/// * `bit_table_sum_in_bytes` - The full bit table size in bytes.
+/// * `num_columns` - The number of columns in a matrix commitment.
+fn pack_bit<T: OffsetToBytes>(
+    column: &[T],
+    packed_scalars: &mut [u8],
+    current_bit_table_sum: usize,
+    offset: usize,
+    current_byte_size: usize,
+    bit_table_sum_in_bytes: usize,
+    num_columns: usize,
+) {
+    let byte_offset = current_bit_table_sum / BYTE_SIZE;
+    column.iter().enumerate().for_each(|(i, value)| {
+        let row_offset = ((i + offset) % num_columns) * bit_table_sum_in_bytes;
+        let col_offset = current_byte_size * ((i + offset) / num_columns);
+        let offset_idx = row_offset + col_offset + byte_offset;
+
+        packed_scalars[offset_idx..offset_idx + current_byte_size]
+            .copy_from_slice(&value.offset_to_bytes()[..]);
+    });
+}
+
+/// Packs the offset bits of a committable column into the packed scalars at the end of the array.
+/// The offsets are 8-bit values used to handle the signed values.
+///
+/// # Arguments
+///
+/// * `column` -  A reference to a signed committable column that needs offsets calculated.
+/// * `packed_scalars` - A mutable reference to the array where the packed scalars will be stored.
+/// * `current_bit_table_sum` - The current sum of the bit table up to the current column.
+/// * `offset` - The offset to the data.
+/// * `bit_table_sum_in_bytes` - The full bit table size in bytes.
+/// * `num_columns` - The number of columns in a matrix commitment.
+fn pack_offset_bit<T: OffsetToBytes>(
+    column: &[T],
+    packed_scalars: &mut [u8],
+    current_bit_table_sum: usize,
+    offset: usize,
+    bit_table_sum_in_bytes: usize,
+    num_columns: usize,
+) {
+    let byte_offset = current_bit_table_sum / BYTE_SIZE;
+    column.iter().enumerate().for_each(|(i, _)| {
+        let row_offset = ((i + offset) % num_columns) * bit_table_sum_in_bytes;
+        let col_offset = (i + offset) / num_columns;
+        let offset_idx = row_offset + col_offset + byte_offset;
+
+        packed_scalars[offset_idx] = 1_u8;
+    });
+}
+
+/// Returns the bit table and packed scalar array to be used in Blitzar's packed_msm function.
+///
+/// # Arguments
+///
+/// * `committable_columns` - A reference to the committable columns.
+/// * `offset` - The offset to the data.
+/// * `num_columns` - The number of columns in a matrix commitment.
+/// * `num_sub_commits_per_full_commit` - The number of sub commits needed for each full commit for the packed_msm function.
+///
+/// # Example
+///
+/// ```ignore
+/// let committable_columns = [
+///     CommittableColumn::SmallInt(&[0, 1, 2]),
+///     CommittableColumn::SmallInt(&[3, 4, 5, 6, 7]),
+/// ];
+/// let offset = 1;
+/// let num_columns = 3;
+///
+/// let num_sub_commits_per_full_commit = get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+///
+/// let (bit_table, packed_scalars) = get_bit_table_and_scalars_for_packed_msm(
+///     &committable_columns,
+///     offset,
+///     num_columns,
+///     num_sub_commits_per_full_commit,
+/// );
+///
+/// assert_eq!(num_of_commits, 2);
+/// assert_eq!(bit_table, [16, 16, 16, 16, 8, 8, 8, 8]);
+/// assert_eq!(packed_scalars.len(), 36); // num_columns * bit_table_sum / BYTE_SIZE
+/// assert_eq!(packed_scalars, [0,   0, 2, 128, 0,   0, 5, 128, 0, 1, 0, 1,
+///                             0, 128, 0,   0, 3, 128, 6, 128, 1, 0, 1, 1,
+///                             1, 128, 0,   0, 4, 128, 7, 128, 1, 0, 1, 1]);
+/// ```
+#[tracing::instrument(
+    name = "pack_scalars::get_bit_table_and_scalars_for_packed_msm (gpu)",
+    level = "debug",
+    skip_all
+)]
+pub fn get_bit_table_and_scalars_for_packed_msm(
+    committable_columns: &[CommittableColumn],
+    offset: usize,
+    num_columns: usize,
+    num_sub_commits_per_full_commit: usize,
+) -> (Vec<u32>, Vec<u8>) {
+    // Get a bit table that represented each of the committable columns bit size.
+    let bit_table_full_commits = get_output_bit_table(committable_columns);
+
+    // Repeat the bit table to account for the appropriate number of sub commitments per full commit.
+    let bit_table_sub_commits =
+        get_repeated_bit_table(&bit_table_full_commits, num_sub_commits_per_full_commit);
+    let bit_table_sub_commits_sum = bit_table_sub_commits.iter().sum::<u32>() as usize;
+
+    // Double the bit table to handle handle the BYTE_SIZE offsets.
+    let mut bit_table = Vec::with_capacity(bit_table_sub_commits.len() * 2);
+    bit_table.extend_from_slice(&bit_table_sub_commits);
+    bit_table.extend(std::iter::repeat(BYTE_SIZE as u32).take(bit_table_sub_commits.len()));
+    let bit_table_sum_in_bytes = bit_table.iter().sum::<u32>() as usize / BYTE_SIZE;
+
+    // Create the packed_scalar vector.
+    let mut packed_scalars = vec![0_u8; bit_table_sum_in_bytes * num_columns];
+
+    // For each committable column, pack the data into the packed_scalar array.
+    committable_columns
+        .iter()
+        .enumerate()
+        .for_each(|(i, column)| {
+            // Get the running sum of the bit table for the signed values.
+            let current_bit_table_sum = if i > 0 {
+                bit_table
+                    .iter()
+                    .take(i * num_sub_commits_per_full_commit)
+                    .sum::<u32>() as usize
+            } else {
+                0
+            };
+
+            // Get the running sum of the bit table for the offsets.
+            let bit_table_offset_sum =
+                bit_table_sub_commits_sum + i * BYTE_SIZE * num_sub_commits_per_full_commit;
+
+            // Get the byte size of the column of data.
+            let byte_size = get_byte_size(&committable_columns[i]);
+
+            // Pack the signed bits and offset bits into the packed_scalars array.
+            match column {
+                CommittableColumn::SmallInt(column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                    pack_offset_bit(
+                        column,
+                        &mut packed_scalars,
+                        bit_table_offset_sum,
+                        offset,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+                CommittableColumn::Int(column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                    pack_offset_bit(
+                        column,
+                        &mut packed_scalars,
+                        bit_table_offset_sum,
+                        offset,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+                CommittableColumn::BigInt(column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                    pack_offset_bit(
+                        column,
+                        &mut packed_scalars,
+                        bit_table_offset_sum,
+                        offset,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+                CommittableColumn::Int128(column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                    pack_offset_bit(
+                        column,
+                        &mut packed_scalars,
+                        bit_table_offset_sum,
+                        offset,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+                CommittableColumn::TimestampTZ(_, _, column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                    pack_offset_bit(
+                        column,
+                        &mut packed_scalars,
+                        bit_table_offset_sum,
+                        offset,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+                CommittableColumn::Boolean(column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+                CommittableColumn::Decimal75(_, _, column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+                CommittableColumn::Scalar(column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+                CommittableColumn::VarChar(column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
+            }
+        });
+
+    (bit_table, packed_scalars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::math::decimal::Precision;
+    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+
+    #[test]
+    fn we_can_get_correct_data_sizes() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[1, 2, 3]),
+            CommittableColumn::Int(&[1, 2, 3]),
+            CommittableColumn::BigInt(&[1, 2, 3]),
+            CommittableColumn::Int128(&[1, 2, 3]),
+            CommittableColumn::Decimal75(
+                Precision::new(1).unwrap(),
+                0,
+                vec![[1, 2, 3, 4], [5, 6, 7, 8]],
+            ),
+            CommittableColumn::Scalar(vec![[1, 2, 3, 4], [5, 6, 7, 8]]),
+            CommittableColumn::VarChar(vec![[1, 2, 3, 4], [5, 6, 7, 8]]),
+            CommittableColumn::Boolean(&[true, false, true]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[1, 2, 3]),
+        ];
+
+        let expected_bit_sizes = [16, 32, 64, 128, 64 * 4, 64 * 4, 64 * 4, 8, 64];
+        let expected_byte_size = expected_bit_sizes
+            .iter()
+            .map(|&x| x / BYTE_SIZE)
+            .collect::<Vec<usize>>();
+
+        for (i, column) in committable_columns.iter().enumerate() {
+            let bit_size = get_bit_size(column);
+            let byte_size = get_byte_size(column);
+
+            assert_eq!(bit_size, expected_bit_sizes[i]);
+            assert_eq!(byte_size, expected_byte_size[i]);
+        }
+    }
+
+    #[test]
+    fn we_can_get_max_committable_column_length_of_the_same_type() {
+        let committable_columns = [
+            CommittableColumn::Scalar(vec![[1, 2, 3, 4], [5, 6, 7, 8]]),
+            CommittableColumn::Scalar(vec![[1, 2, 3, 4]]),
+        ];
+
+        let max_column_length = get_max_committable_column_length(&committable_columns);
+        assert_eq!(max_column_length, 2);
+    }
+
+    #[test]
+    fn we_can_get_max_committable_column_length_of_different_types() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[1, 2, 3]),
+            CommittableColumn::Int(&[1, 2, 3]),
+            CommittableColumn::BigInt(&[1, 2, 3]),
+            CommittableColumn::Int128(&[1, 2, 3, 4, 5, 6]),
+            CommittableColumn::Decimal75(
+                Precision::new(1).unwrap(),
+                0,
+                vec![[1, 0, 0, 0], [2, 0, 0, 0]],
+            ),
+            CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
+            CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
+            CommittableColumn::Boolean(&[true, false, true]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[1, 2, 3]),
+        ];
+
+        let max_column_length = get_max_committable_column_length(&committable_columns);
+        assert_eq!(max_column_length, 6);
+    }
+
+    #[test]
+    fn we_can_get_a_bit_table() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[1, 2, 3]),
+            CommittableColumn::Int(&[1, 2, 3]),
+            CommittableColumn::BigInt(&[1, 2, 3]),
+            CommittableColumn::Int128(&[1, 2, 3]),
+            CommittableColumn::Decimal75(
+                Precision::new(1).unwrap(),
+                0,
+                vec![[1, 0, 0, 0], [2, 0, 0, 0]],
+            ),
+            CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
+            CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
+            CommittableColumn::Boolean(&[true, false, true]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[1, 2, 3]),
+        ];
+
+        let bit_table = get_output_bit_table(&committable_columns);
+        let expected = [16, 32, 64, 128, 64 * 4, 64 * 4, 64 * 4, 8, 64];
+        assert_eq!(bit_table, expected);
+    }
+
+    #[test]
+    fn we_can_get_a_repeated_bit_table() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[1, 2, 3]),
+            CommittableColumn::Int(&[1, 2, 3]),
+            CommittableColumn::BigInt(&[1, 2, 3]),
+            CommittableColumn::Int128(&[1, 2, 3]),
+            CommittableColumn::Decimal75(
+                Precision::new(1).unwrap(),
+                0,
+                vec![[1, 0, 0, 0], [2, 0, 0, 0]],
+            ),
+            CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
+            CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
+            CommittableColumn::Boolean(&[true, false, true]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, &[1, 2, 3]),
+        ];
+
+        let bit_table = get_output_bit_table(&committable_columns);
+        let repeated_bit_table = get_repeated_bit_table(&bit_table, 3);
+        let expected_bit_table = [
+            16,
+            16,
+            16,
+            32,
+            32,
+            32,
+            64,
+            64,
+            64,
+            128,
+            128,
+            128,
+            64 * 4,
+            64 * 4,
+            64 * 4,
+            64 * 4,
+            64 * 4,
+            64 * 4,
+            64 * 4,
+            64 * 4,
+            64 * 4,
+            8,
+            8,
+            8,
+            64,
+            64,
+            64,
+        ];
+        assert_eq!(repeated_bit_table, expected_bit_table);
+    }
+
+    #[test]
+    fn we_can_get_num_sub_commits_per_full_commit_with_less_rows_than_columns() {
+        let committable_columns = [
+            CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
+            CommittableColumn::Scalar(vec![[1, 0, 0, 0]]),
+        ];
+
+        let offset = 0;
+        let num_columns = 1 << 2;
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 1);
+    }
+
+    #[test]
+    fn we_can_get_num_sub_commits_per_full_commit_with_offset_and_less_rows_than_columns() {
+        let committable_columns = [
+            CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0]]),
+            CommittableColumn::Scalar(vec![[1, 0, 0, 0]]),
+        ];
+
+        let offset = 5;
+        let num_columns = 1 << 2;
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 2);
+    }
+
+    #[test]
+    fn we_can_get_num_sub_commits_per_full_commit_with_more_rows_than_generators() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+            ]),
+            CommittableColumn::Int(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+            CommittableColumn::SmallInt(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        ];
+
+        let offset = 0;
+        let num_columns = 1 << 2;
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 5);
+    }
+
+    #[test]
+    fn we_can_get_num_sub_commits_per_full_commit_with_offset_and_more_rows_than_generators() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+            ]),
+            CommittableColumn::Int(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+            CommittableColumn::SmallInt(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        ];
+
+        let offset = 1;
+        let num_columns = 1 << 2;
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 6);
+    }
+
+    #[test]
+    fn we_can_create_a_mixed_packed_scalar_with_more_rows_than_columns() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+            ]),
+            CommittableColumn::Int(&[
+                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+            ]),
+            CommittableColumn::SmallInt(&[
+                38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
+            ]),
+        ];
+
+        let num_columns = 1 << 2;
+        let offset = 0;
+
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 5);
+
+        let (bit_table, packed_scalar) = get_bit_table_and_scalars_for_packed_msm(
+            &committable_columns,
+            offset,
+            num_columns,
+            num_sub_commits_per_full_commit,
+        );
+
+        let expected_bit_table = [
+            16, 16, 16, 16, 16, 32, 32, 32, 32, 32, 16, 16, 16, 16, 16, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+            8, 8, 8, 8, 8, 8,
+        ];
+
+        let expected_packed_scalar = [
+            0, 128, 4, 128, 8, 128, 12, 128, 16, 128, 19, 0, 0, 128, 23, 0, 0, 128, 27, 0, 0, 128,
+            31, 0, 0, 128, 35, 0, 0, 128, 38, 128, 42, 128, 46, 128, 50, 128, 54, 128, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 128, 5, 128, 9, 128, 13, 128, 17, 128, 20, 0, 0,
+            128, 24, 0, 0, 128, 28, 0, 0, 128, 32, 0, 0, 128, 36, 0, 0, 128, 39, 128, 43, 128, 47,
+            128, 51, 128, 55, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 128, 6, 128, 10,
+            128, 14, 128, 18, 128, 21, 0, 0, 128, 25, 0, 0, 128, 29, 0, 0, 128, 33, 0, 0, 128, 37,
+            0, 0, 128, 40, 128, 44, 128, 48, 128, 52, 128, 56, 128, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 3, 128, 7, 128, 11, 128, 15, 128, 0, 0, 22, 0, 0, 128, 26, 0, 0, 128,
+            30, 0, 0, 128, 34, 0, 0, 128, 0, 0, 0, 0, 41, 128, 45, 128, 49, 128, 53, 128, 0, 0, 1,
+            1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0,
+        ];
+
+        assert_eq!(bit_table, expected_bit_table);
+        assert_eq!(packed_scalar, expected_packed_scalar);
+    }
+
+    #[test]
+    fn we_can_create_a_mixed_packed_scalar_with_offset_and_same_num_of_rows_and_columns() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[0, 1, 2, 3]),
+            CommittableColumn::Int(&[4, 5, 6, 7]),
+            CommittableColumn::SmallInt(&[8, 9, 10, 11]),
+        ];
+
+        let num_columns = 1 << 2;
+        let offset = 5;
+
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 3);
+
+        let (bit_table, packed_scalar) = get_bit_table_and_scalars_for_packed_msm(
+            &committable_columns,
+            offset,
+            num_columns,
+            num_sub_commits_per_full_commit,
+        );
+
+        let expected_bit_table = [
+            16, 16, 16, 32, 32, 32, 16, 16, 16, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+        ];
+
+        let expected_packed_scalar = [
+            0, 0, 0, 0, 3, 128, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 128, 0, 0, 0, 0, 11, 128, 0, 0, 1,
+            0, 0, 1, 0, 0, 1, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 4, 0, 0, 128, 0, 0, 0, 0, 0, 0, 8,
+            128, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 128, 0, 0, 0, 0, 0, 0, 5, 0, 0, 128, 0,
+            0, 0, 0, 0, 0, 9, 128, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 2, 128, 0, 0, 0, 0, 0, 0,
+            6, 0, 0, 128, 0, 0, 0, 0, 0, 0, 10, 128, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0,
+        ];
+
+        assert_eq!(bit_table, expected_bit_table);
+        assert_eq!(packed_scalar, expected_packed_scalar);
+    }
+
+    #[test]
+    fn we_can_pack_empty_scalars() {
+        let committable_columns = [];
+
+        let (bit_table, packed_scalar) =
+            get_bit_table_and_scalars_for_packed_msm(&committable_columns, 0, 1, 0);
+
+        assert!(bit_table.is_empty());
+        assert!(packed_scalar.is_empty());
+    }
+
+    #[test]
+    fn we_can_pack_scalars_with_one_full_row() {
+        let committable_columns = [
+            CommittableColumn::BigInt(&[1, 2]),
+            CommittableColumn::BigInt(&[3, 4]),
+        ];
+
+        let offset = 0;
+        let num_columns = 1 << 1;
+
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 1);
+
+        let (bit_table, packed_scalar) = get_bit_table_and_scalars_for_packed_msm(
+            &committable_columns,
+            offset,
+            num_columns,
+            num_sub_commits_per_full_commit,
+        );
+
+        let expected_packed_scalar = [
+            1, 0, 0, 0, 0, 0, 0, 128, 3, 0, 0, 0, 0, 0, 0, 128, 1, 1, 2, 0, 0, 0, 0, 0, 0, 128, 4,
+            0, 0, 0, 0, 0, 0, 128, 1, 1,
+        ];
+
+        let expected_bit_table = [64, 64, 8, 8];
+
+        assert_eq!(bit_table, expected_bit_table);
+        assert_eq!(packed_scalar, expected_packed_scalar);
+    }
+
+    #[test]
+    fn we_can_pack_scalars_with_more_than_one_row() {
+        let committable_columns = [
+            CommittableColumn::BigInt(&[1, 2]),
+            CommittableColumn::BigInt(&[3, 4]),
+        ];
+
+        let offset = 0;
+        let num_columns = 1 << 0;
+
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 2);
+
+        let (bit_table, packed_scalar) = get_bit_table_and_scalars_for_packed_msm(
+            &committable_columns,
+            offset,
+            num_columns,
+            num_sub_commits_per_full_commit,
+        );
+
+        let expected_packed_scalar = [
+            1, 0, 0, 0, 0, 0, 0, 128, 2, 0, 0, 0, 0, 0, 0, 128, 3, 0, 0, 0, 0, 0, 0, 128, 4, 0, 0,
+            0, 0, 0, 0, 128, 1, 1, 1, 1,
+        ];
+
+        let expected_bit_table = [64, 64, 64, 64, 8, 8, 8, 8];
+
+        assert_eq!(bit_table, expected_bit_table);
+        assert_eq!(packed_scalar, expected_packed_scalar);
+    }
+
+    #[test]
+    fn we_can_pack_scalars_with_one_full_row_with_offset() {
+        let committable_columns = [
+            CommittableColumn::BigInt(&[1, 2]),
+            CommittableColumn::BigInt(&[3, 4]),
+        ];
+
+        let offset = 1;
+        let num_columns = 1 << 1;
+
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 2);
+
+        let (bit_table, packed_scalar) = get_bit_table_and_scalars_for_packed_msm(
+            &committable_columns,
+            offset,
+            num_columns,
+            num_sub_commits_per_full_commit,
+        );
+
+        let expected_packed_scalar = [
+            0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0,
+            0, 0, 0, 128, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0,
+            0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
+        ];
+
+        let expected_bit_table = [64, 64, 64, 64, 8, 8, 8, 8];
+
+        assert_eq!(bit_table, expected_bit_table);
+        assert_eq!(packed_scalar, expected_packed_scalar);
+    }
+
+    #[test]
+    fn we_can_pack_scalars_with_offset_and_more_rows_than_columns() {
+        let committable_columns = [
+            CommittableColumn::BigInt(&[1, 2]),
+            CommittableColumn::BigInt(&[3, 4]),
+        ];
+
+        let offset = 1;
+        let num_columns = 1 << 0;
+
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 3);
+
+        let (bit_table, packed_scalar) = get_bit_table_and_scalars_for_packed_msm(
+            &committable_columns,
+            offset,
+            num_columns,
+            num_sub_commits_per_full_commit,
+        );
+
+        let expected_packed_scalar = [
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 128, 2, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0,
+            0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 128, 4, 0, 0, 0, 0, 0, 0, 128, 0, 1, 1, 0, 1, 1,
+        ];
+
+        let expected_bit_table = [64, 64, 64, 64, 64, 64, 8, 8, 8, 8, 8, 8];
+
+        assert_eq!(bit_table, expected_bit_table);
+        assert_eq!(packed_scalar, expected_packed_scalar);
+    }
+
+    #[test]
+    fn we_can_create_a_mixed_packed_scalar_with_offset_and_more_rows_than_columns() {
+        let committable_columns = [
+            CommittableColumn::SmallInt(&[0, 1, 2, 3, 4, 5]),
+            CommittableColumn::Int(&[6, 7, 8, 9]),
+            CommittableColumn::Scalar(vec![[10, 0, 0, 0], [11, 0, 0, 0], [12, 0, 0, 0]]),
+        ];
+
+        let offset = 0;
+        let num_columns = 3;
+
+        let num_sub_commits_per_full_commit =
+            get_num_of_sub_commits_per_full_commit(&committable_columns, offset, num_columns);
+        assert_eq!(num_sub_commits_per_full_commit, 2);
+
+        let (bit_table, packed_scalar) = get_bit_table_and_scalars_for_packed_msm(
+            &committable_columns,
+            offset,
+            num_columns,
+            num_sub_commits_per_full_commit,
+        );
+
+        let expected_packed_scalar = [
+            0, 128, 3, 128, 6, 0, 0, 128, 9, 0, 0, 128, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1,
+            128, 4, 128, 7, 0, 0, 128, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 2, 128, 5,
+            128, 8, 0, 0, 128, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0,
+        ];
+
+        let expected_bit_table = [16, 16, 32, 32, 64 * 4, 64 * 4, 8, 8, 8, 8, 8, 8];
+
+        assert_eq!(bit_table, expected_bit_table);
+        assert_eq!(packed_scalar, expected_packed_scalar);
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -55,19 +55,23 @@ const fn min_as_f(column_type: ColumnType) -> F {
 }
 
 /// Returns a repeated bit table vector that duplicated the
-/// bit table for each element by the num_sub_commits.
+/// bit table for each element by the num_matrix_commitment_columns.
 ///
 /// # Arguments
 ///
-/// * `bit_table` - A reference to the bit table.
-/// * `num_sub_commits` - The number of sub commits.
-fn repeat_bit_table(bit_table: impl Iterator<Item = u32>, num_sub_commits: usize) -> Vec<u32> {
+/// * `bit_table` - A iterable bit table.
+/// * `num_matrix_commitment_columns` - The number of matrix commitment columns needed for each full commit.
+fn repeat_bit_table(
+    bit_table: impl Iterator<Item = u32>,
+    num_matrix_commitment_columns: usize,
+) -> Vec<u32> {
     bit_table
-        .flat_map(|value| itertools::repeat_n(value, num_sub_commits))
+        .flat_map(|value| itertools::repeat_n(value, num_matrix_commitment_columns))
         .collect()
 }
 
-/// Returns the number of commits needed for the packed_msm function.
+/// Returns the number of commits needed for each full
+/// commitment in the packed_msm function.
 ///
 /// # Arguments
 ///
@@ -87,13 +91,14 @@ pub fn num_matrix_commitment_columns(
     (max_column_length + num_columns - 1) / num_columns
 }
 
-/// Modifies the signed sub-commits by adding the offset to the sub-commits.
+/// Modifies the signed matrix commitment columns by adding the offset to the matrix commitment columns.
 ///
 /// # Arguments
 ///
 /// * `commits` - A reference to the signed sub-commits.
 /// * `committable_columns` - A reference to the committable columns.
-/// * `num_matrix_commitment_columns` - The number of matrix commitment colums needed for each full commit for the packed_msm function.
+/// * `num_matrix_commitment_columns` - The number of matrix commitment columns needed
+///                                     for each full commit for the packed_msm function.
 #[tracing::instrument(name = "pack_scalars::modify_commits (gpu)", level = "debug", skip_all)]
 pub fn modify_commits(
     commits: &[G1Affine],
@@ -198,7 +203,8 @@ fn pack_offset_bit<T: OffsetToBytes>(
 /// * `committable_columns` - A reference to the committable columns.
 /// * `offset` - The offset to the data.
 /// * `num_columns` - The number of columns in a matrix commitment.
-/// * `num_matrix_commitment_columns` - The number of matrix commitment columns needed for each full commit for the packed_msm function.
+/// * `num_matrix_commitment_columns` - The number of matrix commitment columns needed for
+///                                     each full commit for the packed_msm function.
 ///
 /// # Example
 ///

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -60,10 +60,10 @@ const fn min_as_f(column_type: ColumnType) -> F {
 ///
 /// * `bit_table` - A reference to the bit table.
 /// * `num_sub_commits` - The number of sub commits.
-fn get_repeated_bit_table(bit_table: &[u32], num_sub_commits: usize) -> Vec<u32> {
+fn repeat_bit_table(bit_table: &[u32], num_sub_commits: usize) -> Vec<u32> {
     bit_table
         .iter()
-        .flat_map(|&value| std::iter::repeat(value).take(num_sub_commits))
+        .flat_map(|&value| itertools::repeat_n(value, num_sub_commits))
         .collect()
 }
 
@@ -241,7 +241,7 @@ pub fn get_bit_table_and_scalars_for_packed_msm(
 
     // Repeat the bit table to account for the appropriate number of sub commitments per full commit.
     let bit_table_sub_commits =
-        get_repeated_bit_table(&bit_table_full_commits, num_sub_commits_per_full_commit);
+        repeat_bit_table(&bit_table_full_commits, num_sub_commits_per_full_commit);
     let bit_table_sub_commits_sum = bit_table_sub_commits.iter().sum::<u32>() as usize;
 
     // Double the bit table to handle handle the BYTE_SIZE offsets.
@@ -503,7 +503,7 @@ mod tests {
         ];
 
         let bit_table = get_output_bit_table(&committable_columns);
-        let repeated_bit_table = get_repeated_bit_table(&bit_table, 3);
+        let repeated_bit_table = repeat_bit_table(&bit_table, 3);
         let expected_bit_table = [
             16,
             16,

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -13,7 +13,7 @@ const BYTE_SIZE: usize = 8;
 /// # Arguments
 ///
 /// * `committable_columns` - A reference to the committable columns.
-pub fn get_output_bit_table(committable_columns: &[CommittableColumn]) -> Vec<u32> {
+fn get_output_bit_table(committable_columns: &[CommittableColumn]) -> Vec<u32> {
     committable_columns
         .iter()
         .map(|column| column.column_type().bit_size())

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -95,27 +95,27 @@ pub fn num_matrix_commitment_columns(
 ///
 /// # Arguments
 ///
-/// * `commits` - A reference to the signed sub-commits.
+/// * `sub_commits` - A reference to the signed sub-commits.
 /// * `committable_columns` - A reference to the committable columns.
 /// * `num_matrix_commitment_columns` - The number of matrix commitment columns needed
 ///                                     for each full commit for the packed_msm function.
 #[tracing::instrument(name = "pack_scalars::modify_commits (gpu)", level = "debug", skip_all)]
 pub fn modify_commits(
-    commits: &[G1Affine],
+    sub_commits: &[G1Affine],
     committable_columns: &[CommittableColumn],
     num_matrix_commitment_columns: usize,
 ) -> Vec<G1Affine> {
     let num_full_commits = committable_columns.len();
     assert_eq!(
         2 * num_full_commits * num_matrix_commitment_columns,
-        commits.len()
+        sub_commits.len()
     );
 
-    // Currently, the packed_scalars doubles the number of commits to deal with
-    // signed sub-commits. Commit i is offset by commit at i + num_matrix_commitment_columns.
-    // Spit the commits into signed sub-commits and offset sub-commits.
+    // Currently, the packed_scalars doubles the number of sub-commits to deal with
+    // signed sub-commits. Sub-commit i is offset by the sub-commit at i + num_matrix_commitment_columns.
+    // Spit the sub-commits into signed sub-commits and offset sub-commits.
     let num_signed_sub_commits = num_full_commits * num_matrix_commitment_columns;
-    let (signed_sub_commits, offset_sub_commits) = commits.split_at(num_signed_sub_commits);
+    let (signed_sub_commits, offset_sub_commits) = sub_commits.split_at(num_signed_sub_commits);
 
     // Ensure the packed_scalars were split correctly
     assert_eq!(signed_sub_commits.len(), offset_sub_commits.len());

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -242,14 +242,11 @@ pub fn get_bit_table_and_scalars_for_packed_msm(
     let bit_table_full_commits = get_output_bit_table(committable_columns);
 
     // Repeat the bit table to account for the appropriate number of sub commitments per full commit.
-    let bit_table_sub_commits =
-        repeat_bit_table(&bit_table_full_commits, num_sub_commits_per_full_commit);
-    let bit_table_sub_commits_sum = bit_table_sub_commits.iter().sum::<u32>() as usize;
+    let mut bit_table = repeat_bit_table(&bit_table_full_commits, num_sub_commits_per_full_commit);
+    let bit_table_sub_commits_sum = bit_table.iter().sum::<u32>() as usize;
 
     // Double the bit table to handle handle the BYTE_SIZE offsets.
-    let mut bit_table = Vec::with_capacity(bit_table_sub_commits.len() * 2);
-    bit_table.extend_from_slice(&bit_table_sub_commits);
-    bit_table.extend(std::iter::repeat(BYTE_SIZE as u32).take(bit_table_sub_commits.len()));
+    bit_table.extend(std::iter::repeat(BYTE_SIZE as u32).take(bit_table.len()));
     let bit_table_sum_in_bytes = bit_table.iter().sum::<u32>() as usize / BYTE_SIZE;
 
     // Create the packed_scalar vector.

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -73,6 +73,18 @@ impl<'a> ProverSetup<'a> {
     ) {
         self.blitzar_handle.msm(res, element_num_bytes, scalars)
     }
+
+    #[cfg(feature = "blitzar")]
+    #[tracing::instrument(name = "ProverSetup::blitzar_packed_msm", level = "debug", skip_all)]
+    pub(super) fn blitzar_packed_msm(
+        &self,
+        res: &mut [blitzar::compute::ElementP2<ark_bls12_381::g1::Config>],
+        output_bit_table: &[u32],
+        scalars: &[u8],
+    ) {
+        self.blitzar_handle
+            .packed_msm(res, output_bit_table, scalars)
+    }
 }
 
 impl<'a> From<&'a PublicParameters> for ProverSetup<'a> {


### PR DESCRIPTION
# Rationale for this change
In order to improve the performance of the Dory protocol, the Dory commitment computation should use Blitzar's `packed_msm` function. Benchmarks indicate that the use of Blitzar's `packed_msm` over `fixed_msm` improves performance of proof generation.

Benchmarks, run on August 15, 2024, for the scalar packing done in this PR, show a speed up over three different VMs.
- Multi-A100 
  - 4.48x speed up of `ProofBuilder::commit_intermediate_mles`
  - 1.82x speed up of entire benchmark
- Multi-T4
  - 3.66x speed up of `ProofBuilder::commit_intermediate_mles`
  - 1.81x speed up of entire benchmark
- Single T4
  - 1.91x speed up of `ProofBuilder::commit_intermediate_mles`
  - 1.30x speed up of entire benchmark
  
# What changes are included in this PR?
- The `dory_commitment_helper_gpu` module replaces Blitzar's `fixed_msm` function with the more efficient `packed_msm` function.
- The `pack_scalars` module is added to get the parameters required by Blitzar's `packed_msm` function.
- The Dory `setup` module exposes Blitzar's `packed_msm` function.

# Are these changes tested?
Yes