### PR TITLE
refactor!: move result cols out of `ResultBuilder`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
@@ -1,11 +1,11 @@
-use super::{ProofBuilder, SumcheckRandomScalars};
+use super::{ProofBuilder, ProvableQueryResult, SumcheckRandomScalars};
 use crate::{
     base::{
         database::{Column, ColumnField, ColumnType},
         polynomial::{compute_evaluation_vector, CompositePolynomial, MultilinearExtension},
         scalar::{compute_commitment_for_testing, Curve25519Scalar},
     },
-    sql::proof::{Indexes, ResultBuilder, SumcheckSubpolynomialType},
+    sql::proof::{Indexes, SumcheckSubpolynomialType},
 };
 #[cfg(feature = "arrow")]
 use arrow::{
@@ -130,10 +130,7 @@ fn we_can_form_the_provable_query_result() {
     let result_indexes = Indexes::Sparse(vec![1, 2]);
     let col1: Column<Curve25519Scalar> = Column::BigInt(&[10_i64, 11, 12]);
     let col2: Column<Curve25519Scalar> = Column::BigInt(&[-2_i64, -3, -4]);
-    let mut builder = ResultBuilder::new(3);
-    builder.set_result_indexes(result_indexes);
-
-    let res = builder.make_provable_query_result(&[col1, col2]);
+    let res = ProvableQueryResult::new(&result_indexes, &[col1, col2]);
 
     let column_fields = vec![
         ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),

--- a/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
@@ -1,7 +1,7 @@
 use super::{ProofBuilder, SumcheckRandomScalars};
 use crate::{
     base::{
-        database::{ColumnField, ColumnType},
+        database::{Column, ColumnField, ColumnType},
         polynomial::{compute_evaluation_vector, CompositePolynomial, MultilinearExtension},
         scalar::{compute_commitment_for_testing, Curve25519Scalar},
     },
@@ -128,14 +128,12 @@ fn we_can_form_an_aggregated_sumcheck_polynomial() {
 #[test]
 fn we_can_form_the_provable_query_result() {
     let result_indexes = Indexes::Sparse(vec![1, 2]);
-    let col1 = [10_i64, 11, 12];
-    let col2 = [-2_i64, -3, -4];
+    let col1: Column<Curve25519Scalar> = Column::BigInt(&[10_i64, 11, 12]);
+    let col2: Column<Curve25519Scalar> = Column::BigInt(&[-2_i64, -3, -4]);
     let mut builder = ResultBuilder::new(3);
     builder.set_result_indexes(result_indexes);
-    builder.produce_result_column(col1);
-    builder.produce_result_column(col2);
 
-    let res = builder.make_provable_query_result();
+    let res = builder.make_provable_query_result(&[col1, col2]);
 
     let column_fields = vec![
         ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -51,7 +51,7 @@ pub trait ProverEvaluate<S: Scalar> {
     /// Evaluate the query and modify `ResultBuilder` to track the result of the query.
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>>;

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -2,7 +2,7 @@ use super::{
     decode_and_convert, decode_multiple_elements, Indexes, ProvableResultColumn, QueryError,
 };
 use crate::base::{
-    database::{ColumnField, ColumnType, OwnedColumn, OwnedTable},
+    database::{Column, ColumnField, ColumnType, OwnedColumn, OwnedTable},
     polynomial::compute_evaluation_vector,
     scalar::Scalar,
 };
@@ -56,10 +56,7 @@ impl ProvableQueryResult {
     }
 
     /// Form intermediate query result from index rows and result columns
-    pub fn new<'a>(
-        indexes: &'a Indexes,
-        columns: &'a [Box<dyn ProvableResultColumn + 'a>],
-    ) -> Self {
+    pub fn new<'a, S: Scalar>(indexes: &'a Indexes, columns: &'a [Column<'a, S>]) -> Self {
         let mut sz = 0;
         for col in columns.iter() {
             sz += col.num_bytes(indexes);

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -54,8 +54,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         let alloc = Bump::new();
         let mut result_builder = ResultBuilder::new(table_length);
-        expr.result_evaluate(&mut result_builder, &alloc, accessor);
-        let provable_result = result_builder.make_provable_query_result();
+        let result_cols = expr.result_evaluate(&mut result_builder, &alloc, accessor);
+        let provable_result = result_builder.make_provable_query_result(&result_cols);
 
         // construct a transcript for the proof
         let mut transcript: Transcript =

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -55,7 +55,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let alloc = Bump::new();
         let mut result_builder = ResultBuilder::new(table_length);
         let result_cols = expr.result_evaluate(&mut result_builder, &alloc, accessor);
-        let provable_result = result_builder.make_provable_query_result(&result_cols);
+        let provable_result =
+            ProvableQueryResult::new(&result_builder.result_index_vector, &result_cols);
 
         // construct a transcript for the proof
         let mut transcript: Transcript =

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -43,14 +43,13 @@ impl Default for TrivialTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let col = alloc.alloc_slice_fill_copy(builder.table_length(), self.column_fill_value);
         let indexes = Indexes::Sparse(vec![0u64]);
         builder.set_result_indexes(indexes);
-        builder.produce_result_column(col as &[_]);
         vec![Column::BigInt(col)]
     }
 
@@ -210,12 +209,11 @@ impl Default for SquareTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         builder.set_result_indexes(Indexes::Sparse(vec![0, 1]));
-        builder.produce_result_column(self.res);
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         vec![Column::BigInt(res)]
     }
@@ -389,12 +387,11 @@ impl Default for DoubleSquareTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         builder.set_result_indexes(Indexes::Sparse(vec![0, 1]));
-        builder.produce_result_column(self.res);
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         vec![Column::BigInt(res)]
     }
@@ -597,12 +594,11 @@ struct ChallengeTestProofPlan {}
 impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         builder.set_result_indexes(Indexes::Sparse(vec![0, 1]));
-        builder.produce_result_column([9, 25]);
         builder.request_post_result_challenges(2);
         vec![Column::BigInt(&[9, 25])]
     }

--- a/crates/proof-of-sql/src/sql/proof/result_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_builder.rs
@@ -1,10 +1,9 @@
-use super::{Indexes, ProvableQueryResult, ProvableResultColumn};
-use crate::base::{database::Column, scalar::Scalar};
+use super::Indexes;
 
 /// Track the result created by a query
 pub struct ResultBuilder {
     table_length: usize,
-    result_index_vector: Indexes,
+    pub(crate) result_index_vector: Indexes,
 
     /// The number of challenges used in the proof.
     /// Specifically, these are the challenges that the verifier sends to
@@ -31,20 +30,6 @@ impl ResultBuilder {
     /// Set the indexes of the rows select in the result
     pub fn set_result_indexes(&mut self, result_index: Indexes) {
         self.result_index_vector = result_index;
-    }
-
-    /// Construct the intermediate query result to be sent to the verifier.
-    pub fn make_provable_query_result<S: Scalar>(
-        &self,
-        cols: &[Column<'_, S>],
-    ) -> ProvableQueryResult {
-        let boxed: Vec<Box<dyn ProvableResultColumn>> = cols
-            .iter()
-            .map(|c| -> Box<dyn ProvableResultColumn> {
-                Box::new(*c) as Box<dyn ProvableResultColumn>
-            })
-            .collect::<Vec<_>>();
-        ProvableQueryResult::new(&self.result_index_vector, &boxed)
     }
 
     /// The number of challenges used in the proof.

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -27,7 +27,7 @@ pub(super) struct EmptyTestQueryExpr {
 impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     fn result_evaluate<'a>(
         &self,
-        _builder: &mut ResultBuilder<'a>,
+        _builder: &mut ResultBuilder,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -1,10 +1,10 @@
 use super::{
-    verifiable_query_result_test::EmptyTestQueryExpr, ProofPlan, ProvableQueryResult,
-    ProvableResultColumn, QueryProof, VerifiableQueryResult,
+    verifiable_query_result_test::EmptyTestQueryExpr, ProofPlan, ProvableQueryResult, QueryProof,
+    VerifiableQueryResult,
 };
 use crate::{
     base::{
-        database::{CommitmentAccessor, OwnedTableTestAccessor, TableRef, TestAccessor},
+        database::{Column, CommitmentAccessor, OwnedTableTestAccessor, TableRef, TestAccessor},
         scalar::{compute_commitment_for_testing, Curve25519Scalar},
     },
     sql::proof::Indexes,
@@ -76,7 +76,7 @@ fn tamper_no_result(
 ) {
     // add a result
     let mut res_p = res.clone();
-    let cols: [Box<dyn ProvableResultColumn>; 1] = [Box::new([0_i64; 0])];
+    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(&[0_i64; 0])];
     res_p.provable_result = Some(ProvableQueryResult::new(&Indexes::Sparse(vec![]), &cols));
     assert!(res_p.verify(expr, accessor, &()).is_err());
 
@@ -99,7 +99,7 @@ fn tamper_empty_result(
 ) {
     // try to add a result
     let mut res_p = res.clone();
-    let cols: [Box<dyn ProvableResultColumn>; 1] = [Box::new([123_i64])];
+    let cols: [Column<'_, Curve25519Scalar>; 1] = [Column::BigInt(&[123_i64])];
     res_p.provable_result = Some(ProvableQueryResult::new(&Indexes::Sparse(vec![0]), &cols));
     assert!(res_p.verify(expr, accessor, &()).is_err());
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -94,7 +94,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
     #[tracing::instrument(name = "DynProofPlan::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut crate::sql::proof::ResultBuilder<'a>,
+        builder: &mut crate::sql::proof::ResultBuilder,
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -149,7 +149,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for FilterExec<C> {
     #[tracing::instrument(name = "FilterExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
@@ -171,10 +171,6 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for FilterExec<C> {
         let (filtered_columns, result_len) = filter_columns(alloc, &columns, selection);
         // 3. set indexes
         builder.set_result_indexes(Indexes::Dense(0..(result_len as u64)));
-        // 4. set filtered_columns
-        for col in &filtered_columns {
-            builder.produce_result_column(*col);
-        }
         builder.request_post_result_challenges(2);
         filtered_columns
     }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -10,7 +10,8 @@ use crate::{
     },
     sql::{
         proof::{
-            exercise_verification, ProofPlan, ProverEvaluate, ResultBuilder, VerifiableQueryResult,
+            exercise_verification, ProofPlan, ProvableQueryResult, ProverEvaluate, ResultBuilder,
+            VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, LiteralExpr, TableExpr},
     },
@@ -202,10 +203,10 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
             ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
         ),
     ];
-    let res = builder
-        .make_provable_query_result(&result_cols)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -247,10 +248,10 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res = builder
-        .make_provable_query_result(&result_cols)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -280,10 +281,10 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
     let mut builder = ResultBuilder::new(5);
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[];
-    let res = builder
-        .make_provable_query_result(&result_cols)
-        .to_owned_table::<Curve25519Scalar>(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
+            .to_owned_table(fields)
+            .unwrap();
     let expected = OwnedTable::try_new(IndexMap::new()).unwrap();
     assert_eq!(res, expected);
 }
@@ -319,10 +320,10 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res = builder
-        .make_provable_query_result(&result_cols)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [3, 5]),
         int128("c", [3, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -192,7 +192,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
     );
     let alloc = Bump::new();
     let mut builder = ResultBuilder::new(0);
-    expr.result_evaluate(&mut builder, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -203,7 +203,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         ),
     ];
     let res = builder
-        .make_provable_query_result()
+        .make_provable_query_result(&result_cols)
         .to_owned_table(fields)
         .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -237,7 +237,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let mut builder = ResultBuilder::new(5);
-    expr.result_evaluate(&mut builder, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -248,7 +248,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         ),
     ];
     let res = builder
-        .make_provable_query_result()
+        .make_provable_query_result(&result_cols)
         .to_owned_table(fields)
         .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -278,10 +278,10 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
     let mut builder = ResultBuilder::new(5);
-    expr.result_evaluate(&mut builder, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[];
     let res = builder
-        .make_provable_query_result()
+        .make_provable_query_result(&result_cols)
         .to_owned_table::<Curve25519Scalar>(fields)
         .unwrap();
     let expected = OwnedTable::try_new(IndexMap::new()).unwrap();
@@ -309,7 +309,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let mut builder = ResultBuilder::new(5);
-    expr.result_evaluate(&mut builder, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -320,7 +320,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         ),
     ];
     let res = builder
-        .make_provable_query_result()
+        .make_provable_query_result(&result_cols)
         .to_owned_table(fields)
         .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -37,7 +37,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec<RistrettoPoint> {
     )]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<Curve25519Scalar>,
     ) -> Vec<Column<'a, Curve25519Scalar>> {
@@ -59,10 +59,6 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec<RistrettoPoint> {
         let filtered_columns = tamper_column(alloc, filtered_columns);
         // 3. set indexes
         builder.set_result_indexes(Indexes::Dense(0..(result_len as u64)));
-        // 4. set filtered_columns
-        for col in &filtered_columns {
-            builder.produce_result_column(*col);
-        }
         builder.request_post_result_challenges(2);
         filtered_columns
     }

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -209,7 +209,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
     #[tracing::instrument(name = "GroupByExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
@@ -243,15 +243,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
             .expect("columns should be aggregatable");
         // 3. set indexes
         builder.set_result_indexes(Indexes::Dense(0..(count_column.len() as u64)));
-        // 4. set filtered_columns
-        for col in &group_by_result_columns {
-            builder.produce_result_column(*col);
-        }
-        for col in &sum_result_columns {
-            builder.produce_result_column(*col);
-        }
         let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(col));
-        builder.produce_result_column(count_column);
         builder.request_post_result_challenges(2);
         Vec::from_iter(
             group_by_result_columns

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -97,7 +97,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
     #[tracing::instrument(name = "ProjectionExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder<'a>,
+        builder: &mut ResultBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
@@ -107,9 +107,6 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
                 .result_evaluate(builder.table_length(), alloc, accessor)
         }));
         builder.set_result_indexes(Indexes::Dense(0..(builder.table_length() as u64)));
-        for col in &columns {
-            builder.produce_result_column(*col);
-        }
         columns
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -165,7 +165,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
     let mut builder = ResultBuilder::new(0);
-    expr.result_evaluate(&mut builder, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -176,7 +176,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
         ),
     ];
     let res = builder
-        .make_provable_query_result()
+        .make_provable_query_result(&result_cols)
         .to_owned_table(fields)
         .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -204,10 +204,10 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     let expr: DynProofPlan<RistrettoPoint> = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
     let mut builder = ResultBuilder::new(5);
-    expr.result_evaluate(&mut builder, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[];
     let res = builder
-        .make_provable_query_result()
+        .make_provable_query_result(&result_cols)
         .to_owned_table::<Curve25519Scalar>(fields)
         .unwrap();
     let expected = OwnedTable::try_new(IndexMap::new()).unwrap();
@@ -240,7 +240,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
     );
     let alloc = Bump::new();
     let mut builder = ResultBuilder::new(5);
-    expr.result_evaluate(&mut builder, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("prod".parse().unwrap(), ColumnType::Int128),
@@ -251,7 +251,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         ),
     ];
     let res = builder
-        .make_provable_query_result()
+        .make_provable_query_result(&result_cols)
         .to_owned_table(fields)
         .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -10,7 +10,8 @@ use crate::{
     },
     sql::{
         proof::{
-            exercise_verification, ProofPlan, ProverEvaluate, ResultBuilder, VerifiableQueryResult,
+            exercise_verification, ProofPlan, ProvableQueryResult, ProverEvaluate, ResultBuilder,
+            VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, TableExpr},
     },
@@ -175,10 +176,10 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
             ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
         ),
     ];
-    let res = builder
-        .make_provable_query_result(&result_cols)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -206,10 +207,10 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     let mut builder = ResultBuilder::new(5);
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[];
-    let res = builder
-        .make_provable_query_result(&result_cols)
-        .to_owned_table::<Curve25519Scalar>(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
+            .to_owned_table(fields)
+            .unwrap();
     let expected = OwnedTable::try_new(IndexMap::new()).unwrap();
     assert_eq!(res, expected);
 }
@@ -250,10 +251,10 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res = builder
-        .make_provable_query_result(&result_cols)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [2, 3, 4, 5, 6]),
         int128("prod", [1, 4, 9, 16, 25]),


### PR DESCRIPTION
# Rationale for this change
In order to make `ProofPlan`s composable to facilitate `SliceExec`, `UnionExec` and `JoinExec` we need to move result cols out of the `ResultBuilder` which is increasingly a misnomer.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- remove `ResultBuilder::produce_result_column`
- remove result columns from `ResultBuilder`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Existing tests should pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
