### PR TITLE
refactor!: Implement Clone rather than Copy for Commitment

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
+++ b/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
@@ -77,7 +77,7 @@ impl<C: Commitment> MetadataAccessor for BenchmarkAccessor<'_, C> {
 }
 impl<C: Commitment> CommitmentAccessor<C> for BenchmarkAccessor<'_, C> {
     fn get_commitment(&self, column: ColumnRef) -> C {
-        *self.commitments.get(&column).unwrap()
+        self.commitments.get(&column).unwrap().clone()
     }
 }
 impl<C: Commitment> SchemaAccessor for BenchmarkAccessor<'_, C> {

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -81,7 +81,7 @@ impl<C: Commitment> ColumnCommitments<C> {
     pub fn get_commitment(&self, identifier: &Identifier) -> Option<C> {
         self.column_metadata
             .get_index_of(identifier)
-            .map(|index| self.commitments[index])
+            .map(|index| self.commitments[index].clone())
     }
 
     /// Returns the metadata for the commitment with the given identifier.

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -46,7 +46,7 @@ pub trait Commitment:
     + SubAssign
     + Sized
     + Default
-    + Copy
+    + Clone
     + core::ops::Neg<Output = Self>
     + Eq
     + core::ops::Sub<Output = Self>

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -70,12 +70,12 @@ pub trait VecCommitmentExt {
 }
 
 fn unsafe_add_assign<C: Commitment>(a: &mut [C], b: &[C]) {
-    a.iter_mut().zip(b).for_each(|(c_a, &ref c_b)| {
+    a.iter_mut().zip(b).for_each(|(c_a, c_b)| {
         *c_a += c_b.clone();
     });
 }
 fn unsafe_sub_assign<C: Commitment>(a: &mut [C], b: &[C]) {
-    a.iter_mut().zip(b).for_each(|(c_a, &ref c_b)| {
+    a.iter_mut().zip(b).for_each(|(c_a, c_b)| {
         *c_a -= c_b.clone();
     });
 }

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -70,13 +70,13 @@ pub trait VecCommitmentExt {
 }
 
 fn unsafe_add_assign<C: Commitment>(a: &mut [C], b: &[C]) {
-    a.iter_mut().zip(b).for_each(|(c_a, &c_b)| {
-        *c_a += c_b;
+    a.iter_mut().zip(b).for_each(|(c_a, &ref c_b)| {
+        *c_a += c_b.clone();
     });
 }
 fn unsafe_sub_assign<C: Commitment>(a: &mut [C], b: &[C]) {
-    a.iter_mut().zip(b).for_each(|(c_a, &c_b)| {
-        *c_a -= c_b;
+    a.iter_mut().zip(b).for_each(|(c_a, &ref c_b)| {
+        *c_a -= c_b.clone();
     });
 }
 

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -101,7 +101,7 @@ impl<CP: CommitmentEvaluationProof> CommitmentAccessor<CP::Commitment>
     fn get_commitment(&self, column: ColumnRef) -> CP::Commitment {
         let (table, offset) = self.tables.get(&column.table_ref()).unwrap();
         let owned_column = table.inner_table().get(&column.column_id()).unwrap();
-        Vec::from_columns_with_offset([owned_column], *offset, self.setup.as_ref().unwrap())[0]
+        Vec::<CP::Commitment>::from_columns_with_offset([owned_column], *offset, self.setup.as_ref().unwrap())[0].clone()
     }
 }
 impl<CP: CommitmentEvaluationProof> MetadataAccessor for OwnedTableTestAccessor<'_, CP> {

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -101,7 +101,12 @@ impl<CP: CommitmentEvaluationProof> CommitmentAccessor<CP::Commitment>
     fn get_commitment(&self, column: ColumnRef) -> CP::Commitment {
         let (table, offset) = self.tables.get(&column.table_ref()).unwrap();
         let owned_column = table.inner_table().get(&column.column_id()).unwrap();
-        Vec::<CP::Commitment>::from_columns_with_offset([owned_column], *offset, self.setup.as_ref().unwrap())[0].clone()
+        Vec::<CP::Commitment>::from_columns_with_offset(
+            [owned_column],
+            *offset,
+            self.setup.as_ref().unwrap(),
+        )[0]
+        .clone()
     }
 }
 impl<CP: CommitmentEvaluationProof> MetadataAccessor for OwnedTableTestAccessor<'_, CP> {

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -92,7 +92,7 @@ impl<'a, C: Commitment> VerificationBuilder<'a, C> {
     ///
     /// An interemdiate MLE is one where the verifier doesn't have access to its commitment
     pub fn consume_intermediate_mle(&mut self) -> C::Scalar {
-        let commitment = self.intermediate_commitments[self.consumed_intermediate_mles];
+        let commitment = self.intermediate_commitments[self.consumed_intermediate_mles].clone();
         self.consumed_intermediate_mles += 1;
         self.consume_anchored_mle(commitment)
     }


### PR DESCRIPTION
# Rationale for this change

In a future PR, a NaiveCommitment will be created which has a vector of scalars as a field. Because this field can't implement Copy, Commitment will have to only use Clone.

# What changes are included in this PR?

1. Commitment becomes Clone rather than Copy.
2. Addressing any errors this change introduces.

# Are these changes tested?

No new tests
