### PR TITLE
feat: replace compute_commitment_for_testing with RistrettoPoint::com…

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/commitment_utility.rs
+++ b/crates/proof-of-sql/src/base/scalar/commitment_utility.rs
@@ -1,6 +1,7 @@
 use crate::base::{scalar::Curve25519Scalar, slice_ops::slice_cast};
 use blitzar::compute::compute_curve25519_commitments;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
+use blitzar::commitment::{Commitment, CommittableColumn};
 
 /// Compute the commitment of a sequence of values.
 ///
@@ -11,8 +12,12 @@ pub fn compute_commitment_for_testing<T: Into<Curve25519Scalar> + Clone + Sync>(
     offset_generators: usize,
 ) -> RistrettoPoint {
     let vals = slice_cast::<Curve25519Scalar, [u64; 4]>(&slice_cast(vals));
-    let table = [vals.as_slice().into()];
-    let mut commitments = [CompressedRistretto::default()];
-    compute_curve25519_commitments(&mut commitments, &table, offset_generators as u64);
-    commitments[0].decompress().unwrap()
+    let mut commitments = [RistrettoPoint::default()];
+    RistrettoPoint::compute_commitments(
+        &mut commitments,
+        &[CommittableColumn::Scalar(vals.iter().cloned())],
+        offset_generators,
+        &(),
+    );
+    commitments[0]
 }


### PR DESCRIPTION
Fixes: #168 
/claim #168 

**Rationale for this change**
The change replaces the custom `compute_commitment_for_testing` function with the more standard `RistrettoPoint::compute_commitments` method. This improves code consistency and leverages the existing Commitment trait implementation for RistrettoPoint.
**What changes are included in this PR?**
1. Updated `compute_commitment_for_testing` function in commitment_utility.rs to use `RistrettoPoint::compute_commitments`.
2. Modified `we_can_access_the_commitments_of_table_columns` test in `owned_table_test_accessor_test.rs` to use `RistrettoPoint::compute_commitments` directly.
3. Updated imports in owned_table_test_accessor_test.rs.
**Are these changes tested?**
Yes, these changes are tested. The existing test we_can_access_the_commitments_of_table_columns in `owned_table_test_accessor_test.rs` has been updated to use the new method of computing commitments. This test should ensure that the new implementation produces the same results as the previous one.
Additionally, all other tests that indirectly used `compute_commitment_for_testing` (through `OwnedTableTestAccessor`) will now be using the new implementation, providing further coverage.
