### PR TITLE
perf: improve `offset_to_bytes` performance

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/offset_to_bytes.rs
@@ -1,59 +1,55 @@
-use zerocopy::AsBytes;
-
-pub trait OffsetToBytes {
-    fn offset_to_bytes(&self) -> Vec<u8>;
+pub trait OffsetToBytes<const LEN: usize> {
+    fn offset_to_bytes(&self) -> [u8; LEN];
 }
 
-impl OffsetToBytes for u8 {
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        vec![*self]
+impl OffsetToBytes<1> for u8 {
+    fn offset_to_bytes(&self) -> [u8; 1] {
+        [*self]
     }
 }
 
-impl OffsetToBytes for i16 {
-    fn offset_to_bytes(&self) -> Vec<u8> {
+impl OffsetToBytes<2> for i16 {
+    fn offset_to_bytes(&self) -> [u8; 2] {
         let shifted = self.wrapping_sub(i16::MIN);
-        shifted.to_le_bytes().to_vec()
+        shifted.to_le_bytes()
     }
 }
 
-impl OffsetToBytes for i32 {
-    fn offset_to_bytes(&self) -> Vec<u8> {
+impl OffsetToBytes<4> for i32 {
+    fn offset_to_bytes(&self) -> [u8; 4] {
         let shifted = self.wrapping_sub(i32::MIN);
-        shifted.to_le_bytes().to_vec()
+        shifted.to_le_bytes()
     }
 }
 
-impl OffsetToBytes for i64 {
-    fn offset_to_bytes(&self) -> Vec<u8> {
+impl OffsetToBytes<8> for i64 {
+    fn offset_to_bytes(&self) -> [u8; 8] {
         let shifted = self.wrapping_sub(i64::MIN);
-        shifted.to_le_bytes().to_vec()
+        shifted.to_le_bytes()
     }
 }
 
-impl OffsetToBytes for i128 {
-    fn offset_to_bytes(&self) -> Vec<u8> {
+impl OffsetToBytes<16> for i128 {
+    fn offset_to_bytes(&self) -> [u8; 16] {
         let shifted = self.wrapping_sub(i128::MIN);
-        shifted.to_le_bytes().to_vec()
+        shifted.to_le_bytes()
     }
 }
 
-impl OffsetToBytes for bool {
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        vec![*self as u8]
+impl OffsetToBytes<1> for bool {
+    fn offset_to_bytes(&self) -> [u8; 1] {
+        [*self as u8]
     }
 }
 
-impl OffsetToBytes for u64 {
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        let bytes = self.to_le_bytes();
-        bytes.to_vec()
+impl OffsetToBytes<8> for u64 {
+    fn offset_to_bytes(&self) -> [u8; 8] {
+        self.to_le_bytes()
     }
 }
 
-impl OffsetToBytes for [u64; 4] {
-    fn offset_to_bytes(&self) -> Vec<u8> {
-        let slice = self.as_bytes();
-        slice.to_vec()
+impl OffsetToBytes<32> for [u64; 4] {
+    fn offset_to_bytes(&self) -> [u8; 32] {
+        bytemuck::cast(*self)
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -148,7 +148,7 @@ pub fn modify_commits(
 /// * `current_byte_size` - The current byte size of the column.
 /// * `bit_table_sum_in_bytes` - The full bit table size in bytes.
 /// * `num_columns` - The number of columns in a matrix commitment.
-fn pack_bit<T: OffsetToBytes>(
+fn pack_bit<const LEN: usize, T: OffsetToBytes<LEN>>(
     column: &[T],
     packed_scalars: &mut [u8],
     current_bit_table_sum: usize,
@@ -179,7 +179,7 @@ fn pack_bit<T: OffsetToBytes>(
 /// * `offset` - The offset to the data.
 /// * `bit_table_sum_in_bytes` - The full bit table size in bytes.
 /// * `num_columns` - The number of columns in a matrix commitment.
-fn pack_offset_bit<T: OffsetToBytes>(
+fn pack_offset_bit<const LEN: usize, T: OffsetToBytes<LEN>>(
     column: &[T],
     packed_scalars: &mut [u8],
     current_bit_table_sum: usize,

--- a/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
@@ -1,7 +1,7 @@
 use crate::proof_primitive::dory::offset_to_bytes::OffsetToBytes;
 
 #[tracing::instrument(name = "transpose_for_fixed_msm (gpu)", level = "debug", skip_all)]
-pub fn transpose_for_fixed_msm<T: OffsetToBytes>(
+pub fn transpose_for_fixed_msm<const LEN: usize, T: OffsetToBytes<LEN>>(
     column: &[T],
     offset: usize,
     rows: usize,


### PR DESCRIPTION
# Rationale for this change

This PR reduces the cost of packing bytes in order to set up a packed MSM.

# What changes are included in this PR?

`offset_to_bytes` now returns an array rather than allocating a `Vec`.

# Are these changes tested?

Yes
