### PR TITLE
refactor: add SubpolynomialType to verifier builder

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -92,7 +92,10 @@ impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
         _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
         assert_eq!(builder.consume_result_mle(), C::Scalar::ZERO);
-        builder.produce_sumcheck_subpolynomial_evaluation(&C::Scalar::from(self.evaluation));
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::ZeroSum,
+            C::Scalar::from(self.evaluation),
+        );
         Ok(vec![C::Scalar::ZERO])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
@@ -273,8 +276,10 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
                 ColumnType::BigInt,
             ));
         let x_eval = builder.consume_anchored_mle(x_commit);
-        let eval = builder.mle_evaluations.random_evaluation * (res_eval - x_eval * x_eval);
-        builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            res_eval - x_eval * x_eval,
+        );
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
@@ -467,12 +472,16 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
         let z_eval = builder.consume_intermediate_mle();
 
         // poly1
-        let eval = builder.mle_evaluations.random_evaluation * (z_eval - x_eval * x_eval);
-        builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            z_eval - x_eval * x_eval,
+        );
 
         // poly2
-        let eval = builder.mle_evaluations.random_evaluation * (res_eval - z_eval * z_eval);
-        builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            res_eval - z_eval * z_eval,
+        );
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
@@ -662,9 +671,10 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
             ColumnType::BigInt,
         ));
         let x_eval = builder.consume_anchored_mle(x_commit);
-        let eval = builder.mle_evaluations.random_evaluation
-            * (alpha * res_eval - alpha * x_eval * x_eval);
-        builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            alpha * res_eval - alpha * x_eval * x_eval,
+        );
         Ok(vec![res_eval])
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -1,4 +1,4 @@
-use super::SumcheckMleEvaluations;
+use super::{SumcheckMleEvaluations, SumcheckSubpolynomialType};
 use crate::base::{bit::BitDistribution, commitment::Commitment};
 use num_traits::Zero;
 
@@ -105,9 +105,18 @@ impl<'a, C: Commitment> VerificationBuilder<'a, C> {
     }
 
     /// Produce the evaluation of a subpolynomial used in sumcheck
-    pub fn produce_sumcheck_subpolynomial_evaluation(&mut self, eval: &C::Scalar) {
-        self.sumcheck_evaluation +=
-            self.subpolynomial_multipliers[self.produced_subpolynomials] * *eval;
+    pub fn produce_sumcheck_subpolynomial_evaluation(
+        &mut self,
+        subpolynomial_type: SumcheckSubpolynomialType,
+        eval: C::Scalar,
+    ) {
+        self.sumcheck_evaluation += self.subpolynomial_multipliers[self.produced_subpolynomials]
+            * match subpolynomial_type {
+                SumcheckSubpolynomialType::Identity => {
+                    eval * self.mle_evaluations.random_evaluation
+                }
+                SumcheckSubpolynomialType::ZeroSum => eval,
+            };
         self.produced_subpolynomials += 1;
     }
 

--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -1,5 +1,5 @@
 use super::{SumcheckMleEvaluations, VerificationBuilder};
-use crate::base::scalar::Curve25519Scalar;
+use crate::{base::scalar::Curve25519Scalar, sql::proof::SumcheckSubpolynomialType};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use num_traits::Zero;
 use rand_core::OsRng;
@@ -45,8 +45,14 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
         &[][..],
         Vec::new(),
     );
-    builder.produce_sumcheck_subpolynomial_evaluation(&Curve25519Scalar::from(2u64));
-    builder.produce_sumcheck_subpolynomial_evaluation(&Curve25519Scalar::from(3u64));
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::ZeroSum,
+        Curve25519Scalar::from(2u64),
+    );
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::ZeroSum,
+        Curve25519Scalar::from(3u64),
+    );
     let expected_sumcheck_evaluation = subpolynomial_multipliers[0] * Curve25519Scalar::from(2u64)
         + subpolynomial_multipliers[1] * Curve25519Scalar::from(3u64);
     assert_eq!(builder.sumcheck_evaluation(), expected_sumcheck_evaluation);

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -97,8 +97,10 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
         let lhs_and_rhs = builder.consume_intermediate_mle();
 
         // subpolynomial: lhs_and_rhs - lhs * rhs
-        let eval = builder.mle_evaluations.random_evaluation * (lhs_and_rhs - lhs * rhs);
-        builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            lhs_and_rhs - lhs * rhs,
+        );
 
         // selection
         Ok(lhs_and_rhs)

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -150,13 +150,16 @@ pub fn verifier_evaluate_equals_zero<C: Commitment>(
     let selection_eval = builder.mle_evaluations.one_evaluation - selection_not_eval;
 
     // subpolynomial: selection * lhs
-    let eval = builder.mle_evaluations.random_evaluation * (selection_eval * lhs_eval);
-    builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        selection_eval * lhs_eval,
+    );
 
     // subpolynomial: selection_not - lhs * lhs_pseudo_inv
-    let eval = builder.mle_evaluations.random_evaluation
-        * (selection_not_eval - lhs_eval * lhs_pseudo_inv_eval);
-    builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        selection_not_eval - lhs_eval * lhs_pseudo_inv_eval,
+    );
 
     selection_eval
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -105,8 +105,10 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
         let lhs_times_rhs = builder.consume_intermediate_mle();
 
         // subpolynomial: lhs_times_rhs - lhs * rhs
-        let eval = builder.mle_evaluations.random_evaluation * (lhs_times_rhs - lhs * rhs);
-        builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            lhs_times_rhs - lhs * rhs,
+        );
 
         // selection
         Ok(lhs_times_rhs)

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -131,8 +131,10 @@ pub fn verifier_evaluate_or<C: Commitment>(
     let lhs_and_rhs = builder.consume_intermediate_mle();
 
     // subpolynomial: lhs_and_rhs - lhs * rhs
-    let eval = builder.mle_evaluations.random_evaluation * (lhs_and_rhs - *lhs * *rhs);
-    builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        lhs_and_rhs - *lhs * *rhs,
+    );
 
     // selection
     *lhs + *rhs - lhs_and_rhs

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
@@ -180,9 +180,10 @@ fn verify_bits_are_binary<C: Commitment>(
     bit_evals: &[C::Scalar],
 ) {
     for bit_eval in bit_evals.iter() {
-        let mut eval = *bit_eval - *bit_eval * *bit_eval;
-        eval *= builder.mle_evaluations.random_evaluation;
-        builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::Identity,
+            *bit_eval - *bit_eval * *bit_eval,
+        );
     }
 }
 
@@ -237,6 +238,5 @@ fn verify_bit_decomposition<C: Commitment>(
         eval -= C::Scalar::from(mult) * sign_eval * bit_eval;
         vary_index += 1;
     });
-    eval *= builder.mle_evaluations.random_evaluation;
-    builder.produce_sumcheck_subpolynomial_evaluation(&eval);
+    builder.produce_sumcheck_subpolynomial_evaluation(SumcheckSubpolynomialType::Identity, eval);
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -226,7 +226,6 @@ fn verify_filter<C: Commitment>(
     d_evals: Vec<C::Scalar>,
 ) -> Result<Vec<C::Scalar>, ProofError> {
     let one_eval = builder.mle_evaluations.one_evaluation;
-    let rand_eval = builder.mle_evaluations.random_evaluation;
 
     let chi_eval = match builder.mle_evaluations.result_indexes_evaluation {
         Some(eval) => eval,
@@ -239,16 +238,21 @@ fn verify_filter<C: Commitment>(
     let d_star_eval = builder.consume_intermediate_mle();
 
     // sum c_star * s - d_star = 0
-    builder.produce_sumcheck_subpolynomial_evaluation(&(c_star_eval * s_eval - d_star_eval));
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::ZeroSum,
+        c_star_eval * s_eval - d_star_eval,
+    );
 
     // c_fold * c_star - 1 = 0
     builder.produce_sumcheck_subpolynomial_evaluation(
-        &(rand_eval * (c_fold_eval * c_star_eval - one_eval)),
+        SumcheckSubpolynomialType::Identity,
+        c_fold_eval * c_star_eval - one_eval,
     );
 
     // d_bar_fold * d_star - chi = 0
     builder.produce_sumcheck_subpolynomial_evaluation(
-        &(rand_eval * (d_bar_fold_eval * d_star_eval - chi_eval)),
+        SumcheckSubpolynomialType::Identity,
+        d_bar_fold_eval * d_star_eval - chi_eval,
     );
 
     Ok(c_evals)

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -317,7 +317,6 @@ fn verify_group_by<C: Commitment>(
     (g_out_evals, sum_out_evals, count_out_eval): (Vec<C::Scalar>, Vec<C::Scalar>, C::Scalar),
 ) -> Result<(), ProofError> {
     let one_eval = builder.mle_evaluations.one_evaluation;
-    let rand_eval = builder.mle_evaluations.random_evaluation;
 
     // g_in_fold = alpha + sum beta^j * g_in[j]
     let g_in_fold_eval = alpha * one_eval + fold_vals(beta, &g_in_evals);
@@ -333,18 +332,20 @@ fn verify_group_by<C: Commitment>(
 
     // sum g_in_star * sel_in * sum_in_fold - g_out_star * sum_out_bar_fold = 0
     builder.produce_sumcheck_subpolynomial_evaluation(
-        &(g_in_star_eval * sel_in_eval * sum_in_fold_eval
-            - g_out_star_eval * sum_out_bar_fold_eval),
+        SumcheckSubpolynomialType::ZeroSum,
+        g_in_star_eval * sel_in_eval * sum_in_fold_eval - g_out_star_eval * sum_out_bar_fold_eval,
     );
 
     // g_in_star * g_in_fold - 1 = 0
     builder.produce_sumcheck_subpolynomial_evaluation(
-        &(rand_eval * (g_in_star_eval * g_in_fold_eval - one_eval)),
+        SumcheckSubpolynomialType::Identity,
+        g_in_star_eval * g_in_fold_eval - one_eval,
     );
 
     // g_out_star * g_out_bar_fold - 1 = 0
     builder.produce_sumcheck_subpolynomial_evaluation(
-        &(rand_eval * (g_out_star_eval * g_out_bar_fold_eval - one_eval)),
+        SumcheckSubpolynomialType::Identity,
+        g_out_star_eval * g_out_bar_fold_eval - one_eval,
     );
 
     Ok(())


### PR DESCRIPTION
# Rationale for this change

The verifier and prover builders are a bit asymmetric with the `sumcheck_subpolynomial`. Additionally, the explicit use of `random_evaluation` is a bit confusing.

# What changes are included in this PR?

* `produce_sumcheck_subpolynomial_evaluation` now accepts a `SumcheckSubpolynomialType` as a parameter.
* Since this is a (only internal) breaking change, this also modifies `produce_sumcheck_subpolynomial_evaluation` to own it's `eval` parameter rather than borrow.

# Are these changes tested?

Yes, by existing code.
