### PR TITLE
refactor!: allow `ProofPlan::verifier_evaluate` to return a vec of evals

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -38,7 +38,7 @@ pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<(), ProofError>;
+    ) -> Result<Vec<C::Scalar>, ProofError>;
 
     /// Return all the result column fields
     fn get_column_result_fields(&self) -> Vec<ColumnField>;

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -91,10 +91,10 @@ impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
         builder: &mut VerificationBuilder<C>,
         _accessor: &dyn CommitmentAccessor<C>,
         _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<(), ProofError> {
+    ) -> Result<Vec<C::Scalar>, ProofError> {
         assert_eq!(builder.consume_result_mle(), C::Scalar::ZERO);
         builder.produce_sumcheck_subpolynomial_evaluation(&C::Scalar::from(self.evaluation));
-        Ok(())
+        Ok(vec![C::Scalar::ZERO])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
@@ -266,7 +266,7 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<(), ProofError> {
+    ) -> Result<Vec<C::Scalar>, ProofError> {
         let res_eval = builder.consume_result_mle();
         let x_commit = C::Scalar::from(self.anchored_commit_multiplier)
             * accessor.get_commitment(ColumnRef::new(
@@ -277,7 +277,7 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
         let x_eval = builder.consume_anchored_mle(x_commit);
         let eval = builder.mle_evaluations.random_evaluation * (res_eval - x_eval * x_eval);
         builder.produce_sumcheck_subpolynomial_evaluation(&eval);
-        Ok(())
+        Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
@@ -459,7 +459,7 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<(), ProofError> {
+    ) -> Result<Vec<C::Scalar>, ProofError> {
         let x_commit = accessor.get_commitment(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
@@ -476,7 +476,7 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
         // poly2
         let eval = builder.mle_evaluations.random_evaluation * (res_eval - z_eval * z_eval);
         builder.produce_sumcheck_subpolynomial_evaluation(&eval);
-        Ok(())
+        Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
@@ -656,7 +656,7 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<(), ProofError> {
+    ) -> Result<Vec<C::Scalar>, ProofError> {
         let alpha = builder.consume_post_result_challenge();
         let _beta = builder.consume_post_result_challenge();
         let res_eval = builder.consume_result_mle();
@@ -669,7 +669,7 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
         let eval = builder.mle_evaluations.random_evaluation
             * (alpha * res_eval - alpha * x_eval * x_eval);
         builder.produce_sumcheck_subpolynomial_evaluation(&eval);
-        Ok(())
+        Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -66,8 +66,8 @@ impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
         _builder: &mut VerificationBuilder<C>,
         _accessor: &dyn CommitmentAccessor<C>,
         _result: Option<&OwnedTable<<C as Commitment>::Scalar>>,
-    ) -> Result<(), ProofError> {
-        Ok(())
+    ) -> Result<Vec<C::Scalar>, ProofError> {
+        Ok(vec![C::Scalar::ZERO])
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec.rs
@@ -89,7 +89,7 @@ where
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<(), ProofError> {
+    ) -> Result<Vec<C::Scalar>, ProofError> {
         // 1. selection
         let selection_eval = self.where_clause.verifier_evaluate(builder, accessor)?;
         // 2. columns
@@ -227,7 +227,7 @@ fn verify_filter<C: Commitment>(
     c_evals: Vec<C::Scalar>,
     s_eval: C::Scalar,
     d_evals: Vec<C::Scalar>,
-) -> Result<(), ProofError> {
+) -> Result<Vec<C::Scalar>, ProofError> {
     let one_eval = builder.mle_evaluations.one_evaluation;
     let rand_eval = builder.mle_evaluations.random_evaluation;
 
@@ -254,7 +254,7 @@ fn verify_filter<C: Commitment>(
         &(rand_eval * (d_bar_fold_eval * d_star_eval - chi_eval)),
     );
 
-    Ok(())
+    Ok(c_evals)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -73,7 +73,7 @@ impl<C: Commitment> ProofPlan<C> for DynProofPlan<C> {
         builder: &mut crate::sql::proof::VerificationBuilder<C>,
         accessor: &dyn crate::base::database::CommitmentAccessor<C>,
         result: Option<&crate::base::database::OwnedTable<C::Scalar>>,
-    ) -> Result<(), crate::base::proof::ProofError> {
+    ) -> Result<Vec<C::Scalar>, crate::base::proof::ProofError> {
         match self {
             DynProofPlan::Projection(expr) => expr.verifier_evaluate(builder, accessor, result),
             DynProofPlan::Filter(expr) => expr.verifier_evaluate(builder, accessor, result),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -83,12 +83,13 @@ where
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<(), ProofError> {
+    ) -> Result<Vec<C::Scalar>, ProofError> {
         let selection_eval = self.where_clause.verifier_evaluate(builder, accessor)?;
-        for expr in self.results.iter() {
-            expr.verifier_evaluate(builder, accessor, &selection_eval);
-        }
-        Ok(())
+        Ok(self
+            .results
+            .iter()
+            .map(|expr| expr.verifier_evaluate(builder, accessor, &selection_eval))
+            .collect())
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_result_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_result_expr.rs
@@ -89,7 +89,7 @@ impl FilterResultExpr {
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         selection_eval: &C::Scalar,
-    ) {
+    ) -> C::Scalar {
         let col_commit = accessor.get_commitment(self.column_ref);
 
         let result_eval = builder.consume_result_mle();
@@ -98,6 +98,7 @@ impl FilterResultExpr {
         let poly_eval =
             builder.mle_evaluations.random_evaluation * (result_eval - col_eval * *selection_eval);
         builder.produce_sumcheck_subpolynomial_evaluation(&poly_eval);
+        result_eval
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -67,15 +67,14 @@ impl<C: Commitment> ProofPlan<C> for ProjectionExec<C> {
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
         _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<(), ProofError> {
+    ) -> Result<Vec<C::Scalar>, ProofError> {
         self.aliased_results
             .iter()
             .map(|aliased_expr| aliased_expr.expr.verifier_evaluate(builder, accessor))
             .collect::<Result<Vec<_>, _>>()?;
-        let _columns_evals = Vec::from_iter(
+        Ok(Vec::from_iter(
             repeat_with(|| builder.consume_result_mle()).take(self.aliased_results.len()),
-        );
-        Ok(())
+        ))
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {


### PR DESCRIPTION
# Rationale for this change
Here is the counterpart of #132 for verifiers.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- make `ProofPlan::verifier_evaluate` return `Vec<C::Scalar>`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
