### PR TITLE
ci: set BLITZAR_BACKEND to be cpu

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -72,10 +72,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=non-interactive
           sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository ppa:graphics-drivers/ppa
-          sudo apt-get update
-          sudo apt-get install -y clang lld nvidia-driver-560
+          sudo apt-get install -y clang lld
       - name: Run cargo test
         run: cargo test --all-features
       - name: Dry run cargo test (proof-of-sql) (test feature only)

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -11,6 +11,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  BLITZAR_BACKEND: cpu
 
 jobs:
   # Run cargo check (with various feature permutations)


### PR DESCRIPTION
# Rationale for this change

https://github.com/spaceandtimelabs/blitzar/pull/175 makes blitzar panic when there is no GPU rather than falling back to CPU. This PR fixes the CI so that it can run tests on the CPU

# Are these changes tested?

See the job.