### PR TITLE
feat: refactor Commitment trait to return Vec<Self> instead of mutating slice

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
+++ b/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
@@ -32,12 +32,12 @@ impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {
                 .collect(),
         );
 
-        let mut commitments = vec![C::default(); columns.len()];
         let committable_columns = columns
             .iter()
             .map(|(_, col)| col.into())
             .collect::<Vec<_>>();
-        C::compute_commitments(&mut commitments, &committable_columns, 0, setup);
+
+        let commitments = C::compute_commitments(&committable_columns, 0, setup);
 
         let mut length = None;
         for (column, commitment) in columns.iter().zip(commitments) {

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -84,11 +84,10 @@ pub trait Commitment:
     ///
     /// `offset` is the amount that `committable_columns` is "offset" by. Logically adding `offset` many 0s to the beginning of each of the `committable_columns`.
     fn compute_commitments(
-        commitments: &mut [Self],
         committable_columns: &[CommittableColumn],
         offset: usize,
         setup: &Self::PublicSetup<'_>,
-    );
+    ) -> Vec<Self>;
 }
 
 impl Commitment for RistrettoPoint {
@@ -96,11 +95,10 @@ impl Commitment for RistrettoPoint {
     type PublicSetup<'a> = ();
     #[cfg(feature = "blitzar")]
     fn compute_commitments(
-        commitments: &mut [Self],
         committable_columns: &[CommittableColumn],
         offset: usize,
         _setup: &Self::PublicSetup<'_>,
-    ) {
+    ) -> Vec<Self>{
         let sequences = Vec::from_iter(committable_columns.iter().map(Into::into));
         let mut compressed_commitments = vec![Default::default(); committable_columns.len()];
         blitzar::compute::compute_curve25519_commitments(
@@ -108,22 +106,19 @@ impl Commitment for RistrettoPoint {
             &sequences,
             offset as u64,
         );
-        commitments
-            .iter_mut()
-            .zip(compressed_commitments.iter())
-            .for_each(|(c, cc)| {
-                *c = cc.decompress().expect(
-                    "invalid ristretto point decompression in Commitment::compute_commitments",
-                );
-            });
+        compressed_commitments
+            .into_iter()
+            .map(|cc| cc.decompress().expect(
+                "invalid ristretto point decompression in Commitment::compute_commitments",
+            ))
+            .collect()
     }
     #[cfg(not(feature = "blitzar"))]
     fn compute_commitments(
-        _commitments: &mut [Self],
         _committable_columns: &[CommittableColumn],
         _offset: usize,
         _setup: &Self::PublicSetup<'_>,
-    ) {
+    ) -> Vec<Self> {
         unimplemented!()
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -98,7 +98,7 @@ impl Commitment for RistrettoPoint {
         committable_columns: &[CommittableColumn],
         offset: usize,
         _setup: &Self::PublicSetup<'_>,
-    ) -> Vec<Self>{
+    ) -> Vec<Self> {
         let sequences = Vec::from_iter(committable_columns.iter().map(Into::into));
         let mut compressed_commitments = vec![Default::default(); committable_columns.len()];
         blitzar::compute::compute_curve25519_commitments(
@@ -108,9 +108,11 @@ impl Commitment for RistrettoPoint {
         );
         compressed_commitments
             .into_iter()
-            .map(|cc| cc.decompress().expect(
-                "invalid ristretto point decompression in Commitment::compute_commitments",
-            ))
+            .map(|cc| {
+                cc.decompress().expect(
+                    "invalid ristretto point decompression in Commitment::compute_commitments",
+                )
+            })
             .collect()
     }
     #[cfg(not(feature = "blitzar"))]

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -1,6 +1,6 @@
 use super::Commitment;
 use crate::base::commitment::committable_column::CommittableColumn;
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use thiserror::Error;
 
 /// Cannot update commitment collections with different column counts

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -102,10 +102,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
         offset: usize,
         setup: &Self::CommitmentPublicSetup<'_>,
     ) -> Self {
-        let mut commitments = vec![C::default(); committable_columns.len()];
-        C::compute_commitments(&mut commitments, committable_columns, offset, setup);
-
-        commitments
+        C::compute_commitments(committable_columns, offset, setup)
     }
 
     fn try_append_rows_with_offset<'a, COL>(
@@ -124,8 +121,7 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
             return Err(NumColumnsMismatch);
         }
 
-        let partial_commitments =
-            Self::from_commitable_columns_with_offset(&committable_columns, offset, setup);
+        let partial_commitments = C::compute_commitments(&committable_columns, offset, setup);
         unsafe_add_assign(self, &partial_commitments);
 
         Ok(())

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -88,14 +88,11 @@ impl Commitment for DoryCommitment {
     type PublicSetup<'a> = DoryProverPublicSetup<'a>;
 
     fn compute_commitments(
-        commitments: &mut [Self],
         committable_columns: &[CommittableColumn],
         offset: usize,
         setup: &Self::PublicSetup<'_>,
-    ) {
-        assert_eq!(commitments.len(), committable_columns.len());
-        let c = super::compute_dory_commitments(committable_columns, offset, setup);
-        commitments.copy_from_slice(&c);
+    ) -> Vec<Self> {
+        super::compute_dory_commitments(committable_columns, offset, setup)
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
@@ -75,13 +75,10 @@ impl Commitment for DynamicDoryCommitment {
     type PublicSetup<'a> = &'a ProverSetup<'a>;
 
     fn compute_commitments(
-        commitments: &mut [Self],
         committable_columns: &[CommittableColumn],
         offset: usize,
         setup: &Self::PublicSetup<'_>,
-    ) {
-        assert_eq!(commitments.len(), committable_columns.len());
-        let c = super::compute_dynamic_dory_commitments(committable_columns, offset, setup);
-        commitments.copy_from_slice(&c);
+    ) -> Vec<Self> {
+        super::compute_dynamic_dory_commitments(committable_columns, offset, setup)
     }
 }


### PR DESCRIPTION
# Rationale for this change
 Mentioned in #165 

# What changes are included in this PR?

-  Modified the `Commitment` trait's `compute_commitments` method to return `Vec<Self>` instead of mutating a pre-allocated slice.
- Updated implementations for `NaiveCommitment`, `DoryCommitment`, and `DynamicDoryCommitment` to align with the new trait definition.

Fixes #165 
/claim #165

