### PR TITLE
feat: add `rayon` feature flag

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -75,6 +75,8 @@ jobs:
           sudo apt-get install -y clang lld
       - name: Run cargo test
         run: cargo test --all-features
+      - name: Run cargo test without rayon
+        run: cargo test --no-default-features --features="arrow blitzar"
       - name: Dry run cargo test (proof-of-sql) (test feature only)
         run: cargo test -p proof-of-sql --no-run --no-default-features --features="test"
       - name: Dry run cargo test (proof-of-sql) (arrow feature only)

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -41,7 +41,7 @@ num-bigint = { workspace = true, default-features = false }
 postcard = { workspace = true, features = ["alloc"] }
 proof-of-sql-parser = { workspace = true }
 rand = { workspace = true, default-features = false, optional = true }
-rayon = { workspace = true }
+rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -72,10 +72,9 @@ flexbuffers = { workspace = true }
 development = ["arrow-csv"]
 
 [features]
-default = ["arrow", "blitzar"]
+default = ["arrow", "blitzar", "rayon"]
 arrow = ["dep:arrow"]
 test = ["dep:rand"]
-rayon = []
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -75,6 +75,7 @@ development = ["arrow-csv"]
 default = ["arrow", "blitzar"]
 arrow = ["dep:arrow"]
 test = ["dep:rand"]
+rayon = []
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql/src/base/mod.rs
+++ b/crates/proof-of-sql/src/base/mod.rs
@@ -14,3 +14,6 @@ pub mod scalar;
 mod serialize;
 pub(crate) use serialize::{impl_serde_for_ark_serde_checked, impl_serde_for_ark_serde_unchecked};
 pub(crate) mod slice_ops;
+
+mod rayon_cfg;
+pub(crate) use rayon_cfg::if_rayon;

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -1,7 +1,10 @@
+use crate::base::if_rayon;
 use core::ops::{Mul, MulAssign, Sub, SubAssign};
 use num_traits::One;
+#[cfg(feature = "rayon")]
 use rayon::prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
+#[cfg(feature = "rayon")]
 const MIN_PARALLEL_LEN: usize = 16; // The minimum size for which we should actually parallelize the compute.
 
 /// This method manipulates left and right such that
@@ -12,19 +15,22 @@ where
 {
     let k = std::cmp::min(left.len(), right.len());
     let one_minus_p = F::one() - p;
-    left.par_iter_mut()
-        .with_min_len(MIN_PARALLEL_LEN)
-        .zip(right.par_iter_mut())
-        .for_each(|(li, ri)| {
-            *ri = *li * p;
-            *li -= *ri;
-        });
-    left[k..]
-        .par_iter_mut()
-        .with_min_len(MIN_PARALLEL_LEN)
-        .for_each(|li| {
-            *li *= one_minus_p;
-        });
+    if_rayon!(
+        left.par_iter_mut().with_min_len(MIN_PARALLEL_LEN),
+        left.iter_mut()
+    )
+    .zip(right)
+    .for_each(|(li, ri)| {
+        *ri = *li * p;
+        *li -= *ri;
+    });
+    if_rayon!(
+        left[k..].par_iter_mut().with_min_len(MIN_PARALLEL_LEN),
+        left[k..].iter_mut()
+    )
+    .for_each(|li| {
+        *li *= one_minus_p;
+    });
 }
 
 /// Given a point of evaluation, computes the vector that allows us

--- a/crates/proof-of-sql/src/base/rayon_cfg.rs
+++ b/crates/proof-of-sql/src/base/rayon_cfg.rs
@@ -1,0 +1,13 @@
+macro_rules! if_rayon {
+    ($rayon_value: expr, $else_value: expr) => {{
+        #[cfg(feature = "rayon")]
+        {
+            ($rayon_value)
+        }
+        #[cfg(not(feature = "rayon"))]
+        {
+            ($else_value)
+        }
+    }};
+}
+pub(crate) use if_rayon;

--- a/crates/proof-of-sql/src/base/scalar/commitment_utility.rs
+++ b/crates/proof-of-sql/src/base/scalar/commitment_utility.rs
@@ -1,7 +1,4 @@
-use crate::base::{
-    scalar::Curve25519Scalar,
-    slice_ops::{iter_cast, slice_cast_to_iter},
-};
+use crate::base::{scalar::Curve25519Scalar, slice_ops::slice_cast};
 use blitzar::compute::compute_curve25519_commitments;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 
@@ -13,7 +10,7 @@ pub fn compute_commitment_for_testing<T: Into<Curve25519Scalar> + Clone + Sync>(
     vals: &[T],
     offset_generators: usize,
 ) -> RistrettoPoint {
-    let vals = iter_cast::<Curve25519Scalar, [u64; 4]>(slice_cast_to_iter(vals));
+    let vals = slice_cast::<Curve25519Scalar, [u64; 4]>(&slice_cast(vals));
     let table = [vals.as_slice().into()];
     let mut commitments = [CompressedRistretto::default()];
     compute_curve25519_commitments(&mut commitments, &table, offset_generators as u64);

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -1,4 +1,6 @@
+use crate::base::if_rayon;
 use core::{iter::Sum, ops::Mul};
+#[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 /// This operation takes the inner product of two slices. In other words, it does `a[0] * b[0] + a[1] * b[1] + ... + a[n] * b[n]`.
@@ -7,9 +9,8 @@ pub fn inner_product<F>(a: &[F], b: &[F]) -> F
 where
     F: Sync + Send + Mul<Output = F> + Sum + Copy,
 {
-    a.par_iter()
-        .with_min_len(super::MIN_RAYON_LEN)
-        .zip(b.par_iter())
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
         .map(|(&a, &b)| a * b)
         .sum()
 }

--- a/crates/proof-of-sql/src/base/slice_ops/mod.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mod.rs
@@ -3,6 +3,7 @@
 //! For example, the inner product will not panic when the two input slices have different lengths.
 //! Instead, it will simply truncate the longer one, which is equivalent to multiply each extra element by zero before summing.
 
+#[cfg(any(feature = "rayon", test))]
 pub const MIN_RAYON_LEN: usize = 1 << 8;
 
 mod inner_product;

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
@@ -1,3 +1,5 @@
+use crate::base::if_rayon;
+#[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 /// This operation takes a slice and casts it to a vector of a different type using the provided function.
@@ -6,11 +8,12 @@ where
     F: Sync,
     T: Send,
 {
-    value
-        .par_iter()
-        .with_min_len(super::MIN_RAYON_LEN)
-        .map(cast)
-        .collect()
+    if_rayon!(
+        value.par_iter().with_min_len(super::MIN_RAYON_LEN),
+        value.iter()
+    )
+    .map(cast)
+    .collect()
 }
 
 /// This operation takes a slice and casts it to a mutable slice of a different type using the provided function.
@@ -22,11 +25,12 @@ pub fn slice_cast_mut_with<'a, F, T>(
     F: Sync,
     T: Send + Sync,
 {
-    value
-        .par_iter()
-        .with_min_len(super::MIN_RAYON_LEN)
-        .zip(result)
-        .for_each(|(a, b)| *b = cast(a));
+    if_rayon!(
+        value.par_iter().with_min_len(super::MIN_RAYON_LEN),
+        value.iter()
+    )
+    .zip(result)
+    .for_each(|(a, b)| *b = cast(a));
 }
 
 /// This operation takes a slice and casts it to a vector of a different type using the provided function.

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -1,6 +1,7 @@
 use super::{pack_scalars, pairings, DoryCommitment, DoryProverPublicSetup, G1Affine};
-use crate::base::{commitment::CommittableColumn, slice_ops::slice_cast};
+use crate::base::{commitment::CommittableColumn, if_rayon, slice_ops::slice_cast};
 use blitzar::compute::ElementP2;
+#[cfg(feature = "rayon")]
 use rayon::prelude::*;
 use tracing::{span, Level};
 
@@ -79,17 +80,19 @@ fn compute_dory_commitments_packed_impl(
 
     // Compute the Dory commitments using multi pairing of sub-commits.
     let span = span!(Level::INFO, "multi_pairing").entered();
-    let dc: Vec<DoryCommitment> = cumulative_sub_commit_sums
-        .par_iter()
-        .zip(num_sub_commits_per_full_commit.par_iter())
-        .map(|(&idx, &num_sub_commits)| {
-            let sub_commits = &modified_sub_commits_update[idx..idx + num_sub_commits];
-            let gamma_2_slice =
-                &gamma_2.last().unwrap()[gamma_2_offset..gamma_2_offset + num_sub_commits];
+    let dc: Vec<DoryCommitment> = if_rayon!(
+        cumulative_sub_commit_sums.par_iter(),
+        cumulative_sub_commit_sums.iter()
+    )
+    .zip(&num_sub_commits_per_full_commit)
+    .map(|(&idx, &num_sub_commits)| {
+        let sub_commits = &modified_sub_commits_update[idx..idx + num_sub_commits];
+        let gamma_2_slice =
+            &gamma_2.last().unwrap()[gamma_2_offset..gamma_2_offset + num_sub_commits];
 
-            DoryCommitment(pairings::multi_pairing(sub_commits, gamma_2_slice))
-        })
-        .collect();
+        DoryCommitment(pairings::multi_pairing(sub_commits, gamma_2_slice))
+    })
+    .collect();
     span.exit();
 
     dc

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -1,5 +1,5 @@
 use super::{pack_scalars, pairings, DoryCommitment, DoryProverPublicSetup, G1Affine};
-use crate::base::commitment::CommittableColumn;
+use crate::base::{commitment::CommittableColumn, slice_ops::slice_cast};
 use blitzar::compute::ElementP2;
 use rayon::prelude::*;
 use tracing::{span, Level};
@@ -48,10 +48,7 @@ fn compute_dory_commitments_packed_impl(
     }
 
     // Convert the sub-commits to G1Affine.
-    let all_sub_commits: Vec<G1Affine> = sub_commits_from_blitzar
-        .par_iter()
-        .map(Into::into)
-        .collect();
+    let all_sub_commits: Vec<G1Affine> = slice_cast(&sub_commits_from_blitzar);
 
     // Modify the sub-commits to account for signed values that were offset.
     let modified_sub_commits_update = pack_scalars::modify_commits(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce_helper.rs
@@ -2,6 +2,8 @@ use super::{
     pairings::{multi_pairing_2, multi_pairing_4},
     DeferredGT, ProverSetup, ProverState, VerifierSetup, VerifierState, F, GT,
 };
+use crate::base::if_rayon;
+#[cfg(feature = "rayon")]
 use rayon::{
     iter::IndexedParallelIterator,
     prelude::{IntoParallelRefMutIterator, ParallelIterator},
@@ -43,14 +45,10 @@ pub fn dory_reduce_prove_mutate_v_vecs(
     setup: &ProverSetup,
     (beta, beta_inv): (F, F),
 ) {
-    state
-        .v1
-        .par_iter_mut()
+    if_rayon!(state.v1.par_iter_mut(), state.v1.iter_mut())
         .zip(setup.Gamma_1[state.nu])
         .for_each(|(v, &g)| *v = (*v + g * beta).into());
-    state
-        .v2
-        .par_iter_mut()
+    if_rayon!(state.v2.par_iter_mut(), state.v2.iter_mut())
         .zip(setup.Gamma_2[state.nu])
         .for_each(|(v, &g)| *v = (*v + g * beta_inv).into());
 }
@@ -80,10 +78,10 @@ pub fn dory_reduce_prove_fold_v_vecs(
 ) {
     let (v_1L, v_1R) = state.v1.split_at_mut(half_n);
     let (v_2L, v_2R) = state.v2.split_at_mut(half_n);
-    v_1L.par_iter_mut()
+    if_rayon!(v_1L.par_iter_mut(), v_1L.iter_mut())
         .zip(v_1R)
         .for_each(|(v_L, v_R)| *v_L = (*v_L * alpha + v_R).into());
-    v_2L.par_iter_mut()
+    if_rayon!(v_2L.par_iter_mut(), v_2L.iter_mut())
         .zip(v_2R)
         .for_each(|(v_L, v_R)| *v_L = (*v_L * alpha_inv + v_R).into());
     state.v1.truncate(half_n);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
@@ -2,14 +2,14 @@
 use super::G1Projective;
 use super::{transpose, G1Affine, ProverSetup, F};
 use crate::base::polynomial::compute_evaluation_vector;
+#[cfg(feature = "blitzar")]
+use crate::base::slice_ops::slice_cast;
 #[cfg(not(feature = "blitzar"))]
 use ark_ec::{AffineRepr, VariableBaseMSM};
 use ark_ff::{BigInt, MontBackend};
 #[cfg(feature = "blitzar")]
 use blitzar::compute::ElementP2;
 use num_traits::{One, Zero};
-#[cfg(feature = "blitzar")]
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 /// Compute the evaluations of the columns of the matrix M that is derived from `a`.
 pub(super) fn compute_v_vec(a: &[F], L_vec: &[F], sigma: usize, nu: usize) -> Vec<F> {
@@ -57,7 +57,7 @@ pub(super) fn compute_T_vec_prime(
         a_transpose.as_slice(),
     );
 
-    blitzar_commits.par_iter().map(Into::into).collect()
+    slice_cast(&blitzar_commits)
 }
 
 #[tracing::instrument(level = "debug", skip_all)]

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -4,7 +4,8 @@
  * See third_party/license/arkworks.LICENSE
  */
 use crate::base::scalar::Scalar;
-use crate::proof_primitive::sumcheck::ProverState;
+use crate::{base::if_rayon, proof_primitive::sumcheck::ProverState};
+#[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
 #[tracing::instrument(level = "debug", skip_all)]
@@ -17,16 +18,17 @@ pub fn prove_round<S: Scalar>(prover_state: &mut ProverState<S>, r_maybe: &Optio
 
         // fix argument
         let r_as_field = prover_state.randomness[prover_state.round - 1];
-        prover_state
-            .flattened_ml_extensions
-            .par_iter_mut()
-            .for_each(|multiplicand| {
-                in_place_fix_variable(
-                    multiplicand,
-                    r_as_field,
-                    prover_state.num_vars - prover_state.round,
-                );
-            });
+        if_rayon!(
+            prover_state.flattened_ml_extensions.par_iter_mut(),
+            prover_state.flattened_ml_extensions.iter_mut()
+        )
+        .for_each(|multiplicand| {
+            in_place_fix_variable(
+                multiplicand,
+                r_as_field,
+                prover_state.num_vars - prover_state.round,
+            );
+        });
     } else if prover_state.round > 0 {
         panic!("verifier message is empty");
     }
@@ -53,43 +55,47 @@ pub fn prove_round<S: Scalar>(prover_state: &mut ProverState<S>, r_maybe: &Optio
     // The order of these loops is changed for the purpose of efficiency.
 
     // The outer loop is the loop over all products in the list_of_products
-    let result = prover_state
-        .list_of_products
-        .par_iter()
-        .map(|(coefficient, multiplicand_indices)| {
-            // The second loop is the loop over the row (b) in 0..round_length
-            (0..round_length)
-                .into_par_iter()
-                .map(|b| {
-                    // We add a vector of products, which takes a bit of extra memory. The reason for this is for the efficient modification described below
-                    let mut products = vec![*coefficient; degree + 1];
+    let sums_iter = if_rayon!(
+        prover_state.list_of_products.par_iter(),
+        prover_state.list_of_products.iter()
+    )
+    .map(|(coefficient, multiplicand_indices)| {
+        // The second loop is the loop over the row (b) in 0..round_length
+        let products_iter =
+            if_rayon!((0..round_length).into_par_iter(), 0..round_length).map(|b| {
+                // We add a vector of products, which takes a bit of extra memory. The reason for this is for the efficient modification described below
+                let mut products = vec![*coefficient; degree + 1];
 
-                    // The third loop is the loop over the factors/multiplicand in the product term.
-                    for &multiplicand_index in multiplicand_indices {
-                        let table = &prover_state.flattened_ml_extensions[multiplicand_index];
+                // The third loop is the loop over the factors/multiplicand in the product term.
+                for &multiplicand_index in multiplicand_indices {
+                    let table = &prover_state.flattened_ml_extensions[multiplicand_index];
 
-                        // This third+final loop give an efficient way of computing
-                        // products[t] *= table[b << 1] * (S::one() - t_as_field) + table[(b << 1) + 1] * t_as_field;
-                        // It requires only 1 addition (plus the cumulative multiplication) to accomplish the same task.
-                        // It relies on the fact that
-                        // table[b << 1] * (S::one() - t_as_field) + table[(b << 1) + 1] * t_as_field == table[b << 1] + t * diff
-                        let mut start = table[b << 1];
-                        let step = table[(b << 1) + 1] - start;
+                    // This third+final loop give an efficient way of computing
+                    // products[t] *= table[b << 1] * (S::one() - t_as_field) + table[(b << 1) + 1] * t_as_field;
+                    // It requires only 1 addition (plus the cumulative multiplication) to accomplish the same task.
+                    // It relies on the fact that
+                    // table[b << 1] * (S::one() - t_as_field) + table[(b << 1) + 1] * t_as_field == table[b << 1] + t * diff
+                    let mut start = table[b << 1];
+                    let step = table[(b << 1) + 1] - start;
 
-                        // The innermost loop loops over the values (t) that we are evaluating at.
-                        products.iter_mut().take(degree).for_each(|product| {
-                            *product *= start;
-                            start += step;
-                        });
-                        products[degree] *= start;
-                    }
-                    products
-                })
-                .reduce(|| vec![S::zero(); degree + 1], vec_elementwise_add)
-        })
-        .reduce(|| vec![S::zero(); degree + 1], vec_elementwise_add);
-
-    result
+                    // The innermost loop loops over the values (t) that we are evaluating at.
+                    products.iter_mut().take(degree).for_each(|product| {
+                        *product *= start;
+                        start += step;
+                    });
+                    products[degree] *= start;
+                }
+                products
+            });
+        if_rayon!(
+            products_iter.reduce(|| vec![S::zero(); degree + 1], vec_elementwise_add),
+            products_iter.fold(vec![S::zero(); degree + 1], vec_elementwise_add)
+        )
+    });
+    if_rayon!(
+        sums_iter.reduce(|| vec![S::zero(); degree + 1], vec_elementwise_add),
+        sums_iter.fold(vec![S::zero(); degree + 1], vec_elementwise_add)
+    )
 }
 
 /// This is equivalent to


### PR DESCRIPTION
# Rationale for this change

One of the components of this repo that is not `no_std` is rayon.

# What changes are included in this PR?

* The `slice_cast` module is simplified and leveraged more.
* An `if_rayon!` macro is added. This is the key to the majority of this PR.
    ```rust
    macro_rules! if_rayon {
        ($rayon_value: expr, $else_value: expr) => {{
            #[cfg(feature = "rayon")]
            {
                ($rayon_value)
            }
            #[cfg(not(feature = "rayon"))]
            {
                ($else_value)
            }
        }};
    }
    ```
* A `rayon` feature flag is added and the `if_rayon!` macro is used everywhere `rayon` shows up.

# Are these changes tested?

Yes, by existing tests.
An additional test run is added for the non-rayon code. This significantly slows down the CI job, so we may want to think through a better way to test this code. Perhaps the rayon can be isolated to a smaller module, and only that module tested.