### PR TITLE
feat: `no_std` parser setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ ark-ff = { version = "0.4.0", features = [ "parallel" ] }
 ark-poly = { version = "0.4.0", features = [ "parallel" ] }
 ark-serialize = { version = "0.4.0" }
 ark-std = { version = "0.4.0", features = [ "parallel" ] }
-arrayvec = { version = "0.7" }
+arrayvec = { version = "0.7", default-features = false }
 arrow = { version = "51.0" }
 arrow-csv = { version = "51.0" }
 bit-iter = { version = "1.1.1" }
-bigdecimal = { version = "0.4.5", features = ["serde"] }
+bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3" }
 blitzar = { version = "3.1.0" }
 bumpalo = { version = "3.11.0" }
@@ -38,7 +38,8 @@ flexbuffers = { version = "2.0.0" }
 # forge-script = { git = "https://github.com/foundry-rs/foundry", tag = "nightly-bf1a39980532f76cd76fd87ee32661180f606435" }
 indexmap = { version = "2.1" }
 itertools = { version = "0.13.0" }
-lalrpop-util = { version = "0.20.0" }
+lalrpop = { version = "0.21.0" }
+lalrpop-util = { version = "0.20.0", default-features = false }
 lazy_static = { version = "1.4.0" }
 merlin = { version = "2" }
 num-traits = { version = "0.2" }
@@ -51,9 +52,9 @@ proof-of-sql-parser = { path = "crates/proof-of-sql-parser" } # We automatically
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 rayon = { version = "1.5" }
-serde = { version = "1" }
+serde = { version = "1", default-features = false }
 serde_json = { version = "1" }
-thiserror = { version = "1" }
+thiserror = { version = "1", default-features = false }
 tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 # tokio = { version = "1.39.3" }
 tracing = { version = "0.1.36" }

--- a/crates/proof-of-sql-parser/Cargo.toml
+++ b/crates/proof-of-sql-parser/Cargo.toml
@@ -19,11 +19,11 @@ arrayvec = { workspace = true, features = ["serde"] }
 bigdecimal = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 lalrpop-util = { workspace = true, features = ["lexer", "unicode"] }
-serde = { workspace = true, features = ["serde_derive"] }
+serde = { workspace = true, features = ["serde_derive", "alloc"] }
 thiserror = { workspace = true }
 
 [build-dependencies]
-lalrpop = { version = "0.20.0" }
+lalrpop = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/proof-of-sql-parser/src/error.rs
+++ b/crates/proof-of-sql-parser/src/error.rs
@@ -16,4 +16,4 @@ pub enum ParseError {
 
 /// General parsing error that may occur, for example if the provided schema/object_name strings
 /// aren't valid postgres-style identifiers (excluding dollar signs).
-pub type ParseResult<T> = std::result::Result<T, ParseError>;
+pub type ParseResult<T> = Result<T, ParseError>;

--- a/crates/proof-of-sql-parser/src/error.rs
+++ b/crates/proof-of-sql-parser/src/error.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use thiserror::Error;
 
 /// Errors encountered during the parsing process

--- a/crates/proof-of-sql-parser/src/identifier.rs
+++ b/crates/proof-of-sql-parser/src/identifier.rs
@@ -1,6 +1,6 @@
 use crate::{sql::IdentifierParser, ParseError, ParseResult};
 use arrayvec::ArrayString;
-use std::{cmp::Ordering, fmt, str::FromStr};
+use std::{cmp::Ordering, fmt, ops::Deref, str::FromStr};
 
 /// Top-level unique identifier.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Ord, PartialOrd, Copy)]
@@ -70,7 +70,7 @@ impl PartialOrd<str> for Identifier {
     }
 }
 
-impl std::ops::Deref for Identifier {
+impl Deref for Identifier {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {

--- a/crates/proof-of-sql-parser/src/identifier.rs
+++ b/crates/proof-of-sql-parser/src/identifier.rs
@@ -1,6 +1,7 @@
 use crate::{sql::IdentifierParser, ParseError, ParseResult};
+use alloc::{format, string::ToString};
 use arrayvec::ArrayString;
-use std::{cmp::Ordering, fmt, ops::Deref, str::FromStr};
+use core::{cmp::Ordering, fmt, ops::Deref, str::FromStr};
 
 /// Top-level unique identifier.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Ord, PartialOrd, Copy)]
@@ -87,6 +88,7 @@ impl AsRef<str> for Identifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{borrow::ToOwned, vec, vec::Vec};
 
     #[test]
     fn from_str_identifier() {

--- a/crates/proof-of-sql-parser/src/intermediate_ast.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast.rs
@@ -5,12 +5,13 @@
 ***/
 
 use crate::{intermediate_decimal::IntermediateDecimal, posql_time::PoSQLTimestamp, Identifier};
-use core::hash::Hash;
-use serde::{Deserialize, Serialize};
-use std::{
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::{
     fmt,
     fmt::{Display, Formatter},
+    hash::Hash,
 };
+use serde::{Deserialize, Serialize};
 
 /// Representation of a SetExpression, a collection of rows, each having one or more columns.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/crates/proof-of-sql-parser/src/intermediate_ast.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast.rs
@@ -7,6 +7,10 @@
 use crate::{intermediate_decimal::IntermediateDecimal, posql_time::PoSQLTimestamp, Identifier};
 use core::hash::Hash;
 use serde::{Deserialize, Serialize};
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 
 /// Representation of a SetExpression, a collection of rows, each having one or more columns.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -128,8 +132,8 @@ pub enum AggregationOperator {
     First,
 }
 
-impl std::fmt::Display for AggregationOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for AggregationOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             AggregationOperator::Max => write!(f, "max"),
             AggregationOperator::Min => write!(f, "min"),
@@ -290,9 +294,9 @@ pub enum OrderByDirection {
     Desc,
 }
 
-impl std::fmt::Display for OrderByDirection {
+impl Display for OrderByDirection {
     // This trait requires `fmt` with this exact signature.
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             OrderByDirection::Asc => write!(f, "asc"),
             OrderByDirection::Desc => write!(f, "desc"),

--- a/crates/proof-of-sql-parser/src/intermediate_ast_tests.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast_tests.rs
@@ -5,6 +5,7 @@ use crate::{
     utility::*,
     SelectStatement,
 };
+use alloc::{borrow::ToOwned, string::ToString, vec};
 
 // Sting parser tests
 #[test]

--- a/crates/proof-of-sql-parser/src/intermediate_decimal.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_decimal.rs
@@ -6,10 +6,10 @@
 //! A decimal must have a decimal point. The lexer does not route
 //! whole integers to this contructor.
 use crate::intermediate_decimal::IntermediateDecimalError::{LossyCast, OutOfRange, ParseError};
+use alloc::string::String;
 use bigdecimal::{num_bigint::BigInt, BigDecimal, ParseBigDecimalError, ToPrimitive};
-use core::hash::Hash;
+use core::{fmt, hash::Hash, str::FromStr};
 use serde::{Deserialize, Serialize};
-use std::{fmt, str::FromStr};
 use thiserror::Error;
 
 /// Errors related to the processing of decimal values in proof-of-sql
@@ -157,6 +157,7 @@ impl TryFrom<IntermediateDecimal> for i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::string::ToString;
 
     #[test]
     fn test_valid_decimal_simple() {

--- a/crates/proof-of-sql-parser/src/intermediate_decimal.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_decimal.rs
@@ -16,8 +16,8 @@ use thiserror::Error;
 #[derive(Error, Debug, PartialEq)]
 pub enum IntermediateDecimalError {
     /// Represents an error encountered during the parsing of a decimal string.
-    #[error(transparent)]
-    ParseError(#[from] ParseBigDecimalError),
+    #[error("{0}")]
+    ParseError(ParseBigDecimalError),
     /// Error occurs when this decimal cannot fit in a primitive.
     #[error("Value out of range for target type")]
     OutOfRange,
@@ -27,6 +27,11 @@ pub enum IntermediateDecimalError {
     /// Cannot cast this decimal to a big integer
     #[error("Conversion to integer failed")]
     ConversionFailure,
+}
+impl From<ParseBigDecimalError> for IntermediateDecimalError {
+    fn from(value: ParseBigDecimalError) -> Self {
+        IntermediateDecimalError::ParseError(value)
+    }
 }
 
 impl Eq for IntermediateDecimalError {}

--- a/crates/proof-of-sql-parser/src/lib.rs
+++ b/crates/proof-of-sql-parser/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+extern crate alloc;
 
 /// Module for handling an intermediate decimal type received from the lexer.
 pub mod intermediate_decimal;
@@ -51,7 +52,8 @@ macro_rules! impl_serde_from_str {
             where
                 D: serde::Deserializer<'d>,
             {
-                let string = String::deserialize(deserializer)?;
+                extern crate alloc;
+                let string = alloc::string::String::deserialize(deserializer)?;
                 <$type>::from_str(&string).map_err(serde::de::Error::custom)
             }
         }

--- a/crates/proof-of-sql-parser/src/posql_time/error.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/error.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -230,7 +230,6 @@ mod tests {
         // Parse timestamps
         let before_leap_dt = PoSQLTimestamp::try_from(before_leap_second).unwrap();
         let leap_second_dt = PoSQLTimestamp::try_from(leap_second).unwrap();
-        dbg!(&leap_second_dt.timestamp.timestamp());
         let after_leap_dt = PoSQLTimestamp::try_from(after_leap_second).unwrap();
 
         // Ensure that "23:59:60Z" - 1 second is considered equivalent to "23:59:59Z"

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -1,4 +1,5 @@
 use super::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError};
+use alloc::{format, string::ToString};
 use chrono::{offset::LocalResult, DateTime, TimeZone, Utc};
 use core::hash::Hash;
 use serde::{Deserialize, Serialize};

--- a/crates/proof-of-sql-parser/src/posql_time/timezone.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timezone.rs
@@ -1,7 +1,7 @@
 use super::PoSQLTimestampError;
+use alloc::{string::ToString, sync::Arc};
 use core::fmt;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 /// Captures a timezone from a timestamp query
 #[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq)]
@@ -75,6 +75,7 @@ impl fmt::Display for PoSQLTimeZone {
 #[cfg(test)]
 mod timezone_parsing_tests {
     use crate::posql_time::timezone;
+    use alloc::format;
 
     #[test]
     fn test_display_fixed_offset_positive() {

--- a/crates/proof-of-sql-parser/src/resource_id.rs
+++ b/crates/proof-of-sql-parser/src/resource_id.rs
@@ -1,6 +1,10 @@
 //! This file defines the resource identifier type.
 use crate::{impl_serde_from_str, sql::ResourceIdParser, Identifier, ParseError, ParseResult};
-use std::{
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+use core::{
     fmt::{self, Display},
     str::FromStr,
 };

--- a/crates/proof-of-sql-parser/src/select_statement.rs
+++ b/crates/proof-of-sql-parser/src/select_statement.rs
@@ -1,7 +1,8 @@
 use super::intermediate_ast::{OrderBy, SetExpression, Slice, TableExpression};
 use crate::{sql::SelectStatementParser, Identifier, ParseError, ParseResult, ResourceId};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
+use core::{fmt, ops::Deref, str::FromStr};
 use serde::{Deserialize, Serialize};
-use std::{fmt, ops::Deref, str::FromStr};
 
 /// Representation of a select statement, that is, the only type of queries allowed.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]

--- a/crates/proof-of-sql-parser/src/sql.lalrpop
+++ b/crates/proof-of-sql-parser/src/sql.lalrpop
@@ -3,6 +3,10 @@ use crate::select_statement;
 use crate::identifier;
 use lalrpop_util::ParseError::User;
 use crate::{intermediate_decimal::IntermediateDecimal, posql_time::PoSQLTimestamp};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 grammar;
 

--- a/crates/proof-of-sql-parser/src/utility.rs
+++ b/crates/proof-of-sql-parser/src/utility.rs
@@ -1,4 +1,5 @@
 use crate::{intermediate_ast::*, Identifier, SelectStatement};
+use alloc::{boxed::Box, vec, vec::Vec};
 
 /// Construct an identifier from a str
 pub fn ident(name: &str) -> Identifier {


### PR DESCRIPTION
# Rationale for this change

We want to support `no_std` environments. `proof-of-sql-parser` can be `no_std` compatible.

# What changes are included in this PR?

* This PR refactors `proof-of-sql-parser` to mostly allow for `no_std`. Two dependencies: `lalrpop` and `thiserror` are still not `no_std`. See #176.

# Are these changes tested?

Yes, existing tests cover this.
