### PR TITLE
build: bump forge-script version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ chrono = { version = "0.4.38", default-features = false }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
 derive_more = { version = "0.99" }
 flexbuffers = { version = "2.0.0" }
-forge-script = { git = "https://github.com/foundry-rs/foundry", rev = "nightly-2442e7a5fc165d7d0b022aa8b9f09dcdf675157b" }
+forge-script = { git = "https://github.com/foundry-rs/foundry", rev = "d663f38be3114ccb94f08fe3b8ea26e27e2043c1" }
 indexmap = { version = "2.1" }
 itertools = { version = "0.13.0" }
 lalrpop-util = { version = "0.20.0" }
@@ -64,27 +64,3 @@ zerocopy = { version = "0.7.34" }
 
 [workspace.lints.rust]
 missing_docs = "warn"
-
-# These patches are copied from https://github.com/foundry-rs/foundry in order for forge-script to compile.
-[patch.crates-io]
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-signer-ledger = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-signer-trezor = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-transport-ipc = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "511ae98" }
-revm = { git = "https://github.com/bluealloy/revm", rev = "caadc71" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "caadc71" }


### PR DESCRIPTION
# Rationale for this change

In order to get `forge-script` to compile, we needed to use various patches used by foundry. https://github.com/foundry-rs/foundry/pull/8838 removed these. So, we can remove the patches from our `Cargo.toml` file.


# Are these changes tested?

Yes