### PR TITLE
fix: correct scale bug in inequality expr

### DIFF
--- a/crates/proof-of-sql/src/sql/ast/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/inequality_expr.rs
@@ -97,7 +97,7 @@ impl<C: Commitment> ProvableExpr<C> for InequalityExpr<C> {
             scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, false)
                 .expect("Failed to scale and subtract")
         } else {
-            scale_and_subtract(alloc, rhs_column, lhs_column, rhs_scale, rhs_scale, false)
+            scale_and_subtract(alloc, rhs_column, lhs_column, rhs_scale, lhs_scale, false)
                 .expect("Failed to scale and subtract")
         };
 

--- a/crates/proof-of-sql/src/sql/ast/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/inequality_expr.rs
@@ -68,7 +68,7 @@ impl<C: Commitment> ProvableExpr<C> for InequalityExpr<C> {
             scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, false)
                 .expect("Failed to scale and subtract")
         } else {
-            scale_and_subtract(alloc, rhs_column, lhs_column, lhs_scale, rhs_scale, false)
+            scale_and_subtract(alloc, rhs_column, lhs_column, rhs_scale, lhs_scale, false)
                 .expect("Failed to scale and subtract")
         };
 
@@ -97,7 +97,7 @@ impl<C: Commitment> ProvableExpr<C> for InequalityExpr<C> {
             scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, false)
                 .expect("Failed to scale and subtract")
         } else {
-            scale_and_subtract(alloc, rhs_column, lhs_column, lhs_scale, rhs_scale, false)
+            scale_and_subtract(alloc, rhs_column, lhs_column, rhs_scale, rhs_scale, false)
                 .expect("Failed to scale and subtract")
         };
 


### PR DESCRIPTION
# Rationale for this change

Suppose I have a table of times denoted in seconds:

```rust
accessor.add_table(
    "sxt.table".parse().unwrap(),
    owned_table([timestamptz(
        "times",
        PoSQLTimeUnit::Second,
        PoSQLTimeZone::Utc,
        test_timestamps,
    )]),
    0,
);
```

Assume that the table contains the following:
```rust
vec![-1, 0, 1];
```

And I wish to query the following against this table:

```sql
"SELECT * FROM table WHERE times < timestamp '1970-01-01T00:00:00.000000001Z'"
```

One would expect that the query should give back [-1, 0], but instead, after parsing the query and generating a proof:

```rust
// Parse and execute the query
let query = QueryExpr::try_new(
    query_str.parse().unwrap(),
    "sxt".parse().unwrap(),
    &accessor,
)
.unwrap();

let proof = VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());

// Verify the results
let owned_table_result = proof
    .verify(query.proof_expr(), &accessor, &())
    .unwrap()
    .table;
```

we receive the following:

```bash
ProofError(VerificationError("sumcheck evaluation check failed"))
```

from the ```unwrap()``` on the ```verify()``` call:

```rust
    // Verify the results
    let owned_table_result = proof
        .verify(query.proof_expr(), &accessor, &())
        .unwrap()
```

The bug is [here](https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/644b0a784abb633f1824ddb73dd3d46c565ee19b/crates/proof-of-sql/src/sql/ast/inequality_expr.rs#L68):

```rust
let diff = if self.is_lte {
    scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, false)
        .expect("Failed to scale and subtract")
} else {
    scale_and_subtract(alloc, rhs_column, lhs_column, lhs_scale, rhs_scale, false)
        .expect("Failed to scale and subtract")
};
 ```
 
 rhs and lhs should be reversed in the gte branch. Additionally, there is a testing gap for >= / gte inequalities. This issue should be resolved in #110 

# What changes are included in this PR?

Corrects the branch for lte and gte and adds tests to cover the gap for gte comparisons.

# Are these changes tested?

yes
