### PR TITLE
feat: add `ProofExprResult`

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -161,6 +161,14 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
 
+    /// Returns the column as a slice of scalars if it is a scalar column. Otherwise, returns None.
+    pub(crate) fn as_scalars(&self) -> Option<&'a [S]> {
+        match self {
+            Self::Scalar(col) => Some(col),
+            _ => None,
+        }
+    }
+
     /// Returns element at index as scalar
     ///
     /// Note that if index is out of bounds, this function will return None

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -1,4 +1,4 @@
-use super::ProofExpr;
+use super::{ProofExpr, ProofExprResult};
 use crate::{
     base::{
         commitment::Commitment,
@@ -50,19 +50,21 @@ impl<C: Commitment> ProofExpr<C> for LiteralExpr<C::Scalar> {
         table_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
-        Column::from_literal_with_length(&self.value, table_length, alloc)
+    ) -> ProofExprResult<'a, C::Scalar> {
+        ProofExprResult::new(
+            Column::from_literal_with_length(&self.value, table_length, alloc),
+            vec![],
+        )
     }
 
     #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
-        alloc: &'a Bump,
+        _builder: &mut ProofBuilder<'a, C::Scalar>,
+        _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
-        let table_length = builder.table_length();
-        Column::from_literal_with_length(&self.value, table_length, alloc)
+        _result: &ProofExprResult<'a, C::Scalar>,
+    ) {
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -4,6 +4,9 @@ pub(crate) use proof_expr::ProofExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod proof_expr_test;
 
+mod proof_expr_result;
+pub(crate) use proof_expr_result::ProofExprResult;
+
 mod aliased_dyn_proof_expr;
 pub(crate) use aliased_dyn_proof_expr::AliasedDynProofExpr;
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,3 +1,4 @@
+use super::ProofExprResult;
 use crate::{
     base::{
         commitment::Commitment,
@@ -26,7 +27,7 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
         table_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar>;
+    ) -> ProofExprResult<'a, C::Scalar>;
 
     /// Evaluate the expression, add components needed to prove it, and return thet resulting column
     /// of values
@@ -34,8 +35,8 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
         &self,
         builder: &mut ProofBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar>;
+        result: &ProofExprResult<'a, C::Scalar>,
+    );
 
     /// Compute the evaluation of a multilinear extension from this expression
     /// at the random sumcheck point and adds components needed to verify the expression to

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_result.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_result.rs
@@ -3,7 +3,9 @@ use crate::base::{commitment::Commitment, database::Column};
 /// Result of evaluation of `ProofExpr`
 #[derive(Clone, Debug)]
 pub struct ProofExprResult<'a, C: Commitment> {
+    /// Evaluation result of the expression itself
     pub result: Column<'a, C::Scalar>,
+    /// `ProofExprResult` of its child expressions
     pub children: Vec<Box<ProofExprResult<'a, C>>>,
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_result.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_result.rs
@@ -1,0 +1,15 @@
+use crate::base::{commitment::Commitment, database::Column};
+
+/// Result of evaluation of `ProofExpr`
+#[derive(Clone, Debug)]
+pub struct ProofExprResult<'a, C: Commitment> {
+    pub result: Column<'a, C::Scalar>,
+    pub children: Vec<Box<ProofExprResult<'a, C>>>,
+}
+
+impl<'a, C: Commitment> ProofExprResult<'a, C> {
+    /// Create a new `ProofExprResult`
+    pub fn new(result: Column<'a, C::Scalar>, children: Vec<Box<ProofExprResult<'a, C>>>) -> Self {
+        Self { result, children }
+    }
+}


### PR DESCRIPTION
# Rationale for this change
This is the second PR in the series of PRs that lead to `UnionExec`. Here we add `ProofExprResult` as a tree of intermediate results so that we can refrain from re-evaluating `ProofExpr`s when proving them.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- Add `ProofExprResult`
- Refactor `ProofExpr` to use it
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Will be.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
