### PR TITLE
chore: disable some unused default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ opentelemetry-jaeger = { version = "0.20.0" }
 postcard = { version = "1.0" }
 proof-of-sql = { path = "crates/proof-of-sql" } # We automatically update this line during release. So do not modify it!
 proof-of-sql-parser = { path = "crates/proof-of-sql-parser" } # We automatically update this line during release. So do not modify it!
-rand = { version = "0.8" }
-rand_core = { version = "0.6" }
+rand = { version = "0.8", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 rayon = { version = "1.5" }
 serde = { version = "1" }
 serde_json = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytemuck = {version = "1.16.3", features = ["derive"]}
 byte-slice-cast = { version = "1.2.1" }
 clap = { version = "4.5.4" }
 criterion = { version = "0.5.1" }
-chrono = { version = "0.4.38" }
+chrono = { version = "0.4.38", default-features = false }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
 derive_more = { version = "0.99" }
 flexbuffers = { version = "2.0.0" }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -30,7 +30,7 @@ bumpalo = { workspace = true, features = ["collections"] }
 bytemuck = { workspace = true }
 byte-slice-cast = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
-chrono = {workspace = true, features = ["serde"]}
+chrono = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -40,7 +40,7 @@ num-traits = { workspace = true }
 num-bigint = { workspace = true, default-features = false }
 postcard = { workspace = true, features = ["alloc"] }
 proof-of-sql-parser = { workspace = true }
-rand = { workspace = true, optional = true }
+rand = { workspace = true, default-features = false, optional = true }
 rayon = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
@@ -55,8 +55,8 @@ clap = { workspace = true, features = ["derive"] }
 criterion = { workspace = true, features = ["html_reports"] }
 opentelemetry = { workspace = true }
 opentelemetry-jaeger = { workspace = true }
-rand = { workspace = true }
-rand_core = { workspace = true }
+rand = { workspace = true, default-features = false }
+rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }


### PR DESCRIPTION
# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
To build this crate for `wasm32-unknown-unknown` to run on runtimes with a limited custom API available (e.g., Linera contracts), `wasm-bindgen` should not be a dependency. That's because `wasm-bindgen` generates bindings for the Javascript APIs available in browsers (and similar runtimes). For more bare-bones runtimes, these APIs aren't available.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Disabling the `default` features of `chrono`, `rand` and `rand-core`.

Unfortunately, this doesn't complete the work to support `wasm32-unknown-unknown` without JS, because a fix is also needed in `merlin` (https://github.com/zkcrypto/merlin/pull/8).

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Tested with `cargo test`.