### PR TITLE
feat: add function converting evaluations to coefficients

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
@@ -3,10 +3,10 @@
  *
  * See third_party/license/arkworks.LICENSE
  */
-use crate::base::polynomial::interpolate::*;
-use crate::base::scalar::Curve25519Scalar;
+use super::interpolate::*;
+use crate::base::scalar::{Curve25519Scalar, Curve25519Scalar as S};
 use ark_std::UniformRand;
-use num_traits::Zero;
+use num_traits::{Inv, Zero};
 
 #[test]
 fn test_interpolate_uni_poly_for_random_polynomials() {
@@ -92,4 +92,71 @@ fn interpolate_uni_poly_gives_correct_value_for_known_evaluation() {
             evaluations[i]
         );
     }
+}
+
+#[test]
+fn we_can_interpolate_evaluations_to_reverse_coefficients_with_empty_input() {
+    assert_eq!(
+        interpolate_evaluations_to_reverse_coefficients(&[] as &[S]),
+        vec![]
+    );
+}
+
+#[test]
+fn we_can_interpolate_evaluations_to_reverse_coefficients_with_degree_0() {
+    assert_eq!(
+        interpolate_evaluations_to_reverse_coefficients(&[S::from(2)]),
+        vec![S::from(2)]
+    );
+}
+
+#[test]
+fn we_can_interpolate_evaluations_to_reverse_coefficients_with_degree_1() {
+    assert_eq!(
+        interpolate_evaluations_to_reverse_coefficients(&[S::from(2), S::from(3)]),
+        vec![S::from(1), S::from(2)]
+    );
+}
+
+#[test]
+fn we_can_interpolate_evaluations_to_reverse_coefficients_with_degree_2() {
+    assert_eq!(
+        interpolate_evaluations_to_reverse_coefficients(&[S::from(2), S::from(3), S::from(5)]),
+        vec![
+            S::from(1) * S::from(2).inv().unwrap(),
+            S::from(1) * S::from(2).inv().unwrap(),
+            S::from(2)
+        ]
+    );
+}
+
+#[test]
+fn we_can_interpolate_evaluations_to_reverse_coefficients_with_degree_3() {
+    assert_eq!(
+        interpolate_evaluations_to_reverse_coefficients(&[
+            S::from(2),
+            S::from(3),
+            S::from(5),
+            S::from(7)
+        ]),
+        vec![
+            S::from(-1) * S::from(6).inv().unwrap(),
+            S::from(1),
+            S::from(1) * S::from(6).inv().unwrap(),
+            S::from(2)
+        ]
+    );
+}
+
+#[test]
+fn we_can_interpolate_evaluations_to_reverse_coefficients_with_degree_3_degenerate_evals() {
+    assert_eq!(
+        interpolate_evaluations_to_reverse_coefficients(&[
+            S::from(1),
+            S::from(3),
+            S::from(5),
+            S::from(7)
+        ]),
+        vec![S::from(0), S::from(0), S::from(2), S::from(1)]
+    );
 }

--- a/crates/proof-of-sql/src/base/polynomial/mod.rs
+++ b/crates/proof-of-sql/src/base/polynomial/mod.rs
@@ -6,7 +6,8 @@ mod composite_polynomial_test;
 mod interpolate;
 #[cfg(test)]
 mod interpolate_test;
-pub use interpolate::interpolate_uni_poly;
+#[allow(unused_imports)]
+pub use interpolate::{interpolate_evaluations_to_reverse_coefficients, interpolate_uni_poly};
 
 mod evaluation_vector;
 pub use evaluation_vector::compute_evaluation_vector;


### PR DESCRIPTION
# Rationale for this change

In order for the sumcheck verifier to be able to be verify proofs more efficiently (and for the sake of the solidity port, with less code), the proof should consist of polynomial coefficients rather than evaluations. This PR adds the code to make the conversion. A later PR will do the switch.

# What changes are included in this PR?

* A `interpolate_evaluations_to_reverse_coefficients` method is added.
* Tests for this method are added.

# Are these changes tested?

Yes