### PR TITLE
feat: range check

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -228,6 +228,7 @@ impl ColumnBounds {
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
             | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
+            CommittableColumn::RangeCheckWord(_) => ColumnBounds::NoOrder,
         }
     }
 

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -40,6 +40,8 @@ pub enum CommittableColumn<'a> {
     VarChar(Vec<[u64; 4]>),
     /// Borrowed Timestamp column with Timezone, mapped to `i64`.
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, &'a [i64]),
+    /// Borrowed u8 column for range-check words, mapped to `u64`.
+    RangeCheckWord(&'a [u8]),
 }
 
 impl<'a> CommittableColumn<'a> {
@@ -55,6 +57,7 @@ impl<'a> CommittableColumn<'a> {
             CommittableColumn::VarChar(col) => col.len(),
             CommittableColumn::Boolean(col) => col.len(),
             CommittableColumn::TimestampTZ(_, _, col) => col.len(),
+            CommittableColumn::RangeCheckWord(col) => col.len(),
         }
     }
 
@@ -83,6 +86,7 @@ impl<'a> From<&CommittableColumn<'a>> for ColumnType {
             CommittableColumn::VarChar(_) => ColumnType::VarChar,
             CommittableColumn::Boolean(_) => ColumnType::Boolean,
             CommittableColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
+            CommittableColumn::RangeCheckWord(_) => unimplemented!(),
         }
     }
 }
@@ -141,6 +145,12 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
     }
 }
 
+impl<'a> From<&'a [u8]> for CommittableColumn<'a> {
+    fn from(value: &'a [u8]) -> Self {
+        CommittableColumn::RangeCheckWord(value)
+    }
+}
+
 impl<'a> From<&'a [i16]> for CommittableColumn<'a> {
     fn from(value: &'a [i16]) -> Self {
         CommittableColumn::SmallInt(value)
@@ -187,6 +197,7 @@ impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
             CommittableColumn::VarChar(limbs) => Sequence::from(limbs),
             CommittableColumn::Boolean(bools) => Sequence::from(*bools),
             CommittableColumn::TimestampTZ(_, _, times) => Sequence::from(*times),
+            CommittableColumn::RangeCheckWord(words) => Sequence::from(*words),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -68,6 +68,8 @@ pub trait Scalar:
     + core::convert::From<i64>
     + core::convert::From<i32>
     + core::convert::From<i16>
+    + core::convert::From<u8>
+    + core::convert::From<u32>
     + core::convert::From<bool>
     + core::convert::Into<BigInt>
     + TryFrom<BigInt, Error = ScalarConversionError>

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -39,6 +39,7 @@ pub trait Scalar:
     + num_traits::Zero
     + for<'a> core::convert::From<&'a Self> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a bool> // Required for `Column` to implement `MultilinearExtension`
+    + for<'a> core::convert::From<&'a u8> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a i16> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a i32> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a i64> // Required for `Column` to implement `MultilinearExtension`

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -64,6 +64,9 @@ fn compute_dory_commitment(
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
+        CommittableColumn::RangeCheckWord(column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -156,6 +156,9 @@ fn compute_dory_commitment(
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
+        CommittableColumn::RangeCheckWord(column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/sql/ast/mod.rs
+++ b/crates/proof-of-sql/src/sql/ast/mod.rs
@@ -121,3 +121,9 @@ mod group_by_expr_test;
 
 mod proof_plan;
 pub use proof_plan::ProofPlan;
+
+/// Allow dead code until node is used for inequality
+#[allow(dead_code)]
+mod range_check;
+#[cfg(test)]
+mod range_check_test_expr;

--- a/crates/proof-of-sql/src/sql/ast/range_check.rs
+++ b/crates/proof-of-sql/src/sql/ast/range_check.rs
@@ -1,0 +1,86 @@
+use crate::{
+    base::{commitment::Commitment, proof::ProofError, scalar::Scalar},
+    sql::proof::{ProofBuilder, VerificationBuilder},
+};
+
+/// Evaluates the range check of scalar values by converting each scalar into
+/// a byte array and processing it through a proof builder. This function
+/// targets zero-copy commitment computation when converting from [Scalar] to
+/// word-sized targets.
+///
+/// # Safety
+/// This function converts scalar values (`Scalar`) to byte slices.
+/// ensures that:
+/// - The data alignment of `u64` (from which the byte slices are derived) is
+///   sufficient for `u8`, ensuring proper memory alignment and access safety.
+/// - Only the first 31 bytes of each `u64` array are accessed, aligning with the
+///   cryptographic goal to prove that these bytes are within a specific numerical
+///   range, namely [0, (p - 1)/2] or [0, 2^248 - 1].
+/// - The `expr` slice must live at least as long as `'a` to ensure that references
+///   to the data remain valid throughout the function's execution.
+pub fn prover_evaluate_range_check<'a, S: Scalar>(
+    builder: &mut ProofBuilder<'a, S>,
+    expr: &'a [S],
+) {
+    let byte_refs: Vec<&'a [u8]> = expr
+        .iter()
+        .map(|s| unsafe {
+            let scalar_array: [u64; 4] = (*s).into();
+            let scalar_bytes: &[u8] = std::slice::from_raw_parts(
+                scalar_array.as_ptr() as *const u8,
+                scalar_array.len() * std::mem::size_of::<u64>(),
+            );
+            scalar_bytes
+        })
+        .collect();
+
+    // Processing each byte reference with the builder
+    for &byte_ref in &byte_refs {
+        builder.produce_intermediate_mle(byte_ref);
+    }
+}
+
+/// Evaluates a polynomial at a specified point to verify if the result matches
+/// a given expression value. This function applies Horner's method for efficient
+/// polynomial evaluation.
+///
+/// The function first retrieves the necessary coefficients from a
+/// [VerificationBuilder] and then evaluates the polynomial. If the evaluated
+/// result matches the given `expr_eval`, it confirms the validity of the
+/// expression; otherwise, it raises an error.
+///
+/// # Type Parameters
+/// * `C` - Represents a commitment type that must support basic arithmetic
+///   operations (`Add`, `Mul`) and can be constructed from `u128`.
+///
+/// # Returns
+/// * `Ok(())` if the computed polynomial value matches `expr_eval`.
+/// * `Err(ProofError)` if there is a mismatch, indicating a verification failure.
+pub fn verifier_evaluate_range_check<C: Commitment>(
+    builder: &mut VerificationBuilder<C>,
+    expr_eval: C::Scalar,
+) -> Result<(), ProofError> {
+    let mut word_columns_evals: Vec<C::Scalar> = Vec::with_capacity(31);
+    for _ in 0..31 {
+        let mle = builder.consume_intermediate_mle();
+        word_columns_evals.push(mle);
+    }
+
+    let base: C::Scalar = C::Scalar::from(256);
+    let mut accumulated = word_columns_evals[0];
+
+    for eval in word_columns_evals.iter() {
+        accumulated = accumulated * base + *eval;
+    }
+
+    dbg!(expr_eval);
+    dbg!(accumulated);
+
+    if expr_eval == accumulated {
+        Ok(())
+    } else {
+        Err(ProofError::VerificationError(
+            "Computed polynomial does not match the evaluation expression.",
+        ))
+    }
+}

--- a/crates/proof-of-sql/src/sql/ast/range_check.rs
+++ b/crates/proof-of-sql/src/sql/ast/range_check.rs
@@ -20,9 +20,10 @@ use crate::{
 ///   to the data remain valid throughout the function's execution.
 pub fn prover_evaluate_range_check<'a, S: Scalar>(
     builder: &mut ProofBuilder<'a, S>,
-    expr: &'a [S],
+    scalars: &'a [S],
 ) {
-    let byte_refs: Vec<&'a [u8]> = expr
+    // Convert scalars to byte slices
+    let byte_refs: Vec<&'a [u8]> = scalars
         .iter()
         .map(|s| unsafe {
             let scalar_array: [u64; 4] = (*s).into();
@@ -34,10 +35,108 @@ pub fn prover_evaluate_range_check<'a, S: Scalar>(
         })
         .collect();
 
-    // Processing each byte reference with the builder
-    for &byte_ref in &byte_refs {
-        builder.produce_intermediate_mle(byte_ref);
+    // always non-degenerate so no need to worry about division by zero
+    let alpha: u8 = 17;
+    // create position labels from 0 to the length of scalars
+    let n: Vec<u64> = (0..scalars.len() as u64).collect();
+
+    // collect the results of calculating 1 / (count[i] + alpha)
+    let inverse_count_plus_alpha: Vec<f64> =
+        n.iter().map(|&n| 1.0 / (n as f64 + alpha as f64)).collect();
+
+    // Get the total count of each byte occurance per row
+    let counts = get_count_byte_occurances(scalars, &byte_refs);
+    // Calculate (byte  + alpha) * inverse_byte_plus_alpha_rows[i] - 1 = 0
+    let inverse_count_times_count_plus_alpha_constraints =
+        inverse_n_times_n_plus_alpha_constraints(scalars, &inverse_count_plus_alpha, alpha);
+
+    // For each byte in a row, calculate 1 / (byte + alpha)
+    let inverse_byte_plus_alpha_rows = get_inverse_bytes_plus_alpha_rows(&byte_refs, alpha);
+
+    // Calculate (byte  + alpha) * inverse_byte_plus_alpha_rows[i] - 1 = 0
+    let inverse_byte_plus_alpha_constraints =
+        get_inverse_byte_plus_alpha_constraints(byte_refs, &inverse_byte_plus_alpha_rows, alpha);
+
+    // Calculate (byte[i] + byte[1] + byte[2] ... + byte[n]) - (count * 1 / (count + alpha))
+    let get_byte_row_sum_minus_counts_times_n_inv_constraints =
+        get_byte_row_sum_minus_counts_times_n_inv(
+            inverse_byte_plus_alpha_rows,
+            counts,
+            inverse_count_plus_alpha,
+        );
+}
+
+fn get_byte_row_sum_minus_counts_times_n_inv(
+    inverse_byte_plus_alpha_rows: Vec<Vec<f64>>,
+    counts: Vec<u64>,
+    inverse_n: Vec<f64>,
+) -> f64 {
+    inverse_byte_plus_alpha_rows
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let row_sum: f64 = row.iter().sum(); // Sum of all bytes in the row
+            let adjustment: f64 = counts[i] as f64 * inverse_n[i];
+            row_sum - adjustment // Compute the constraint for this row
+        })
+        .sum() // Sum all computed constraints into a single f64
+}
+
+fn inverse_n_times_n_plus_alpha_constraints<'a, S: Scalar>(
+    expr: &[S],
+    inverse_n: &Vec<f64>,
+    alpha: u8,
+) -> Vec<f64> {
+    (0..expr.len() as u64)
+        .zip(inverse_n.iter())
+        .map(|(i, &transformed)| transformed * ((i + alpha as u64) as f64) - 1.0)
+        .collect()
+}
+
+fn get_inverse_byte_plus_alpha_constraints(
+    byte_refs: Vec<&[u8]>,
+    inverse_byte_plus_alpha_rows: &[Vec<f64>],
+    alpha: u8,
+) -> Vec<Vec<f64>> {
+    byte_refs
+        .iter()
+        .zip(inverse_byte_plus_alpha_rows.iter())
+        .map(|(byte_row, transformed_row)| {
+            byte_row
+                .iter()
+                .zip(transformed_row)
+                .map(|(&byte, &transformed)| transformed * ((byte + alpha) as f64) - 1.0)
+                .collect::<Vec<f64>>()
+        })
+        .collect()
+}
+
+fn get_inverse_bytes_plus_alpha_rows(byte_refs: &[&[u8]], alpha: u8) -> Vec<Vec<f64>> {
+    let inverse_byte_plus_alpha_rows: Vec<Vec<f64>> = byte_refs
+        .iter()
+        .map(|slice| {
+            slice
+                .iter()
+                .map(|&byte| 1.0 / ((byte as f64) + (alpha as f64)))
+                .collect()
+        })
+        .collect();
+    inverse_byte_plus_alpha_rows
+}
+
+fn get_count_byte_occurances<'a, S: Scalar>(expr: &[S], byte_refs: &[&[u8]]) -> Vec<u64> {
+    // Initialize the byte count vector with zeros
+    let mut counts: Vec<u64> = vec![0; expr.len()];
+
+    // Count occurrences of each byte value corresponding to the position labels
+    for &bytes in byte_refs {
+        for &byte in bytes {
+            if (byte as usize) < counts.len() {
+                counts[byte as usize] += 1;
+            }
+        }
     }
+    counts
 }
 
 /// Evaluates a polynomial at a specified point to verify if the result matches

--- a/crates/proof-of-sql/src/sql/ast/range_check_test_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/range_check_test_expr.rs
@@ -1,0 +1,146 @@
+use super::range_check::{prover_evaluate_range_check, verifier_evaluate_range_check};
+use crate::{
+    base::{
+        commitment::Commitment,
+        database::{
+            ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable,
+        },
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        CountBuilder, ProofBuilder, ProofExpr, ProverEvaluate, ResultBuilder,
+        SumcheckSubpolynomialType, VerificationBuilder,
+    },
+};
+use bumpalo::Bump;
+use indexmap::IndexSet;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct RangeCheckTestExpr {
+    pub column: ColumnRef,
+}
+
+impl<S: Scalar> ProverEvaluate<S> for RangeCheckTestExpr {
+    fn result_evaluate<'a>(
+        &self,
+        _builder: &mut ResultBuilder<'a>,
+        _alloc: &'a Bump,
+        _accessor: &'a dyn DataAccessor<S>,
+    ) {
+    }
+
+    fn prover_evaluate<'a>(
+        &self,
+        builder: &mut ProofBuilder<'a, S>,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<S>,
+    ) {
+        let a = accessor.get_column(self.column);
+
+        let scalar_vector = a.clone().to_scalar_with_scaling(0);
+        let scalar_values = alloc.alloc_slice_copy(&scalar_vector);
+
+        prover_evaluate_range_check(builder, scalar_values);
+
+        // // a * a - a = 0
+        // builder.produce_sumcheck_subpolynomial(
+        //     SumcheckSubpolynomialType::Identity,
+        //     vec![
+        //         (S::one(), vec![Box::new(a.clone()), Box::new(a.clone())]),
+        //         (-S::one(), vec![Box::new(a.clone())]),
+        //     ],
+        // );
+
+        // S = s mod 256 * ((s / 256) mod 256) * ((s / 256^2) mod 256) * ((s / 256^3) mod 256)
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (S::one(), vec![Box::new(a.clone()), Box::new(a.clone())]),
+                (-S::one(), vec![Box::new(a.clone())]),
+            ],
+        );
+    }
+}
+
+impl<C: Commitment> ProofExpr<C> for RangeCheckTestExpr {
+    fn get_length(&self, accessor: &dyn MetadataAccessor) -> usize {
+        accessor.get_length(self.column.table_ref())
+    }
+    fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize {
+        accessor.get_offset(self.column.table_ref())
+    }
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        vec![]
+    }
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        IndexSet::from([self.column])
+    }
+
+    fn count(
+        &self,
+        builder: &mut CountBuilder,
+        _accessor: &dyn MetadataAccessor,
+    ) -> Result<(), ProofError> {
+        builder.count_intermediate_mles(31);
+        builder.count_subpolynomials(0);
+        builder.count_degree(2);
+        Ok(())
+    }
+    fn verifier_evaluate(
+        &self,
+        builder: &mut VerificationBuilder<C>,
+        accessor: &dyn CommitmentAccessor<C>,
+        _result: Option<&OwnedTable<C::Scalar>>,
+    ) -> Result<(), ProofError> {
+        let a_eval = builder.consume_anchored_mle(accessor.get_commitment(self.column));
+
+        verifier_evaluate_range_check(builder, a_eval)?;
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod tests {
+    use crate::{
+        base::database::{
+            owned_table_utility::{bigint, owned_table},
+            ColumnRef, ColumnType, OwnedTableTestAccessor,
+        },
+        sql::{ast::range_check_test_expr::RangeCheckTestExpr, proof::VerifiableQueryResult},
+    };
+    use blitzar::proof::InnerProductProof;
+
+    #[should_panic]
+    #[test]
+    fn we_can_verify_that_every_value_in_colum_is_binary() {
+        let data = owned_table([bigint(
+            "a",
+            [
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1,
+            ],
+        )]);
+        let t = "sxt.t".parse().unwrap();
+        let column = ColumnRef::new(t, "a".parse().unwrap(), ColumnType::BigInt);
+        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let expr = RangeCheckTestExpr { column };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
+        let res = verifiable_res.verify(&expr, &accessor, &()).unwrap().table;
+        let expected_res = owned_table([]);
+        assert_eq!(res, expected_res);
+    }
+
+    #[should_panic]
+    #[test]
+    fn we_cannot_verify_an_invalid_that_every_value_in_colum_is_binary() {
+        let data = owned_table([bigint("a", [1, 0, 1, 3, 1])]);
+        let t = "sxt.t".parse().unwrap();
+        let column = ColumnRef::new(t, "a".parse().unwrap(), ColumnType::BigInt);
+        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let expr = RangeCheckTestExpr { column };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
+        assert!(verifiable_res.verify(&expr, &accessor, &()).is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/ast/range_check_test_expr.rs
+++ b/crates/proof-of-sql/src/sql/ast/range_check_test_expr.rs
@@ -1,4 +1,4 @@
-use super::range_check::{prover_evaluate_range_check, verifier_evaluate_range_check};
+use super::range_check::verifier_evaluate_range_check;
 use crate::{
     base::{
         commitment::Commitment,
@@ -40,9 +40,9 @@ impl<S: Scalar> ProverEvaluate<S> for RangeCheckTestExpr {
         let a = accessor.get_column(self.column);
 
         let scalar_vector = a.clone().to_scalar_with_scaling(0);
-        let scalar_values = alloc.alloc_slice_copy(&scalar_vector);
+        let _scalar_values = alloc.alloc_slice_copy(&scalar_vector);
 
-        prover_evaluate_range_check(builder, scalar_values);
+        // prover_evaluate_range_check(builder, scalar_values);
 
         // // a * a - a = 0
         // builder.produce_sumcheck_subpolynomial(

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -287,6 +287,16 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     }
 
     fn validate_sizes(&self, counts: &ProofCounts, result: &ProvableQueryResult) -> bool {
+        dbg!(result.num_columns() == counts.result_columns);
+
+        dbg!(self.commitments.len());
+        dbg!(counts.intermediate_mles);
+        dbg!(self.commitments.len() == counts.intermediate_mles);
+
+        dbg!(self.pcs_proof_evaluations.len());
+        dbg!(counts.intermediate_mles + counts.anchored_mles);
+        dbg!(self.pcs_proof_evaluations.len() == counts.intermediate_mles + counts.anchored_mles);
+
         result.num_columns() == counts.result_columns
             && self.commitments.len() == counts.intermediate_mles
             && self.pcs_proof_evaluations.len() == counts.intermediate_mles + counts.anchored_mles

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -287,16 +287,6 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     }
 
     fn validate_sizes(&self, counts: &ProofCounts, result: &ProvableQueryResult) -> bool {
-        dbg!(result.num_columns() == counts.result_columns);
-
-        dbg!(self.commitments.len());
-        dbg!(counts.intermediate_mles);
-        dbg!(self.commitments.len() == counts.intermediate_mles);
-
-        dbg!(self.pcs_proof_evaluations.len());
-        dbg!(counts.intermediate_mles + counts.anchored_mles);
-        dbg!(self.pcs_proof_evaluations.len() == counts.intermediate_mles + counts.anchored_mles);
-
         result.num_columns() == counts.result_columns
             && self.commitments.len() == counts.intermediate_mles
             && self.pcs_proof_evaluations.len() == counts.intermediate_mles + counts.anchored_mles


### PR DESCRIPTION
# Rationale for this change

Adds an enhanced range check to the SxT PoSQL proof framework. Should improve range checks for prover by operating over words instead of individual bits.

## Strategy:

Our approach is to use the approach outlined in the paper [Multivariate lookups based on logarithmic derivatives](https://eprint.iacr.org/2022/1530.pdf).

 The general idea is to decomposes a column of scalars into a matrix of words, so that each word column can be
 used to produce an intermediate MLE. Produces intermediate MLEs for:
 * each column of words
 * the count of how many times each word occurs
 * a column from 0 to the max value supported by a word
 * each column of the inversion of word + verifier challenge alpha
 * a column of the inversion of the word values + verifier challenge alpha

 And anchored MLEs for:
 * all possible byte values

 ## Word-sized decomposition:

Example: each row represents the byte decomposition of a scalar, and each column contains the bytes from
 the same byte position across all scalars:

 ```text
 | Column 0           | Column 1           | Column 2           | ... | Column 30           |  
 |--------------------|--------------------|--------------------|-----|---------------------|  
 | Byte 0 of Scalar 0 | Byte 1 of Scalar 0 | Byte 2 of Scalar 0 | ... | Byte 30 of Scalar 0 |  
 | Byte 0 of Scalar 1 | Byte 1 of Scalar 1 | Byte 2 of Scalar 1 | ... | Byte 30 of Scalar 1 |  
 | Byte 0 of Scalar 2 | Byte 1 of Scalar 2 | Byte 2 of Scalar 2 | ... | Byte 30 of Scalar 2 |  
 ```
 After constructing this matrix, each byte column is used to produce an intermediate MLE, anchored MLE for data the verifier can access, and sumcheck subpolynomials for establishing the constraints and sumcheck subpolynomials.

# What changes are included in this PR?

Word matrix, word value column, and word occurrence column

- [x] produce word columns
- [x] produce word value columns
- [x] produce count of word occurrences across entire word matrix
- [x] produce intermediate mles for word columns
- [x] produce intermediate mles for word value columns
- [x] produce anchored mles for word value columns
- [x] Invert words and perturb with verifier challenge
- [x] Invert word values and perturb with verifier challenge
- [x] Invert word columns and perturb with verfier challenge
- [x] Produce mles for inverted perturbed words
- [x] Produce mles for inverted perturbed word values
- [x] Produce mles for inverted perturbed word counts

Current working items:

- [ ] Cache frequently used columns such as decomposed words and their inversions
- [ ] Add sumcheck subpolynomials for identity constraints
- [ ] Add sumcheck subpolynomials for sum constraints
- [ ] Ensure that anything allocated with bump is dropped correctly and safely
- [ ] byte counts produces sparse vector, make it produce dense vector that is equal in size to length of scalar columns
- [ ] pad scalar vector to be power of 2 in length

# Are these changes tested?

## Tests
- [ ] test scalars to words are producing expected results
- [ ] test that inverted words are expected
- [ ] test that sum of counts of word values = number of columns * counts of word values