### PR TITLE
fix: safely handle max integer type

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -313,10 +313,11 @@ impl ColumnType {
         if !self.is_integer() || !other.is_integer() {
             return None;
         }
-        Self::from_integer_bits(std::cmp::max(
-            self.to_integer_bits().unwrap(),
-            other.to_integer_bits().unwrap(),
-        ))
+        self.to_integer_bits().and_then(|self_bits| {
+            other.to_integer_bits().and_then(|other_bits| {
+                Self::from_integer_bits(std::cmp::max(self_bits, other_bits))
+            })
+        })
     }
 
     /// Returns the precision of a ColumnType if it is converted to a decimal wrapped in Some(). If it can not be converted to a decimal, return None.


### PR DESCRIPTION
# Rationale for this change

This PR fixes the function ```max_integer_type``` to safely handle the conversion from ```ColumnType``` into ```integer_bits```, if the type is an integer.

# What changes are included in this PR?

Dont unwrap ```to_integer_bits```, use an ```and_then``` chain instead.

# Are these changes tested?

yes, existing tests pass
