### PR TITLE
perf: parallelize v2 construction within `eval_vmv_re_prove`

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use ark_ec::VariableBaseMSM;
 use merlin::Transcript;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 /// This is the prover side of the Eval-VMV-RE algorithm in section 5 of https://eprint.iacr.org/2020/1274.pdf.
 ///
@@ -32,10 +33,11 @@ pub fn eval_vmv_re_prove(
     messages.prover_send_GT_message(transcript, C);
     messages.prover_send_GT_message(transcript, D_2);
     messages.prover_send_G1_message(transcript, E_1);
+    let Gamma_2_fin = setup.Gamma_2_fin;
     let v2 = state
         .v_vec
-        .iter()
-        .map(|c| (setup.Gamma_2_fin * c).into())
+        .par_iter()
+        .map(|c| (Gamma_2_fin * c).into())
         .collect::<Vec<_>>();
     ExtendedProverState::from_vmv_prover_state(state, v2)
 }


### PR DESCRIPTION
# Rationale for this change

This reduces the `eval_vmv_re_prove` component of the proof time from one of the larger factors to a negligible amount.

# What changes are included in this PR?

The computation of v2 within `eval_vmv_re_prove` now uses a rayon iterator.

# Are these changes tested?

Yes
