### PR TITLE
feat: commitable byte columns and unconstrained range check

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -228,6 +228,7 @@ impl ColumnBounds {
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
             | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
+            CommittableColumn::RangeCheckWord(_) => ColumnBounds::NoOrder,
         }
     }
 

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -43,6 +43,7 @@ pub trait Scalar:
     + for<'a> core::convert::From<&'a i32> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a i64> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a i128> // Required for `Column` to implement `MultilinearExtension`
+    + for<'a> core::convert::From<&'a u8> // Required for `Column` to implement `MultilinearExtension`
     + core::convert::TryInto <bool>
     + core::convert::TryInto <i8>
     + core::convert::TryInto <i16>

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -64,6 +64,9 @@ fn compute_dory_commitment(
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
+        CommittableColumn::RangeCheckWord(column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -421,6 +421,17 @@ pub fn bit_table_and_scalars_for_packed_msm(
                         num_columns,
                     );
                 }
+                CommittableColumn::RangeCheckWord(column) => {
+                    pack_bit(
+                        column,
+                        &mut packed_scalars,
+                        current_bit_table_sum,
+                        offset,
+                        byte_size,
+                        bit_table_sum_in_bytes,
+                        num_columns,
+                    );
+                }
             }
         });
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -1,6 +1,5 @@
 //! This module proves provable expressions.
 mod proof_expr;
-
 pub(crate) use proof_expr::ProofExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod proof_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -1,5 +1,6 @@
 //! This module proves provable expressions.
 mod proof_expr;
+
 pub(crate) use proof_expr::ProofExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod proof_expr_test;
@@ -81,3 +82,10 @@ mod column_expr;
 pub(crate) use column_expr::ColumnExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod column_expr_test;
+
+#[allow(dead_code, unused_variables)]
+mod range_check;
+
+#[cfg(test)]
+#[allow(dead_code, unused_variables)]
+mod range_check_tests;

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
@@ -15,17 +15,8 @@ use bumpalo::Bump;
 /// ## Word-sized decomposition:
 ///
 /// Each row represents the byte decomposition of a scalar, and each column contains the bytes from
-/// the same byte position across all scalars. First, we produce this word-wise decomposition:
-///
-/// ```text
-/// | Column 0           | Column 1           | Column 2           | ... | Column 31           |  
-/// |--------------------|--------------------|--------------------|-----|---------------------|  
-/// | Byte 0 of Scalar 0 | Byte 1 of Scalar 0 | Byte 2 of Scalar 0 | ... | Byte 31 of Scalar 0 |  
-/// | Byte 0 of Scalar 1 | Byte 1 of Scalar 1 | Byte 2 of Scalar 1 | ... | Byte 31 of Scalar 1 |  
-/// | Byte 0 of Scalar 2 | Byte 1 of Scalar 2 | Byte 2 of Scalar 2 | ... | Byte 31 of Scalar 2 |  
-/// ```
-///
-/// The next step is to compute intermediate MLEs over the word columns:
+/// the same byte position across all scalars. First, we produce this word-wise decomposition,
+/// as well as computing intermediate MLEs over the word columns:
 ///
 /// ```text
 /// | Column 0           | Column 1           | Column 2           | ... | Column 31           |
@@ -40,7 +31,7 @@ use bumpalo::Bump;
 /// ```
 ///
 /// A column containing every single possible value the word can take is established and
-/// populated. An anchored MLE is produced over this column, since the verifier knows range
+/// populated. An anchored MLE is produced over this column, since the verifier knows the range
 /// of the words. A column containing the counts of all of word occurrences in the decomposition
 /// matrix is established, and an intermediate MLE over this column is produced.
 ///

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
@@ -1,0 +1,171 @@
+use crate::{
+    base::{commitment::Commitment, proof::ProofError, scalar::Scalar, slice_ops},
+    sql::proof::{ProofBuilder, VerificationBuilder},
+};
+use bumpalo::Bump;
+
+/// Decomposes a column of scalars into a matrix of words, so that each word column can be
+/// used to produce an intermediate MLE. Produces intermediate MLEs for:
+/// * each column of words
+/// * the count of how many times each word occurs
+///
+/// And anchored MLEs for:
+/// * all possible byte values
+///
+/// ## Word-sized decomposition:
+///
+/// Each row represents the byte decomposition of a scalar, and each column contains the bytes from
+/// the same byte position across all scalars:
+///
+/// ```text
+/// | Column 0           | Column 1           | Column 2           | ... | Column 30           |  
+/// |--------------------|--------------------|--------------------|-----|---------------------|  
+/// | Byte 0 of Scalar 0 | Byte 1 of Scalar 0 | Byte 2 of Scalar 0 | ... | Byte 30 of Scalar 0 |  
+/// | Byte 0 of Scalar 1 | Byte 1 of Scalar 1 | Byte 2 of Scalar 1 | ... | Byte 30 of Scalar 1 |  
+/// | Byte 0 of Scalar 2 | Byte 1 of Scalar 2 | Byte 2 of Scalar 2 | ... | Byte 30 of Scalar 2 |  
+/// ```
+/// After constructing this matrix, each byte column is used to produce an intermediate MLE.
+pub fn result_evaluate_range_check<'a, S: Scalar + 'a>(
+    builder: &mut ProofBuilder<'a, S>,
+    scalars: &mut [S],
+    alloc: &'a Bump,
+) {
+    // Create 31 columns, each will collect the corresponding byte from all scalars.
+    // 31 because a scalar will only ever have 248 bits of data set.
+    let mut columns: Vec<&mut [u8]> = (0..31)
+        .map(|_| alloc.alloc_slice_fill_with(scalars.len(), |_| 0))
+        .collect();
+
+    // Initialize a vector to count occurrences of each byte (0-255) using field elements `S`.
+    // The vector has 256 elements padded with zeros to match the length of the word columns
+    // and are each initialized to the zero element of `S`.
+    // TODO: this should equal the length of the column of scalars
+    let byte_counts: &mut [S] = alloc.alloc_slice_fill_with(256, |_| S::zero());
+
+    // Iterate through scalars and fill columns
+    for (i, scalar) in scalars.iter().enumerate() {
+        // Convert scalar into an array of u64, then into byte-sized words
+        let scalar_array: [u64; 4] = (*scalar).into();
+        let scalar_bytes = bytemuck::cast_slice::<u64, u8>(&scalar_array); // Safer casting using bytemuck
+
+        // Populate columns and update byte counts
+        for (col, &byte) in columns.iter_mut().zip(scalar_bytes.iter()) {
+            col[i] = byte;
+
+            // Update the byte count in the corresponding position
+            byte_counts[byte as usize] += S::one(); // Increment the count of the byte value
+        }
+    }
+
+    // Allocate and initialize byte_values to represent each possible byte as a scalar directly
+    let byte_values: &mut [S] =
+        alloc.alloc_slice_fill_with(256, |i| S::try_from(i.into()).unwrap());
+
+    // 1. Produce an MLE over each column of words
+    for column in columns {
+        builder.produce_intermediate_mle(column as &[u8]);
+    }
+
+    // 2. Produce the anchored MLE that the verifier has access to, consisting
+    // of all possible word values. These serve as values to lookup
+    // in the lookup table
+    builder.produce_anchored_mle(byte_values as &[S]);
+
+    // 3. Next produce an MLE over the counts of each word value
+    builder.produce_intermediate_mle(byte_counts as &[S]);
+
+    // Invert the scalars, and get the inverted words.
+    // This modifies the column in place.
+    slice_ops::batch_inversion(&mut scalars[..]);
+    let mut inverted_word_columns: Vec<&mut [S]> = (0..31)
+        .map(|_| alloc.alloc_slice_fill_with(scalars.len(), |_| S::ZERO))
+        .collect();
+
+    // Get the alpha challenge from the verifier
+    let alpha = builder.consume_post_result_challenge();
+
+    // Iterate through the inverted scalars and fill columns
+    for (i, inverted_scalar) in scalars.iter().enumerate() {
+        let inverted_scalar_array: [u64; 4] = (*inverted_scalar).into();
+        let inverted_scalar_words = bytemuck::cast_slice::<u64, u8>(&inverted_scalar_array);
+
+        // Allocate and initialize row for each inverted scalar processing
+        let row: &mut [S] = alloc.alloc_slice_fill_with(inverted_scalar_words.len(), |_| S::zero());
+
+        for ((col, &inverted_word), row_entry) in inverted_word_columns
+            .iter_mut()
+            .zip(inverted_scalar_words.iter())
+            .zip(row.iter_mut())
+        {
+            // Convert a word into a scalar so that we can perform arithmetic on it
+            let value =
+                S::try_from(inverted_word.into()).expect("u8 will always fit in scalar") + alpha;
+            col[i] = value;
+            *row_entry = value;
+        }
+        builder.produce_intermediate_mle(&*row);
+    }
+
+    // Now produce an intermediate MLE over the inverted word values + verifier challenge alpha
+    let inverted_word_values: &mut [S] =
+        alloc.alloc_slice_fill_with(256, |i| S::try_from(i.into()).unwrap() + alpha);
+    slice_ops::batch_inversion(&mut inverted_word_values[..]);
+    builder.produce_anchored_mle(inverted_word_values as &[S]);
+
+    // // word * (alpha + word) - 1 = 0
+    // builder.produce_sumcheck_subpolynomial(
+    //     SumcheckSubpolynomialType::Identity,
+    //     vec![
+    //         (
+    //             S::one(),
+    //             vec![Box::new(g_in_star as &[_]), Box::new(g_in_fold as &[_])],
+    //         ),
+    //         (-S::one(), vec![]),
+    //     ],
+    // );
+}
+
+/// Evaluates a polynomial at a specified point to verify if the result matches
+/// a given expression value. This function applies Horner's method for efficient
+/// polynomial evaluation.
+///
+/// The function first retrieves the necessary coefficients from a
+/// [VerificationBuilder] and then evaluates the polynomial. If the evaluated
+/// result matches the given `expr_eval`, it confirms the validity of the
+/// expression; otherwise, it raises an error.
+///
+/// # Type Parameters
+/// * `C` - Represents a commitment type that must support basic arithmetic
+///   operations (`Add`, `Mul`) and can be constructed from `u128`.
+///
+/// # Returns
+/// * `Ok(())` if the computed polynomial value matches `expr_eval`.
+/// * `Err(ProofError)` if there is a mismatch, indicating a verification failure.
+pub fn verifier_evaluate_range_check<C: Commitment>(
+    builder: &mut VerificationBuilder<C>,
+    expr_eval: C::Scalar,
+) -> Result<(), ProofError> {
+    let mut word_columns_evals: Vec<C::Scalar> = Vec::with_capacity(31);
+    for _ in 0..31 {
+        let mle = builder.consume_intermediate_mle();
+        word_columns_evals.push(mle);
+    }
+
+    let base: C::Scalar = C::Scalar::from(256);
+    let mut accumulated = word_columns_evals[0];
+
+    for eval in word_columns_evals.iter() {
+        accumulated = accumulated * base + *eval;
+    }
+
+    dbg!(expr_eval);
+    dbg!(accumulated);
+
+    if expr_eval == accumulated {
+        Ok(())
+    } else {
+        Err(ProofError::VerificationError(
+            "Computed polynomial does not match the evaluation expression.",
+        ))
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
@@ -119,10 +119,13 @@ pub fn prover_evaluate_range_check<'a, S: Scalar + 'a>(
         // | Column i            | Column i+1            | Column i+2            | ... | Column_||word||     |
         // |---------------------|-----------------------|-----------------------|-----|---------------------|
         // | 1/(word[i] + alpha) | 1/(word[i+1] + alpha) | 1/(word[i+2] + alpha) | ... | 1/(word[n] + alpha) |
-        for (j, &word_scalar) in inverted_words.iter().enumerate() {
-            // Add the verifier challenge to the word, then invert the sum in the scalar field
-            let value: S = (word_scalar + alpha).inv().unwrap_or(S::ZERO);
-            inverted_word_columns[j][i] = value; // j is column index, i is row index
+        for ((j, word_scalar), column) in inverted_words
+            .iter()
+            .enumerate()
+            .zip(inverted_word_columns.iter_mut())
+        {
+            let value: S = (*word_scalar + alpha).inv().unwrap_or(S::ZERO);
+            column[i] = value; // j is column index, i is the row index specific to this iteration of scalars
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
@@ -25,7 +25,7 @@ use bumpalo::Bump;
 /// | Byte 0 of Scalar 2 | Byte 1 of Scalar 2 | Byte 2 of Scalar 2 | ... | Byte 30 of Scalar 2 |  
 /// ```
 /// After constructing this matrix, each byte column is used to produce an intermediate MLE.
-pub fn result_evaluate_range_check<'a, S: Scalar + 'a>(
+pub fn prover_evaluate_range_check<'a, S: Scalar + 'a>(
     builder: &mut ProofBuilder<'a, S>,
     scalars: &mut [S],
     alloc: &'a Bump,
@@ -111,18 +111,6 @@ pub fn result_evaluate_range_check<'a, S: Scalar + 'a>(
         alloc.alloc_slice_fill_with(256, |i| S::try_from(i.into()).unwrap() + alpha);
     slice_ops::batch_inversion(&mut inverted_word_values[..]);
     builder.produce_anchored_mle(inverted_word_values as &[S]);
-
-    // // word * (alpha + word) - 1 = 0
-    // builder.produce_sumcheck_subpolynomial(
-    //     SumcheckSubpolynomialType::Identity,
-    //     vec![
-    //         (
-    //             S::one(),
-    //             vec![Box::new(g_in_star as &[_]), Box::new(g_in_fold as &[_])],
-    //         ),
-    //         (-S::one(), vec![]),
-    //     ],
-    // );
 }
 
 /// Evaluates a polynomial at a specified point to verify if the result matches
@@ -145,27 +133,5 @@ pub fn verifier_evaluate_range_check<C: Commitment>(
     builder: &mut VerificationBuilder<C>,
     expr_eval: C::Scalar,
 ) -> Result<(), ProofError> {
-    let mut word_columns_evals: Vec<C::Scalar> = Vec::with_capacity(31);
-    for _ in 0..31 {
-        let mle = builder.consume_intermediate_mle();
-        word_columns_evals.push(mle);
-    }
-
-    let base: C::Scalar = C::Scalar::from(256);
-    let mut accumulated = word_columns_evals[0];
-
-    for eval in word_columns_evals.iter() {
-        accumulated = accumulated * base + *eval;
-    }
-
-    dbg!(expr_eval);
-    dbg!(accumulated);
-
-    if expr_eval == accumulated {
-        Ok(())
-    } else {
-        Err(ProofError::VerificationError(
-            "Computed polynomial does not match the evaluation expression.",
-        ))
-    }
+    unimplemented!("Fill this method when when ready to add verification")
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
@@ -1,4 +1,4 @@
-use super::{range_check::result_evaluate_range_check, ProofExpr};
+use super::range_check::prover_evaluate_range_check;
 use crate::{
     base::{
         commitment::Commitment,
@@ -65,8 +65,8 @@ impl<S: Scalar> ProverEvaluate<S> for RangeCheckTestExpr {
     fn result_evaluate<'a>(
         &self,
         builder: &mut ResultBuilder<'a>,
-        _alloc: &'a Bump,
-        _accessor: &'a dyn DataAccessor<S>,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<S>,
     ) {
         // result builder needs ability to produce intermediate MLE
         builder.request_post_result_challenges(1);
@@ -82,50 +82,10 @@ impl<S: Scalar> ProverEvaluate<S> for RangeCheckTestExpr {
         let a = accessor.get_column(self.column);
 
         let scalar_values = alloc.alloc_slice_copy(&a.to_scalar_with_scaling(0));
-        result_evaluate_range_check(builder, scalar_values, alloc);
+        prover_evaluate_range_check(builder, scalar_values, alloc);
 
         // TODO: enable this
         // prover_evaluate_range_check(builder, scalar_values);
-    }
-}
-
-impl<C: Commitment> ProofExpr<C> for RangeCheckTestExpr {
-    fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
-        todo!()
-    }
-
-    fn data_type(&self) -> crate::base::database::ColumnType {
-        todo!()
-    }
-
-    fn result_evaluate<'a>(
-        &self,
-        table_length: usize,
-        alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<<C as Commitment>::Scalar>,
-    ) -> crate::base::database::Column<'a, <C as Commitment>::Scalar> {
-        todo!()
-    }
-
-    fn prover_evaluate<'a>(
-        &self,
-        builder: &mut ProofBuilder<'a, <C as Commitment>::Scalar>,
-        alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<<C as Commitment>::Scalar>,
-    ) -> crate::base::database::Column<'a, <C as Commitment>::Scalar> {
-        todo!()
-    }
-
-    fn verifier_evaluate(
-        &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
-    ) -> Result<<C as Commitment>::Scalar, ProofError> {
-        todo!()
-    }
-
-    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
-        todo!()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
@@ -104,10 +104,7 @@ mod tests {
             scalar::Curve25519Scalar,
         },
         sql::{
-            proof::{
-                ProofBuilder, ProverEvaluate, ResultBuilder, SumcheckMleEvaluations,
-                SumcheckRandomScalars,
-            },
+            proof::{ProofBuilder, ProverEvaluate, ResultBuilder},
             proof_exprs::range_check_tests::RangeCheckTestExpr,
         },
     };
@@ -133,19 +130,6 @@ mod tests {
 
             let mut proof_builder = ProofBuilder::new(2, 1, vec![Curve25519Scalar::from(123)]);
             let prover_res = expr.prover_evaluate(&mut proof_builder, &alloc, &accessor);
-
-            let scalars = [Curve25519Scalar::from(123)];
-            let sumcheck_random_scalars = SumcheckRandomScalars::new(&scalars, 8, 2);
-            let evaluation_point = [Curve25519Scalar::from(123)];
-            let sumcheck_evaluations = SumcheckMleEvaluations::new(
-                8,
-                &evaluation_point,
-                &sumcheck_random_scalars,
-                &[],
-                &[],
-                &Default::default(),
-            );
-            let one_eval = sumcheck_evaluations.one_evaluation;
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
@@ -1,0 +1,171 @@
+use super::{range_check::result_evaluate_range_check, ProofExpr};
+use crate::{
+    base::{
+        commitment::Commitment,
+        database::{
+            ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable,
+        },
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        CountBuilder, ProofBuilder, ProofPlan, ProverEvaluate, ResultBuilder, VerificationBuilder,
+    },
+};
+use bumpalo::Bump;
+use indexmap::IndexSet;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct RangeCheckTestExpr {
+    pub column: ColumnRef,
+}
+
+impl<C: Commitment> ProofPlan<C> for RangeCheckTestExpr {
+    fn count(
+        &self,
+        builder: &mut CountBuilder,
+        accessor: &dyn MetadataAccessor,
+    ) -> Result<(), ProofError> {
+        todo!()
+    }
+
+    fn get_length(&self, accessor: &dyn MetadataAccessor) -> usize {
+        todo!()
+    }
+
+    fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize {
+        todo!()
+    }
+
+    fn verifier_evaluate(
+        &self,
+        builder: &mut VerificationBuilder<C>,
+        accessor: &dyn CommitmentAccessor<C>,
+        result: Option<&OwnedTable<<C as Commitment>::Scalar>>,
+    ) -> Result<(), ProofError> {
+        todo!()
+    }
+
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        todo!()
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        todo!()
+    }
+}
+
+impl<S: Scalar> ProverEvaluate<S> for RangeCheckTestExpr {
+    /// 1st round of prover
+    /// This produces the challenge alpha for the prover, however for now
+    /// this happens here because ```ProofBuilder``` at current does not have
+    /// the ability to produce a result challenge. TODO: add suport for this
+    /// in proof builder.
+    fn result_evaluate<'a>(
+        &self,
+        builder: &mut ResultBuilder<'a>,
+        _alloc: &'a Bump,
+        _accessor: &'a dyn DataAccessor<S>,
+    ) {
+        // result builder needs ability to produce intermediate MLE
+        builder.request_post_result_challenges(1);
+    }
+
+    // second round
+    fn prover_evaluate<'a>(
+        &self,
+        builder: &mut ProofBuilder<'a, S>,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<S>,
+    ) {
+        let a = accessor.get_column(self.column);
+
+        let scalar_values = alloc.alloc_slice_copy(&a.to_scalar_with_scaling(0));
+        result_evaluate_range_check(builder, scalar_values, alloc);
+
+        // TODO: enable this
+        // prover_evaluate_range_check(builder, scalar_values);
+    }
+}
+
+impl<C: Commitment> ProofExpr<C> for RangeCheckTestExpr {
+    fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
+        todo!()
+    }
+
+    fn data_type(&self) -> crate::base::database::ColumnType {
+        todo!()
+    }
+
+    fn result_evaluate<'a>(
+        &self,
+        table_length: usize,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<<C as Commitment>::Scalar>,
+    ) -> crate::base::database::Column<'a, <C as Commitment>::Scalar> {
+        todo!()
+    }
+
+    fn prover_evaluate<'a>(
+        &self,
+        builder: &mut ProofBuilder<'a, <C as Commitment>::Scalar>,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<<C as Commitment>::Scalar>,
+    ) -> crate::base::database::Column<'a, <C as Commitment>::Scalar> {
+        todo!()
+    }
+
+    fn verifier_evaluate(
+        &self,
+        builder: &mut VerificationBuilder<C>,
+        accessor: &dyn CommitmentAccessor<C>,
+    ) -> Result<<C as Commitment>::Scalar, ProofError> {
+        todo!()
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        todo!()
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod tests {
+    use crate::{
+        base::database::{
+            owned_table_utility::{bigint, owned_table},
+            ColumnRef, ColumnType, OwnedTableTestAccessor,
+        },
+        sql::{proof::VerifiableQueryResult, proof_exprs::range_check_tests::RangeCheckTestExpr},
+    };
+    use blitzar::proof::InnerProductProof;
+
+    #[should_panic]
+    #[test]
+    fn we_can_verify_that_every_value_in_colum_is_binary() {
+        let data = owned_table([bigint(
+            "a",
+            [1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007],
+        )]);
+        let t = "sxt.t".parse().unwrap();
+        let column = ColumnRef::new(t, "a".parse().unwrap(), ColumnType::BigInt);
+        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let expr = RangeCheckTestExpr { column };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
+        let res = verifiable_res.verify(&expr, &accessor, &()).unwrap().table;
+        let expected_res = owned_table([]);
+        assert_eq!(res, expected_res);
+    }
+
+    #[should_panic]
+    #[test]
+    fn we_cannot_verify_an_invalid_that_every_value_in_colum_is_binary() {
+        let data = owned_table([bigint("a", [1, 0, 1, 3, 1])]);
+        let t = "sxt.t".parse().unwrap();
+        let column = ColumnRef::new(t, "a".parse().unwrap(), ColumnType::BigInt);
+        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let expr = RangeCheckTestExpr { column };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
+        assert!(verifiable_res.verify(&expr, &accessor, &()).is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
@@ -48,7 +48,7 @@ impl<C: Commitment> ProofPlan<C> for RangeCheckTestExpr {
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         result: Option<&OwnedTable<<C as Commitment>::Scalar>>,
-    ) -> Result<(), ProofError> {
+    ) -> Result<Vec<<C as Commitment>::Scalar>, ProofError> {
         todo!()
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check_tests.rs
@@ -3,7 +3,8 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTable,
+            Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
+            OwnedTable,
         },
         proof::ProofError,
         scalar::Scalar,
@@ -67,9 +68,10 @@ impl<S: Scalar> ProverEvaluate<S> for RangeCheckTestExpr {
         builder: &mut ResultBuilder<'a>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) {
+    ) -> Vec<Column<'a, S>> {
         // result builder needs ability to produce intermediate MLE
         builder.request_post_result_challenges(1);
+        todo!()
     }
 
     // second round
@@ -78,7 +80,7 @@ impl<S: Scalar> ProverEvaluate<S> for RangeCheckTestExpr {
         builder: &mut ProofBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) {
+    ) -> Vec<Column<'a, S>> {
         let a = accessor.get_column(self.column);
 
         let scalar_values = alloc.alloc_slice_copy(&a.to_scalar_with_scaling(0));
@@ -86,6 +88,7 @@ impl<S: Scalar> ProverEvaluate<S> for RangeCheckTestExpr {
 
         // TODO: enable this
         // prover_evaluate_range_check(builder, scalar_values);
+        todo!()
     }
 }
 


### PR DESCRIPTION
# Rationale for this change

Support for a range check over words decomposed byte-wise requires an ``` &[u8]``` to the commitable column. This PR introduces this small change, as well as preliminary support for a range check. It is **unsound** in its current form and does not constrain the claims of integrity made by the prover. 

# What changes are included in this PR?

- [x] support byte-wise word decomposition and commitment
- [x] produce word columns
- [x] produce word value columns
- [x] produce count of word occurrences across entire word matrix
- [x] produce intermediate mles for word columns
- [x] produce intermediate mles for word value columns
- [x] produce anchored mles for word value columns
- [x] Invert words and perturb with verifier challenge
- [x] Invert word values and perturb with verifier challenge
- [x] Invert word columns and perturb with verfier challenge
- [x] Produce mles for inverted perturbed words
- [x] Produce mles for inverted perturbed word values
- [x] Produce mles for inverted perturbed word counts

# Are these changes tested?

- [x] test scalars to words are producing expected results
- [x] test that inverted words match expected
- [ ] test that the prover is producing the correct MLEs? How do we do this?

# Split:

Current working items:

- [ ] Cache frequently used columns such as decomposed words and their inversions
- [ ] Add sumcheck subpolynomials for identity constraints
- [ ] Add sumcheck subpolynomials for sum constraints
- [ ] Ensure that anything allocated with bump is dropped correctly and safely
- [x] byte counts produces sparse vector, make it produce dense vector that is equal in size to length of scalar columns
- [ ] pad scalar vector to be power of 2 in length
- [ ] test that sum of counts of word values = number of columns * counts of word values