### PR TITLE
feat: bump rust toolchain to 1.81.0

### DIFF
--- a/crates/proof-of-sql/README.md
+++ b/crates/proof-of-sql/README.md
@@ -35,7 +35,7 @@ Get started with Proof of SQL by using the published crate on [crates.io](https:
 * NVIDIA GPU & Drivers (Strongly Recommended)
 * lld (`sudo apt install lld`)
 * clang (`sudo apt install clang`)
-* [Rust 1.78.0](https://www.rust-lang.org/tools/install)
+* [Rust 1.81.0](https://www.rust-lang.org/tools/install)
 
 <!-- TDDO: add this in when we put it on crates.io
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"


### PR DESCRIPTION
# Rationale for this change

In order to keep rust up to date, we should be periodically updating the toolchain we use.

# What changes are included in this PR?

* Update toolchain.toml
* Update README

# Are these changes tested?

Yes, by existing tests.