### PR TITLE
fix: derive copy for Column to prevent unnecessary cloning

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
+++ b/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
@@ -43,7 +43,7 @@ impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {
         for (column, commitment) in columns.iter().zip(commitments) {
             self.columns.insert(
                 ColumnRef::new(table_ref, column.0, column.1.column_type()),
-                column.1.clone(),
+                column.1,
             );
             self.commitments.insert(
                 ColumnRef::new(table_ref, column.0, column.1.column_type()),
@@ -64,7 +64,7 @@ impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {
 
 impl<C: Commitment> DataAccessor<C::Scalar> for BenchmarkAccessor<'_, C> {
     fn get_column(&self, column: ColumnRef) -> Column<C::Scalar> {
-        self.columns.get(&column).unwrap().clone()
+        *self.columns.get(&column).unwrap()
     }
 }
 impl<C: Commitment> MetadataAccessor for BenchmarkAccessor<'_, C> {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 /// Note: The types here should correspond to native SQL database types.
 /// See `<https://ignite.apache.org/docs/latest/sql-reference/data-types>` for
 /// a description of the native types used by Apache Ignite.
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[non_exhaustive]
 pub enum Column<'a, S: Scalar> {
     /// Boolean columns
@@ -179,7 +179,7 @@ impl<'a, S: Scalar> Column<'a, S> {
     }
 
     /// Convert a column to a vector of Scalar values with scaling
-    pub(crate) fn to_scalar_with_scaling(&self, scale: i8) -> Vec<S> {
+    pub(crate) fn to_scalar_with_scaling(self, scale: i8) -> Vec<S> {
         let scale_factor = scale_scalar(S::ONE, scale).expect("Invalid scale factor");
         match self {
             Self::Boolean(col) => col

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -14,8 +14,8 @@ fn we_can_aggregate_empty_columns() {
     let column_b = Column::VarChar((&[], &[]));
     let column_c = Column::Int128(&[]);
     let column_d = Column::Scalar(&[]);
-    let group_by = &[column_a.clone(), column_b.clone()];
-    let sum_columns = &[column_c.clone(), column_d.clone()];
+    let group_by = &[column_a, column_b];
+    let sum_columns = &[column_c, column_d];
     let selection = &[];
     let alloc = Bump::new();
     let aggregate_result = aggregate_columns(&alloc, group_by, sum_columns, &[], &[], selection)
@@ -37,9 +37,9 @@ fn we_can_aggregate_columns_with_empty_group_by_and_no_rows_selected() {
     let column_c = Column::Int128(slice_c);
     let column_d = Column::Scalar(&scals_d);
     let group_by = &[];
-    let sum_columns = &[column_c.clone(), column_d.clone()];
-    let max_columns = &[column_c.clone(), column_d.clone()];
-    let min_columns = &[column_c.clone(), column_d.clone()];
+    let sum_columns = &[column_c, column_d];
+    let max_columns = &[column_c, column_d];
+    let min_columns = &[column_c, column_d];
     let alloc = Bump::new();
     let aggregate_result = aggregate_columns(
         &alloc,
@@ -73,9 +73,9 @@ fn we_can_aggregate_columns_with_empty_group_by() {
     let column_c = Column::Int128(slice_c);
     let column_d = Column::Scalar(&scals_d);
     let group_by = &[];
-    let sum_columns = &[column_c.clone(), column_d.clone()];
-    let max_columns = &[column_c.clone(), column_d.clone()];
-    let min_columns = &[column_c.clone(), column_d.clone()];
+    let sum_columns = &[column_c, column_d];
+    let max_columns = &[column_c, column_d];
+    let min_columns = &[column_c, column_d];
     let alloc = Bump::new();
     let aggregate_result = aggregate_columns(
         &alloc,
@@ -128,10 +128,10 @@ fn we_can_aggregate_columns() {
     let column_b = Column::VarChar((slice_b, &scals_b));
     let column_c = Column::Int128(slice_c);
     let column_d = Column::Scalar(&scals_d);
-    let group_by = &[column_a.clone(), column_b.clone()];
-    let sum_columns = &[column_c.clone(), column_d.clone()];
-    let max_columns = &[column_c.clone(), column_d.clone()];
-    let min_columns = &[column_c.clone(), column_d.clone()];
+    let group_by = &[column_a, column_b];
+    let sum_columns = &[column_c, column_d];
+    let max_columns = &[column_c, column_d];
+    let min_columns = &[column_c, column_d];
     let alloc = Bump::new();
     let aggregate_result = aggregate_columns(
         &alloc,
@@ -233,19 +233,19 @@ fn we_can_compare_indexes_by_columns_for_bigint_columns() {
     let column_b = Column::BigInt::<DoryScalar>(slice_b);
     let column_c = Column::BigInt::<DoryScalar>(slice_c);
 
-    let columns = &[column_a.clone()];
+    let columns = &[column_a];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Equal);
     assert_eq!(compare_indexes_by_columns(columns, 2, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 0), Ordering::Less);
-    let columns = &[column_a.clone(), column_b.clone()];
+    let columns = &[column_a, column_b];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 3, 4), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 2, 7), Ordering::Equal);
-    let columns = &[column_a.clone(), column_b.clone(), column_c.clone()];
+    let columns = &[column_a, column_b, column_c];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Less);
@@ -263,19 +263,19 @@ fn we_can_compare_indexes_by_columns_for_mixed_columns() {
     let column_b = Column::Int128(slice_b);
     let column_c = Column::BigInt(slice_c);
 
-    let columns = &[column_a.clone()];
+    let columns = &[column_a];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Equal);
     assert_eq!(compare_indexes_by_columns(columns, 2, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 0), Ordering::Less);
-    let columns = &[column_a.clone(), column_b.clone()];
+    let columns = &[column_a, column_b];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 3, 4), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 2, 7), Ordering::Equal);
-    let columns = &[column_a.clone(), column_b.clone(), column_c.clone()];
+    let columns = &[column_a, column_b, column_c];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Less);
@@ -373,19 +373,19 @@ fn we_can_compare_indexes_by_columns_for_scalar_columns() {
     let column_b = Column::Int128(slice_b);
     let column_c = Column::BigInt(slice_c);
 
-    let columns = &[column_a.clone()];
+    let columns = &[column_a];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Equal);
     assert_eq!(compare_indexes_by_columns(columns, 2, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 0), Ordering::Less);
-    let columns = &[column_a.clone(), column_b.clone()];
+    let columns = &[column_a, column_b];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 3, 4), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 2, 7), Ordering::Equal);
-    let columns = &[column_a.clone(), column_b.clone(), column_c.clone()];
+    let columns = &[column_a, column_b, column_c];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less);
     assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Less);

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -62,82 +62,82 @@ impl<S: Scalar> OwnedColumn<S> {
                 rhs.len(),
             ));
         }
-        match (self, rhs.clone()) {
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_eq(lhs, &rhs))),
+        match (self, rhs) {
+            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
             (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_eq(lhs, &rhs))),
+            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
             (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
             }
             (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
             }
             (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
             }
             (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_eq(lhs, &rhs))),
+            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
             (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(lhs, rhs)))
             }
             (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
             }
             (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
             }
             (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_eq_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_eq_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_eq(lhs, &rhs))),
+            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
             (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -145,7 +145,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -153,7 +153,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -161,7 +161,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -170,14 +170,14 @@ impl<S: Scalar> OwnedColumn<S> {
             (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(eq_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_eq(lhs, &rhs))),
-            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_eq(lhs, &rhs))),
-            (Self::VarChar(lhs), Self::VarChar(rhs)) => Ok(Self::Boolean(slice_eq(lhs, &rhs))),
+            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
+            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
+            (Self::VarChar(lhs), Self::VarChar(rhs)) => Ok(Self::Boolean(slice_eq(lhs, rhs))),
             (Self::TimestampTZ(_, _, _), Self::TimestampTZ(_, _, _)) => {
                 todo!("Implement equality check for TimeStampTZ")
             }
@@ -197,82 +197,82 @@ impl<S: Scalar> OwnedColumn<S> {
                 rhs.len(),
             ));
         }
-        match (self, rhs.clone()) {
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_le(lhs, &rhs))),
+        match (self, rhs) {
+            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
             (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_le(lhs, &rhs))),
+            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
             (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
             }
             (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
             }
             (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
             }
             (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_le(lhs, &rhs))),
+            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
             (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_le_with_casting(lhs, rhs)))
             }
             (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
             }
             (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
             }
             (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_le(lhs, &rhs))),
+            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
             (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -280,7 +280,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -288,7 +288,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -296,7 +296,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -305,13 +305,13 @@ impl<S: Scalar> OwnedColumn<S> {
             (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_le(lhs, &rhs))),
-            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_le(lhs, &rhs))),
+            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
+            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_le(lhs, rhs))),
             (Self::TimestampTZ(_, _, _), Self::TimestampTZ(_, _, _)) => {
                 todo!("Implement inequality check for TimeStampTZ")
             }
@@ -331,82 +331,82 @@ impl<S: Scalar> OwnedColumn<S> {
                 rhs.len(),
             ));
         }
-        match (self, rhs.clone()) {
-            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_ge(lhs, &rhs))),
+        match (self, rhs) {
+            (Self::SmallInt(lhs), Self::SmallInt(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
             (Self::SmallInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
             }
             (Self::SmallInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Int(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
             }
-            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_ge(lhs, &rhs))),
+            (Self::Int(lhs), Self::Int(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
             (Self::Int(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
             }
             (Self::Int(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
             }
             (Self::Int(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::BigInt(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
             }
             (Self::BigInt(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
             }
-            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_ge(lhs, &rhs))),
+            (Self::BigInt(lhs), Self::BigInt(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
             (Self::BigInt(lhs), Self::Int128(rhs)) => {
-                Ok(Self::Boolean(slice_ge_with_casting(lhs, &rhs)))
+                Ok(Self::Boolean(slice_ge_with_casting(lhs, rhs)))
             }
             (Self::BigInt(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Int128(lhs), Self::SmallInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
             }
             (Self::Int128(lhs), Self::Int(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
             }
             (Self::Int128(lhs), Self::BigInt(rhs)) => {
-                Ok(Self::Boolean(slice_le_with_casting(&rhs, lhs)))
+                Ok(Self::Boolean(slice_le_with_casting(rhs, lhs)))
             }
-            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_ge(lhs, &rhs))),
+            (Self::Int128(lhs), Self::Int128(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
             (Self::Int128(lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
             (Self::Decimal75(_, _, lhs_values), Self::SmallInt(rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -414,7 +414,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::Int(rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -422,7 +422,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::BigInt(rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -430,7 +430,7 @@ impl<S: Scalar> OwnedColumn<S> {
             }
             (Self::Decimal75(_, _, lhs_values), Self::Int128(rhs_values)) => {
                 Ok(Self::Boolean(le_decimal_columns(
-                    &rhs_values,
+                    rhs_values,
                     lhs_values,
                     rhs.column_type(),
                     self.column_type(),
@@ -439,13 +439,13 @@ impl<S: Scalar> OwnedColumn<S> {
             (Self::Decimal75(_, _, lhs_values), Self::Decimal75(_, _, rhs_values)) => {
                 Ok(Self::Boolean(ge_decimal_columns(
                     lhs_values,
-                    &rhs_values,
+                    rhs_values,
                     self.column_type(),
                     rhs.column_type(),
                 )))
             }
-            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_ge(lhs, &rhs))),
-            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_ge(lhs, &rhs))),
+            (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
+            (Self::Scalar(lhs), Self::Scalar(rhs)) => Ok(Self::Boolean(slice_ge(lhs, rhs))),
             (Self::TimestampTZ(_, _, _), Self::TimestampTZ(_, _, _)) => {
                 todo!("Implement inequality check for TimeStampTZ")
             }

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -69,9 +69,9 @@ fn get_aggregate_and_remainder_expressions(
     aggregation_expr_map: &mut IndexMap<(AggregationOperator, Expression), Identifier>,
 ) -> Expression {
     match expr {
-        Expression::Column(_) | Expression::Literal(_) | Expression::Wildcard => expr.clone(),
+        Expression::Column(_) | Expression::Literal(_) | Expression::Wildcard => expr,
         Expression::Aggregation { op, expr } => {
-            let key = (op, (*expr).clone());
+            let key = (op, (*expr));
             if !aggregation_expr_map.contains_key(&key) {
                 let new_col_id = format!("__col_agg_{}", aggregation_expr_map.len())
                     .parse()

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -232,12 +232,12 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
             ColumnType::BigInt,
         ));
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        builder.produce_anchored_mle(x.clone());
+        builder.produce_anchored_mle(x);
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
             vec![
                 (S::ONE, vec![Box::new(res)]),
-                (-S::ONE, vec![Box::new(x.clone()), Box::new(x)]),
+                (-S::ONE, vec![Box::new(x), Box::new(x)]),
             ],
         );
         vec![Column::BigInt(res)]
@@ -412,7 +412,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
         ));
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         let z: &[_] = alloc.alloc_slice_copy(&self.z);
-        builder.produce_anchored_mle(x.clone());
+        builder.produce_anchored_mle(x);
         builder.produce_intermediate_mle(z);
 
         // poly1
@@ -420,7 +420,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
             SumcheckSubpolynomialType::Identity,
             vec![
                 (S::ONE, vec![Box::new(z)]),
-                (-S::ONE, vec![Box::new(x.clone()), Box::new(x)]),
+                (-S::ONE, vec![Box::new(x), Box::new(x)]),
             ],
         );
 
@@ -621,12 +621,12 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         let res: &[_] = alloc.alloc_slice_copy(&[9, 25]);
         let alpha = builder.consume_post_result_challenge();
         let _beta = builder.consume_post_result_challenge();
-        builder.produce_anchored_mle(x.clone());
+        builder.produce_anchored_mle(x);
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
             vec![
                 (alpha, vec![Box::new(res)]),
-                (-alpha, vec![Box::new(x.clone()), Box::new(x)]),
+                (-alpha, vec![Box::new(x), Box::new(x)]),
             ],
         );
         vec![Column::BigInt(&[9, 25])]

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -80,7 +80,7 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
         let column = accessor.get_column(self.column_ref);
-        builder.produce_anchored_mle(column.clone());
+        builder.produce_anchored_mle(column);
         column
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec.rs
@@ -173,7 +173,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DenseFilterExec<C> {
         builder.set_result_indexes(Indexes::Dense(0..(result_len as u64)));
         // 4. set filtered_columns
         for col in &filtered_columns {
-            builder.produce_result_column(col.clone());
+            builder.produce_result_column(*col);
         }
         builder.request_post_result_challenges(2);
         filtered_columns

--- a/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dense_filter_exec_test_dishonest_prover.rs
@@ -61,7 +61,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestDenseFilterExec<RistrettoPoin
         builder.set_result_indexes(Indexes::Dense(0..(result_len as u64)));
         // 4. set filtered_columns
         for col in &filtered_columns {
-            builder.produce_result_column(col.clone());
+            builder.produce_result_column(*col);
         }
         builder.request_post_result_challenges(2);
         filtered_columns

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_result_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_result_expr.rs
@@ -52,7 +52,7 @@ impl FilterResultExpr {
         accessor: &'a dyn DataAccessor<S>,
     ) -> Column<'a, S> {
         let col = accessor.get_column(self.column_ref);
-        builder.produce_result_column(col.clone());
+        builder.produce_result_column(col);
         col
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -245,7 +245,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
         builder.set_result_indexes(Indexes::Dense(0..(count_column.len() as u64)));
         // 4. set filtered_columns
         for col in &group_by_result_columns {
-            builder.produce_result_column(col.clone());
+            builder.produce_result_column(*col);
         }
         for col in &sum_result_columns {
             builder.produce_result_column(*col);

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -108,7 +108,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
         }));
         builder.set_result_indexes(Indexes::Dense(0..(builder.table_length() as u64)));
         for col in &columns {
-            builder.produce_result_column(col.clone());
+            builder.produce_result_column(*col);
         }
         columns
     }


### PR DESCRIPTION
# Rationale for this change

Derives Copy for Column, reducing the need for cloning in production and test code. Note the diff includes changes to test code where this change isnt really necessary, but these changes satisfy clippy.

# What changes are included in this PR?

1. Derives Copy on Column
2. Removes unnecessary clones where applicable 

# Are these changes tested?

existing tests pass
