### PR TITLE
feat!: allow `ProofPlan::result_evaluate` and `ProofPlan::prover_evaluate` to return columns

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -2,7 +2,8 @@ use super::{CountBuilder, ProofBuilder, ResultBuilder, VerificationBuilder};
 use crate::base::{
     commitment::Commitment,
     database::{
-        ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable,
+        Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
+        OwnedTable,
     },
     proof::ProofError,
     scalar::Scalar,
@@ -53,7 +54,7 @@ pub trait ProverEvaluate<S: Scalar> {
         builder: &mut ResultBuilder<'a>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    );
+    ) -> Vec<Column<'a, S>>;
 
     /// Evaluate the query and modify `ProofBuilder` to store an intermediate representation
     /// of the query result and track all the components needed to form the query's proof.
@@ -66,7 +67,7 @@ pub trait ProverEvaluate<S: Scalar> {
         builder: &mut ProofBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    );
+    ) -> Vec<Column<'a, S>>;
 }
 
 /// Marker used as a trait bound for generic [`ProofPlan`] types to indicate the honesty of their implementation.

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -7,8 +7,8 @@ use crate::{
         commitment::{Commitment, InnerProductProof},
         database::{
             owned_table_utility::{bigint, owned_table},
-            ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor,
-            OwnedTable, TestAccessor, UnimplementedTestAccessor,
+            Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
+            MetadataAccessor, OwnedTable, TestAccessor, UnimplementedTestAccessor,
         },
         proof::ProofError,
         scalar::Scalar,
@@ -28,16 +28,22 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     fn result_evaluate<'a>(
         &self,
         _builder: &mut ResultBuilder<'a>,
-        _alloc: &'a Bump,
+        alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) {
+    ) -> Vec<Column<'a, S>> {
+        let zeros = vec![0; self.length];
+        let res: &[_] = alloc.alloc_slice_copy(&zeros);
+        vec![Column::BigInt(res); self.columns]
     }
     fn prover_evaluate<'a>(
         &self,
         _builder: &mut ProofBuilder<'a, S>,
-        _alloc: &'a Bump,
+        alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) {
+    ) -> Vec<Column<'a, S>> {
+        let zeros = vec![0; self.length];
+        let res: &[_] = alloc.alloc_slice_copy(&zeros);
+        vec![Column::BigInt(res); self.columns]
     }
 }
 impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {

--- a/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec.rs
@@ -152,7 +152,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DenseFilterExec<C> {
         builder: &mut ResultBuilder<'a>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) {
+    ) -> Vec<Column<'a, C::Scalar>> {
         // 1. selection
         let selection_column: Column<'a, C::Scalar> =
             self.where_clause
@@ -172,10 +172,11 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DenseFilterExec<C> {
         // 3. set indexes
         builder.set_result_indexes(Indexes::Dense(0..(result_len as u64)));
         // 4. set filtered_columns
-        for col in filtered_columns {
-            builder.produce_result_column(col);
+        for col in &filtered_columns {
+            builder.produce_result_column(col.clone());
         }
         builder.request_post_result_challenges(2);
+        filtered_columns
     }
 
     #[tracing::instrument(name = "DenseFilterExec::prover_evaluate", level = "debug", skip_all)]
@@ -185,7 +186,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DenseFilterExec<C> {
         builder: &mut ProofBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) {
+    ) -> Vec<Column<'a, C::Scalar>> {
         // 1. selection
         let selection_column: Column<'a, C::Scalar> =
             self.where_clause.prover_evaluate(builder, alloc, accessor);
@@ -215,6 +216,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DenseFilterExec<C> {
             &filtered_columns,
             result_len,
         );
+        filtered_columns
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec_test_dishonest_prover.rs
@@ -40,7 +40,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestDenseFilterExec<RistrettoPoin
         builder: &mut ResultBuilder<'a>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<Curve25519Scalar>,
-    ) {
+    ) -> Vec<Column<'a, Curve25519Scalar>> {
         // 1. selection
         let selection_column: Column<'a, Curve25519Scalar> =
             self.where_clause
@@ -60,10 +60,11 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestDenseFilterExec<RistrettoPoin
         // 3. set indexes
         builder.set_result_indexes(Indexes::Dense(0..(result_len as u64)));
         // 4. set filtered_columns
-        for col in filtered_columns {
-            builder.produce_result_column(col);
+        for col in &filtered_columns {
+            builder.produce_result_column(col.clone());
         }
         builder.request_post_result_challenges(2);
+        filtered_columns
     }
 
     #[tracing::instrument(
@@ -77,7 +78,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestDenseFilterExec<RistrettoPoin
         builder: &mut ProofBuilder<'a, Curve25519Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<Curve25519Scalar>,
-    ) {
+    ) -> Vec<Column<'a, Curve25519Scalar>> {
         // 1. selection
         let selection_column: Column<'a, Curve25519Scalar> =
             self.where_clause.prover_evaluate(builder, alloc, accessor);
@@ -107,6 +108,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestDenseFilterExec<RistrettoPoin
             &filtered_columns,
             result_len,
         );
+        filtered_columns
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,6 +1,6 @@
 use super::{DenseFilterExec, FilterExec, GroupByExec, ProjectionExec};
 use crate::{
-    base::commitment::Commitment,
+    base::{commitment::Commitment, database::Column},
     sql::proof::{ProofPlan, ProverEvaluate},
 };
 use serde::{Deserialize, Serialize};
@@ -108,7 +108,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
         builder: &mut crate::sql::proof::ResultBuilder<'a>,
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
-    ) {
+    ) -> Vec<Column<'a, C::Scalar>> {
         match self {
             DynProofPlan::Projection(expr) => expr.result_evaluate(builder, alloc, accessor),
             DynProofPlan::Filter(expr) => expr.result_evaluate(builder, alloc, accessor),
@@ -123,7 +123,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
         builder: &mut crate::sql::proof::ProofBuilder<'a, C::Scalar>,
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
-    ) {
+    ) -> Vec<Column<'a, C::Scalar>> {
         match self {
             DynProofPlan::Projection(expr) => expr.prover_evaluate(builder, alloc, accessor),
             DynProofPlan::Filter(expr) => expr.prover_evaluate(builder, alloc, accessor),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -33,7 +33,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec {
         builder: &mut ResultBuilder<'a>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<Curve25519Scalar>,
-    ) {
+    ) -> Vec<Column<'a, Curve25519Scalar>> {
         // evaluate where clause
         let selection_column: Column<'a, Curve25519Scalar> =
             self.where_clause
@@ -51,6 +51,11 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec {
             .collect();
         indexes[0] += 1;
         builder.set_result_indexes(Indexes::Sparse(indexes));
+        Vec::from_iter(
+            self.results
+                .iter()
+                .map(|expr| expr.result_evaluate(builder, accessor)),
+        )
     }
 
     #[tracing::instrument(
@@ -63,7 +68,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec {
         builder: &mut ProofBuilder<'a, Curve25519Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<Curve25519Scalar>,
-    ) {
+    ) -> Vec<Column<'a, Curve25519Scalar>> {
         // evaluate where clause
         let selection_column: Column<'a, Curve25519Scalar> =
             self.where_clause.prover_evaluate(builder, alloc, accessor);
@@ -72,9 +77,11 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec {
             .expect("selection is not boolean");
 
         // evaluate result columns
-        for expr in self.results.iter() {
-            expr.prover_evaluate(builder, alloc, accessor, selection);
-        }
+        Vec::from_iter(
+            self.results
+                .iter()
+                .map(|expr| expr.prover_evaluate(builder, alloc, accessor, selection)),
+        )
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_result_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_result_expr.rs
@@ -50,8 +50,10 @@ impl FilterResultExpr {
         &self,
         builder: &mut ResultBuilder<'a>,
         accessor: &'a dyn DataAccessor<S>,
-    ) {
-        builder.produce_result_column(accessor.get_column(self.column_ref));
+    ) -> Column<'a, S> {
+        let col = accessor.get_column(self.column_ref);
+        builder.produce_result_column(col.clone());
+        col
     }
 
     /// Given the selected rows (as a slice of booleans), evaluate the filter result expression and
@@ -62,7 +64,7 @@ impl FilterResultExpr {
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
         selection: &'a [bool],
-    ) {
+    ) -> Column<'a, S> {
         match accessor.get_column(self.column_ref) {
             Column::Boolean(col) => prover_evaluate_impl(builder, alloc, selection, col),
             Column::SmallInt(col) => prover_evaluate_impl(builder, alloc, selection, col),
@@ -77,6 +79,7 @@ impl FilterResultExpr {
             Column::VarChar((_, scals)) => prover_evaluate_impl(builder, alloc, selection, scals),
             Column::TimestampTZ(_, _, col) => prover_evaluate_impl(builder, alloc, selection, col),
         };
+        accessor.get_column(self.column_ref)
     }
 
     /// Given the evaluation of the selected row's multilinear extension at sumcheck's random point,


### PR DESCRIPTION
# Rationale for this change
This is a simple PR to make it possible to compose `ProofPlan`s which facilitates `SliceExec` and `UnionExec`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- make `ProofPlan::result_evaluate` and `ProofPlan::prover_evaluate` return `Vec<Column<'a, S>>`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
