### PR TITLE
ci: install Nvidia drivers when running CI (PROOF-911)

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -34,8 +34,6 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
-      - name: Install NVIDIA Driver
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y nvidia-driver-560
       - name: Run cargo check (no features, exclude examples)
         run: cargo check --no-default-features
       - name: Run cargo check (default features)
@@ -70,7 +68,7 @@ jobs:
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
       - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld nvidia-driver-560
       - name: Run cargo test
         run: cargo test --all-features
       - name: Dry run cargo test (proof-of-sql) (test feature only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
       - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
-      - name: Install NVIDIA Driver
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y nvidia-driver-560        
+        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld     
       - name: Run cargo check (no features, exclude examples)
         run: cargo check --no-default-features
       - name: Run cargo check (default features)
@@ -70,9 +68,13 @@ jobs:
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
       - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
-      - name: Install NVIDIA Driver
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y nvidia-driver-560
+        run: |
+          export DEBIAN_FRONTEND=non-interactive
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository ppa:graphics-drivers/ppa
+          sudo apt-get update
+          sudo apt-get install -y clang lld nvidia-driver-560
       - name: Run cargo test
         run: cargo test --all-features
       - name: Dry run cargo test (proof-of-sql) (test feature only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -68,7 +68,12 @@ jobs:
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
       - name: Install Dependencies
-        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld nvidia-driver-560
+        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Install NVIDIA Driver
+        run: |
+          export DEBIAN_FRONTEND=non-interactive
+          sudo apt-get update
+          sudo apt-get install -y nvidia-driver-560  
       - name: Run cargo test
         run: cargo test --all-features
       - name: Dry run cargo test (proof-of-sql) (test feature only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=non-interactive
           sudo apt-get update
-          sudo apt-get install -y nvidia-driver-560  
+          sudo apt-get install -y nvidia-driver-550  
       - name: Run cargo test
         run: cargo test --all-features
       - name: Dry run cargo test (proof-of-sql) (test feature only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -34,6 +34,8 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Install NVIDIA Driver
+        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y nvidia-driver-560        
       - name: Run cargo check (no features, exclude examples)
         run: cargo check --no-default-features
       - name: Run cargo check (default features)
@@ -70,10 +72,7 @@ jobs:
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
       - name: Install NVIDIA Driver
-        run: |
-          export DEBIAN_FRONTEND=non-interactive
-          sudo apt-get update
-          sudo apt-get install -y nvidia-driver-550  
+        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y nvidia-driver-560
       - name: Run cargo test
         run: cargo test --all-features
       - name: Dry run cargo test (proof-of-sql) (test feature only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -34,6 +34,8 @@ jobs:
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
+      - name: Install NVIDIA Driver
+        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y nvidia-driver-560
       - name: Run cargo check (no features, exclude examples)
         run: cargo check --no-default-features
       - name: Run cargo check (default features)


### PR DESCRIPTION
# Rationale for this change
Blitzar now checks to the version of the Nvidia driver. It currently throws an error if the version is under `nvidia-driver-560`, causing the CI to fail. This PR installs the Nvidia driver before running tests with the GPU.

# What changes are included in this PR?
- The Test Suite portion of the Github workflow now:
  - Adds the NVIDIA package repository since the`nvidia-driver-560` package is not yet available in the default Ubuntu repositories.
  - Installs the`nvidia-driver-560` package when installing dependencies.

# Are these changes tested?
Yes, via Github CI.
