### PR TITLE
docs: add `missing_docs_in_private_items` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,5 +62,6 @@ tracing-subscriber = { version = "0.3.0" }
 wasm-bindgen = { version = "0.2.92" }
 zerocopy = { version = "0.7.34" }
 
-[workspace.lints.rust]
-missing_docs = "warn"
+[workspace.lints]
+rust.missing_docs = "warn"
+clippy.missing_docs_in_private_items = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+missing-docs-in-crate-items = true

--- a/crates/proof-of-sql-parser/src/intermediate_ast.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast.rs
@@ -339,6 +339,7 @@ impl From<bool> for Literal {
     }
 }
 
+/// TODO: add docs
 macro_rules! impl_int_to_literal {
     ($tt:ty) => {
         impl From<$tt> for Literal {
@@ -363,6 +364,7 @@ impl From<i128> for Literal {
     }
 }
 
+/// TODO: add docs
 macro_rules! impl_string_to_literal {
     ($tt:ty) => {
         impl From<$tt> for Literal {

--- a/crates/proof-of-sql-parser/src/lib.rs
+++ b/crates/proof-of-sql-parser/src/lib.rs
@@ -15,6 +15,7 @@ mod intermediate_ast_tests;
 /// Shortcuts to construct intermediate AST nodes.
 pub mod utility;
 
+/// TODO: add docs
 pub(crate) mod select_statement;
 pub use select_statement::SelectStatement;
 
@@ -23,6 +24,7 @@ pub mod error;
 pub use error::ParseError;
 pub(crate) use error::ParseResult;
 
+/// TODO: add docs
 pub(crate) mod identifier;
 pub use identifier::Identifier;
 
@@ -30,7 +32,7 @@ pub mod resource_id;
 pub use resource_id::ResourceId;
 
 // lalrpop-generated code is not clippy-compliant
-lalrpop_mod!(#[allow(clippy::all, missing_docs)] pub sql);
+lalrpop_mod!(#[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items)] pub sql);
 
 /// Implement Deserialize through FromStr to avoid invalid identifiers.
 #[macro_export]

--- a/crates/proof-of-sql/benches/bench_append_rows.rs
+++ b/crates/proof-of-sql/benches/bench_append_rows.rs
@@ -5,7 +5,7 @@
 //! ```bash
 //! cargo bench --features "test" --bench bench_append_rows
 //! ```
-#![allow(missing_docs)]
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use proof_of_sql::{
     base::{

--- a/crates/proof-of-sql/benches/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger_benches.rs
@@ -13,11 +13,13 @@ use proof_of_sql::proof_primitive::dory::{
     DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup,
     PublicParameters, VerifierSetup,
 };
+/// TODO: add docs
 mod scaffold;
 use crate::scaffold::querys::QUERIES;
 use scaffold::jaeger_scaffold;
 use std::env;
 
+/// TODO: add docs
 const SIZE: usize = 1_000_000;
 
 fn main() {

--- a/crates/proof-of-sql/benches/posql_benches.rs
+++ b/crates/proof-of-sql/benches/posql_benches.rs
@@ -3,7 +3,7 @@
 //! ```bash
 //! cargo bench -p proof-of-sql --bench criterion_benches
 //! ```
-#![allow(missing_docs)]
+#![allow(missing_docs, clippy::missing_docs_in_private_items)]
 use blitzar::proof::InnerProductProof;
 use criterion::{criterion_group, criterion_main, Criterion};
 

--- a/crates/proof-of-sql/examples/hello_world/main.rs
+++ b/crates/proof-of-sql/examples/hello_world/main.rs
@@ -10,11 +10,13 @@ use std::{
     time::Instant,
 };
 
+/// TODO: add docs
 fn start_timer(message: &str) -> Instant {
     print!("{}...", message);
     stdout().flush().unwrap();
     Instant::now()
 }
+/// TODO: add docs
 fn end_timer(instant: Instant) {
     println!(" {:?}", instant.elapsed());
 }

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -1,6 +1,9 @@
 #![doc = include_str!("README.md")]
+/// TODO: add docs
 mod commit_accessor;
+/// TODO: add docs
 mod csv_accessor;
+/// TODO: add docs
 mod record_batch_accessor;
 use arrow::{
     datatypes::{DataType, Field, Schema},
@@ -36,14 +39,18 @@ struct CliArgs {
     #[arg(short, long, default_value = ".")]
     path: String,
     #[command(subcommand)]
+    /// TODO: add docs
     command: Commands,
 }
 
 #[derive(Clone, ValueEnum, Debug)]
 #[value(rename_all = "UPPER")]
 enum CsvDataType {
+    /// TODO: add docs
     BigInt,
+    /// TODO: add docs
     VarChar,
+    /// TODO: add docs
     Decimal,
 }
 impl From<&CsvDataType> for DataType {
@@ -56,6 +63,7 @@ impl From<&CsvDataType> for DataType {
     }
 }
 
+/// TODO: add docs
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Creates a new csv for an empty table and initializes the commitment of that table.
@@ -112,6 +120,7 @@ fn start_timer(message: &str) -> Instant {
     stdout().flush().unwrap();
     Instant::now()
 }
+/// TODO: add docs
 fn end_timer(instant: Instant) {
     println!(" {:?}", instant.elapsed());
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -43,6 +43,7 @@ pub use owned_column::OwnedColumn;
 mod owned_column_error;
 pub use owned_column_error::{OwnedColumnError, OwnedColumnResult};
 
+/// TODO: add docs
 pub(crate) mod owned_column_operation;
 
 mod owned_table;
@@ -52,6 +53,7 @@ pub(crate) use owned_table::OwnedTableError;
 mod owned_table_test;
 pub mod owned_table_utility;
 
+/// TODO: add docs
 pub(crate) mod expression_evaluation;
 mod expression_evaluation_error;
 #[cfg(test)]
@@ -87,6 +89,7 @@ mod owned_table_test_accessor_test;
 #[cfg(feature = "arrow")]
 pub mod scalar_and_i256_conversions;
 
+/// TODO: add docs
 pub(crate) mod filter_util;
 #[cfg(test)]
 mod filter_util_test;

--- a/crates/proof-of-sql/src/base/database/record_batch_utility.rs
+++ b/crates/proof-of-sql/src/base/database/record_batch_utility.rs
@@ -75,6 +75,7 @@ impl ToArrow for Vec<Time> {
     }
 }
 
+/// TODO: add docs
 macro_rules! int_to_arrow_array {
     ($tt:ty, $dtt:expr, $att:ty) => {
         impl ToArrow for Vec<$tt> {
@@ -123,6 +124,7 @@ impl ToArrow for Vec<i128> {
     }
 }
 
+/// TODO: add docs
 macro_rules! string_to_arrow_array {
     ($tt:ty, $dtt:expr, $att:ty) => {
         impl ToArrow for Vec<$tt> {

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -64,6 +64,7 @@ fn zigzag_decode(from: u64) -> i64 {
     ((from >> 1) ^ (-((from & 1) as i64)) as u64) as i64
 }
 
+/// TODO: add docs
 macro_rules! impl_varint {
     ($t:ty, unsigned) => {
         impl VarInt for $t {

--- a/crates/proof-of-sql/src/base/math/mod.rs
+++ b/crates/proof-of-sql/src/base/math/mod.rs
@@ -5,4 +5,5 @@ pub mod decimal;
 mod decimal_tests;
 mod log;
 pub(crate) use log::log2_up;
+/// TODO: add docs
 pub(crate) mod permutation;

--- a/crates/proof-of-sql/src/base/mod.rs
+++ b/crates/proof-of-sql/src/base/mod.rs
@@ -1,9 +1,12 @@
 //! This module contains basic shared functionalities of the library.
+/// TODO: add docs
 pub(crate) mod bit;
 pub mod commitment;
 pub mod database;
+/// TODO: add docs
 pub(crate) mod encode;
 pub mod math;
+/// TODO: add docs
 pub(crate) mod polynomial;
 pub(crate) mod proof;
 pub(crate) mod ref_into;

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -57,6 +57,7 @@ where
     }
 }
 
+/// TODO: add docs
 macro_rules! slice_like_mle_impl {
     () => {
         fn inner_product(&self, evaluation_vec: &[S]) -> S {

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_from.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_from.rs
@@ -2,6 +2,7 @@ use crate::base::scalar::MontScalar;
 use ark_ff::MontConfig;
 use num_traits::Zero;
 
+/// TODO: add docs
 macro_rules! impl_from_for_mont_scalar_for_type_supported_by_from {
     ($tt:ty) => {
         impl<T: MontConfig<4>> From<$tt> for MontScalar<T> {
@@ -24,6 +25,7 @@ impl<T: MontConfig<4>> From<&[u8]> for MontScalar<T> {
         Self::from_le_bytes_mod_order(&bytes)
     }
 }
+/// TODO: add docs
 macro_rules! impl_from_for_mont_scalar_for_string {
     ($tt:ty) => {
         impl<T: MontConfig<4>> From<$tt> for MontScalar<T> {

--- a/crates/proof-of-sql/src/base/serialize.rs
+++ b/crates/proof-of-sql/src/base/serialize.rs
@@ -1,3 +1,4 @@
+/// TODO: add docs
 macro_rules! impl_serde_for_ark_serde_checked {
     ($t:ty) => {
         impl serde::Serialize for $t {
@@ -20,6 +21,7 @@ macro_rules! impl_serde_for_ark_serde_checked {
     };
 }
 
+/// TODO: add docs
 macro_rules! impl_serde_for_ark_serde_unchecked {
     ($t:ty) => {
         impl serde::Serialize for $t {

--- a/crates/proof-of-sql/src/proof_primitive/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/mod.rs
@@ -1,3 +1,4 @@
 //! TODO: add docs
 pub mod dory;
+/// TODO: add docs
 pub(crate) mod sumcheck;

--- a/crates/proof-of-sql/src/sql/parse/mod.rs
+++ b/crates/proof-of-sql/src/sql/parse/mod.rs
@@ -16,6 +16,7 @@ pub use query_expr::QueryExpr;
 mod filter_exec_builder;
 pub(crate) use filter_exec_builder::FilterExecBuilder;
 
+/// TODO: add docs
 pub(crate) mod query_context;
 pub(crate) use query_context::QueryContext;
 

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -92,6 +92,7 @@ impl QueryContext {
         self.in_agg_scope
     }
 
+    /// TODO: add docs
     pub(crate) fn has_agg(&self) -> bool {
         self.agg_counter > 0 || !self.group_by_exprs.is_empty()
     }

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -241,6 +241,7 @@ impl<'a> QueryContextBuilder<'a> {
     }
 }
 
+/// TODO: add docs
 pub(crate) fn type_check_binary_operation(
     left_dtype: &ColumnType,
     right_dtype: &ColumnType,

--- a/crates/proof-of-sql/src/sql/proof/result_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_builder.rs
@@ -3,6 +3,7 @@ use super::Indexes;
 /// Track the result created by a query
 pub struct ResultBuilder {
     table_length: usize,
+    /// TODO: add docs
     pub(crate) result_index_vector: Indexes,
 
     /// The number of challenges used in the proof.

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -34,6 +34,7 @@ use serde::{Deserialize, Serialize};
 pub struct OstensibleFilterExec<C: Commitment, H: ProverHonestyMarker> {
     pub(super) aliased_results: Vec<AliasedDynProofExpr<C>>,
     pub(super) table: TableExpr,
+    /// TODO: add docs
     pub(crate) where_clause: DynProofExpr<C>,
     phantom: PhantomData<H>,
 }


### PR DESCRIPTION
# Rationale for this change

In order to improve our internal documentation, we should be documenting functionality. Enforcing this in CI simplifies review and development.

# What changes are included in this PR?

The `missing_docs_in_private_items` lint with the `missing-docs-in-crate-items` option set to true. This option means that missing docs are only warned if they have `pub(crate)` visibility. We could set this to `false` to be even more stringent. However, this would cause 473 more warnings for missing docs, and is likely a bit too much.

# Are these changes tested?

Yes