### PR TITLE
feat: add initial `no_std` support (for commitments)

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -45,9 +45,11 @@ jobs:
         run: cargo check -p proof-of-sql --no-default-features
       - name: Run cargo check (proof-of-sql) (all features)
         run: cargo check -p proof-of-sql --all-features
-      - name: Run cargo check (proof-of-sql) (just "test" feature)
+      - name: Run cargo check (proof-of-sql) (just "std" feature)
+        run: cargo check -p proof-of-sql --no-default-features --features="std"
+      - name: Run cargo check (proof-of-sql) (just "test" (and "std") feature)
         run: cargo check -p proof-of-sql --no-default-features --features="test"
-      - name: Run cargo check (proof-of-sql) (just "blitzar" feature)
+      - name: Run cargo check (proof-of-sql) (just "blitzar" (and "std") feature)
         run: cargo check -p proof-of-sql --no-default-features --features="blitzar"
 
   test:
@@ -75,11 +77,13 @@ jobs:
           sudo apt-get install -y clang lld
       - name: Run cargo test
         run: cargo test --all-features
-      - name: Dry run cargo test (proof-of-sql) (test feature only)
+      - name: Dry run cargo test (proof-of-sql) (std feature only)
+        run: cargo test -p proof-of-sql --no-run --no-default-features --features="std"
+      - name: Dry run cargo test (proof-of-sql) (test (and "std") feature only)
         run: cargo test -p proof-of-sql --no-run --no-default-features --features="test"
-      - name: Dry run cargo test (proof-of-sql) (arrow feature only)
+      - name: Dry run cargo test (proof-of-sql) (arrow (and "std") feature only)
         run: cargo test -p proof-of-sql --no-run --no-default-features --features="arrow"
-      - name: Dry run cargo test (proof-of-sql) (blitzar feature only)
+      - name: Dry run cargo test (proof-of-sql) (blitzar (and "std") feature only)
         run: cargo test -p proof-of-sql --no-run --no-default-features --features="blitzar"
       - name: Dry run cargo test (proof-of-sql) (no features)
         run: cargo test -p proof-of-sql --no-run --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rand_core = { version = "0.6", default-features = false }
 rayon = { version = "1.5" }
 serde = { version = "1" }
 serde_json = { version = "1" }
-thiserror = { version = "1" }
+thiserror = { git = "https://github.com/dtolnay/thiserror", rev = "44737a516b7fd0cc9dabcab07e7b1f927f8f5636", default-features = false }
 tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 # tokio = { version = "1.39.3" }
 tracing = { version = "0.1.36" }

--- a/crates/proof-of-sql-parser/src/lib.rs
+++ b/crates/proof-of-sql-parser/src/lib.rs
@@ -43,6 +43,8 @@ macro_rules! impl_serde_from_str {
             where
                 S: serde::Serializer,
             {
+                extern crate alloc;
+                use alloc::string::ToString;
                 serializer.serialize_str(&self.to_string())
             }
         }
@@ -51,7 +53,8 @@ macro_rules! impl_serde_from_str {
             where
                 D: serde::Deserializer<'d>,
             {
-                let string = String::deserialize(deserializer)?;
+                extern crate alloc;
+                let string = alloc::string::String::deserialize(deserializer)?;
                 <$type>::from_str(&string).map_err(serde::de::Error::custom)
             }
         }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -72,9 +72,11 @@ flexbuffers = { workspace = true }
 development = ["arrow-csv"]
 
 [features]
-default = ["arrow", "blitzar"]
-arrow = ["dep:arrow"]
-test = ["dep:rand"]
+default = ["arrow", "blitzar", "std"]
+arrow = ["dep:arrow", "std"]
+test = ["dep:rand", "std"]
+blitzar = ["dep:blitzar", "std"]
+std = []
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -1,4 +1,5 @@
 use super::committable_column::CommittableColumn;
+use alloc::boxed::Box;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -290,6 +291,7 @@ impl ColumnBounds {
 mod tests {
     use super::*;
     use crate::base::{database::OwnedColumn, math::decimal::Precision, scalar::Curve25519Scalar};
+    use alloc::{string::String, vec};
     use itertools::Itertools;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -1,7 +1,7 @@
 use super::{column_bounds::BoundsInner, committable_column::CommittableColumn, ColumnBounds};
 use crate::base::database::ColumnType;
+use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 use thiserror::Error;
 
 /// Errors that can occur when constructing invalid [`ColumnCommitmentMetadata`].
@@ -169,6 +169,7 @@ mod tests {
         commitment::column_bounds::Bounds, database::OwnedColumn, math::decimal::Precision,
         scalar::Curve25519Scalar,
     };
+    use alloc::string::String;
     use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
     #[test]

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -3,6 +3,7 @@ use super::{
     CommittableColumn,
 };
 use crate::base::database::ColumnField;
+use alloc::string::{String, ToString};
 use indexmap::IndexMap;
 use proof_of_sql_parser::Identifier;
 use thiserror::Error;
@@ -132,6 +133,7 @@ mod tests {
         database::{owned_table_utility::*, ColumnType, OwnedTable},
         scalar::Curve25519Scalar,
     };
+    use alloc::vec::Vec;
     use itertools::Itertools;
 
     fn metadata_map_from_owned_table(

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -3,11 +3,16 @@ use super::{
     ColumnCommitmentMetadataMapExt, ColumnCommitmentsMismatch, Commitment, VecCommitmentExt,
 };
 use crate::base::database::{ColumnField, ColumnRef, CommitmentAccessor, TableRef};
+use alloc::{
+    borrow::ToOwned,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use core::{iter, slice};
 use indexmap::IndexSet;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
-use std::vec;
 use thiserror::Error;
 
 /// Cannot create commitments with duplicate identifier.

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -3,9 +3,11 @@ use super::{
     ColumnCommitmentMetadataMapExt, ColumnCommitmentsMismatch, Commitment, VecCommitmentExt,
 };
 use crate::base::database::{ColumnField, ColumnRef, CommitmentAccessor, TableRef};
+use core::{iter, slice};
 use indexmap::IndexSet;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
+use std::vec;
 use thiserror::Error;
 
 /// Cannot create commitments with duplicate identifier.
@@ -269,8 +271,8 @@ impl<C: Commitment> ColumnCommitments<C> {
 }
 
 /// Owning iterator for [`ColumnCommitments`].
-pub type IntoIter<C> = std::iter::Map<
-    std::iter::Zip<<ColumnCommitmentMetadataMap as IntoIterator>::IntoIter, std::vec::IntoIter<C>>,
+pub type IntoIter<C> = iter::Map<
+    iter::Zip<<ColumnCommitmentMetadataMap as IntoIterator>::IntoIter, vec::IntoIter<C>>,
     fn(((Identifier, ColumnCommitmentMetadata), C)) -> (Identifier, ColumnCommitmentMetadata, C),
 >;
 
@@ -286,11 +288,8 @@ impl<C> IntoIterator for ColumnCommitments<C> {
 }
 
 /// Borrowing iterator for [`ColumnCommitments`].
-pub type Iter<'a, C> = std::iter::Map<
-    std::iter::Zip<
-        <&'a ColumnCommitmentMetadataMap as IntoIterator>::IntoIter,
-        std::slice::Iter<'a, C>,
-    >,
+pub type Iter<'a, C> = iter::Map<
+    iter::Zip<<&'a ColumnCommitmentMetadataMap as IntoIterator>::IntoIter, slice::Iter<'a, C>>,
     fn(
         ((&'a Identifier, &'a ColumnCommitmentMetadata), &'a C),
     ) -> (&'a Identifier, &'a ColumnCommitmentMetadata, &'a C),

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -4,6 +4,7 @@ use crate::base::{
     ref_into::RefInto,
     scalar::Scalar,
 };
+use alloc::vec::Vec;
 #[cfg(feature = "blitzar")]
 use blitzar::sequence::Sequence;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -130,5 +130,6 @@ impl Commitment for RistrettoPoint {
 
 mod commitment_evaluation_proof;
 pub use commitment_evaluation_proof::CommitmentEvaluationProof;
+#[cfg(feature = "std")]
 #[cfg(test)]
 pub(crate) mod commitment_evaluation_proof_test;

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -62,13 +62,13 @@ impl AddAssign for NaiveCommitment {
 impl PartialEq for NaiveCommitment {
     fn eq(&self, other: &Self) -> bool {
         match self.0.len().cmp(&other.0.len()) {
-            std::cmp::Ordering::Less => {
+            cmp::Ordering::Less => {
                 let mut extended_self = self.0.clone();
                 extended_self.extend((self.0.len()..other.0.len()).map(|_i| TestScalar::ZERO));
                 extended_self == other.0
             }
-            std::cmp::Ordering::Equal => self.0 == other.0,
-            std::cmp::Ordering::Greater => {
+            cmp::Ordering::Equal => self.0 == other.0,
+            cmp::Ordering::Greater => {
                 let mut extended_other = other.0.clone();
                 extended_other.extend((other.0.len()..self.0.len()).map(|_i| TestScalar::ZERO));
                 extended_other == self.0

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -3,11 +3,13 @@ use crate::base::{
     commitment::CommittableColumn,
     scalar::{test_scalar::TestScalar, Scalar},
 };
-use serde::{Deserialize, Serialize};
-use std::{
+use alloc::{vec, vec::Vec};
+use core::{
+    cmp,
     fmt::Debug,
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
+use serde::{Deserialize, Serialize};
 
 /// A naive [Commitment] implementation that should only be used for the purpose of unit testing.
 #[derive(Clone, Debug, Eq, Default, Serialize, Deserialize)]

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment_test.rs
@@ -2,6 +2,7 @@ use crate::base::{
     commitment::naive_commitment::NaiveCommitment,
     scalar::{test_scalar::TestScalar, Scalar},
 };
+use alloc::vec::Vec;
 
 // PartialEq Tests
 

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -3,6 +3,7 @@ use crate::base::database::{
     ColumnField, ColumnRef, ColumnType, CommitmentAccessor, MetadataAccessor, SchemaAccessor,
     TableRef,
 };
+use alloc::vec::Vec;
 use indexmap::IndexMap;
 use proof_of_sql_parser::Identifier;
 

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -8,12 +8,13 @@ use crate::base::{
     database::{Column, ColumnField, CommitmentAccessor, OwnedTable, TableRef},
     scalar::Scalar,
 };
+use alloc::vec::Vec;
 #[cfg(feature = "arrow")]
 use arrow::record_batch::RecordBatch;
 use bumpalo::Bump;
+use core::ops::Range;
 use proof_of_sql_parser::{Identifier, ParseError};
 use serde::{Deserialize, Serialize};
-use std::ops::Range;
 use thiserror::Error;
 
 /// Cannot create a [`TableCommitment`] with a negative range.

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -1,5 +1,6 @@
 use super::Commitment;
 use crate::base::commitment::committable_column::CommittableColumn;
+use alloc::{vec, vec::Vec};
 use thiserror::Error;
 
 /// Cannot update commitment collections with different column counts

--- a/crates/proof-of-sql/src/base/database/accessor.rs
+++ b/crates/proof-of-sql/src/base/database/accessor.rs
@@ -3,6 +3,7 @@ use crate::base::{
     database::{Column, ColumnRef, ColumnType, TableRef},
     scalar::Scalar,
 };
+use alloc::vec::Vec;
 use proof_of_sql_parser::Identifier;
 
 /// Access metadata of a table span in a database.

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -3,20 +3,21 @@ use crate::base::{
     math::decimal::{scale_scalar, Precision},
     scalar::Scalar,
 };
+use alloc::{sync::Arc, vec::Vec};
 #[cfg(feature = "arrow")]
 use arrow::datatypes::{DataType, Field, TimeUnit as ArrowTimeUnit};
 use bumpalo::Bump;
+use core::{
+    fmt,
+    fmt::{Display, Formatter},
+    mem::size_of,
+};
 use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     Identifier,
 };
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt,
-    fmt::{Display, Formatter},
-    sync::Arc,
-};
 
 /// Represents a read-only view of a column in an in-memory,
 /// column-oriented database.
@@ -546,6 +547,10 @@ impl From<&ColumnField> for Field {
 mod tests {
     use super::*;
     use crate::{base::scalar::Curve25519Scalar, proof_primitive::dory::DoryScalar};
+    use alloc::{
+        string::{String, ToString},
+        vec,
+    };
 
     #[test]
     fn column_type_serializes_to_string() {

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -543,6 +543,7 @@ impl From<&ColumnField> for Field {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -12,7 +12,11 @@ use proof_of_sql_parser::{
 };
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+    sync::Arc,
+};
 
 /// Represents a read-only view of a column in an in-memory,
 /// column-oriented database.
@@ -314,9 +318,9 @@ impl ColumnType {
             return None;
         }
         self.to_integer_bits().and_then(|self_bits| {
-            other.to_integer_bits().and_then(|other_bits| {
-                Self::from_integer_bits(std::cmp::max(self_bits, other_bits))
-            })
+            other
+                .to_integer_bits()
+                .and_then(|other_bits| Self::from_integer_bits(self_bits.max(other_bits)))
         })
     }
 
@@ -353,12 +357,12 @@ impl ColumnType {
     /// Returns the byte size of the column type.
     pub fn byte_size(&self) -> usize {
         match self {
-            Self::Boolean => std::mem::size_of::<bool>(),
-            Self::SmallInt => std::mem::size_of::<i16>(),
-            Self::Int => std::mem::size_of::<i32>(),
-            Self::BigInt | Self::TimestampTZ(_, _) => std::mem::size_of::<i64>(),
-            Self::Int128 => std::mem::size_of::<i128>(),
-            Self::Scalar | Self::Decimal75(_, _) | Self::VarChar => std::mem::size_of::<[u64; 4]>(),
+            Self::Boolean => size_of::<bool>(),
+            Self::SmallInt => size_of::<i16>(),
+            Self::Int => size_of::<i32>(),
+            Self::BigInt | Self::TimestampTZ(_, _) => size_of::<i64>(),
+            Self::Int128 => size_of::<i128>(),
+            Self::Scalar | Self::Decimal75(_, _) | Self::VarChar => size_of::<[u64; 4]>(),
         }
     }
 
@@ -441,8 +445,8 @@ impl TryFrom<DataType> for ColumnType {
 }
 
 /// Display the column type as a str name (in all caps)
-impl std::fmt::Display for ColumnType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for ColumnType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ColumnType::Boolean => write!(f, "BOOLEAN"),
             ColumnType::SmallInt => write!(f, "SMALLINT"),

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,4 +1,5 @@
 use crate::base::{database::ColumnType, math::decimal::Precision, scalar::Scalar};
+use alloc::string::String;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -7,12 +7,16 @@ pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAcc
 mod column;
 pub use column::{Column, ColumnField, ColumnRef, ColumnType};
 
+#[cfg(feature = "std")]
 mod column_operation;
+#[cfg(feature = "std")]
 pub use column_operation::{
     try_add_subtract_column_types, try_divide_column_types, try_multiply_column_types,
 };
 
+#[cfg(feature = "std")]
 mod column_operation_error;
+#[cfg(feature = "std")]
 pub use column_operation_error::{ColumnOperationError, ColumnOperationResult};
 
 mod literal_value;
@@ -44,20 +48,26 @@ mod owned_column_error;
 pub use owned_column_error::{OwnedColumnError, OwnedColumnResult};
 
 /// TODO: add docs
+#[cfg(feature = "std")]
 pub(crate) mod owned_column_operation;
 
 mod owned_table;
 pub use owned_table::OwnedTable;
 pub(crate) use owned_table::OwnedTableError;
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod owned_table_test;
 pub mod owned_table_utility;
 
 /// TODO: add docs
+#[cfg(feature = "std")]
 pub(crate) mod expression_evaluation;
+#[cfg(feature = "std")]
 mod expression_evaluation_error;
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod expression_evaluation_test;
+#[cfg(feature = "std")]
 pub use expression_evaluation_error::{ExpressionEvaluationError, ExpressionEvaluationResult};
 
 #[cfg(feature = "arrow")]
@@ -68,20 +78,27 @@ pub use owned_and_arrow_conversions::OwnedArrowConversionError;
 mod owned_and_arrow_conversions_test;
 
 #[cfg(any(test, feature = "test"))]
+#[cfg(feature = "std")]
 mod test_accessor;
 #[cfg(any(test, feature = "test"))]
+#[cfg(feature = "std")]
 pub use test_accessor::TestAccessor;
 #[cfg(test)]
+#[cfg(feature = "std")]
 pub(crate) use test_accessor::UnimplementedTestAccessor;
 
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod test_schema_accessor;
 #[cfg(test)]
+#[cfg(feature = "std")]
 pub(crate) use test_schema_accessor::TestSchemaAccessor;
 
 #[cfg(any(test, feature = "test"))]
+#[cfg(feature = "std")]
 mod owned_table_test_accessor;
 #[cfg(any(test, feature = "test"))]
+#[cfg(feature = "std")]
 pub use owned_table_test_accessor::OwnedTableTestAccessor;
 #[cfg(all(test, feature = "blitzar"))]
 mod owned_table_test_accessor_test;
@@ -90,10 +107,14 @@ mod owned_table_test_accessor_test;
 pub mod scalar_and_i256_conversions;
 
 /// TODO: add docs
+#[cfg(feature = "std")]
 pub(crate) mod filter_util;
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod filter_util_test;
 
+#[cfg(feature = "std")]
 pub(crate) mod group_by_util;
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod group_by_util_test;

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -10,6 +10,10 @@ use crate::base::{
     },
     scalar::Scalar,
 };
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::cmp::Ordering;
 use proof_of_sql_parser::{
     intermediate_ast::OrderByDirection,
@@ -344,6 +348,7 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
 mod test {
     use super::*;
     use crate::base::{math::decimal::Precision, scalar::Curve25519Scalar};
+    use alloc::vec;
     use bumpalo::Bump;
     use proof_of_sql_parser::intermediate_ast::OrderByDirection;
 

--- a/crates/proof-of-sql/src/base/database/owned_column_error.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_error.rs
@@ -1,4 +1,5 @@
 use crate::base::database::ColumnType;
+use alloc::string::String;
 use thiserror::Error;
 
 /// Errors from operations related to `OwnedColumn`s.

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -15,6 +15,7 @@
 //! ```
 use super::{OwnedColumn, OwnedTable};
 use crate::base::scalar::Scalar;
+use alloc::string::String;
 use core::ops::Deref;
 use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -1,5 +1,9 @@
 use proof_of_sql_parser::{impl_serde_from_str, Identifier, ResourceId};
-use std::str::FromStr;
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 
 /// Expression for an SQL table
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
@@ -37,8 +41,8 @@ impl FromStr for TableRef {
     }
 }
 
-impl std::fmt::Display for TableRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for TableRef {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.resource_id.fmt(f)
     }
 }

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -1,9 +1,9 @@
-use proof_of_sql_parser::{impl_serde_from_str, Identifier, ResourceId};
-use std::{
+use core::{
     fmt,
     fmt::{Display, Formatter},
     str::FromStr,
 };
+use proof_of_sql_parser::{impl_serde_from_str, Identifier, ResourceId};
 
 /// Expression for an SQL table
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]

--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -3,7 +3,7 @@ use crate::base::{
     scalar::MontScalar,
 };
 use ark_ff::MontConfig;
-use std::cmp::{max, Ordering};
+use core::cmp::{max, Ordering};
 
 /// This function writes the input scalar x as a varint encoding to buf slice
 ///

--- a/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
@@ -3,6 +3,7 @@ use super::scalar_varint::{
     write_scalar_varint, write_scalar_varints,
 };
 use crate::base::{encode::U256, scalar::Curve25519Scalar};
+use alloc::vec;
 
 #[test]
 fn small_scalars_are_encoded_as_positive_varints_and_consume_few_bytes() {

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -17,6 +17,8 @@ use super::{
     U256,
 };
 use crate::base::scalar::MontScalar;
+#[cfg(test)]
+use alloc::{vec, vec::Vec};
 use ark_ff::MontConfig;
 
 /// Most-significant byte, == 0x80

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -1,5 +1,6 @@
 use super::VarInt;
 use crate::base::scalar::{Curve25519Scalar, Scalar};
+use alloc::{vec, vec::Vec};
 use core::{
     fmt::Debug,
     ops::{Add, Neg},

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -1,5 +1,9 @@
 //! Module for parsing an `IntermediateDecimal` into a `Decimal75`.
 use crate::base::scalar::{Scalar, ScalarConversionError};
+use alloc::{
+    format,
+    string::{String, ToString},
+};
 use proof_of_sql_parser::intermediate_decimal::{IntermediateDecimal, IntermediateDecimalError};
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;

--- a/crates/proof-of-sql/src/base/math/log.rs
+++ b/crates/proof-of-sql/src/base/math/log.rs
@@ -1,5 +1,5 @@
+use core::mem;
 use num_traits::{PrimInt, Unsigned};
-use std::mem;
 
 pub fn log2_down<T: PrimInt + Unsigned>(x: T) -> usize {
     mem::size_of::<T>() * 8 - (x.leading_zeros() as usize) - 1

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -1,3 +1,4 @@
+use alloc::{format, string::String, vec::Vec};
 use thiserror::Error;
 
 /// An error that occurs when working with permutations
@@ -78,6 +79,7 @@ impl Permutation {
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_apply_permutation() {

--- a/crates/proof-of-sql/src/base/mod.rs
+++ b/crates/proof-of-sql/src/base/mod.rs
@@ -1,5 +1,6 @@
 //! This module contains basic shared functionalities of the library.
 /// TODO: add docs
+#[cfg(feature = "std")]
 pub(crate) mod bit;
 pub mod commitment;
 pub mod database;
@@ -7,10 +8,14 @@ pub mod database;
 pub(crate) mod encode;
 pub mod math;
 /// TODO: add docs
+#[cfg(feature = "std")]
 pub(crate) mod polynomial;
 pub(crate) mod proof;
 pub(crate) mod ref_into;
 pub mod scalar;
+#[cfg(feature = "std")]
 mod serialize;
+#[cfg(feature = "std")]
 pub(crate) use serialize::{impl_serde_for_ark_serde_checked, impl_serde_for_ark_serde_unchecked};
+#[cfg(feature = "std")]
 pub(crate) mod slice_ops;

--- a/crates/proof-of-sql/src/base/proof/mod.rs
+++ b/crates/proof-of-sql/src/base/proof/mod.rs
@@ -1,12 +1,17 @@
 //! Contains the transcript protocol used to construct a proof,
 //! as well as an error type which can occur when verification fails.
+#[cfg(feature = "std")]
 mod error;
+#[cfg(feature = "std")]
 pub use error::ProofError;
 
 /// Contains an extension trait for `merlin::Transcript`, which is used to construct a proof.
+#[cfg(feature = "std")]
 mod transcript_protocol;
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod transcript_protocol_test;
+#[cfg(feature = "std")]
 pub use transcript_protocol::{MessageLabel, TranscriptProtocol};
 
 mod transcript;

--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -1,4 +1,5 @@
 use crate::base::scalar::Scalar;
+use alloc::vec::Vec;
 use zerocopy::{AsBytes, FromBytes};
 
 /// A public-coin transcript.
@@ -55,6 +56,7 @@ pub trait Transcript {
 mod tests {
     use super::Transcript;
     use crate::base::proof::Keccak256Transcript;
+    use alloc::{string::ToString, vec};
 
     #[test]
     fn we_can_extend_transcript_with_serialize() {

--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -94,6 +94,7 @@ mod tests {
         assert_ne!(transcript1.challenge_as_le(), transcript2.challenge_as_le());
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn we_can_extend_transcript_with_wrapped_transcript() {
         let mut transcript1: Keccak256Transcript = Transcript::new();

--- a/crates/proof-of-sql/src/base/scalar/error.rs
+++ b/crates/proof-of-sql/src/base/scalar/error.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -4,6 +4,7 @@ pub use error::ScalarConversionError;
 mod mont_scalar;
 #[cfg(test)]
 mod mont_scalar_test;
+use alloc::string::String;
 use core::{cmp::Ordering, ops::Sub};
 pub use mont_scalar::Curve25519Scalar;
 pub(crate) use mont_scalar::MontScalar;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -1,5 +1,6 @@
 use super::{Scalar, ScalarConversionError};
 use crate::base::math::decimal::MAX_SUPPORTED_PRECISION;
+use alloc::{format, vec::Vec};
 use ark_ff::{BigInteger, Field, Fp, Fp256, MontBackend, MontConfig, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bytemuck::TransparentWrapper;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -5,6 +5,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bytemuck::TransparentWrapper;
 use core::{
     cmp::Ordering,
+    fmt,
     fmt::{Debug, Display, Formatter},
     hash::{Hash, Hasher},
     iter::{Product, Sum},
@@ -96,7 +97,7 @@ impl<T: MontConfig<4>> Default for MontScalar<T> {
     }
 }
 impl<T: MontConfig<4>> Debug for MontScalar<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_tuple("MontScalar").field(&self.0).finish()
     }
 }
@@ -292,7 +293,7 @@ impl<T: MontConfig<4>> From<&MontScalar<T>> for [u64; 4] {
 }
 
 impl<T: MontConfig<4>> Display for MontScalar<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let sign = match f.sign_plus() {
             true => {
                 let n = -self;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_from.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_from.rs
@@ -1,4 +1,5 @@
 use crate::base::scalar::MontScalar;
+use alloc::string::String;
 use ark_ff::MontConfig;
 use num_traits::Zero;
 

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
@@ -1,4 +1,5 @@
 use crate::base::scalar::{Curve25519Scalar, Scalar};
+use alloc::{format, string::ToString, vec::Vec};
 use byte_slice_cast::AsByteSlice;
 use core::cmp::Ordering;
 use indexmap::IndexSet;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -1,4 +1,5 @@
 use crate::base::scalar::{Curve25519Scalar, Scalar, ScalarConversionError};
+use alloc::format;
 use num_bigint::BigInt;
 use num_traits::{Inv, One};
 

--- a/crates/proof-of-sql/src/lib.rs
+++ b/crates/proof-of-sql/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+extern crate alloc;
 
 pub mod base;
 pub mod proof_primitive;

--- a/crates/proof-of-sql/src/lib.rs
+++ b/crates/proof-of-sql/src/lib.rs
@@ -1,9 +1,13 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 pub mod base;
+#[cfg(feature = "std")]
 pub mod proof_primitive;
+#[cfg(feature = "std")]
 pub mod sql;
 
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod tests;


### PR DESCRIPTION
# Rationale for this change

In order to be able to update commitments from within a no_std environment (like Substrate's WASM), we need to allow a portion of the `proof-of-sql` crate to be no_std compatible. This PR is a follow-up of #172 that completes the work.

# What changes are included in this PR?

* A "std" feature is added to the `proof-of-sql` crate.
* `#[cfg(feature = "std")]` are added to large portions of the code. These can eventually be removed. At the moment, only the relevant portions are made `no_std`.
* `thiserror` is bumped to a non-release branch that supports `core::error::Error`.

# Are these changes tested?

Yes, by existing tests.
