### PR TITLE
feat: publicize CommittableColumn

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -9,7 +9,7 @@ use core::ops::{AddAssign, SubAssign};
 use curve25519_dalek::ristretto::RistrettoPoint;
 
 mod committable_column;
-pub(crate) use committable_column::CommittableColumn;
+pub use committable_column::CommittableColumn;
 
 mod vec_commitment_ext;
 pub use vec_commitment_ext::{NumColumnsMismatch, VecCommitmentExt};


### PR DESCRIPTION
# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This change allows for custom column representations to be used in the commitment API by implementing a borrowing conversion to `CommittableColumn`. For my use case, I preferred doing this over implementing a conversion to `OwnedColumn` to avoid copying, and over implementing a conversion to `Column` to avoid invoking an allocator.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
`CommittableColumn` is made public.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
These changes do not affect functionality, which is verified by existing tests.