### PR TITLE
feat: add a range check word type for mle

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -228,6 +228,7 @@ impl ColumnBounds {
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
             | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
+            CommittableColumn::RangeCheckWord(_) => ColumnBounds::NoOrder,
         }
     }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -64,6 +64,9 @@ fn compute_dory_commitment(
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
+        CommittableColumn::RangeCheckWord(column) => {
+            compute_dory_commitment_impl(column, offset, setup)
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -474,6 +474,17 @@ pub fn bit_table_and_scalars_for_packed_msm(
                     num_matrix_commitment_columns,
                 );
             }
+            CommittableColumn::RangeCheckWord(column) => {
+                pack_bit(
+                    column,
+                    &mut packed_scalars,
+                    cumulative_bit_sum_table[i],
+                    offset,
+                    committable_columns[i].column_type().byte_size(),
+                    bit_table_full_sum_in_bytes,
+                    num_matrix_commitment_columns,
+                );
+            }
         });
 
     (bit_table, packed_scalars)


### PR DESCRIPTION
# Rationale for this change

The ```CommitableColumn``` types are defined as types that can be used to produce an MLE. We need to add support here for committable columns of u8s, as this is the initial word size we have chosen for the range check.

# What changes are included in this PR?

- [x] Add CommitableColumn RangeCheckWord type
- [x] Add RangeCheckWord match arm in column bounds ordering
- [x] Add support for RangeCheckWord in dory commitment cpu helper
- [x] Add support for RangeCheckWord in pack scalars
- [x] Add from [u8] implementation for CommitableColumn   

# Are these changes tested?

- [x] we_can_commit_to_rangecheckword_column_through_committable_column
- [x] we_can_get_length_of_rangecheckword_column

