### PR TITLE
refactor!: put `arrow` behind a feature flag

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -73,6 +73,8 @@ jobs:
         run: cargo test --all-features
       - name: Dry run cargo test (proof-of-sql) (test feature only)
         run: cargo test -p proof-of-sql --no-run --no-default-features --features="test"
+      - name: Dry run cargo test (proof-of-sql) (arrow feature only)
+        run: cargo test -p proof-of-sql --no-run --no-default-features --features="arrow"
       - name: Dry run cargo test (proof-of-sql) (blitzar feature only)
         run: cargo test -p proof-of-sql --no-run --no-default-features --features="blitzar"
       - name: Dry run cargo test (proof-of-sql) (no features)

--- a/crates/proof-of-sql-parser/Cargo.toml
+++ b/crates/proof-of-sql-parser/Cargo.toml
@@ -22,9 +22,6 @@ lalrpop-util = { workspace = true, features = ["lexer", "unicode"] }
 serde = { workspace = true, features = ["serde_derive"] }
 thiserror = { workspace = true }
 
-[features]
-default = []
-
 [build-dependencies]
 lalrpop = { version = "0.20.0" }
 

--- a/crates/proof-of-sql-parser/Cargo.toml
+++ b/crates/proof-of-sql-parser/Cargo.toml
@@ -15,7 +15,6 @@ doctest = true
 test = true
 
 [dependencies]
-arrow = { workspace = true, optional = true }
 arrayvec = { workspace = true, features = ["serde"] }
 bigdecimal = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
@@ -24,7 +23,6 @@ serde = { workspace = true, features = ["serde_derive"] }
 thiserror = { workspace = true }
 
 [features]
-arrow = ["dep:arrow"]
 default = []
 
 [build-dependencies]

--- a/crates/proof-of-sql-parser/Cargo.toml
+++ b/crates/proof-of-sql-parser/Cargo.toml
@@ -15,13 +15,17 @@ doctest = true
 test = true
 
 [dependencies]
-arrow = { workspace = true }
+arrow = { workspace = true, optional = true }
 arrayvec = { workspace = true, features = ["serde"] }
 bigdecimal = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 lalrpop-util = { workspace = true, features = ["lexer", "unicode"] }
 serde = { workspace = true, features = ["serde_derive"] }
 thiserror = { workspace = true }
+
+[features]
+arrow = ["dep:arrow"]
+default = []
 
 [build-dependencies]
 lalrpop = { version = "0.20.0" }

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -30,30 +30,6 @@ impl TryFrom<&str> for PoSQLTimeUnit {
     }
 }
 
-#[cfg(feature = "arrow")]
-impl From<PoSQLTimeUnit> for ArrowTimeUnit {
-    fn from(unit: PoSQLTimeUnit) -> Self {
-        match unit {
-            PoSQLTimeUnit::Second => ArrowTimeUnit::Second,
-            PoSQLTimeUnit::Millisecond => ArrowTimeUnit::Millisecond,
-            PoSQLTimeUnit::Microsecond => ArrowTimeUnit::Microsecond,
-            PoSQLTimeUnit::Nanosecond => ArrowTimeUnit::Nanosecond,
-        }
-    }
-}
-
-#[cfg(feature = "arrow")]
-impl From<ArrowTimeUnit> for PoSQLTimeUnit {
-    fn from(unit: ArrowTimeUnit) -> Self {
-        match unit {
-            ArrowTimeUnit::Second => PoSQLTimeUnit::Second,
-            ArrowTimeUnit::Millisecond => PoSQLTimeUnit::Millisecond,
-            ArrowTimeUnit::Microsecond => PoSQLTimeUnit::Microsecond,
-            ArrowTimeUnit::Nanosecond => PoSQLTimeUnit::Nanosecond,
-        }
-    }
-}
-
 impl fmt::Display for PoSQLTimeUnit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -1,4 +1,5 @@
 use super::PoSQLTimestampError;
+#[cfg(feature = "arrow")]
 use arrow::datatypes::TimeUnit as ArrowTimeUnit;
 use core::fmt;
 use serde::{Deserialize, Serialize};
@@ -29,6 +30,7 @@ impl TryFrom<&str> for PoSQLTimeUnit {
     }
 }
 
+#[cfg(feature = "arrow")]
 impl From<PoSQLTimeUnit> for ArrowTimeUnit {
     fn from(unit: PoSQLTimeUnit) -> Self {
         match unit {
@@ -40,6 +42,7 @@ impl From<PoSQLTimeUnit> for ArrowTimeUnit {
     }
 }
 
+#[cfg(feature = "arrow")]
 impl From<ArrowTimeUnit> for PoSQLTimeUnit {
     fn from(unit: ArrowTimeUnit) -> Self {
         match unit {

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -1,6 +1,4 @@
 use super::PoSQLTimestampError;
-#[cfg(feature = "arrow")]
-use arrow::datatypes::TimeUnit as ArrowTimeUnit;
 use core::fmt;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -21,7 +21,7 @@ ark-ff = { workspace = true }
 ark-poly = { workspace = true }
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
-arrow = { workspace = true }
+arrow = { workspace = true, optional = true }
 bit-iter = { workspace = true }
 bigdecimal = { workspace = true }
 blake3 = { workspace = true }
@@ -63,8 +63,12 @@ tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 flexbuffers = { workspace = true }
 
+[package.metadata.cargo-udeps.ignore]
+development = ["arrow-csv"]
+
 [features]
 default = ["blitzar"]
+arrow = ["dep:arrow", "proof-of-sql-parser/arrow"]
 test = ["dep:rand"]
 
 [lints]
@@ -76,7 +80,7 @@ required-features = [ "blitzar", "test" ]
 
 [[example]]
 name = "posql_db"
-required-features = [ "blitzar" ]
+required-features = [ "arrow", "blitzar" ]
 
 [[bench]]
 name = "criterion_benches"

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -67,8 +67,8 @@ flexbuffers = { workspace = true }
 development = ["arrow-csv"]
 
 [features]
-default = ["blitzar"]
-arrow = ["dep:arrow", "proof-of-sql-parser/arrow"]
+default = ["arrow", "blitzar"]
+arrow = ["dep:arrow"]
 test = ["dep:rand"]
 
 [lints]

--- a/crates/proof-of-sql/examples/posql_db/run_example.sh
+++ b/crates/proof-of-sql/examples/posql_db/run_example.sh
@@ -1,5 +1,5 @@
 cd crates/proof-of-sql/examples/posql_db
-cargo run --example posql_db create -t sxt.table -c a,b -d BIGINT,VARCHAR
-cargo run --example posql_db append -t sxt.table -f hello_world.csv
-cargo run --example posql_db prove -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
-cargo run --example posql_db verify -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
+cargo run --features="arrow blitzar" --example posql_db create -t sxt.table -c a,b -d BIGINT,VARCHAR
+cargo run --features="arrow blitzar" --example posql_db append -t sxt.table -f hello_world.csv
+cargo run --features="arrow blitzar" --example posql_db prove -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
+cargo run --features="arrow blitzar" --example posql_db verify -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -2,13 +2,13 @@ use super::{
     committable_column::CommittableColumn, AppendColumnCommitmentsError, ColumnCommitments,
     ColumnCommitmentsMismatch, Commitment, DuplicateIdentifiers,
 };
+#[cfg(feature = "arrow")]
+use crate::base::database::{ArrayRefExt, ArrowArrayToColumnConversionError};
 use crate::base::{
-    database::{
-        ArrayRefExt, ArrowArrayToColumnConversionError, Column, ColumnField, CommitmentAccessor,
-        OwnedTable, TableRef,
-    },
+    database::{Column, ColumnField, CommitmentAccessor, OwnedTable, TableRef},
     scalar::Scalar,
 };
+#[cfg(feature = "arrow")]
 use arrow::record_batch::RecordBatch;
 use bumpalo::Bump;
 use proof_of_sql_parser::{Identifier, ParseError};
@@ -63,6 +63,7 @@ pub enum TableCommitmentArithmeticError {
 }
 
 /// Errors that can occur when trying to create or extend a [`TableCommitment`] from a record batch.
+#[cfg(feature = "arrow")]
 #[derive(Debug, Error)]
 pub enum RecordBatchToColumnsError {
     /// Error converting from arrow array
@@ -74,6 +75,7 @@ pub enum RecordBatchToColumnsError {
 }
 
 /// Errors that can occur when attempting to append a record batch to a [`TableCommitment`].
+#[cfg(feature = "arrow")]
 #[derive(Debug, Error)]
 pub enum AppendRecordBatchTableCommitmentError {
     /// During commitment operation, metadata indicates that operand tables cannot be the same.
@@ -354,6 +356,7 @@ impl<C: Commitment> TableCommitment<C> {
     /// The row offset is assumed to be the end of the [`TableCommitment`]'s current range.
     ///
     /// Will error on a variety of mismatches, or if the provided columns have mixed length.
+    #[cfg(feature = "arrow")]
     pub fn try_append_record_batch(
         &mut self,
         batch: &RecordBatch,
@@ -380,6 +383,7 @@ impl<C: Commitment> TableCommitment<C> {
         }
     }
     /// Returns a [`TableCommitment`] to the provided arrow [`RecordBatch`].
+    #[cfg(feature = "arrow")]
     pub fn try_from_record_batch(
         batch: &RecordBatch,
         setup: &C::PublicSetup<'_>,
@@ -388,6 +392,7 @@ impl<C: Commitment> TableCommitment<C> {
     }
 
     /// Returns a [`TableCommitment`] to the provided arrow [`RecordBatch`] with the given row offset.
+    #[cfg(feature = "arrow")]
     pub fn try_from_record_batch_with_offset(
         batch: &RecordBatch,
         offset: usize,
@@ -411,6 +416,7 @@ impl<C: Commitment> TableCommitment<C> {
     }
 }
 
+#[cfg(feature = "arrow")]
 fn batch_to_columns<'a, S: Scalar + 'a>(
     batch: &'a RecordBatch,
     alloc: &'a Bump,
@@ -446,7 +452,7 @@ fn num_rows_of_columns<'a>(
     Ok(num_rows)
 }
 
-#[cfg(all(test, feature = "blitzar"))]
+#[cfg(all(test, feature = "arrow, blitzar"))]
 mod tests {
     use super::*;
     use crate::{

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -3,6 +3,7 @@ use crate::base::{
     math::decimal::{scale_scalar, Precision},
     scalar::Scalar,
 };
+#[cfg(feature = "arrow")]
 use arrow::datatypes::{DataType, Field, TimeUnit as ArrowTimeUnit};
 use bumpalo::Bump;
 use proof_of_sql_parser::{
@@ -350,6 +351,7 @@ impl ColumnType {
 }
 
 /// Convert ColumnType values to some arrow DataType
+#[cfg(feature = "arrow")]
 impl From<&ColumnType> for DataType {
     fn from(column_type: &ColumnType) -> Self {
         match column_type {
@@ -372,6 +374,7 @@ impl From<&ColumnType> for DataType {
 }
 
 /// Convert arrow DataType values to some ColumnType
+#[cfg(feature = "arrow")]
 impl TryFrom<DataType> for ColumnType {
     type Error = String;
 
@@ -482,6 +485,7 @@ impl ColumnField {
 }
 
 /// Convert ColumnField values to arrow Field
+#[cfg(feature = "arrow")]
 impl From<&ColumnField> for Field {
     fn from(column_field: &ColumnField) -> Self {
         Field::new(

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -21,15 +21,19 @@ pub use literal_value::LiteralValue;
 mod table_ref;
 pub use table_ref::TableRef;
 
+#[cfg(feature = "arrow")]
 mod arrow_array_to_column_conversion;
+#[cfg(feature = "arrow")]
 pub use arrow_array_to_column_conversion::{ArrayRefExt, ArrowArrayToColumnConversionError};
 
+#[cfg(feature = "arrow")]
 mod record_batch_utility;
+#[cfg(feature = "arrow")]
 pub use record_batch_utility::ToArrow;
 
-#[cfg(any(test, feature = "test"))]
+#[cfg(all(test, feature = "arrow, test"))]
 mod test_accessor_utility;
-#[cfg(any(test, feature = "test"))]
+#[cfg(all(test, feature = "arrow, test"))]
 pub use test_accessor_utility::{make_random_test_accessor_data, RandomTestAccessorDescriptor};
 
 mod owned_column;
@@ -54,9 +58,11 @@ mod expression_evaluation_error;
 mod expression_evaluation_test;
 pub use expression_evaluation_error::{ExpressionEvaluationError, ExpressionEvaluationResult};
 
+#[cfg(feature = "arrow")]
 mod owned_and_arrow_conversions;
+#[cfg(feature = "arrow")]
 pub use owned_and_arrow_conversions::OwnedArrowConversionError;
-#[cfg(test)]
+#[cfg(all(test, feature = "arrow"))]
 mod owned_and_arrow_conversions_test;
 
 #[cfg(any(test, feature = "test"))]
@@ -78,6 +84,7 @@ pub use owned_table_test_accessor::OwnedTableTestAccessor;
 #[cfg(all(test, feature = "blitzar"))]
 mod owned_table_test_accessor_test;
 /// Contains traits for scalar <-> i256 conversions
+#[cfg(feature = "arrow")]
 pub mod scalar_and_i256_conversions;
 
 pub(crate) mod filter_util;

--- a/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor_utility.rs
@@ -39,6 +39,7 @@ impl Default for RandomTestAccessorDescriptor {
 }
 
 /// Generate a DataFrame with random data
+#[allow(dead_code)]
 pub fn make_random_test_accessor_data(
     rng: &mut StdRng,
     cols: &[(&str, ColumnType)],

--- a/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/dense_filter_expr_test.rs
@@ -16,13 +16,11 @@ use crate::{
         },
     },
 };
-use arrow::datatypes::{Field, Schema};
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{Identifier, ResourceId};
-use std::sync::Arc;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -60,19 +58,13 @@ fn we_can_correctly_fetch_the_query_result_schema() {
         .unwrap(),
     );
 
-    let column_fields: Vec<Field> = provable_ast
-        .get_column_result_fields()
-        .iter()
-        .map(|v| v.into())
-        .collect();
-    let schema = Arc::new(Schema::new(column_fields));
-
+    let column_fields: Vec<ColumnField> = provable_ast.get_column_result_fields();
     assert_eq!(
-        schema,
-        Arc::new(Schema::new(vec![
-            Field::new("a", (&ColumnType::BigInt).into(), false,),
-            Field::new("b", (&ColumnType::BigInt).into(), false,)
-        ]))
+        column_fields,
+        vec![
+            ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
+            ColumnField::new("b".parse().unwrap(), ColumnType::BigInt)
+        ]
     );
 }
 

--- a/crates/proof-of-sql/src/sql/ast/filter_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/filter_expr_test.rs
@@ -18,13 +18,11 @@ use crate::{
         },
     },
 };
-use arrow::datatypes::{Field, Schema};
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{Identifier, ResourceId};
-use std::sync::Arc;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -53,20 +51,13 @@ fn we_can_correctly_fetch_the_query_result_schema() {
         )
         .unwrap(),
     );
-
-    let column_fields: Vec<Field> = provable_ast
-        .get_column_result_fields()
-        .iter()
-        .map(|v| v.into())
-        .collect();
-    let schema = Arc::new(Schema::new(column_fields));
-
+    let column_fields: Vec<ColumnField> = provable_ast.get_column_result_fields();
     assert_eq!(
-        schema,
-        Arc::new(Schema::new(vec![
-            Field::new("a", (&ColumnType::BigInt).into(), false,),
-            Field::new("b", (&ColumnType::BigInt).into(), false,)
-        ]))
+        column_fields,
+        vec![
+            ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
+            ColumnField::new("b".parse().unwrap(), ColumnType::BigInt)
+        ]
     );
 }
 

--- a/crates/proof-of-sql/src/sql/ast/projection_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/ast/projection_expr_test.rs
@@ -16,13 +16,11 @@ use crate::{
         },
     },
 };
-use arrow::datatypes::{Field, Schema};
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
 use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{Identifier, ResourceId};
-use std::sync::Arc;
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -50,20 +48,13 @@ fn we_can_correctly_fetch_the_query_result_schema() {
         ],
         TableExpr { table_ref },
     );
-
-    let column_fields: Vec<Field> = provable_ast
-        .get_column_result_fields()
-        .iter()
-        .map(|v| v.into())
-        .collect();
-    let schema = Arc::new(Schema::new(column_fields));
-
+    let column_fields: Vec<ColumnField> = provable_ast.get_column_result_fields();
     assert_eq!(
-        schema,
-        Arc::new(Schema::new(vec![
-            Field::new("a", (&ColumnType::BigInt).into(), false,),
-            Field::new("b", (&ColumnType::BigInt).into(), false,)
-        ]))
+        column_fields,
+        vec![
+            ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
+            ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
+        ]
     );
 }
 

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use provable_result_column::ProvableResultColumn;
 
 mod provable_query_result;
 pub use provable_query_result::ProvableQueryResult;
-#[cfg(test)]
+#[cfg(all(test, feature = "arrow"))]
 mod provable_query_result_test;
 
 mod sumcheck_mle_evaluations;

--- a/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     sql::proof::{Indexes, ResultBuilder, SumcheckSubpolynomialType},
 };
+#[cfg(feature = "arrow")]
 use arrow::{
     array::Int64Array,
     datatypes::{Field, Schema},
@@ -123,6 +124,7 @@ fn we_can_form_an_aggregated_sumcheck_polynomial() {
     assert_eq!(eval, expected_eval);
 }
 
+#[cfg(feature = "arrow")]
 #[test]
 fn we_can_form_the_provable_query_result() {
     let result_indexes = Indexes::Sparse(vec![1, 2]);

--- a/crates/proof-of-sql/src/sql/proof/query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_result.rs
@@ -3,6 +3,7 @@ use crate::base::{
     proof::ProofError,
     scalar::Scalar,
 };
+#[cfg(feature = "arrow")]
 use arrow::{error::ArrowError, record_batch::RecordBatch};
 use thiserror::Error;
 
@@ -48,12 +49,13 @@ pub struct QueryData<S: Scalar> {
 }
 
 impl<S: Scalar> QueryData<S> {
-    #[cfg(test)]
+    #[cfg(all(test, feature = "arrow"))]
     pub fn into_record_batch(self) -> RecordBatch {
         self.try_into().unwrap()
     }
 }
 
+#[cfg(feature = "arrow")]
 impl<S: Scalar> TryFrom<QueryData<S>> for RecordBatch {
     type Error = ArrowError;
 


### PR DESCRIPTION
# Rationale for this change
Please review #101 and #84 first.
In order to deal with use cases that require really small binaries it is a great idea to put arrow behind a feature flag.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
See title
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
