### PR TITLE
feat: add test commitment and test scalar

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -77,6 +77,11 @@ pub trait Commitment:
     type PublicSetup<'a>;
 
     /// Compute the commitments for the given columns.
+    ///
+    /// The resulting commitments are written to the slice in `commitments`, which is a buffer.
+    /// `commitments` is expected to have the same length as `committable_columns` and the behavior is undefined if it does not.
+    ///
+    /// `offset` is the amount that `committable_columns` is "offset" by. Logically adding `offset` many 0s to the beginning of each of the `committable_columns`.
     fn compute_commitments(
         commitments: &mut [Self],
         committable_columns: &[CommittableColumn],

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -40,6 +40,14 @@ pub use table_commitment::{
 mod query_commitments;
 pub use query_commitments::{QueryCommitments, QueryCommitmentsExt};
 
+/// Module for providing a mock commitment.
+#[cfg(test)]
+pub mod naive_commitment;
+
+/// Module for providing a test commitment evaluation proof.
+#[cfg(test)]
+pub mod test_evaluation_proof;
+
 /// A trait for using commitment schemes generically.
 pub trait Commitment:
     AddAssign

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -48,6 +48,9 @@ pub mod naive_commitment;
 #[cfg(test)]
 pub mod test_evaluation_proof;
 
+#[cfg(test)]
+mod naive_commitment_test;
+
 /// A trait for using commitment schemes generically.
 pub trait Commitment:
     AddAssign

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -80,6 +80,7 @@ pub trait Commitment:
     ///
     /// The resulting commitments are written to the slice in `commitments`, which is a buffer.
     /// `commitments` is expected to have the same length as `committable_columns` and the behavior is undefined if it does not.
+    /// The length of each CommittableColumn should be the same.
     ///
     /// `offset` is the amount that `committable_columns` is "offset" by. Logically adding `offset` many 0s to the beginning of each of the `committable_columns`.
     fn compute_commitments(

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -167,7 +167,7 @@ fn we_can_compute_commitments_from_commitable_columns() {
     let column_b_scalars: Vec<TestScalar> = column_b.iter().map(|b| b.into()).collect();
     let commitable_column_a = CommittableColumn::BigInt(&column_a);
     let commitable_column_b = CommittableColumn::VarChar(column_b);
-    let committable_columns: &[CommittableColumn] = &vec![commitable_column_a, commitable_column_b];
+    let committable_columns: &[CommittableColumn] = &[commitable_column_a, commitable_column_b];
     let mut commitments: Vec<NaiveCommitment> = vec![NaiveCommitment(Vec::new()); 2];
     NaiveCommitment::compute_commitments(&mut commitments, committable_columns, 0, &());
     assert_eq!(commitments[0].0, column_a_scalars);
@@ -179,7 +179,7 @@ fn we_can_compute_commitments_from_commitable_columns_with_offset() {
     let column_a = [0i64, 1, 10, -5, 0, 10];
     let column_a_scalars: Vec<TestScalar> = column_a.iter().map(|a| a.into()).collect();
     let commitable_column_a = CommittableColumn::BigInt(&column_a[1..]);
-    let committable_columns: &[CommittableColumn] = &vec![commitable_column_a];
+    let committable_columns: &[CommittableColumn] = &[commitable_column_a];
     let mut commitments: Vec<NaiveCommitment> = vec![NaiveCommitment(Vec::new()); 2];
     NaiveCommitment::compute_commitments(&mut commitments, committable_columns, 1, &());
     assert_eq!(commitments[0].0, column_a_scalars);

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -80,19 +80,19 @@ impl PartialEq for NaiveCommitment {
 impl core::ops::Mul<NaiveCommitment> for TestScalar {
     type Output = NaiveCommitment;
     fn mul(self, rhs: NaiveCommitment) -> Self::Output {
-        NaiveCommitment(rhs.0.iter().map(|s| self * *s).collect())
+        self * &rhs
     }
 }
 impl core::ops::Mul<TestScalar> for NaiveCommitment {
     type Output = NaiveCommitment;
     fn mul(self, rhs: TestScalar) -> Self::Output {
-        NaiveCommitment(self.0.iter().map(|s| rhs * *s).collect())
+        &self * rhs
     }
 }
 impl core::ops::Mul<&NaiveCommitment> for TestScalar {
     type Output = NaiveCommitment;
     fn mul(self, rhs: &NaiveCommitment) -> Self::Output {
-        NaiveCommitment(rhs.0.iter().map(|s| self * *s).collect())
+        rhs * self
     }
 }
 impl core::ops::Mul<TestScalar> for &NaiveCommitment {

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -26,9 +26,10 @@ impl Add for NaiveCommitment {
 impl Sub for NaiveCommitment {
     type Output = NaiveCommitment;
 
-    #[allow(clippy::suspicious_arithmetic_impl)]
     fn sub(self, rhs: Self) -> Self::Output {
-        self + rhs.neg()
+        let mut new_self = self.clone();
+        new_self.sub_assign(rhs);
+        new_self
     }
 }
 impl Neg for NaiveCommitment {
@@ -79,25 +80,25 @@ impl PartialEq for NaiveCommitment {
 impl core::ops::Mul<NaiveCommitment> for TestScalar {
     type Output = NaiveCommitment;
     fn mul(self, rhs: NaiveCommitment) -> Self::Output {
-        NaiveCommitment(rhs.0.iter().map(|s| self + *s).collect())
+        NaiveCommitment(rhs.0.iter().map(|s| self * *s).collect())
     }
 }
 impl core::ops::Mul<TestScalar> for NaiveCommitment {
     type Output = NaiveCommitment;
     fn mul(self, rhs: TestScalar) -> Self::Output {
-        NaiveCommitment(self.0.iter().map(|s| rhs + *s).collect())
+        NaiveCommitment(self.0.iter().map(|s| rhs * *s).collect())
     }
 }
 impl core::ops::Mul<&NaiveCommitment> for TestScalar {
     type Output = NaiveCommitment;
     fn mul(self, rhs: &NaiveCommitment) -> Self::Output {
-        NaiveCommitment(rhs.0.iter().map(|s| self + *s).collect())
+        NaiveCommitment(rhs.0.iter().map(|s| self * *s).collect())
     }
 }
 impl core::ops::Mul<TestScalar> for &NaiveCommitment {
     type Output = NaiveCommitment;
     fn mul(self, rhs: TestScalar) -> Self::Output {
-        NaiveCommitment(self.0.iter().map(|s| rhs + *s).collect())
+        NaiveCommitment(self.0.iter().map(|s| rhs * *s).collect())
     }
 }
 

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -9,7 +9,7 @@ use std::{
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
 
-/// This should only be used for the purpose of unit testing.
+/// A naive [Commitment] implementation that should only be used for the purpose of unit testing.
 #[derive(Clone, Debug, Eq, Default, Serialize, Deserialize)]
 pub struct NaiveCommitment(pub Vec<TestScalar>);
 

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -142,6 +142,9 @@ impl Commitment for NaiveCommitment {
                     CommittableColumn::TimestampTZ(_, _, i64_vec) => {
                         i64_vec.iter().map(|b| b.into()).collect()
                     }
+                    CommittableColumn::RangeCheckWord(u8_scalar_vec) => {
+                        u8_scalar_vec.iter().map(|b| b.into()).collect()
+                    }
                 };
                 vectors.append(&mut existing_scalars);
                 vectors

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -1,0 +1,153 @@
+use super::Commitment;
+use crate::base::{
+    commitment::CommittableColumn,
+    scalar::{test_scalar::TestScalar, Scalar},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::Debug,
+    ops::{Add, AddAssign, Neg, Sub, SubAssign},
+};
+
+/// This should only be used for the purpose of unit testing.
+#[derive(Clone, Debug, Eq, Default, Serialize, Deserialize)]
+pub struct NaiveCommitment(pub Vec<TestScalar>);
+
+impl Add for NaiveCommitment {
+    type Output = NaiveCommitment;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut new_self = self.clone();
+        new_self.add_assign(rhs);
+        new_self
+    }
+}
+
+impl Sub for NaiveCommitment {
+    type Output = NaiveCommitment;
+
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn sub(self, rhs: Self) -> Self::Output {
+        self + rhs.neg()
+    }
+}
+impl Neg for NaiveCommitment {
+    type Output = NaiveCommitment;
+
+    fn neg(self) -> Self::Output {
+        Self(self.0.iter().map(|s| s.neg()).collect())
+    }
+}
+
+impl SubAssign for NaiveCommitment {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.add_assign(rhs.neg())
+    }
+}
+
+impl AddAssign for NaiveCommitment {
+    fn add_assign(&mut self, rhs: Self) {
+        if self.0.len() < rhs.0.len() {
+            self.0
+                .extend((self.0.len()..rhs.0.len()).map(|_i| TestScalar::ZERO));
+        }
+        self.0
+            .iter_mut()
+            .zip(rhs.0)
+            .for_each(|(lhs, rhs)| *lhs += rhs);
+    }
+}
+
+impl PartialEq for NaiveCommitment {
+    fn eq(&self, other: &Self) -> bool {
+        match self.0.len().cmp(&other.0.len()) {
+            std::cmp::Ordering::Less => {
+                let mut extended_self = self.0.clone();
+                extended_self.extend((self.0.len()..other.0.len()).map(|_i| TestScalar::ZERO));
+                extended_self == other.0
+            }
+            std::cmp::Ordering::Equal => self.0 == other.0,
+            std::cmp::Ordering::Greater => {
+                let mut extended_other = other.0.clone();
+                extended_other.extend((other.0.len()..self.0.len()).map(|_i| TestScalar::ZERO));
+                extended_other == self.0
+            }
+        }
+    }
+}
+
+impl core::ops::Mul<NaiveCommitment> for TestScalar {
+    type Output = NaiveCommitment;
+    fn mul(self, rhs: NaiveCommitment) -> Self::Output {
+        NaiveCommitment(rhs.0.iter().map(|s| self + *s).collect())
+    }
+}
+impl core::ops::Mul<TestScalar> for NaiveCommitment {
+    type Output = NaiveCommitment;
+    fn mul(self, rhs: TestScalar) -> Self::Output {
+        NaiveCommitment(self.0.iter().map(|s| rhs + *s).collect())
+    }
+}
+impl core::ops::Mul<&NaiveCommitment> for TestScalar {
+    type Output = NaiveCommitment;
+    fn mul(self, rhs: &NaiveCommitment) -> Self::Output {
+        NaiveCommitment(rhs.0.iter().map(|s| self + *s).collect())
+    }
+}
+impl core::ops::Mul<TestScalar> for &NaiveCommitment {
+    type Output = NaiveCommitment;
+    fn mul(self, rhs: TestScalar) -> Self::Output {
+        NaiveCommitment(self.0.iter().map(|s| rhs + *s).collect())
+    }
+}
+
+impl Commitment for NaiveCommitment {
+    type Scalar = TestScalar;
+    type PublicSetup<'a> = ();
+
+    fn compute_commitments(
+        commitments: &mut [Self],
+        committable_columns: &[CommittableColumn],
+        offset: usize,
+        _setup: &Self::PublicSetup<'_>,
+    ) {
+        let vectors: Vec<Vec<TestScalar>> = committable_columns
+            .iter()
+            .map(|cc| {
+                let mut vectors: Vec<TestScalar> = vec![TestScalar::ZERO; offset];
+                let mut existing_scalars: Vec<TestScalar> = match cc {
+                    CommittableColumn::Boolean(bool_vec) => {
+                        bool_vec.iter().map(|b| b.into()).collect()
+                    }
+                    CommittableColumn::SmallInt(small_int_vec) => {
+                        small_int_vec.iter().map(|b| b.into()).collect()
+                    }
+                    CommittableColumn::Int(int_vec) => int_vec.iter().map(|b| b.into()).collect(),
+                    CommittableColumn::BigInt(big_int_vec) => {
+                        big_int_vec.iter().map(|b| b.into()).collect()
+                    }
+                    CommittableColumn::Int128(int_128_vec) => {
+                        int_128_vec.iter().map(|b| b.into()).collect()
+                    }
+                    CommittableColumn::Decimal75(_, _, u64_vec) => {
+                        u64_vec.iter().map(|b| b.into()).collect()
+                    }
+                    CommittableColumn::Scalar(scalar_vec) => {
+                        scalar_vec.iter().map(|b| b.into()).collect()
+                    }
+                    CommittableColumn::VarChar(varchar_vec) => {
+                        varchar_vec.iter().map(|b| b.into()).collect()
+                    }
+                    CommittableColumn::TimestampTZ(_, _, i64_vec) => {
+                        i64_vec.iter().map(|b| b.into()).collect()
+                    }
+                };
+                vectors.append(&mut existing_scalars);
+                vectors
+            })
+            .collect();
+        commitments.iter_mut().zip(vectors).for_each(|(nc, v)| {
+            *nc += NaiveCommitment(v);
+        });
+    }
+}

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment_test.rs
@@ -1,0 +1,327 @@
+use crate::base::{
+    commitment::naive_commitment::NaiveCommitment,
+    scalar::{test_scalar::TestScalar, Scalar},
+};
+
+// PartialEq Tests
+
+#[test]
+fn we_can_compare_columns_with_equal_length() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = [1i64, 10, -5, 0, 11].iter().map(|bi| bi.into()).collect();
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let commitment_b = NaiveCommitment(column_b);
+    let commitment_c = NaiveCommitment(column_a);
+    assert_ne!(commitment_a, commitment_b);
+    assert_eq!(commitment_a, commitment_c);
+}
+
+#[test]
+fn we_can_compare_columns_with_different_length() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 11, 0]
+        .iter()
+        .map(|bi| bi.into())
+        .collect();
+    let column_b: Vec<TestScalar> = [1i64, 10, -5, 0, 11].iter().map(|bi| bi.into()).collect();
+    let column_c: Vec<TestScalar> = [1i64, 10, -5].iter().map(|bi| bi.into()).collect();
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let commitment_b = NaiveCommitment(column_b);
+    let commitment_c = NaiveCommitment(column_c);
+    assert_eq!(commitment_a, commitment_b);
+    // Confirm < and > are handled the same.
+    assert_eq!(commitment_b, commitment_a);
+    assert_ne!(commitment_b, commitment_c);
+    // Confirm < and > are handled the same.
+    assert_ne!(commitment_c, commitment_b);
+}
+
+#[test]
+fn we_can_compare_columns_with_at_least_one_empty() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = Vec::new();
+    let commitment_a = NaiveCommitment(column_a);
+    let commitment_b = NaiveCommitment(column_b.clone());
+    let commitment_c = NaiveCommitment(column_b);
+    assert_ne!(commitment_a, commitment_b);
+    assert_eq!(commitment_b, commitment_c);
+}
+
+// PartialEq Tests End
+
+// Add Tests
+
+#[test]
+fn we_can_add_naive_commitments() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = [2i64, -10, -5, 5, 100].iter().map(|bi| bi.into()).collect();
+    let column_sum: Vec<TestScalar> = [3i64, 0, -10, 5, 110].iter().map(|bi| bi.into()).collect();
+
+    let commitment_a = NaiveCommitment(column_a);
+    let commitment_b = NaiveCommitment(column_b);
+    let commitment_sum = NaiveCommitment(column_sum);
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a.clone() + commitment_b.clone(), commitment_sum);
+    // Check commutativity
+    assert_eq!(commitment_b + commitment_a, commitment_sum);
+}
+
+#[test]
+fn we_can_add_naive_commitments_with_one_empty() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = Vec::new();
+
+    let commitment_a = NaiveCommitment(column_a);
+    let commitment_b = NaiveCommitment(column_b);
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a.clone() + commitment_b.clone(), commitment_a);
+    // Check commutativity
+    assert_eq!(commitment_b + commitment_a.clone(), commitment_a);
+}
+
+#[test]
+fn we_can_add_naive_commitments_with_both_empty() {
+    let column_a: Vec<TestScalar> = Vec::new();
+
+    let commitment_a = NaiveCommitment(column_a);
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a.clone() + commitment_a.clone(), commitment_a);
+}
+
+// Add Tests End
+
+// Sub Tests
+
+#[test]
+fn we_can_subtract_naive_commitments() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = [2i64, -10, -5, 5, 100].iter().map(|bi| bi.into()).collect();
+    let column_difference: Vec<TestScalar> =
+        [-1i64, 20, 0, -5, -90].iter().map(|bi| bi.into()).collect();
+
+    let commitment_a = NaiveCommitment(column_a);
+    let commitment_b = NaiveCommitment(column_b);
+    let commitment_difference = NaiveCommitment(column_difference);
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a - commitment_b, commitment_difference);
+}
+
+#[test]
+fn we_can_subtract_naive_commitments_with_one_empty() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = Vec::new();
+    let column_b_minus_a = [-1i64, -10, 5, 0, -10].iter().map(|bi| bi.into()).collect();
+
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let commitment_b = NaiveCommitment(column_b);
+    let commitment_b_minus_a = NaiveCommitment(column_b_minus_a);
+    let commitment_a_minus_b = NaiveCommitment(column_a);
+
+    // Confirm homeomorphic property
+    assert_eq!(
+        commitment_a.clone() - commitment_b.clone(),
+        commitment_a_minus_b
+    );
+    assert_eq!(commitment_b - commitment_a, commitment_b_minus_a);
+}
+
+#[test]
+fn we_can_subtract_naive_commitments_with_both_empty() {
+    let column_a: Vec<TestScalar> = Vec::new();
+
+    let commitment_a = NaiveCommitment(column_a);
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a.clone() - commitment_a.clone(), commitment_a);
+}
+
+// Sub Tests End
+
+// AddAssign Tests
+
+#[test]
+fn we_can_add_assign_naive_commitments() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = [2i64, -10, -5, 5, 100].iter().map(|bi| bi.into()).collect();
+    let column_sum: Vec<TestScalar> = [3i64, 0, -10, 5, 110].iter().map(|bi| bi.into()).collect();
+
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let commitment_b = NaiveCommitment(column_b.clone());
+    let mut commitment_a_mutable = NaiveCommitment(column_a);
+    let mut commitment_b_mutable = NaiveCommitment(column_b);
+    let commitment_sum = NaiveCommitment(column_sum);
+
+    // Add assign a + b and b + a
+    commitment_a_mutable += commitment_b;
+    commitment_b_mutable += commitment_a;
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a_mutable, commitment_sum);
+    // Check commutativity
+    assert_eq!(commitment_b_mutable, commitment_sum);
+}
+
+#[test]
+fn we_can_add_assign_naive_commitments_with_one_empty() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = Vec::new();
+
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let commitment_b = NaiveCommitment(column_b.clone());
+    let mut commitment_a_mutable = NaiveCommitment(column_a.clone());
+    let mut commitment_b_mutable = NaiveCommitment(column_b);
+    let commitment_sum = NaiveCommitment(column_a.clone());
+
+    // Add assign a + b and b + a
+    commitment_a_mutable += commitment_b;
+    commitment_b_mutable += commitment_a;
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a_mutable, commitment_sum);
+    // Check commutativity
+    assert_eq!(commitment_b_mutable, commitment_sum);
+}
+
+#[test]
+fn we_can_add_assign_naive_commitments_with_both_empty() {
+    let column_a: Vec<TestScalar> = Vec::new();
+
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let mut commitment_a_mutable = NaiveCommitment(column_a.clone());
+    let commitment_sum = NaiveCommitment(column_a);
+    commitment_a_mutable += commitment_a.clone();
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a_mutable, commitment_sum);
+}
+
+// AddAssign Tests End
+
+// SubAssign Tests
+
+#[test]
+fn we_can_sub_assign_naive_commitments() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = [2i64, -10, -5, 5, 100].iter().map(|bi| bi.into()).collect();
+    let column_difference: Vec<TestScalar> =
+        [-1i64, 20, 0, -5, -90].iter().map(|bi| bi.into()).collect();
+
+    let commitment_b = NaiveCommitment(column_b.clone());
+    let mut commitment_a_mutable = NaiveCommitment(column_a);
+    let commitment_difference = NaiveCommitment(column_difference);
+
+    // Sub assign a - b
+    commitment_a_mutable -= commitment_b;
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a_mutable, commitment_difference);
+}
+
+#[test]
+fn we_can_sub_assign_naive_commitments_with_one_empty() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_b: Vec<TestScalar> = Vec::new();
+    let column_b_minus_a = [-1i64, -10, 5, 0, -10].iter().map(|bi| bi.into()).collect();
+
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let commitment_b = NaiveCommitment(column_b.clone());
+    let mut commitment_a_mutable = NaiveCommitment(column_a.clone());
+    let mut commitment_b_mutable = NaiveCommitment(column_b);
+    let commitment_b_minus_a = NaiveCommitment(column_b_minus_a);
+    let commitment_a_minus_b = NaiveCommitment(column_a);
+
+    // Sub assign a - b and b - a
+    commitment_a_mutable -= commitment_b;
+    commitment_b_mutable -= commitment_a;
+
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a_mutable, commitment_a_minus_b);
+    // Check commutativity
+    assert_eq!(commitment_b_mutable, commitment_b_minus_a);
+}
+
+#[test]
+fn we_can_sub_assign_naive_commitments_with_both_empty() {
+    let column_a: Vec<TestScalar> = Vec::new();
+
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let mut commitment_a_mutable = NaiveCommitment(column_a.clone());
+    commitment_a_mutable -= commitment_a.clone();
+    // Confirm homeomorphic property
+    assert_eq!(commitment_a_mutable, commitment_a);
+}
+
+// SubAssign Tests End
+
+// Neg Tests
+
+#[test]
+fn we_can_negate_naive_commitments() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_negation: Vec<TestScalar> =
+        [-1i64, -10, 5, 0, -10].iter().map(|bi| bi.into()).collect();
+
+    let commitment_a = NaiveCommitment(column_a);
+    let commitment_negation = NaiveCommitment(column_negation);
+
+    // Confirm homeomorphic property
+    assert_eq!(-commitment_a, commitment_negation);
+}
+
+#[test]
+fn we_can_negate_empty_naive_commitments() {
+    let column_a: Vec<TestScalar> = Vec::new();
+
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let commitment_negation = NaiveCommitment(column_a);
+
+    // Confirm homeomorphic property
+    assert_eq!(-commitment_a, commitment_negation);
+}
+
+// Neg Tests End
+
+// Scalar Multiplication Tests
+
+#[test]
+fn we_can_do_scalar_multiplication() {
+    let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10].iter().map(|bi| bi.into()).collect();
+    let column_empty: Vec<TestScalar> = Vec::new();
+    let scalar: TestScalar = (-2i64).into();
+    let zero = TestScalar::ZERO;
+    let column_a_multiplied_by_scalar: Vec<TestScalar> = [-2i64, -20, 10, 0, -20]
+        .iter()
+        .map(|bi| bi.into())
+        .collect();
+
+    let commitment_a = NaiveCommitment(column_a.clone());
+    let commitment_empty = NaiveCommitment(column_empty);
+    let commitment_a_multiplied_by_scalar = NaiveCommitment(column_a_multiplied_by_scalar);
+
+    assert_eq!(&commitment_a * scalar, commitment_a_multiplied_by_scalar);
+    assert_eq!(&commitment_a * zero, commitment_empty);
+    assert_eq!(scalar * &commitment_a, commitment_a_multiplied_by_scalar);
+    assert_eq!(zero * &commitment_a, commitment_empty);
+    assert_eq!(&commitment_empty * scalar, commitment_empty);
+    assert_eq!(&commitment_empty * zero, commitment_empty);
+    assert_eq!(scalar * &commitment_empty, commitment_empty);
+    assert_eq!(zero * &commitment_empty, commitment_empty);
+    assert_eq!(
+        commitment_a.clone() * scalar,
+        commitment_a_multiplied_by_scalar
+    );
+    assert_eq!(commitment_a.clone() * zero, commitment_empty);
+    assert_eq!(
+        scalar * commitment_a.clone(),
+        commitment_a_multiplied_by_scalar
+    );
+    assert_eq!(zero * commitment_a.clone(), commitment_empty);
+    assert_eq!(commitment_empty.clone() * scalar, commitment_empty);
+    assert_eq!(commitment_empty.clone() * zero, commitment_empty);
+    assert_eq!(scalar * commitment_empty.clone(), commitment_empty);
+    assert_eq!(zero * commitment_empty.clone(), commitment_empty);
+}
+
+// Scalar Multiplication Tests End

--- a/crates/proof-of-sql/src/base/commitment/test_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/test_evaluation_proof.rs
@@ -1,0 +1,46 @@
+use super::{naive_commitment::NaiveCommitment, CommitmentEvaluationProof};
+use crate::base::scalar::test_scalar::TestScalar;
+
+/// This should only be used for the purpose of unit testing.
+pub struct TestEvaluationProof {}
+
+/// This should only be used for the purpose of unit testing.
+/// For now it is only being created for the purpose of implementing
+/// CommitmentEvaluationProof for TestEvaluationProof.
+pub enum TestErrorType {}
+
+impl CommitmentEvaluationProof for TestEvaluationProof {
+    type Scalar = TestScalar;
+
+    type Commitment = NaiveCommitment;
+
+    type Error = TestErrorType;
+
+    type ProverPublicSetup<'a> = ();
+
+    type VerifierPublicSetup<'a> = ();
+
+    fn new(
+        _transcript: &mut merlin::Transcript,
+        _a: &[Self::Scalar],
+        _b_point: &[Self::Scalar],
+        _generators_offset: u64,
+        _setup: &Self::ProverPublicSetup<'_>,
+    ) -> Self {
+        unimplemented!()
+    }
+
+    fn verify_batched_proof(
+        &self,
+        _transcript: &mut merlin::Transcript,
+        _commit_batch: &[Self::Commitment],
+        _batching_factors: &[Self::Scalar],
+        _product: &Self::Scalar,
+        _b_point: &[Self::Scalar],
+        _generators_offset: u64,
+        _table_length: usize,
+        _setup: &Self::VerifierPublicSetup<'_>,
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+}

--- a/crates/proof-of-sql/src/base/commitment/test_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/test_evaluation_proof.rs
@@ -27,7 +27,7 @@ impl CommitmentEvaluationProof for TestEvaluationProof {
         _generators_offset: u64,
         _setup: &Self::ProverPublicSetup<'_>,
     ) -> Self {
-        unimplemented!()
+        unimplemented!("The `CommitmentEvaluationProof` methods are unimplemented for `TestEvaluationProof`. There is nothing preventing a naive implementation here. If this gets done, this type should likely be renamed as `NaiveEvaluationProof` to reflect this.")
     }
 
     fn verify_batched_proof(

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -10,6 +10,9 @@ pub(crate) use mont_scalar::MontScalar;
 mod mont_scalar_from;
 #[cfg(test)]
 mod mont_scalar_from_test;
+/// Module for a test Scalar
+#[cfg(test)]
+pub mod test_scalar;
 
 #[cfg(any(test, feature = "test"))]
 #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -13,6 +13,8 @@ mod mont_scalar_from_test;
 /// Module for a test Scalar
 #[cfg(test)]
 pub mod test_scalar;
+#[cfg(test)]
+mod test_scalar_test;
 
 #[cfg(any(test, feature = "test"))]
 #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -1,9 +1,9 @@
 use super::{MontScalar, Scalar};
 use ark_ff::{Fp, MontBackend, MontConfig};
 
-/// A wrapper type around the field element `ark_curve25519::Fr` and should be used in place of `ark_curve25519::Fr`.
+/// An implementation of `Scalar` intended for use in testing when a concrete implementation is required.
 ///
-/// Using the `Scalar` trait rather than this type is encouraged to allow for easier switching of the underlying field.
+/// Ultimately, a wrapper type around the field element `ark_curve25519::Fr` and should be used in place of `ark_curve25519::Fr`.
 pub type TestScalar = MontScalar<TestMontConfig>;
 
 impl Scalar for TestScalar {

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -2,7 +2,7 @@ use super::{MontScalar, Scalar};
 use ark_ff::{Fp, MontBackend, MontConfig};
 
 /// An implementation of `Scalar` intended for use in testing when a concrete implementation is required.
-/// 
+///
 /// Ultimately, a wrapper type around the field element `ark_curve25519::Fr` and should be used in place of `ark_curve25519::Fr`.
 pub type TestScalar = MontScalar<TestMontConfig>;
 

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -1,0 +1,40 @@
+use super::{MontScalar, Scalar};
+use ark_ff::{Fp, MontBackend, MontConfig};
+
+/// A wrapper type around the field element `ark_curve25519::Fr` and should be used in place of `ark_curve25519::Fr`.
+///
+/// Using the `Scalar` trait rather than this type is encouraged to allow for easier switching of the underlying field.
+pub type TestScalar = MontScalar<TestMontConfig>;
+
+impl Scalar for TestScalar {
+    const MAX_SIGNED: Self = Self(ark_ff::MontFp!(
+        "3618502788666131106986593281521497120428558179689953803000975469142727125494"
+    ));
+    const ZERO: Self = Self(ark_ff::MontFp!("0"));
+    const ONE: Self = Self(ark_ff::MontFp!("1"));
+    const TWO: Self = Self(ark_ff::MontFp!("2"));
+}
+
+pub struct TestMontConfig(pub ark_curve25519::FrConfig);
+
+impl TestMontConfig {
+    const fn convert_curve_25519_backend_to_test_backend(
+        backend: Fp<MontBackend<ark_curve25519::FrConfig, 4>, 4>,
+    ) -> Fp<MontBackend<Self, 4>, 4> {
+        Fp::new(backend.0)
+    }
+}
+
+impl MontConfig<4> for TestMontConfig {
+    const MODULUS: ark_ff::BigInt<4> = <ark_curve25519::FrConfig as MontConfig<4>>::MODULUS;
+
+    const GENERATOR: Fp<MontBackend<Self, 4>, 4> =
+        Self::convert_curve_25519_backend_to_test_backend(
+            <ark_curve25519::FrConfig as MontConfig<4>>::GENERATOR,
+        );
+
+    const TWO_ADIC_ROOT_OF_UNITY: ark_ff::Fp<ark_ff::MontBackend<Self, 4>, 4> =
+        Self::convert_curve_25519_backend_to_test_backend(
+            <ark_curve25519::FrConfig as MontConfig<4>>::TWO_ADIC_ROOT_OF_UNITY,
+        );
+}

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -2,7 +2,7 @@ use super::{MontScalar, Scalar};
 use ark_ff::{Fp, MontBackend, MontConfig};
 
 /// An implementation of `Scalar` intended for use in testing when a concrete implementation is required.
-///
+/// 
 /// Ultimately, a wrapper type around the field element `ark_curve25519::Fr` and should be used in place of `ark_curve25519::Fr`.
 pub type TestScalar = MontScalar<TestMontConfig>;
 
@@ -17,24 +17,12 @@ impl Scalar for TestScalar {
 
 pub struct TestMontConfig(pub ark_curve25519::FrConfig);
 
-impl TestMontConfig {
-    const fn convert_curve_25519_backend_to_test_backend(
-        backend: Fp<MontBackend<ark_curve25519::FrConfig, 4>, 4>,
-    ) -> Fp<MontBackend<Self, 4>, 4> {
-        Fp::new(backend.0)
-    }
-}
-
 impl MontConfig<4> for TestMontConfig {
     const MODULUS: ark_ff::BigInt<4> = <ark_curve25519::FrConfig as MontConfig<4>>::MODULUS;
 
     const GENERATOR: Fp<MontBackend<Self, 4>, 4> =
-        Self::convert_curve_25519_backend_to_test_backend(
-            <ark_curve25519::FrConfig as MontConfig<4>>::GENERATOR,
-        );
+        Fp::new(<ark_curve25519::FrConfig as MontConfig<4>>::GENERATOR.0);
 
     const TWO_ADIC_ROOT_OF_UNITY: ark_ff::Fp<ark_ff::MontBackend<Self, 4>, 4> =
-        Self::convert_curve_25519_backend_to_test_backend(
-            <ark_curve25519::FrConfig as MontConfig<4>>::TWO_ADIC_ROOT_OF_UNITY,
-        );
+        Fp::new(<ark_curve25519::FrConfig as MontConfig<4>>::TWO_ADIC_ROOT_OF_UNITY.0);
 }

--- a/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
@@ -1,0 +1,12 @@
+use num_traits::Inv;
+
+use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+
+#[test]
+fn we_can_get_test_scalar_constants_from_z_p(){
+    assert_eq!(TestScalar::from(0), TestScalar::ZERO);
+    assert_eq!(TestScalar::from(1), TestScalar::ONE);
+    assert_eq!(TestScalar::from(2), TestScalar::TWO);
+    // -1/2 == least upper bound
+    assert_eq!(-TestScalar::TWO.inv().unwrap(), TestScalar::MAX_SIGNED);
+}

--- a/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
@@ -1,9 +1,8 @@
+use crate::base::scalar::{test_scalar::TestScalar, Scalar};
 use num_traits::Inv;
 
-use crate::base::scalar::{test_scalar::TestScalar, Scalar};
-
 #[test]
-fn we_can_get_test_scalar_constants_from_z_p(){
+fn we_can_get_test_scalar_constants_from_z_p() {
     assert_eq!(TestScalar::from(0), TestScalar::ZERO);
     assert_eq!(TestScalar::from(1), TestScalar::ONE);
     assert_eq!(TestScalar::from(2), TestScalar::TWO);


### PR DESCRIPTION
# Rationale for this change

In order to remove InnerProduct from the base directory, there will need to be several new test types so that the InnerProduct types are no longer need for the base tests.

# What changes are included in this PR?

1. New types: TestScalar, NaiveCommitment, TestEvaluationProof.

# Are these changes tested?

New unit tests for NaiveCommitment.
