### PR TITLE
feat: remove `std` usage by `indexmap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.0.0" # DO NOT CHANGE THIS LINE! This will be automatically updated
 license-file = "LICENSE"
 
 [workspace.dependencies]
+ahash = { version = "0.8.11", default-features = false, features = ["runtime-rng"] }
 # alloy-primitives = { version = "0.8.1" }
 # alloy-sol-types = { version = "0.8.1" }
 ark-bls12-381 = { version = "0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ curve25519-dalek = { version = "4", features = ["rand_core"] }
 derive_more = { version = "0.99" }
 flexbuffers = { version = "2.0.0" }
 # forge-script = { git = "https://github.com/foundry-rs/foundry", tag = "nightly-bf1a39980532f76cd76fd87ee32661180f606435" }
-indexmap = { version = "2.1" }
+indexmap = { version = "2.1", default-features = false }
 itertools = { version = "0.13.0" }
 lalrpop = { version = "0.21.0" }
 lalrpop-util = { version = "0.20.0", default-features = false }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -14,6 +14,7 @@ doctest = true
 test = true
 
 [dependencies]
+ahash = { workspace = true }
 ark-bls12-381 = { workspace = true }
 ark-curve25519 = { workspace = true }
 ark-ec = { workspace = true }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -2,9 +2,8 @@ use super::{
     column_commitment_metadata::ColumnCommitmentMetadataMismatch, ColumnCommitmentMetadata,
     CommittableColumn,
 };
-use crate::base::database::ColumnField;
+use crate::base::{database::ColumnField, map::IndexMap};
 use alloc::string::{String, ToString};
-use indexmap::IndexMap;
 use proof_of_sql_parser::Identifier;
 use thiserror::Error;
 

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -2,7 +2,10 @@ use super::{
     committable_column::CommittableColumn, ColumnCommitmentMetadata, ColumnCommitmentMetadataMap,
     ColumnCommitmentMetadataMapExt, ColumnCommitmentsMismatch, Commitment, VecCommitmentExt,
 };
-use crate::base::database::{ColumnField, ColumnRef, CommitmentAccessor, TableRef};
+use crate::base::{
+    database::{ColumnField, ColumnRef, CommitmentAccessor, TableRef},
+    map::IndexSet,
+};
 use alloc::{
     borrow::ToOwned,
     string::{String, ToString},
@@ -10,7 +13,6 @@ use alloc::{
     vec::Vec,
 };
 use core::{iter, slice};
-use indexmap::IndexSet;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -111,7 +113,7 @@ impl<C: Commitment> ColumnCommitments<C> {
         COL: Into<CommittableColumn<'a>>,
     {
         // Check for duplicate identifiers
-        let mut unique_identifiers = IndexSet::new();
+        let mut unique_identifiers = IndexSet::default();
         let unique_columns = columns
             .into_iter()
             .map(|(identifier, column)| {
@@ -161,7 +163,7 @@ impl<C: Commitment> ColumnCommitments<C> {
         COL: Into<CommittableColumn<'a>>,
     {
         // Check for duplicate identifiers.
-        let mut unique_identifiers = IndexSet::new();
+        let mut unique_identifiers = IndexSet::default();
         let unique_columns = columns
             .into_iter()
             .map(|(identifier, column)| {

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -1,10 +1,12 @@
 use super::{Commitment, TableCommitment};
-use crate::base::database::{
-    ColumnField, ColumnRef, ColumnType, CommitmentAccessor, MetadataAccessor, SchemaAccessor,
-    TableRef,
+use crate::base::{
+    database::{
+        ColumnField, ColumnRef, ColumnType, CommitmentAccessor, MetadataAccessor, SchemaAccessor,
+        TableRef,
+    },
+    map::IndexMap,
 };
 use alloc::vec::Vec;
-use indexmap::IndexMap;
 use proof_of_sql_parser::Identifier;
 
 /// The commitments for all of the tables in a query.
@@ -34,13 +36,16 @@ impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
     ) -> Self {
         columns
             .into_iter()
-            .fold(IndexMap::<_, Vec<_>>::new(), |mut table_columns, column| {
-                table_columns
-                    .entry(column.table_ref())
-                    .or_default()
-                    .push(ColumnField::new(column.column_id(), *column.column_type()));
-                table_columns
-            })
+            .fold(
+                IndexMap::<_, Vec<_>>::default(),
+                |mut table_columns, column| {
+                    table_columns
+                        .entry(column.table_ref())
+                        .or_default()
+                        .push(ColumnField::new(column.column_id(), *column.column_type()));
+                    table_columns
+                },
+            )
             .into_iter()
             .map(|(table_ref, columns)| {
                 (

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -459,12 +459,12 @@ mod tests {
     use crate::{
         base::{
             database::{owned_table_utility::*, OwnedColumn},
+            map::IndexMap,
             scalar::Curve25519Scalar,
         },
         record_batch,
     };
     use curve25519_dalek::RistrettoPoint;
-    use indexmap::IndexMap;
 
     #[test]
     #[allow(clippy::reversed_empty_ranges)]
@@ -479,7 +479,7 @@ mod tests {
     fn we_can_construct_table_commitment_from_columns_and_identifiers() {
         // no-columns case
         let mut empty_columns_iter: IndexMap<Identifier, OwnedColumn<Curve25519Scalar>> =
-            IndexMap::new();
+            IndexMap::default();
         let empty_table_commitment =
             TableCommitment::<RistrettoPoint>::try_from_columns_with_offset(
                 &empty_columns_iter,

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -18,6 +18,7 @@ use crate::base::{
         scalar_and_i256_conversions::convert_i256_to_scalar, OwnedColumn, OwnedTable,
         OwnedTableError,
     },
+    map::IndexMap,
     math::decimal::Precision,
     scalar::Scalar,
 };
@@ -31,7 +32,6 @@ use arrow::{
     error::ArrowError,
     record_batch::RecordBatch,
 };
-use indexmap::IndexMap;
 use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError},
     Identifier, ParseError,

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -2,6 +2,7 @@ use super::{OwnedColumn, OwnedTable};
 use crate::{
     base::{
         database::{owned_table_utility::*, OwnedArrowConversionError},
+        map::IndexMap,
         scalar::Curve25519Scalar,
     },
     record_batch,
@@ -11,7 +12,6 @@ use arrow::{
     datatypes::Schema,
     record_batch::RecordBatch,
 };
-use indexmap::IndexMap;
 use std::sync::Arc;
 
 fn we_can_convert_between_owned_column_and_array_ref_impl(
@@ -93,7 +93,7 @@ fn we_can_convert_between_owned_table_and_record_batch_impl(
 #[test]
 fn we_can_convert_between_owned_table_and_record_batch() {
     we_can_convert_between_owned_table_and_record_batch_impl(
-        OwnedTable::<Curve25519Scalar>::try_new(IndexMap::new()).unwrap(),
+        OwnedTable::<Curve25519Scalar>::try_new(IndexMap::default()).unwrap(),
         RecordBatch::new_empty(Arc::new(Schema::empty())),
     );
     we_can_convert_between_owned_table_and_record_batch_impl(

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -1,6 +1,5 @@
 use super::OwnedColumn;
-use crate::base::scalar::Scalar;
-use indexmap::IndexMap;
+use crate::base::{map::IndexMap, scalar::Scalar};
 use proof_of_sql_parser::Identifier;
 use thiserror::Error;
 

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -1,11 +1,11 @@
 use crate::{
     base::{
         database::{owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableError},
+        map::IndexMap,
         scalar::Curve25519Scalar,
     },
     proof_primitive::dory::DoryScalar,
 };
-use indexmap::IndexMap;
 use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
     Identifier,
@@ -13,7 +13,7 @@ use proof_of_sql_parser::{
 
 #[test]
 fn we_can_create_an_owned_table_with_no_columns() {
-    let table = OwnedTable::<Curve25519Scalar>::try_new(IndexMap::new()).unwrap();
+    let table = OwnedTable::<Curve25519Scalar>::try_new(IndexMap::default()).unwrap();
     assert_eq!(table.num_columns(), 0);
 }
 #[test]
@@ -25,7 +25,7 @@ fn we_can_create_an_empty_owned_table() {
         scalar("scalar", [0; 0]),
         boolean("boolean", [true; 0]),
     ]);
-    let mut table = IndexMap::new();
+    let mut table = IndexMap::default();
     table.insert(
         Identifier::try_new("bigint").unwrap(),
         OwnedColumn::BigInt(vec![]),
@@ -66,7 +66,7 @@ fn we_can_create_an_owned_table_with_data() {
             [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
         ),
     ]);
-    let mut table = IndexMap::new();
+    let mut table = IndexMap::default();
     table.insert(
         Identifier::try_new("time_stamp").unwrap(),
         OwnedColumn::TimestampTZ(

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -2,9 +2,11 @@ use super::{
     Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedColumn,
     OwnedTable, SchemaAccessor, TableRef, TestAccessor,
 };
-use crate::base::commitment::{CommitmentEvaluationProof, VecCommitmentExt};
+use crate::base::{
+    commitment::{CommitmentEvaluationProof, VecCommitmentExt},
+    map::IndexMap,
+};
 use bumpalo::Bump;
-use indexmap::IndexMap;
 use proof_of_sql_parser::Identifier;
 
 /// A test accessor that uses OwnedTable as the underlying table type.

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -1,5 +1,5 @@
 use super::{ColumnType, SchemaAccessor, TableRef};
-use indexmap::IndexMap;
+use crate::base::map::IndexMap;
 use proof_of_sql_parser::Identifier;
 
 /// A simple in-memory `SchemaAccessor` for testing intermediate AST -> Provable AST conversion.
@@ -22,7 +22,7 @@ impl SchemaAccessor for TestSchemaAccessor {
     fn lookup_schema(&self, table_ref: TableRef) -> Vec<(Identifier, ColumnType)> {
         self.schemas
             .get(&table_ref)
-            .unwrap_or(&IndexMap::new())
+            .unwrap_or(&IndexMap::default())
             .iter()
             .map(|(id, col)| (*id, *col))
             .collect()
@@ -32,7 +32,7 @@ impl SchemaAccessor for TestSchemaAccessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use indexmap::indexmap;
+    use crate::base::map::indexmap;
 
     fn sample_test_schema_accessor() -> TestSchemaAccessor {
         let table1: TableRef = TableRef::new("schema.table1".parse().unwrap());

--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -1,0 +1,24 @@
+pub(crate) type IndexMap<K, V> =
+    indexmap::IndexMap<K, V, core::hash::BuildHasherDefault<ahash::AHasher>>;
+pub(crate) type IndexSet<T> = indexmap::IndexSet<T, core::hash::BuildHasherDefault<ahash::AHasher>>;
+
+// Adapted from `indexmap`.
+
+/// Create an [`IndexMap`][self::IndexMap] from a list of key-value pairs
+macro_rules! indexmap_macro {
+    ($($key:expr => $value:expr,)+) => { $crate::base::map::indexmap!($($key => $value),+) };
+    ($($key:expr => $value:expr),*) => {
+        {
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
+            let mut map = $crate::base::map::IndexMap::with_capacity_and_hasher(CAP, <_>::default());
+            $(
+                map.insert($key, $value);
+            )*
+            map
+        }
+    };
+}
+
+pub(crate) use indexmap_macro as indexmap;

--- a/crates/proof-of-sql/src/base/mod.rs
+++ b/crates/proof-of-sql/src/base/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod ref_into;
 pub mod scalar;
 mod serialize;
 pub(crate) use serialize::{impl_serde_for_ark_serde_checked, impl_serde_for_ark_serde_unchecked};
+pub(crate) mod map;
 pub(crate) mod slice_ops;
 
 mod rayon_cfg;

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -1,5 +1,4 @@
-use crate::base::scalar::Scalar;
-use indexmap::IndexMap;
+use crate::base::{map::IndexMap, scalar::Scalar};
 /**
  * Adopted from arkworks
  *
@@ -53,7 +52,7 @@ impl<S: Scalar> CompositePolynomial<S> {
             num_variables,
             products: Vec::new(),
             flattened_ml_extensions: Vec::new(),
-            raw_pointers_lookup_table: IndexMap::new(),
+            raw_pointers_lookup_table: IndexMap::default(),
         }
     }
 

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_from_test.rs
@@ -1,8 +1,10 @@
-use crate::base::scalar::{Curve25519Scalar, Scalar};
+use crate::base::{
+    map::IndexSet,
+    scalar::{Curve25519Scalar, Scalar},
+};
 use alloc::{format, string::ToString, vec::Vec};
 use byte_slice_cast::AsByteSlice;
 use core::cmp::Ordering;
-use indexmap::IndexSet;
 use num_traits::{One, Zero};
 use rand::{
     distributions::{Distribution, Uniform},
@@ -120,7 +122,7 @@ fn byte_arrays_with_the_same_content_but_different_types_map_to_different_scalar
 
 #[test]
 fn strings_of_arbitrary_size_map_to_different_scalars() {
-    let mut prev_scalars = IndexSet::new();
+    let mut prev_scalars = IndexSet::default();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let dist = Uniform::new(1, 100);
 
@@ -137,7 +139,7 @@ fn strings_of_arbitrary_size_map_to_different_scalars() {
 
 #[test]
 fn byte_arrays_of_arbitrary_size_map_to_different_scalars() {
-    let mut prev_scalars = IndexSet::new();
+    let mut prev_scalars = IndexSet::default();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let dist = Uniform::new(1, 100);
 
@@ -157,7 +159,7 @@ fn the_string_hash_implementation_uses_the_full_range_of_bits() {
 
     for i in 0..252 {
         let mut curr_iters = 0;
-        let mut bset = IndexSet::new();
+        let mut bset = IndexSet::default();
 
         loop {
             let s: Curve25519Scalar = dist.sample(&mut rng).to_string().as_str().into();
@@ -167,7 +169,7 @@ fn the_string_hash_implementation_uses_the_full_range_of_bits() {
 
             bset.insert(is_ith_bit_set);
 
-            if bset == IndexSet::from([false, true]) {
+            if bset == IndexSet::from_iter([false, true]) {
                 break;
             }
 

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -3,6 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{ColumnRef, LiteralValue},
+        map::IndexMap,
         math::decimal::{try_into_to_scalar, DecimalError::InvalidPrecision, Precision},
     },
     sql::{
@@ -10,7 +11,6 @@ use crate::{
         proof_exprs::{ColumnExpr, DynProofExpr, ProofExpr},
     },
 };
-use indexmap::IndexMap;
 use proof_of_sql_parser::{
     intermediate_ast::{AggregationOperator, BinaryOperator, Expression, Literal, UnaryOperator},
     posql_time::{PoSQLTimeUnit, PoSQLTimestampError},

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -1,9 +1,8 @@
 use super::DynProofExprBuilder;
 use crate::{
-    base::{commitment::Commitment, database::ColumnRef},
+    base::{commitment::Commitment, database::ColumnRef, map::IndexMap},
     sql::proof_exprs::DynProofExpr,
 };
-use indexmap::IndexMap;
 use proof_of_sql_parser::{
     intermediate_ast::{AliasedResultExpr, Expression},
     Identifier,

--- a/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
@@ -3,13 +3,13 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{ColumnRef, LiteralValue, TableRef},
+        map::IndexMap,
     },
     sql::{
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, TableExpr},
         proof_plans::FilterExec,
     },
 };
-use indexmap::IndexMap;
 use itertools::Itertools;
 use proof_of_sql_parser::{intermediate_ast::Expression, Identifier};
 

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -2,6 +2,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{ColumnRef, LiteralValue, TableRef},
+        map::{IndexMap, IndexSet},
     },
     sql::{
         parse::{ConversionError, ConversionResult, DynProofExprBuilder, WhereExprBuilder},
@@ -9,7 +10,6 @@ use crate::{
         proof_plans::GroupByExec,
     },
 };
-use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{
     intermediate_ast::{AggregationOperator, AliasedResultExpr, Expression, OrderBy, Slice},
     Identifier,

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1,6 +1,9 @@
 use super::ConversionError;
 use crate::{
-    base::database::{ColumnType, TableRef, TestSchemaAccessor},
+    base::{
+        database::{ColumnType, TableRef, TestSchemaAccessor},
+        map::{indexmap, IndexMap},
+    },
     sql::{
         parse::QueryExpr,
         postprocessing::{test_utility::*, PostprocessingError},
@@ -9,7 +12,6 @@ use crate::{
     },
 };
 use curve25519_dalek::RistrettoPoint;
-use indexmap::{indexmap, IndexMap};
 use itertools::Itertools;
 use proof_of_sql_parser::{
     intermediate_ast::OrderByDirection::*,

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -3,10 +3,10 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{ColumnRef, ColumnType},
+        map::IndexMap,
     },
     sql::proof_exprs::{DynProofExpr, ProofExpr},
 };
-use indexmap::IndexMap;
 use proof_of_sql_parser::{intermediate_ast::Expression, Identifier};
 
 /// Builder that enables building a `proof_of_sql::sql::proof_exprs::DynProofExpr` from a `proof_of_sql_parser::intermediate_ast::Expression` that is

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -1,6 +1,7 @@
 use crate::{
     base::{
         database::{ColumnRef, ColumnType, LiteralValue, TestSchemaAccessor},
+        map::{indexmap, IndexMap},
         math::decimal::Precision,
     },
     sql::{
@@ -9,7 +10,6 @@ use crate::{
     },
 };
 use curve25519_dalek::RistrettoPoint;
-use indexmap::{indexmap, IndexMap};
 use proof_of_sql_parser::{
     intermediate_decimal::IntermediateDecimal,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
@@ -20,7 +20,7 @@ use std::str::FromStr;
 
 fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
     let tab_ref = "sxt.sxt_tab".parse().unwrap();
-    let mut column_mapping = IndexMap::new();
+    let mut column_mapping = IndexMap::default();
     // Setup column mapping
     column_mapping.insert(
         ident("boolean_column"),
@@ -281,7 +281,7 @@ fn we_can_not_have_non_boolean_column_as_where_clause() {
 
 #[test]
 fn we_can_not_have_non_boolean_literal_as_where_clause() {
-    let column_mapping = IndexMap::new();
+    let column_mapping = IndexMap::default();
 
     let builder = WhereExprBuilder::new(&column_mapping);
 

--- a/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
@@ -1,9 +1,9 @@
 use super::{PostprocessingResult, PostprocessingStep};
 use crate::base::{
     database::{OwnedColumn, OwnedTable},
+    map::IndexMap,
     scalar::Scalar,
 };
-use indexmap::IndexMap;
 use proof_of_sql_parser::{intermediate_ast::AliasedResultExpr, Identifier};
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -1,9 +1,9 @@
 use crate::base::{
     if_rayon,
+    map::IndexMap,
     polynomial::{CompositePolynomial, MultilinearExtension},
     scalar::Scalar,
 };
-use indexmap::IndexMap;
 use num_traits::{One, Zero};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
@@ -28,7 +28,7 @@ impl<S: Scalar> CompositePolynomialBuilder<S> {
             fr_multiplicands_rest: vec![],
             zerosum_multiplicands: vec![],
             fr: fr.to_sumcheck_term(num_sumcheck_variables),
-            mles: IndexMap::new(),
+            mles: IndexMap::default(),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -5,11 +5,11 @@ use crate::base::{
         Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
         OwnedTable,
     },
+    map::IndexSet,
     proof::ProofError,
     scalar::Scalar,
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use std::fmt::Debug;
 
 /// Provable nodes in the provable AST.

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -10,13 +10,13 @@ use crate::{
             MetadataAccessor, OwnedTable, OwnedTableTestAccessor, TestAccessor,
             UnimplementedTestAccessor,
         },
+        map::IndexSet,
         proof::ProofError,
         scalar::{Curve25519Scalar, Scalar},
     },
     sql::proof::{Indexes, QueryData, ResultBuilder, SumcheckSubpolynomialType},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use serde::Serialize;
 
 /// Type to allow us to prove and verify an artificial polynomial where we prove

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -10,13 +10,13 @@ use crate::{
             Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
             MetadataAccessor, OwnedTable, TestAccessor, UnimplementedTestAccessor,
         },
+        map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
     },
     sql::proof::{QueryData, ResultBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Default)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -6,12 +6,12 @@ use crate::{
             try_add_subtract_column_types, Column, ColumnRef, ColumnType, CommitmentAccessor,
             DataAccessor,
         },
+        map::IndexSet,
         proof::ProofError,
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -3,12 +3,12 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        map::IndexSet,
         proof::ProofError,
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -3,12 +3,12 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        map::IndexSet,
         proof::ProofError,
     },
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -3,13 +3,13 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        map::IndexSet,
         proof::ProofError,
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
 use core::marker::PhantomData;
-use indexmap::IndexSet;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
 /// Provable expression for a column

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -6,6 +6,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
+        map::IndexSet,
         proof::ProofError,
     },
     sql::{
@@ -14,7 +15,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use proof_of_sql_parser::intermediate_ast::{AggregationOperator, BinaryOperator};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -3,6 +3,7 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
         slice_ops,
@@ -10,7 +11,6 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
 /// Provable AST expression for an equals expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -8,12 +8,12 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        map::IndexSet,
         proof::ProofError,
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
 /// Provable AST expression for an inequality expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -3,13 +3,13 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
+        map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
 /// Provable CONST expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -6,6 +6,7 @@ use crate::{
             try_multiply_column_types, Column, ColumnRef, ColumnType, CommitmentAccessor,
             DataAccessor,
         },
+        map::IndexSet,
         proof::ProofError,
     },
     sql::{
@@ -14,7 +15,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use num_traits::One;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -3,12 +3,12 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        map::IndexSet,
         proof::ProofError,
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
 /// Provable logical NOT expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -3,13 +3,13 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
     },
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
 /// Provable logical OR expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -2,12 +2,12 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        map::IndexSet,
         proof::ProofError,
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
-use indexmap::IndexSet;
 use std::fmt::Debug;
 
 /// Provable AST column expression that evaluates to a `Column`

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,6 +1,6 @@
 use super::{FilterExec, GroupByExec, ProjectionExec};
 use crate::{
-    base::{commitment::Commitment, database::Column},
+    base::{commitment::Commitment, database::Column, map::IndexSet},
     sql::proof::{ProofPlan, ProverEvaluate},
 };
 use serde::{Deserialize, Serialize};
@@ -81,7 +81,7 @@ impl<C: Commitment> ProofPlan<C> for DynProofPlan<C> {
         }
     }
 
-    fn get_column_references(&self) -> indexmap::IndexSet<crate::base::database::ColumnRef> {
+    fn get_column_references(&self) -> IndexSet<crate::base::database::ColumnRef> {
         match self {
             DynProofPlan::Projection(expr) => expr.get_column_references(),
             DynProofPlan::GroupBy(expr) => expr.get_column_references(),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -6,6 +6,7 @@ use crate::{
             filter_util::filter_columns, Column, ColumnField, ColumnRef, CommitmentAccessor,
             DataAccessor, MetadataAccessor, OwnedTable,
         },
+        map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
         slice_ops,
@@ -20,7 +21,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use core::{iter::repeat_with, marker::PhantomData};
-use indexmap::IndexSet;
 use num_traits::{One, Zero};
 use serde::{Deserialize, Serialize};
 
@@ -131,7 +131,7 @@ where
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        let mut columns = IndexSet::new();
+        let mut columns = IndexSet::default();
 
         for aliased_expr in self.aliased_results.iter() {
             aliased_expr.expr.get_column_references(&mut columns);

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -5,6 +5,7 @@ use crate::{
             owned_table_utility::*, ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTable,
             OwnedTableTestAccessor, TableRef, TestAccessor,
         },
+        map::{IndexMap, IndexSet},
         math::decimal::Precision,
         scalar::Curve25519Scalar,
     },
@@ -19,7 +20,6 @@ use crate::{
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
-use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{Identifier, ResourceId};
 
 #[test]
@@ -130,7 +130,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
 
     assert_eq!(
         ref_columns,
-        IndexSet::from([
+        IndexSet::from_iter([
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("a").unwrap(),
@@ -285,7 +285,7 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
         ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
             .to_owned_table(fields)
             .unwrap();
-    let expected = OwnedTable::try_new(IndexMap::new()).unwrap();
+    let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
     assert_eq!(res, expected);
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -9,6 +9,7 @@ use crate::{
             Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
             MetadataAccessor, OwnedTable,
         },
+        map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
         slice_ops,
@@ -23,7 +24,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use core::iter::repeat_with;
-use indexmap::IndexSet;
 use num_traits::One;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
@@ -190,7 +190,7 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        let mut columns = IndexSet::new();
+        let mut columns = IndexSet::default();
 
         for col in self.group_by_exprs.iter() {
             columns.insert(col.get_column_reference());

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -5,6 +5,7 @@ use crate::{
             Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
             OwnedTable,
         },
+        map::IndexSet,
         proof::ProofError,
     },
     sql::{
@@ -17,7 +18,6 @@ use crate::{
 };
 use bumpalo::Bump;
 use core::iter::repeat_with;
-use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
 /// Provable expressions for queries of the form
@@ -85,7 +85,7 @@ impl<C: Commitment> ProofPlan<C> for ProjectionExec<C> {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        let mut columns = IndexSet::new();
+        let mut columns = IndexSet::default();
         self.aliased_results.iter().for_each(|aliased_expr| {
             aliased_expr.expr.get_column_references(&mut columns);
         });

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -5,6 +5,7 @@ use crate::{
             owned_table_utility::*, ColumnField, ColumnRef, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TestAccessor,
         },
+        map::{IndexMap, IndexSet},
         math::decimal::Precision,
         scalar::Curve25519Scalar,
     },
@@ -19,7 +20,6 @@ use crate::{
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use curve25519_dalek::RistrettoPoint;
-use indexmap::{IndexMap, IndexSet};
 use proof_of_sql_parser::{Identifier, ResourceId};
 
 #[test]
@@ -89,7 +89,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
 
     assert_eq!(
         ref_columns,
-        IndexSet::from([
+        IndexSet::from_iter([
             ColumnRef::new(
                 table_ref,
                 Identifier::try_new("a").unwrap(),
@@ -211,7 +211,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
         ProvableQueryResult::new(&builder.result_index_vector, &result_cols)
             .to_owned_table(fields)
             .unwrap();
-    let expected = OwnedTable::try_new(IndexMap::new()).unwrap();
+    let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
     assert_eq!(res, expected);
 }
 


### PR DESCRIPTION
# Rationale for this change

The `indexmap` crate is `no_std` compatible, but a few changes must be made in order to not use the `std` feature.

# What changes are included in this PR?

A `base::map::IndexMap` and `base::map::IndexSet` type alias are created to be a replacement for `indexmap::IndexMap` and `indexmap::IndexSet` respectively. This is needed because `indexmap` does not have a default `BuildHasher` type parameter in `no_std` mode.
Additionally, `indexmap` does no expose the `indexmap!` macro in `no_std` mode. So, this PR adds a replacement macro.

Finally,
* `Index*::new` is replaced by `Index*::default` which exists in `no_std`.
* `Index*::from` is replaced by `Index*::from_iter` which exists in `no_std`.

# Are these changes tested?

Yes, by existing tests