### PR TITLE
refactor: eliminate std usage

### DIFF
--- a/crates/proof-of-sql/examples/posql_db/commit_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/commit_accessor.rs
@@ -1,9 +1,10 @@
+use core::error::Error;
 use proof_of_sql::base::{
     commitment::{Commitment, QueryCommitments, TableCommitment},
     database::{CommitmentAccessor, MetadataAccessor, SchemaAccessor, TableRef},
 };
 use serde::{Deserialize, Serialize};
-use std::{error::Error, fs, path::PathBuf};
+use std::{fs, path::PathBuf};
 pub struct CommitAccessor<C: Commitment> {
     base_path: PathBuf,
     inner: QueryCommitments<C>,

--- a/crates/proof-of-sql/examples/posql_db/csv_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/csv_accessor.rs
@@ -1,12 +1,12 @@
 use super::record_batch_accessor::RecordBatchAccessor;
 use arrow::{datatypes::Schema, record_batch::RecordBatch};
 use arrow_csv::{ReaderBuilder, WriterBuilder};
+use core::error::Error;
 use proof_of_sql::base::{
     database::{Column, ColumnRef, DataAccessor, MetadataAccessor, SchemaAccessor, TableRef},
     scalar::Scalar,
 };
 use std::{
-    error::Error,
     fs::{File, OpenOptions},
     path::{Path, PathBuf},
     sync::Arc,

--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -1,7 +1,7 @@
 use crate::base::{bit::make_abs_bit_mask, scalar::Scalar};
 use bit_iter::BitIter;
 use serde::{Deserialize, Serialize};
-use std::convert::Into;
+use core::convert::Into;
 
 /// Describe the distribution of bit values in a table column
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -1,7 +1,7 @@
 use crate::base::{bit::make_abs_bit_mask, scalar::Scalar};
 use bit_iter::BitIter;
-use serde::{Deserialize, Serialize};
 use core::convert::Into;
+use serde::{Deserialize, Serialize};
 
 /// Describe the distribution of bit values in a table column
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/proof-of-sql/src/base/bit/bit_matrix.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix.rs
@@ -2,6 +2,7 @@ use crate::base::{
     bit::{make_abs_bit_mask, BitDistribution},
     scalar::Scalar,
 };
+use alloc::vec::Vec;
 use bumpalo::Bump;
 
 /// Let x1, ..., xn denote the values of a data column. Let

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -379,7 +379,8 @@ mod tests {
     use super::*;
     use crate::{base::scalar::Curve25519Scalar, proof_primitive::dory::DoryScalar};
     use arrow::array::Decimal256Builder;
-    use std::{str::FromStr, sync::Arc};
+    use core::str::FromStr;
+    use std::sync::Arc;
 
     #[test]
     fn we_can_convert_timestamp_array_normal_range() {

--- a/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_array_to_column_conversion.rs
@@ -9,9 +9,9 @@ use arrow::{
     datatypes::{i256, DataType, TimeUnit as ArrowTimeUnit},
 };
 use bumpalo::Bump;
+use core::ops::Range;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError};
 use snafu::Snafu;
-use std::ops::Range;
 
 #[derive(Snafu, Debug, PartialEq)]
 /// Errors caused by conversions between Arrow and owned types.
@@ -378,9 +378,9 @@ mod tests {
 
     use super::*;
     use crate::{base::scalar::Curve25519Scalar, proof_primitive::dory::DoryScalar};
+    use alloc::sync::Arc;
     use arrow::array::Decimal256Builder;
     use core::str::FromStr;
-    use std::sync::Arc;
 
     #[test]
     fn we_can_convert_timestamp_array_normal_range() {

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -5,6 +5,7 @@ use crate::base::{
     math::decimal::{scale_scalar, DecimalError, Precision, MAX_SUPPORTED_PRECISION},
     scalar::Scalar,
 };
+use alloc::{format, string::ToString, vec::Vec};
 use core::{cmp::Ordering, fmt::Debug};
 use num_bigint::BigInt;
 use num_traits::{

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -1,4 +1,5 @@
 use crate::base::{database::ColumnType, math::decimal::DecimalError};
+use core::result::Result;
 use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
 use snafu::Snafu;
 
@@ -54,4 +55,4 @@ pub enum ColumnOperationError {
 }
 
 /// Result type for column operations
-pub type ColumnOperationResult<T> = std::result::Result<T, ColumnOperationError>;
+pub type ColumnOperationResult<T> = Result<T, ColumnOperationError>;

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -1,4 +1,5 @@
 use crate::base::{database::ColumnType, math::decimal::DecimalError};
+use alloc::string::String;
 use core::result::Result;
 use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
 use snafu::Snafu;

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -4,6 +4,7 @@ use crate::base::{
     math::decimal::{try_into_to_scalar, Precision},
     scalar::Scalar,
 };
+use alloc::{format, string::ToString, vec};
 use proof_of_sql_parser::{
     intermediate_ast::{BinaryOperator, Expression, Literal, UnaryOperator},
     Identifier,

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
@@ -1,4 +1,5 @@
 use crate::base::{database::ColumnOperationError, math::decimal::DecimalError};
+use alloc::string::String;
 use core::result::Result;
 use snafu::Snafu;
 

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
@@ -1,4 +1,5 @@
 use crate::base::{database::ColumnOperationError, math::decimal::DecimalError};
+use core::result::Result;
 use snafu::Snafu;
 
 /// Errors from evaluation of `Expression`s.
@@ -31,4 +32,4 @@ pub enum ExpressionEvaluationError {
 }
 
 /// Result type for expression evaluation
-pub type ExpressionEvaluationResult<T> = std::result::Result<T, ExpressionEvaluationError>;
+pub type ExpressionEvaluationResult<T> = Result<T, ExpressionEvaluationError>;

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -1,4 +1,5 @@
 use crate::base::{database::Column, scalar::Scalar};
+use alloc::vec::Vec;
 use bumpalo::Bump;
 
 /// This function takes a selection vector and a set of columns and returns a

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -5,6 +5,7 @@ use crate::base::{
     if_rayon,
     scalar::Scalar,
 };
+use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::cmp::Ordering;
 use itertools::Itertools;

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions.rs
@@ -22,6 +22,7 @@ use crate::base::{
     math::decimal::Precision,
     scalar::Scalar,
 };
+use alloc::sync::Arc;
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
@@ -37,7 +38,6 @@ use proof_of_sql_parser::{
     Identifier, ParseError,
 };
 use snafu::Snafu;
-use std::sync::Arc;
 
 #[derive(Snafu, Debug)]
 #[non_exhaustive]

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -12,7 +12,7 @@ use arrow::{
     datatypes::Schema,
     record_batch::RecordBatch,
 };
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 fn we_can_convert_between_owned_column_and_array_ref_impl(
     owned_column: OwnedColumn<Curve25519Scalar>,

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -7,12 +7,12 @@ use crate::{
     },
     record_batch,
 };
+use alloc::sync::Arc;
 use arrow::{
     array::{ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, StringArray},
     datatypes::Schema,
     record_batch::RecordBatch,
 };
-use alloc::sync::Arc;
 
 fn we_can_convert_between_owned_column_and_array_ref_impl(
     owned_column: OwnedColumn<Curve25519Scalar>,

--- a/crates/proof-of-sql/src/base/database/record_batch_utility.rs
+++ b/crates/proof-of-sql/src/base/database/record_batch_utility.rs
@@ -3,7 +3,7 @@ use arrow::array::{
     TimestampSecondArray,
 };
 use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 /// Extension trait for Vec<T> to convert it to an Arrow array
 pub trait ToArrow {
@@ -155,7 +155,7 @@ string_to_arrow_array!(
 macro_rules! record_batch {
     ($($col_name:expr => $slice:expr), + $(,)?) => {
         {
-            use std::sync::Arc;
+            use alloc::sync::Arc;
             use arrow::datatypes::Field;
             use arrow::datatypes::Schema;
             use arrow::record_batch::RecordBatch;
@@ -180,7 +180,7 @@ mod tests {
         datatypes::{Field, Schema},
         record_batch::RecordBatch,
     };
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     #[test]
     fn test_record_batch_macro() {

--- a/crates/proof-of-sql/src/base/database/record_batch_utility.rs
+++ b/crates/proof-of-sql/src/base/database/record_batch_utility.rs
@@ -1,9 +1,9 @@
+use alloc::sync::Arc;
 use arrow::array::{
     TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
     TimestampSecondArray,
 };
 use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
-use alloc::sync::Arc;
 
 /// Extension trait for Vec<T> to convert it to an Arrow array
 pub trait ToArrow {
@@ -176,11 +176,11 @@ macro_rules! record_batch {
 #[cfg(test)]
 mod tests {
     use crate::record_batch;
+    use alloc::sync::Arc;
     use arrow::{
         datatypes::{Field, Schema},
         record_batch::RecordBatch,
     };
-    use alloc::sync::Arc;
 
     #[test]
     fn test_record_batch_macro() {

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -1,3 +1,4 @@
+use alloc::string::ToString;
 use core::{
     fmt,
     fmt::{Display, Formatter},

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -4,8 +4,8 @@ use crate::base::{map::IndexMap, scalar::Scalar};
  *
  * See third_party/license/arkworks.LICENSE
  */
-use std::cmp::max;
-use std::{rc::Rc, vec::Vec};
+use core::cmp::max;
+use alloc::{rc::Rc, vec::Vec};
 
 /// Stores a list of products of `DenseMultilinearExtension` that is meant to be added together.
 ///

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -1,11 +1,11 @@
 use crate::base::{map::IndexMap, scalar::Scalar};
+use alloc::{rc::Rc, vec::Vec};
 /**
  * Adopted from arkworks
  *
  * See third_party/license/arkworks.LICENSE
  */
 use core::cmp::max;
-use alloc::{rc::Rc, vec::Vec};
 
 /// Stores a list of products of `DenseMultilinearExtension` that is meant to be added together.
 ///

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -1,6 +1,6 @@
 use super::CompositePolynomial;
 use crate::base::scalar::Curve25519Scalar;
-use std::rc::Rc;
+use alloc::rc::Rc;
 
 #[test]
 fn test_composite_polynomial_evaluation() {

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -1,5 +1,8 @@
 use crate::base::if_rayon;
-use core::ops::{Mul, MulAssign, Sub, SubAssign};
+use core::{
+    cmp,
+    ops::{Mul, MulAssign, Sub, SubAssign},
+};
 use num_traits::One;
 #[cfg(feature = "rayon")]
 use rayon::prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
@@ -13,7 +16,7 @@ fn compute_evaluation_vector_impl<F>(left: &mut [F], right: &mut [F], p: F)
 where
     F: One + Sub<Output = F> + MulAssign + SubAssign + Mul<Output = F> + Send + Sync + Copy,
 {
-    let k = std::cmp::min(left.len(), right.len());
+    let k = cmp::min(left.len(), right.len());
     let one_minus_p = F::one() - p;
     if_rayon!(
         left.par_iter_mut().with_min_len(MIN_PARALLEL_LEN),

--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 /**
  * Adapted from arkworks
  *

--- a/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
@@ -6,6 +6,7 @@
 use super::interpolate::*;
 use crate::base::scalar::{Curve25519Scalar, Curve25519Scalar as S};
 use ark_std::UniformRand;
+use core::iter;
 use num_traits::{Inv, Zero};
 
 #[test]
@@ -15,7 +16,7 @@ fn test_interpolate_uni_poly_for_random_polynomials() {
     let num_points = vec![0, 1, 2, 3, 4, 5, 10, 20, 32, 33, 64, 65];
 
     for n in num_points {
-        let poly = std::iter::repeat_with(|| Curve25519Scalar::rand(&mut prng))
+        let poly = iter::repeat_with(|| Curve25519Scalar::rand(&mut prng))
             .take(n)
             .collect::<Vec<_>>();
         let evals = (0..n)

--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
@@ -7,7 +7,7 @@ use crate::base::{
 };
 use ark_std::UniformRand;
 use num_traits::Zero;
-use std::iter;
+use core::iter;
 
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_0_variables() {

--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
@@ -6,8 +6,8 @@ use crate::base::{
     scalar::Curve25519Scalar,
 };
 use ark_std::UniformRand;
-use num_traits::Zero;
 use core::iter;
+use num_traits::Zero;
 
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_0_variables() {

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -1,8 +1,9 @@
 use crate::base::{database::Column, if_rayon, scalar::Scalar, slice_ops};
+use core::ffi::c_void;
 use num_traits::Zero;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use std::{ffi::c_void, rc::Rc};
+use std::rc::Rc;
 
 /// Interface for operating on multilinear extension's in-place
 pub trait MultilinearExtension<S: Scalar> {

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -3,7 +3,7 @@ use core::ffi::c_void;
 use num_traits::Zero;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use std::rc::Rc;
+use alloc::rc::Rc;
 
 /// Interface for operating on multilinear extension's in-place
 pub trait MultilinearExtension<S: Scalar> {

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -1,9 +1,9 @@
 use crate::base::{database::Column, if_rayon, scalar::Scalar, slice_ops};
+use alloc::{rc::Rc, vec::Vec};
 use core::ffi::c_void;
 use num_traits::Zero;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use alloc::rc::Rc;
 
 /// Interface for operating on multilinear extension's in-place
 pub trait MultilinearExtension<S: Scalar> {

--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
@@ -7,6 +7,7 @@
 //! Additionally, `num_elem_per_thread` rounds up instead of down.
 
 use crate::base::if_rayon;
+use alloc::vec::Vec;
 #[cfg(feature = "rayon")]
 use core::cmp::max;
 use core::ops::{Mul, MulAssign};

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast.rs
@@ -1,4 +1,5 @@
 use crate::base::if_rayon;
+use alloc::vec::Vec;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/build_vmv_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/build_vmv_state.rs
@@ -2,6 +2,7 @@ use super::{
     compute_L_R_vec, compute_l_r_tensors, compute_v_vec, DeferredGT, G1Affine, VMVProverState,
     VMVVerifierState, F,
 };
+use alloc::vec::Vec;
 
 /// Builds a VMVProverState from the given parameters.
 pub(super) fn build_vmv_prover_state(

--- a/crates/proof-of-sql/src/proof_primitive/dory/deferred_msm.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/deferred_msm.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use ark_ec::VariableBaseMSM;
 use core::ops::{Add, AddAssign, Mul, MulAssign};
 use itertools::Itertools;

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -28,6 +28,7 @@ use crate::base::{
     impl_serde_for_ark_serde_checked,
     scalar::{MontScalar, Scalar},
 };
+use alloc::vec::Vec;
 use ark_ec::pairing::PairingOutput;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::Mul;

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -1,5 +1,6 @@
 use super::{pairings, DoryCommitment, DoryProverPublicSetup, DoryScalar, G1Projective};
 use crate::base::commitment::CommittableColumn;
+use alloc::vec::Vec;
 use ark_ec::VariableBaseMSM;
 use core::iter::once;
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
@@ -1,5 +1,6 @@
 use super::{DoryScalar, G1Affine, G2Affine, F, GT};
 use crate::base::{impl_serde_for_ark_serde_checked, proof::Transcript};
+use alloc::vec::Vec;
 use ark_ff::Field;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use num_traits::Zero;

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
@@ -9,6 +9,8 @@ use ark_ec::{AffineRepr, VariableBaseMSM};
 use ark_ff::{BigInt, MontBackend};
 #[cfg(feature = "blitzar")]
 use blitzar::compute::ElementP2;
+#[cfg(feature = "blitzar")]
+use core::mem;
 use num_traits::{One, Zero};
 
 /// Compute the evaluations of the columns of the matrix M that is derived from `a`.
@@ -43,7 +45,7 @@ pub(super) fn compute_T_vec_prime(
 ) -> Vec<G1Affine> {
     let num_columns = 1 << sigma;
     let num_outputs = 1 << nu;
-    let data_size = std::mem::size_of::<F>();
+    let data_size = mem::size_of::<F>();
 
     let a_array = convert_scalar_to_array(a);
     let a_transpose =

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
@@ -4,6 +4,7 @@ use super::{transpose, G1Affine, ProverSetup, F};
 use crate::base::polynomial::compute_evaluation_vector;
 #[cfg(feature = "blitzar")]
 use crate::base::slice_ops::slice_cast;
+use alloc::{vec, vec::Vec};
 #[cfg(not(feature = "blitzar"))]
 use ark_ec::{AffineRepr, VariableBaseMSM};
 use ark_ff::{BigInt, MontBackend};

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_build_vmv_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_build_vmv_state.rs
@@ -2,6 +2,7 @@ use super::{
     dynamic_dory_helper::{compute_dynamic_v_vec, compute_dynamic_vecs},
     DeferredGT, G1Affine, VMVProverState, VMVVerifierState, F,
 };
+use alloc::vec::Vec;
 
 /// Builds a VMVProverState from the given parameters.
 pub(super) fn build_dynamic_vmv_prover_state(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
@@ -27,6 +27,7 @@ use crate::base::{
     commitment::{Commitment, CommittableColumn},
     impl_serde_for_ark_serde_checked,
 };
+use alloc::vec::Vec;
 use ark_ec::pairing::PairingOutput;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::Mul;

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -3,6 +3,7 @@ use super::{
     G1Affine, G1Projective, ProverSetup,
 };
 use crate::base::commitment::CommittableColumn;
+use alloc::{vec, vec::Vec};
 
 #[tracing::instrument(name = "compute_dory_commitment_impl (cpu)", level = "debug", skip_all)]
 fn compute_dory_commitment_impl<'a, T>(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
@@ -4,6 +4,7 @@ use super::{
     ProverSetup, F,
 };
 use crate::proof_primitive::dory::dynamic_dory_standard_basis_helper::compute_dynamic_standard_basis_vecs;
+use alloc::{vec, vec::Vec};
 use ark_ff::Field;
 use itertools::Itertools;
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
@@ -3,6 +3,7 @@ use super::{
     ProverSetup, VMVProverState, VMVVerifierState, VerifierSetup,
 };
 use crate::base::{if_rayon, proof::Transcript};
+use alloc::vec::Vec;
 use ark_ec::VariableBaseMSM;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs
@@ -3,6 +3,7 @@ use super::{
 };
 #[cfg(test)]
 use super::{G1Affine, G1Projective, G2Projective, ProverSetup};
+use alloc::{vec, vec::Vec};
 #[cfg(test)]
 use ark_ec::VariableBaseMSM;
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -3,6 +3,7 @@ use crate::{
     base::{commitment::CommittableColumn, database::ColumnType},
     proof_primitive::dory::offset_to_bytes::OffsetToBytes,
 };
+use alloc::{vec, vec::Vec};
 use ark_ff::MontFp;
 use ark_std::ops::Mul;
 use core::iter;

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use ark_ff::MontFp;
 use ark_std::ops::Mul;
+use core::iter;
 
 const BYTE_SIZE: usize = 8;
 const OFFSET_SIZE: usize = 2;
@@ -311,7 +312,7 @@ fn compute_cumulative_bit_sum_table(
                 .take(sub_commits)
                 .sum::<u32>() as usize;
             num_sub_commits_completed += sub_commits;
-            std::iter::once(current_sum)
+            iter::once(current_sum)
         })
         .collect()
 }
@@ -344,8 +345,7 @@ pub fn bit_table_and_scalars_for_packed_msm(
     let bit_table_sub_commits_sum = bit_table.iter().sum::<u32>() as usize;
 
     // Add offsets to handle signed values to the bit table.
-    bit_table
-        .extend(std::iter::repeat(BYTE_SIZE as u32).take(OFFSET_SIZE + committable_columns.len()));
+    bit_table.extend(iter::repeat(BYTE_SIZE as u32).take(OFFSET_SIZE + committable_columns.len()));
     let bit_table_full_sum_in_bytes = bit_table.iter().sum::<u32>() as usize / BYTE_SIZE;
 
     // Create the packed_scalar array.

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -1,4 +1,5 @@
 use super::{G1Affine, G2Affine};
+use alloc::vec::Vec;
 /// The public parameters for the Dory protocol. See section 5 of https://eprint.iacr.org/2020/1274.pdf for details.
 ///
 /// Note: even though H_1 and H_2 are marked as blue, they are still needed.

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -1,5 +1,6 @@
 use super::{G1Affine, G2Affine, PublicParameters, GT};
 use crate::base::impl_serde_for_ark_serde_unchecked;
+use alloc::vec::Vec;
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use itertools::MultiUnzip;

--- a/crates/proof-of-sql/src/proof_primitive/dory/state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/state.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 use super::ProverSetup;
 use super::{DeferredGT, G1Affine, G2Affine};
+use alloc::vec::Vec;
 #[cfg(test)]
 use ark_ec::pairing::Pairing;
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
@@ -25,6 +25,7 @@ pub fn transpose_for_fixed_msm<const LEN: usize, T: OffsetToBytes<LEN>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::mem;
     use zerocopy::AsBytes;
 
     #[test]
@@ -34,7 +35,7 @@ mod tests {
         let offset = 0;
         let rows = 0;
         let cols = 2;
-        let data_size = std::mem::size_of::<T>();
+        let data_size = mem::size_of::<T>();
 
         let expected_len = data_size * (column.len() + offset);
 
@@ -51,7 +52,7 @@ mod tests {
         let offset = 0;
         let rows = 2;
         let cols = 2;
-        let data_size = std::mem::size_of::<T>();
+        let data_size = mem::size_of::<T>();
 
         let expected_len = data_size * (column.len() + offset);
 
@@ -78,7 +79,7 @@ mod tests {
         let offset = 2;
         let rows = 2;
         let cols = 3;
-        let data_size = std::mem::size_of::<T>();
+        let data_size = mem::size_of::<T>();
 
         let expected_len = data_size * (column.len() + offset + 1);
 
@@ -107,7 +108,7 @@ mod tests {
         let offset = 1;
         let rows = 2;
         let cols = 2;
-        let data_size = std::mem::size_of::<T>();
+        let data_size = mem::size_of::<T>();
 
         let expected_len = data_size * (column.len() + offset);
 
@@ -134,7 +135,7 @@ mod tests {
         let offset = 0;
         let rows = 2;
         let cols = 2;
-        let data_size = std::mem::size_of::<T>();
+        let data_size = mem::size_of::<T>();
 
         let expected_len = data_size * (column.len() + offset);
 
@@ -167,7 +168,7 @@ mod tests {
         let offset = 0;
         let rows = 2;
         let cols = 2;
-        let data_size = std::mem::size_of::<T>();
+        let data_size = mem::size_of::<T>();
 
         let expected_len = data_size * (column.len() + offset);
 
@@ -200,7 +201,7 @@ mod tests {
         let offset = 0;
         let rows = 2;
         let cols = 2;
-        let data_size = std::mem::size_of::<T>();
+        let data_size = mem::size_of::<T>();
 
         let expected_len = data_size * (column.len() + offset);
 
@@ -227,7 +228,7 @@ mod tests {
         let offset = 0;
         let rows = 2;
         let cols = 2;
-        let data_size = std::mem::size_of::<T>();
+        let data_size = mem::size_of::<T>();
 
         let expected_len = data_size * (column.len() + offset);
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
@@ -1,4 +1,5 @@
 use crate::proof_primitive::dory::offset_to_bytes::OffsetToBytes;
+use alloc::{vec, vec::Vec};
 
 #[tracing::instrument(name = "transpose_for_fixed_msm (gpu)", level = "debug", skip_all)]
 pub fn transpose_for_fixed_msm<const LEN: usize, T: OffsetToBytes<LEN>>(

--- a/crates/proof-of-sql/src/proof_primitive/dory/vmv_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/vmv_state.rs
@@ -1,4 +1,5 @@
 use super::{DeferredGT, G1Affine, F};
+use alloc::vec::Vec;
 
 /// The state of the verifier during the VMV evaluation proof verification.
 /// See section 5 of https://eprint.iacr.org/2020/1274.pdf for details.

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -6,13 +6,13 @@ use crate::{
     },
     proof_primitive::sumcheck::{prove_round, ProverState, Subclaim},
 };
-use serde::{Deserialize, Serialize};
 /**
  * Adopted from arkworks
  *
  * See third_party/license/arkworks.LICENSE
  */
 use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SumcheckProof<S: Scalar> {

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
  *
  * See third_party/license/arkworks.LICENSE
  */
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SumcheckProof<S: Scalar> {

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -7,10 +7,10 @@ use crate::base::{
  * See third_party/license/arkworks.LICENSE
  */
 use crate::proof_primitive::sumcheck::proof::*;
+use alloc::rc::Rc;
 use ark_std::UniformRand;
 use merlin::Transcript;
 use num_traits::{One, Zero};
-use alloc::rc::Rc;
 
 #[test]
 fn test_create_verify_proof() {

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -10,7 +10,7 @@ use crate::proof_primitive::sumcheck::proof::*;
 use ark_std::UniformRand;
 use merlin::Transcript;
 use num_traits::{One, Zero};
-use std::rc::Rc;
+use alloc::rc::Rc;
 
 #[test]
 fn test_create_verify_proof() {

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -5,6 +5,7 @@
  */
 use crate::base::scalar::Scalar;
 use crate::{base::if_rayon, proof_primitive::sumcheck::ProverState};
+use alloc::{vec, vec::Vec};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -5,6 +5,7 @@ use crate::base::polynomial::CompositePolynomial;
  * See third_party/license/arkworks.LICENSE
  */
 use crate::base::scalar::Scalar;
+use alloc::vec::Vec;
 
 pub struct ProverState<S: Scalar> {
     /// sampled randomness given by the verifier

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/subclaim.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/subclaim.rs
@@ -5,6 +5,7 @@
  */
 use crate::base::scalar::Scalar;
 use crate::base::{polynomial::interpolate_uni_poly, proof::ProofError};
+use alloc::vec::Vec;
 
 pub struct Subclaim<S: Scalar> {
     pub evaluation_point: Vec<S>,

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -11,6 +11,7 @@ use crate::{
         proof_exprs::{ColumnExpr, DynProofExpr, ProofExpr},
     },
 };
+use alloc::{borrow::ToOwned, boxed::Box, format, string::ToString};
 use proof_of_sql_parser::{
     intermediate_ast::{AggregationOperator, BinaryOperator, Expression, Literal, UnaryOperator},
     posql_time::{PoSQLTimeUnit, PoSQLTimestampError},

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -3,6 +3,7 @@ use crate::{
     base::{commitment::Commitment, database::ColumnRef, map::IndexMap},
     sql::proof_exprs::DynProofExpr,
 };
+use alloc::boxed::Box;
 use proof_of_sql_parser::{
     intermediate_ast::{AliasedResultExpr, Expression},
     Identifier,

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -2,6 +2,7 @@ use crate::base::{
     database::{ColumnOperationError, ColumnType},
     math::decimal::DecimalError,
 };
+use core::result::Result;
 use proof_of_sql_parser::{
     intermediate_decimal::IntermediateDecimalError, posql_time::PoSQLTimestampError, Identifier,
     ResourceId,
@@ -171,4 +172,4 @@ impl ConversionError {
     }
 }
 
-pub type ConversionResult<T> = std::result::Result<T, ConversionError>;
+pub type ConversionResult<T> = Result<T, ConversionError>;

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -2,6 +2,11 @@ use crate::base::{
     database::{ColumnOperationError, ColumnType},
     math::decimal::DecimalError,
 };
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+};
 use core::result::Result;
 use proof_of_sql_parser::{
     intermediate_decimal::IntermediateDecimalError, posql_time::PoSQLTimestampError, Identifier,

--- a/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
@@ -10,6 +10,7 @@ use crate::{
         proof_plans::FilterExec,
     },
 };
+use alloc::{boxed::Box, vec, vec::Vec};
 use itertools::Itertools;
 use proof_of_sql_parser::{intermediate_ast::Expression, Identifier};
 

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -10,6 +10,7 @@ use crate::{
         proof_plans::GroupByExec,
     },
 };
+use alloc::{borrow::ToOwned, boxed::Box, string::ToString, vec::Vec};
 use proof_of_sql_parser::{
     intermediate_ast::{AggregationOperator, AliasedResultExpr, Expression, OrderBy, Slice},
     Identifier,

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -6,6 +6,7 @@ use crate::base::{
     },
     math::decimal::Precision,
 };
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use proof_of_sql_parser::{
     intermediate_ast::{
         AggregationOperator, AliasedResultExpr, BinaryOperator, Expression, Literal, OrderBy,

--- a/crates/proof-of-sql/src/sql/parse/query_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr.rs
@@ -10,9 +10,9 @@ use crate::{
         proof_plans::{DynProofPlan, GroupByExec},
     },
 };
+use alloc::{fmt, vec, vec::Vec};
 use proof_of_sql_parser::{intermediate_ast::SetExpression, Identifier, SelectStatement};
 use serde::{Deserialize, Serialize};
-use alloc::fmt;
 
 #[derive(PartialEq, Serialize, Deserialize)]
 /// A `QueryExpr` represents a Proof of SQL query that can be executed against a database.

--- a/crates/proof-of-sql/src/sql/parse/query_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use proof_of_sql_parser::{intermediate_ast::SetExpression, Identifier, SelectStatement};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use alloc::fmt;
 
 #[derive(PartialEq, Serialize, Deserialize)]
 /// A `QueryExpr` represents a Proof of SQL query that can be executed against a database.

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     sql::proof_exprs::{DynProofExpr, ProofExpr},
 };
+use alloc::boxed::Box;
 use proof_of_sql_parser::{intermediate_ast::Expression, Identifier};
 
 /// Builder that enables building a `proof_of_sql::sql::proof_exprs::DynProofExpr` from a `proof_of_sql_parser::intermediate_ast::Expression` that is

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -9,6 +9,7 @@ use crate::{
         proof_exprs::{ColumnExpr, DynProofExpr, LiteralExpr},
     },
 };
+use core::str::FromStr;
 use curve25519_dalek::RistrettoPoint;
 use proof_of_sql_parser::{
     intermediate_decimal::IntermediateDecimal,
@@ -16,7 +17,6 @@ use proof_of_sql_parser::{
     utility::*,
     Identifier, SelectStatement,
 };
-use core::str::FromStr;
 
 fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
     let tab_ref = "sxt.sxt_tab".parse().unwrap();

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -16,7 +16,7 @@ use proof_of_sql_parser::{
     utility::*,
     Identifier, SelectStatement,
 };
-use std::str::FromStr;
+use core::str::FromStr;
 
 fn get_column_mappings_for_testing() -> IndexMap<Identifier, ColumnRef> {
     let tab_ref = "sxt.sxt_tab".parse().unwrap();

--- a/crates/proof-of-sql/src/sql/postprocessing/error.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/error.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use proof_of_sql_parser::Identifier;
 use snafu::Snafu;
 

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -4,6 +4,7 @@ use crate::base::{
     map::{indexmap, IndexMap, IndexSet},
     scalar::Scalar,
 };
+use alloc::{boxed::Box, format, string::ToString, vec, vec::Vec};
 use bumpalo::Bump;
 use itertools::{izip, Itertools};
 use proof_of_sql_parser::{

--- a/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
@@ -5,6 +5,7 @@ use crate::base::{
     math::permutation::Permutation,
     scalar::Scalar,
 };
+use alloc::{string::ToString, vec::Vec};
 use proof_of_sql_parser::intermediate_ast::{OrderBy, OrderByDirection};
 #[cfg(feature = "rayon")]
 use rayon::prelude::ParallelSliceMut;

--- a/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
@@ -4,6 +4,7 @@ use crate::base::{
     map::IndexMap,
     scalar::Scalar,
 };
+use alloc::vec::Vec;
 use proof_of_sql_parser::{intermediate_ast::AliasedResultExpr, Identifier};
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -4,11 +4,11 @@ use crate::base::{
     polynomial::{CompositePolynomial, MultilinearExtension},
     scalar::Scalar,
 };
-use core::iter;
+use core::{ffi::c_void, iter};
 use num_traits::{One, Zero};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
-use std::{ffi::c_void, rc::Rc};
+use std::rc::Rc;
 
 // Build up a composite polynomial from individual MLE expressions
 pub struct CompositePolynomialBuilder<S: Scalar> {

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -4,6 +4,7 @@ use crate::base::{
     polynomial::{CompositePolynomial, MultilinearExtension},
     scalar::Scalar,
 };
+use core::iter;
 use num_traits::{One, Zero};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
@@ -99,7 +100,7 @@ impl<S: Scalar> CompositePolynomialBuilder<S> {
             One::one(),
         );
         for (mult, terms) in self.fr_multiplicands_rest.iter() {
-            let fr_iter = std::iter::once(self.fr.clone());
+            let fr_iter = iter::once(self.fr.clone());
             let terms_iter = terms.iter().cloned();
             res.add_product(fr_iter.chain(terms_iter), *mult)
         }

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -4,11 +4,11 @@ use crate::base::{
     polynomial::{CompositePolynomial, MultilinearExtension},
     scalar::Scalar,
 };
+use alloc::{boxed::Box, rc::Rc, vec, vec::Vec};
 use core::{ffi::c_void, iter};
 use num_traits::{One, Zero};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
-use alloc::rc::Rc;
 
 // Build up a composite polynomial from individual MLE expressions
 pub struct CompositePolynomialBuilder<S: Scalar> {

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -8,7 +8,7 @@ use core::{ffi::c_void, iter};
 use num_traits::{One, Zero};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
-use std::rc::Rc;
+use alloc::rc::Rc;
 
 // Build up a composite polynomial from individual MLE expressions
 pub struct CompositePolynomialBuilder<S: Scalar> {

--- a/crates/proof-of-sql/src/sql/proof/count_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/count_builder.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{bit::BitDistribution, proof::ProofError},
     sql::proof::ProofCounts,
 };
-use std::cmp::max;
+use core::cmp::max;
 
 /// Track the number of components expected for in a query's proof
 pub struct CountBuilder<'a> {

--- a/crates/proof-of-sql/src/sql/proof/indexes.rs
+++ b/crates/proof-of-sql/src/sql/proof/indexes.rs
@@ -1,4 +1,5 @@
 use crate::base::{polynomial::compute_truncated_lagrange_basis_sum, scalar::Scalar};
+use alloc::vec::Vec;
 use core::{ops::Range, slice};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};

--- a/crates/proof-of-sql/src/sql/proof/indexes.rs
+++ b/crates/proof-of-sql/src/sql/proof/indexes.rs
@@ -1,5 +1,5 @@
 use crate::base::{polynomial::compute_truncated_lagrange_basis_sum, scalar::Scalar};
-use core::ops::Range;
+use core::{ops::Range, slice};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -46,8 +46,8 @@ impl Indexes {
     /// Get an iterator over the indexes
     pub fn iter(&self) -> impl Iterator<Item = u64> + '_ {
         enum Iter<'a> {
-            Sparse(std::slice::Iter<'a, u64>),
-            Dense(std::ops::Range<u64>),
+            Sparse(slice::Iter<'a, u64>),
+            Dense(Range<u64>),
         }
         impl<'a> Iterator for Iter<'a> {
             type Item = u64;

--- a/crates/proof-of-sql/src/sql/proof/proof_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder.rs
@@ -8,6 +8,7 @@ use crate::base::{
     polynomial::{CompositePolynomial, MultilinearExtension},
     scalar::Scalar,
 };
+use alloc::{boxed::Box, vec, vec::Vec};
 use num_traits::Zero;
 
 /// Track components used to form a query's proof

--- a/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
@@ -16,7 +16,7 @@ use arrow::{
 };
 use curve25519_dalek::RistrettoPoint;
 use num_traits::{One, Zero};
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 #[test]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {

--- a/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder_test.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     sql::proof::{Indexes, SumcheckSubpolynomialType},
 };
+use alloc::sync::Arc;
 #[cfg(feature = "arrow")]
 use arrow::{
     array::Int64Array,
@@ -16,7 +17,6 @@ use arrow::{
 };
 use curve25519_dalek::RistrettoPoint;
 use num_traits::{One, Zero};
-use alloc::sync::Arc;
 
 #[test]
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {

--- a/crates/proof-of-sql/src/sql/proof/proof_counts.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_counts.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// Counters for different terms used within a proof
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]

--- a/crates/proof-of-sql/src/sql/proof/proof_counts.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_counts.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use core::fmt::Debug;
+use serde::{Deserialize, Serialize};
 
 /// Counters for different terms used within a proof
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -10,7 +10,7 @@ use crate::base::{
     scalar::Scalar,
 };
 use bumpalo::Bump;
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// Provable nodes in the provable AST.
 pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -9,6 +9,7 @@ use crate::base::{
     proof::ProofError,
     scalar::Scalar,
 };
+use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::fmt::Debug;
 

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -6,6 +6,7 @@ use crate::base::{
     polynomial::compute_evaluation_vector,
     scalar::Scalar,
 };
+use alloc::{vec, vec::Vec};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -14,7 +14,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use num_traits::Zero;
-use std::sync::Arc;
+use alloc::sync::Arc;
 
 #[test]
 fn we_can_convert_an_empty_provable_result_to_a_final_result() {

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -8,13 +8,13 @@ use crate::{
     },
     sql::proof::Indexes,
 };
+use alloc::sync::Arc;
 use arrow::{
     array::{Decimal128Array, Decimal256Array, Int64Array, StringArray},
     datatypes::{i256, Field, Schema},
     record_batch::RecordBatch,
 };
 use num_traits::Zero;
-use alloc::sync::Arc;
 
 #[test]
 fn we_can_convert_an_empty_provable_result_to_a_final_result() {

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -17,7 +17,7 @@ use crate::{
 use bumpalo::Bump;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
-use std::cmp;
+use core::cmp;
 
 /// The proof for a query.
 ///

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -14,10 +14,11 @@ use crate::{
     proof_primitive::sumcheck::SumcheckProof,
     sql::proof::{QueryData, ResultBuilder},
 };
+use alloc::{vec, vec::Vec};
 use bumpalo::Bump;
+use core::cmp;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
-use core::cmp;
 
 /// The proof for a query.
 ///

--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -1,5 +1,6 @@
 use super::QueryError;
 use crate::base::encode::VarInt;
+use core::str;
 
 pub trait ProvableResultElement<'a> {
     fn required_bytes(&self) -> usize;
@@ -75,7 +76,7 @@ impl<'a> ProvableResultElement<'a> for &'a str {
         }
 
         Ok((
-            std::str::from_utf8(data).map_err(|_e| QueryError::InvalidString)?,
+            str::from_utf8(data).map_err(|_e| QueryError::InvalidString)?,
             bytes_read,
         ))
     }

--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -1,5 +1,6 @@
 use super::QueryError;
 use crate::base::encode::VarInt;
+use alloc::{string::String, vec::Vec};
 use core::str;
 
 pub trait ProvableResultElement<'a> {

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_random_scalars.rs
@@ -1,4 +1,5 @@
 use crate::base::{polynomial::compute_evaluation_vector, scalar::Scalar};
+use alloc::{vec, vec::Vec};
 
 /// Accessor for the random scalars used to form the sumcheck polynomial of a query proof
 pub struct SumcheckRandomScalars<'a, S: Scalar> {

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -1,5 +1,6 @@
 use super::CompositePolynomialBuilder;
 use crate::base::{polynomial::MultilinearExtension, scalar::Scalar};
+use alloc::{boxed::Box, vec::Vec};
 
 /// The type of a sumcheck subpolynomial
 pub enum SumcheckSubpolynomialType {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -7,6 +7,7 @@ use crate::base::{
     proof::ProofError,
     scalar::Scalar,
 };
+use alloc::{vec, vec::Vec};
 use serde::{Deserialize, Serialize};
 
 /// The result of an sql query along with a proof that the query is valid. The

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -1,5 +1,6 @@
 use super::{SumcheckMleEvaluations, SumcheckSubpolynomialType};
 use crate::base::{bit::BitDistribution, commitment::Commitment};
+use alloc::vec::Vec;
 use num_traits::Zero;
 
 /// Track components used to verify a query's proof

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
+use alloc::boxed::Box;
 use bumpalo::Bump;
 use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
+use alloc::boxed::Box;
 use bumpalo::Bump;
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use serde::{Deserialize, Serialize};

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
+use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use num_traits::One;
 use serde::{Deserialize, Serialize};

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -8,6 +8,7 @@ use crate::{
     sql::parse::{type_check_binary_operation, ConversionError, ConversionResult},
 };
 use bumpalo::Bump;
+use core::cmp;
 use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
@@ -59,7 +60,7 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
             right_type: rhs_type.to_string(),
         });
     }
-    let max_scale = std::cmp::max(lhs_scale, rhs_scale);
+    let max_scale = cmp::max(lhs_scale, rhs_scale);
     let lhs_upscale = max_scale - lhs_scale;
     let rhs_upscale = max_scale - rhs_scale;
     // Only check precision overflow issues if at least one side is decimal
@@ -70,7 +71,7 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
         let rhs_precision_value = rhs_type
             .precision_value()
             .expect("If scale is set, precision must be set");
-        let max_precision_value = std::cmp::max(
+        let max_precision_value = cmp::max(
             lhs_precision_value + (max_scale - lhs_scale) as u8,
             rhs_precision_value + (max_scale - rhs_scale) as u8,
         );

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     sql::parse::{type_check_binary_operation, ConversionError, ConversionResult},
 };
+use alloc::string::ToString;
 use bumpalo::Bump;
 use core::cmp;
 use proof_of_sql_parser::intermediate_ast::BinaryOperator;

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -17,7 +17,7 @@ use crate::{
 use bumpalo::Bump;
 use proof_of_sql_parser::intermediate_ast::{AggregationOperator, BinaryOperator};
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -14,10 +14,11 @@ use crate::{
         proof::{CountBuilder, ProofBuilder, VerificationBuilder},
     },
 };
+use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
+use core::fmt::Debug;
 use proof_of_sql_parser::intermediate_ast::{AggregationOperator, BinaryOperator};
 use serde::{Deserialize, Serialize};
-use core::fmt::Debug;
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
+use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
+use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -14,6 +14,7 @@ use crate::{
         proof_exprs::multiply_columns,
     },
 };
+use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use num_traits::One;
 use serde::{Deserialize, Serialize};

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
+use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
+use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -8,7 +8,7 @@ use crate::{
     sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// Provable AST column expression that evaluates to a `Column`
 pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
@@ -1,4 +1,5 @@
 use crate::base::{scalar::Scalar, slice_ops};
+use alloc::vec::Vec;
 use bytemuck::cast_slice;
 
 // Decomposes a scalar to requisite words, additionally tracks the total

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
@@ -14,6 +14,7 @@ use crate::{
         VerificationBuilder,
     },
 };
+use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
 
 /// Count the number of components needed to prove a sign decomposition

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -3,6 +3,7 @@ use crate::{
     base::{commitment::Commitment, database::Column, map::IndexSet},
     sql::proof::{ProofPlan, ProverEvaluate},
 };
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// The query plan for proving a query

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -19,6 +19,7 @@ use crate::{
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
     },
 };
+use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
 use core::{iter::repeat_with, marker::PhantomData};
 use num_traits::{One, Zero};

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -23,7 +23,7 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use core::iter::repeat_with;
+use core::{iter, iter::repeat_with};
 use num_traits::One;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
@@ -172,7 +172,7 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
             group_by_result_columns_evals
                 .into_iter()
                 .chain(sum_result_columns_evals)
-                .chain(std::iter::once(count_column_eval)),
+                .chain(iter::once(count_column_eval)),
         ))
     }
 
@@ -183,7 +183,7 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
             .chain(self.sum_expr.iter().map(|aliased_expr| {
                 ColumnField::new(aliased_expr.alias, aliased_expr.expr.data_type())
             }))
-            .chain(std::iter::once(ColumnField::new(
+            .chain(iter::once(ColumnField::new(
                 self.count_alias,
                 ColumnType::BigInt,
             )))
@@ -250,7 +250,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
             group_by_result_columns
                 .into_iter()
                 .chain(sum_result_columns_iter)
-                .chain(std::iter::once(Column::BigInt(count_column))),
+                .chain(iter::once(Column::BigInt(count_column))),
         )
     }
 
@@ -305,7 +305,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
             group_by_result_columns
                 .into_iter()
                 .chain(sum_result_columns_iter)
-                .chain(std::iter::once(Column::BigInt(count_column))),
+                .chain(iter::once(Column::BigInt(count_column))),
         )
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -22,6 +22,7 @@ use crate::{
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, ProofExpr, TableExpr},
     },
 };
+use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
 use core::{iter, iter::repeat_with};
 use num_traits::One;

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -16,6 +16,7 @@ use crate::{
         proof_exprs::{AliasedDynProofExpr, ProofExpr, TableExpr},
     },
 };
+use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::iter::repeat_with;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
# Rationale for this change

In order to support `no_std`, we need to eliminate uses of `std` from the repo as much as possible.

# What changes are included in this PR?

* explicit uses of `std` are removed.
* implicit uses of `std` are no longer required via usage of `use alloc::vec::Vec` and friends.

It is possible I missed a few spots, but these can be cleaned up in the final PR that enables `no_std`. This PR functionally does nothing until we enable `no_std`.

# Are these changes tested?

Yes, by existing tests.