### PR TITLE
feat: add nullable variant in `column`

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
+++ b/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
@@ -82,7 +82,7 @@ impl<C: Commitment> CommitmentAccessor<C> for BenchmarkAccessor<'_, C> {
 }
 impl<C: Commitment> SchemaAccessor for BenchmarkAccessor<'_, C> {
     fn lookup_column(&self, table_ref: TableRef, column_id: Identifier) -> Option<ColumnType> {
-        self.column_types.get(&(table_ref, column_id)).copied()
+        self.column_types.get(&(table_ref, column_id)).cloned()
     }
     fn lookup_schema(&self, table_ref: TableRef) -> Vec<(Identifier, ColumnType)> {
         self.table_schemas.get(&table_ref).unwrap().clone()

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -20,7 +20,7 @@ pub struct ColumnCommitmentMetadataMismatch(ColumnType, ColumnType);
 const EXPECT_BOUNDS_MATCH_MESSAGE: &str = "we've already checked the column types match, which is a stronger requirement (mapping of type variants to bounds variants is surjective)";
 
 /// Anonymous metadata associated with a column commitment.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ColumnCommitmentMetadata {
     column_type: ColumnType,
     bounds: ColumnBounds,
@@ -35,7 +35,7 @@ impl ColumnCommitmentMetadata {
         column_type: ColumnType,
         bounds: ColumnBounds,
     ) -> Result<ColumnCommitmentMetadata, InvalidColumnCommitmentMetadata> {
-        match (column_type, bounds) {
+        match (column_type.clone(), bounds) {
             (ColumnType::SmallInt, ColumnBounds::SmallInt(_))
             | (ColumnType::Int, ColumnBounds::Int(_))
             | (ColumnType::BigInt, ColumnBounds::BigInt(_))
@@ -457,7 +457,10 @@ mod tests {
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
-            boolean_metadata.try_union(boolean_metadata).unwrap(),
+            boolean_metadata
+                .clone()
+                .try_union(boolean_metadata)
+                .unwrap(),
             boolean_metadata
         );
 
@@ -466,7 +469,10 @@ mod tests {
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
-            decimal_metadata.try_union(decimal_metadata).unwrap(),
+            decimal_metadata
+                .clone()
+                .try_union(decimal_metadata)
+                .unwrap(),
             decimal_metadata
         );
 
@@ -475,7 +481,10 @@ mod tests {
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
-            varchar_metadata.try_union(varchar_metadata).unwrap(),
+            varchar_metadata
+                .clone()
+                .try_union(varchar_metadata)
+                .unwrap(),
             varchar_metadata
         );
 
@@ -484,7 +493,7 @@ mod tests {
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
-            scalar_metadata.try_union(scalar_metadata).unwrap(),
+            scalar_metadata.clone().try_union(scalar_metadata).unwrap(),
             scalar_metadata
         );
 
@@ -569,6 +578,7 @@ mod tests {
         let timestamp_metadata_b = ColumnCommitmentMetadata::from_column(&timestamp_column_b);
 
         let b_difference_a = timestamp_metadata_b
+            .clone()
             .try_difference(timestamp_metadata_a)
             .unwrap();
         assert_eq!(
@@ -588,12 +598,14 @@ mod tests {
 
         assert_eq!(
             timestamp_metadata_b
+                .clone()
                 .try_difference(timestamp_metadata_empty)
                 .unwrap(),
             timestamp_metadata_b
         );
         assert_eq!(
             timestamp_metadata_empty
+                .clone()
                 .try_difference(timestamp_metadata_b)
                 .unwrap(),
             timestamp_metadata_empty
@@ -609,7 +621,10 @@ mod tests {
         let bigint_column_b = CommittableColumn::BigInt(&ints);
         let bigint_metadata_b = ColumnCommitmentMetadata::from_column(&bigint_column_b);
 
-        let b_difference_a = bigint_metadata_b.try_difference(bigint_metadata_a).unwrap();
+        let b_difference_a = bigint_metadata_b
+            .clone()
+            .try_difference(bigint_metadata_a)
+            .unwrap();
         assert_eq!(b_difference_a.column_type, ColumnType::BigInt);
         if let ColumnBounds::BigInt(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
@@ -623,12 +638,14 @@ mod tests {
 
         assert_eq!(
             bigint_metadata_b
+                .clone()
                 .try_difference(bigint_metadata_empty)
                 .unwrap(),
             bigint_metadata_b
         );
         assert_eq!(
             bigint_metadata_empty
+                .clone()
                 .try_difference(bigint_metadata_b)
                 .unwrap(),
             bigint_metadata_empty
@@ -645,6 +662,7 @@ mod tests {
         let smallint_metadata_b = ColumnCommitmentMetadata::from_column(&smallint_column_b);
 
         let b_difference_a = smallint_metadata_b
+            .clone()
             .try_difference(smallint_metadata_a)
             .unwrap();
         assert_eq!(b_difference_a.column_type, ColumnType::SmallInt);
@@ -660,12 +678,14 @@ mod tests {
 
         assert_eq!(
             smallint_metadata_b
+                .clone()
                 .try_difference(smallint_metadata_empty)
                 .unwrap(),
             smallint_metadata_b
         );
         assert_eq!(
             smallint_metadata_empty
+                .clone()
                 .try_difference(smallint_metadata_b)
                 .unwrap(),
             smallint_metadata_empty
@@ -681,7 +701,10 @@ mod tests {
         let int_column_b = CommittableColumn::Int(&ints);
         let int_metadata_b = ColumnCommitmentMetadata::from_column(&int_column_b);
 
-        let b_difference_a = int_metadata_b.try_difference(int_metadata_a).unwrap();
+        let b_difference_a = int_metadata_b
+            .clone()
+            .try_difference(int_metadata_a)
+            .unwrap();
         assert_eq!(b_difference_a.column_type, ColumnType::Int);
         if let ColumnBounds::Int(Bounds::Bounded(bounds)) = b_difference_a.bounds() {
             assert_eq!(bounds.min(), &0);
@@ -694,11 +717,17 @@ mod tests {
         let int_metadata_empty = ColumnCommitmentMetadata::from_column(&int_column_empty);
 
         assert_eq!(
-            int_metadata_b.try_difference(int_metadata_empty).unwrap(),
+            int_metadata_b
+                .clone()
+                .try_difference(int_metadata_empty)
+                .unwrap(),
             int_metadata_b
         );
         assert_eq!(
-            int_metadata_empty.try_difference(int_metadata_b).unwrap(),
+            int_metadata_empty
+                .clone()
+                .try_difference(int_metadata_b)
+                .unwrap(),
             int_metadata_empty
         );
     }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -467,7 +467,7 @@ mod tests {
         assert_eq!(
             boolean_metadata
                 .clone()
-                .try_union(boolean_metadata)
+                .try_union(boolean_metadata.clone())
                 .unwrap(),
             boolean_metadata
         );
@@ -479,7 +479,7 @@ mod tests {
         assert_eq!(
             decimal_metadata
                 .clone()
-                .try_union(decimal_metadata)
+                .try_union(decimal_metadata.clone())
                 .unwrap(),
             decimal_metadata
         );
@@ -491,7 +491,7 @@ mod tests {
         assert_eq!(
             varchar_metadata
                 .clone()
-                .try_union(varchar_metadata)
+                .try_union(varchar_metadata.clone())
                 .unwrap(),
             varchar_metadata
         );
@@ -501,7 +501,10 @@ mod tests {
             bounds: ColumnBounds::NoOrder,
         };
         assert_eq!(
-            scalar_metadata.clone().try_union(scalar_metadata).unwrap(),
+            scalar_metadata
+                .clone()
+                .try_union(scalar_metadata.clone())
+                .unwrap(),
             scalar_metadata
         );
 
@@ -607,14 +610,14 @@ mod tests {
         assert_eq!(
             timestamp_metadata_b
                 .clone()
-                .try_difference(timestamp_metadata_empty)
+                .try_difference(timestamp_metadata_empty.clone())
                 .unwrap(),
             timestamp_metadata_b
         );
         assert_eq!(
             timestamp_metadata_empty
                 .clone()
-                .try_difference(timestamp_metadata_b)
+                .try_difference(timestamp_metadata_b.clone())
                 .unwrap(),
             timestamp_metadata_empty
         );
@@ -647,7 +650,7 @@ mod tests {
         assert_eq!(
             bigint_metadata_b
                 .clone()
-                .try_difference(bigint_metadata_empty)
+                .try_difference(bigint_metadata_empty.clone())
                 .unwrap(),
             bigint_metadata_b
         );
@@ -687,16 +690,17 @@ mod tests {
         assert_eq!(
             smallint_metadata_b
                 .clone()
-                .try_difference(smallint_metadata_empty)
+                .try_difference(smallint_metadata_empty.clone())
                 .unwrap(),
             smallint_metadata_b
         );
         assert_eq!(
             smallint_metadata_empty
                 .clone()
+                .clone()
                 .try_difference(smallint_metadata_b)
                 .unwrap(),
-            smallint_metadata_empty
+            smallint_metadata_empty.clone()
         );
     }
 
@@ -727,16 +731,17 @@ mod tests {
         assert_eq!(
             int_metadata_b
                 .clone()
-                .try_difference(int_metadata_empty)
+                .try_difference(int_metadata_empty.clone())
                 .unwrap(),
             int_metadata_b
         );
         assert_eq!(
             int_metadata_empty
                 .clone()
+                .clone()
                 .try_difference(int_metadata_b)
                 .unwrap(),
-            int_metadata_empty
+            int_metadata_empty.clone()
         );
     }
 
@@ -775,104 +780,302 @@ mod tests {
             bounds: ColumnBounds::Int128(Bounds::Empty),
         };
 
-        assert!(smallint_metadata.try_union(scalar_metadata).is_err());
-        assert!(scalar_metadata.try_union(smallint_metadata).is_err());
+        assert!(smallint_metadata
+            .clone()
+            .try_union(scalar_metadata.clone())
+            .is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_union(smallint_metadata.clone())
+            .is_err());
 
-        assert!(smallint_metadata.try_union(decimal75_metadata).is_err());
-        assert!(decimal75_metadata.try_union(smallint_metadata).is_err());
+        assert!(smallint_metadata
+            .clone()
+            .try_union(decimal75_metadata.clone())
+            .is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_union(smallint_metadata.clone())
+            .is_err());
 
-        assert!(smallint_metadata.try_union(varchar_metadata).is_err());
-        assert!(varchar_metadata.try_union(smallint_metadata).is_err());
+        assert!(smallint_metadata
+            .clone()
+            .try_union(varchar_metadata.clone())
+            .is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_union(smallint_metadata.clone())
+            .is_err());
 
-        assert!(smallint_metadata.try_union(boolean_metadata).is_err());
-        assert!(boolean_metadata.try_union(smallint_metadata).is_err());
+        assert!(smallint_metadata
+            .clone()
+            .try_union(boolean_metadata.clone())
+            .is_err());
+        assert!(boolean_metadata
+            .clone()
+            .try_union(smallint_metadata.clone())
+            .is_err());
 
-        assert!(int_metadata.try_union(scalar_metadata).is_err());
-        assert!(scalar_metadata.try_union(int_metadata).is_err());
+        assert!(int_metadata
+            .clone()
+            .try_union(scalar_metadata.clone())
+            .is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_union(int_metadata.clone())
+            .is_err());
 
-        assert!(int_metadata.try_union(decimal75_metadata).is_err());
-        assert!(decimal75_metadata.try_union(int_metadata).is_err());
+        assert!(int_metadata
+            .clone()
+            .try_union(decimal75_metadata.clone())
+            .is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_union(int_metadata.clone())
+            .is_err());
 
-        assert!(int_metadata.try_union(varchar_metadata).is_err());
-        assert!(varchar_metadata.try_union(int_metadata).is_err());
+        assert!(int_metadata
+            .clone()
+            .try_union(varchar_metadata.clone())
+            .is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_union(int_metadata.clone())
+            .is_err());
 
-        assert!(int_metadata.try_union(boolean_metadata).is_err());
-        assert!(boolean_metadata.try_union(int_metadata).is_err());
+        assert!(int_metadata
+            .clone()
+            .try_union(boolean_metadata.clone())
+            .is_err());
+        assert!(boolean_metadata
+            .clone()
+            .try_union(int_metadata.clone())
+            .is_err());
 
-        assert!(varchar_metadata.try_union(scalar_metadata).is_err());
-        assert!(scalar_metadata.try_union(varchar_metadata).is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_union(scalar_metadata.clone())
+            .is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_union(varchar_metadata.clone())
+            .is_err());
 
-        assert!(varchar_metadata.try_union(bigint_metadata).is_err());
-        assert!(bigint_metadata.try_union(varchar_metadata).is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_union(bigint_metadata.clone())
+            .is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_union(varchar_metadata.clone())
+            .is_err());
 
-        assert!(varchar_metadata.try_union(int128_metadata).is_err());
-        assert!(int128_metadata.try_union(varchar_metadata).is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_union(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_union(varchar_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_union(scalar_metadata).is_err());
-        assert!(scalar_metadata.try_union(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_union(scalar_metadata.clone())
+            .is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_union(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_union(bigint_metadata).is_err());
-        assert!(bigint_metadata.try_union(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_union(bigint_metadata.clone())
+            .is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_union(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_union(varchar_metadata).is_err());
-        assert!(varchar_metadata.try_union(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_union(varchar_metadata.clone())
+            .is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_union(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_union(int128_metadata).is_err());
-        assert!(int128_metadata.try_union(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_union(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_union(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(scalar_metadata.try_union(bigint_metadata).is_err());
-        assert!(bigint_metadata.try_union(scalar_metadata).is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_union(bigint_metadata.clone())
+            .is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_union(scalar_metadata.clone())
+            .is_err());
 
-        assert!(scalar_metadata.try_union(int128_metadata).is_err());
-        assert!(int128_metadata.try_union(scalar_metadata).is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_union(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_union(scalar_metadata.clone())
+            .is_err());
 
-        assert!(bigint_metadata.try_union(int128_metadata).is_err());
-        assert!(int128_metadata.try_union(bigint_metadata).is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_union(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_union(bigint_metadata.clone())
+            .is_err());
 
-        assert!(varchar_metadata.try_difference(scalar_metadata).is_err());
-        assert!(scalar_metadata.try_difference(varchar_metadata).is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_difference(scalar_metadata.clone())
+            .is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_difference(varchar_metadata.clone())
+            .is_err());
 
-        assert!(varchar_metadata.try_difference(bigint_metadata).is_err());
-        assert!(bigint_metadata.try_difference(varchar_metadata).is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_difference(bigint_metadata.clone())
+            .is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_difference(varchar_metadata.clone())
+            .is_err());
 
-        assert!(varchar_metadata.try_difference(int128_metadata).is_err());
-        assert!(int128_metadata.try_difference(varchar_metadata).is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_difference(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_difference(varchar_metadata.clone())
+            .is_err());
 
-        assert!(scalar_metadata.try_difference(bigint_metadata).is_err());
-        assert!(bigint_metadata.try_difference(scalar_metadata).is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_difference(bigint_metadata.clone())
+            .is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_difference(scalar_metadata.clone())
+            .is_err());
 
-        assert!(scalar_metadata.try_difference(int128_metadata).is_err());
-        assert!(int128_metadata.try_difference(scalar_metadata).is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_difference(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_difference(scalar_metadata.clone())
+            .is_err());
 
-        assert!(bigint_metadata.try_difference(int128_metadata).is_err());
-        assert!(int128_metadata.try_difference(bigint_metadata).is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_difference(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_difference(bigint_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_difference(scalar_metadata).is_err());
-        assert!(scalar_metadata.try_difference(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_difference(scalar_metadata.clone())
+            .is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_difference(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_difference(bigint_metadata).is_err());
-        assert!(bigint_metadata.try_difference(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_difference(bigint_metadata.clone())
+            .is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_difference(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_difference(int128_metadata).is_err());
-        assert!(int128_metadata.try_difference(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_difference(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_difference(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_difference(varchar_metadata).is_err());
-        assert!(varchar_metadata.try_difference(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_difference(varchar_metadata.clone())
+            .is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_difference(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(decimal75_metadata.try_difference(boolean_metadata).is_err());
-        assert!(boolean_metadata.try_difference(decimal75_metadata).is_err());
+        assert!(decimal75_metadata
+            .clone()
+            .try_difference(boolean_metadata.clone())
+            .is_err());
+        assert!(boolean_metadata
+            .clone()
+            .try_difference(decimal75_metadata.clone())
+            .is_err());
 
-        assert!(boolean_metadata.try_difference(bigint_metadata).is_err());
-        assert!(bigint_metadata.try_difference(boolean_metadata).is_err());
+        assert!(boolean_metadata
+            .clone()
+            .try_difference(bigint_metadata.clone())
+            .is_err());
+        assert!(bigint_metadata
+            .clone()
+            .try_difference(boolean_metadata.clone())
+            .is_err());
 
-        assert!(boolean_metadata.try_difference(int128_metadata).is_err());
-        assert!(int128_metadata.try_difference(boolean_metadata).is_err());
+        assert!(boolean_metadata
+            .clone()
+            .try_difference(int128_metadata.clone())
+            .is_err());
+        assert!(int128_metadata
+            .clone()
+            .try_difference(boolean_metadata.clone())
+            .is_err());
 
-        assert!(boolean_metadata.try_difference(varchar_metadata).is_err());
-        assert!(varchar_metadata.try_difference(boolean_metadata).is_err());
+        assert!(boolean_metadata
+            .clone()
+            .try_difference(varchar_metadata.clone())
+            .is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_difference(boolean_metadata.clone())
+            .is_err());
 
-        assert!(boolean_metadata.try_difference(scalar_metadata).is_err());
-        assert!(scalar_metadata.try_difference(boolean_metadata).is_err());
+        assert!(boolean_metadata
+            .clone()
+            .try_difference(scalar_metadata.clone())
+            .is_err());
+        assert!(scalar_metadata
+            .clone()
+            .try_difference(boolean_metadata.clone())
+            .is_err());
 
         let different_decimal75_metadata = ColumnCommitmentMetadata {
             column_type: ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
@@ -880,17 +1083,21 @@ mod tests {
         };
 
         assert!(decimal75_metadata
-            .try_difference(different_decimal75_metadata)
+            .clone()
+            .try_difference(different_decimal75_metadata.clone())
             .is_err());
         assert!(different_decimal75_metadata
-            .try_difference(decimal75_metadata)
+            .clone()
+            .try_difference(decimal75_metadata.clone())
             .is_err());
 
         assert!(decimal75_metadata
-            .try_union(different_decimal75_metadata)
+            .clone()
+            .try_union(different_decimal75_metadata.clone())
             .is_err());
         assert!(different_decimal75_metadata
-            .try_union(decimal75_metadata)
+            .clone()
+            .try_union(decimal75_metadata.clone())
             .is_err());
 
         let timestamp_tz_metadata_a = ColumnCommitmentMetadata {
@@ -904,31 +1111,42 @@ mod tests {
         };
 
         // Tests for union operations
-        assert!(timestamp_tz_metadata_a.try_union(varchar_metadata).is_err());
-        assert!(varchar_metadata.try_union(timestamp_tz_metadata_a).is_err());
+        assert!(timestamp_tz_metadata_a
+            .clone()
+            .try_union(varchar_metadata.clone())
+            .is_err());
+        assert!(varchar_metadata
+            .clone()
+            .try_union(timestamp_tz_metadata_a.clone())
+            .is_err());
 
         // Tests for difference operations
         assert!(timestamp_tz_metadata_a
-            .try_difference(scalar_metadata)
+            .clone()
+            .try_difference(scalar_metadata.clone())
             .is_err());
         assert!(scalar_metadata
-            .try_difference(timestamp_tz_metadata_a)
+            .clone()
+            .try_difference(timestamp_tz_metadata_a.clone())
             .is_err());
 
         // Tests for different time units within the same type
         assert!(timestamp_tz_metadata_a
-            .try_union(timestamp_tz_metadata_b)
+            .clone()
+            .try_union(timestamp_tz_metadata_b.clone())
             .is_err());
         assert!(timestamp_tz_metadata_b
-            .try_union(timestamp_tz_metadata_a)
+            .clone()
+            .try_union(timestamp_tz_metadata_a.clone())
             .is_err());
 
         // Difference with different time units
         assert!(timestamp_tz_metadata_a
-            .try_difference(timestamp_tz_metadata_b)
+            .clone()
+            .try_difference(timestamp_tz_metadata_b.clone())
             .is_err());
         assert!(timestamp_tz_metadata_b
-            .try_difference(timestamp_tz_metadata_a)
+            .try_difference(timestamp_tz_metadata_a.clone())
             .is_err());
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -42,7 +42,10 @@ impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
                     table_columns
                         .entry(column.table_ref())
                         .or_default()
-                        .push(ColumnField::new(column.column_id(), *column.column_type()));
+                        .push(ColumnField::new(
+                            column.column_id(),
+                            column.column_type().clone(),
+                        ));
                     table_columns
                 },
             )
@@ -56,7 +59,7 @@ impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
                             accessor
                                 .lookup_schema(table_ref)
                                 .iter()
-                                .filter_map(|c| columns.iter().find(|x| x.name() == c.0).copied()),
+                                .filter_map(|c| columns.iter().find(|x| x.name() == c.0).cloned()),
                         ),
                         accessor,
                     ),
@@ -102,7 +105,7 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
         table_commitment
             .column_commitments()
             .get_metadata(&column_id)
-            .map(|column_metadata| *column_metadata.column_type())
+            .map(|column_metadata| column_metadata.column_type().clone())
     }
 
     fn lookup_schema(
@@ -115,7 +118,9 @@ impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
             .column_commitments()
             .column_metadata()
             .iter()
-            .map(|(identifier, column_metadata)| (*identifier, *column_metadata.column_type()))
+            .map(|(identifier, column_metadata)| {
+                (*identifier, column_metadata.column_type().clone())
+            })
             .collect()
     }
 }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -369,8 +369,11 @@ impl ColumnType {
     }
 
     /// Convert a column type to its nullable variant
-    pub fn to_nullable(self) -> ColumnType {
-        ColumnType::Nullable(Box::new(self))
+    pub fn into_nullable(self) -> ColumnType {
+        match self {
+            ColumnType::Nullable(_) => self,
+            val => ColumnType::Nullable(Box::new(val)),
+        }
     }
 
     /// Get the inner column type if nullable

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -243,23 +243,27 @@ pub enum ColumnType {
 impl ColumnType {
     /// Returns true if this column is numeric and false otherwise
     pub fn is_numeric(&self) -> bool {
-        matches!(
-            self,
+        match self {
+            ColumnType::Nullable(v) => v.is_numeric(),
             ColumnType::SmallInt
-                | ColumnType::Int
-                | ColumnType::BigInt
-                | ColumnType::Int128
-                | ColumnType::Scalar
-                | ColumnType::Decimal75(_, _)
-        )
+            | ColumnType::Int
+            | ColumnType::BigInt
+            | ColumnType::Int128
+            | ColumnType::Scalar
+            | ColumnType::Decimal75(_, _) => true,
+            _ => false,
+        }
     }
 
     /// Returns true if this column is an integer and false otherwise
     pub fn is_integer(&self) -> bool {
-        matches!(
-            self,
-            ColumnType::SmallInt | ColumnType::Int | ColumnType::BigInt | ColumnType::Int128
-        )
+        match self {
+            ColumnType::Nullable(v) => v.is_integer(),
+            ColumnType::SmallInt | ColumnType::Int | ColumnType::BigInt | ColumnType::Int128 => {
+                true
+            }
+            _ => false,
+        }
     }
 
     /// Returns the number of bits in the integer type if it is an integer type. Otherwise, return None.
@@ -269,6 +273,7 @@ impl ColumnType {
             ColumnType::Int => Some(32),
             ColumnType::BigInt => Some(64),
             ColumnType::Int128 => Some(128),
+            ColumnType::Nullable(v) => v.to_integer_bits(),
             _ => None,
         }
     }

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-
 use super::{ColumnOperationError, ColumnOperationResult};
 use crate::base::{
     database::ColumnType,
@@ -36,15 +35,16 @@ pub fn try_add_subtract_column_types(
     }
     if lhs.is_integer() && rhs.is_integer() {
         // We can unwrap here because we know that both types are integers
+        let result = lhs.max_integer_type(&rhs).unwrap();
         return if is_nullable {
-            Ok(ColumnType::Scalar.to_nullable())
+            Ok(result.into_nullable())
         } else {
-            Ok(ColumnType::Scalar)
+            Ok(result)
         };
     }
     if lhs == ColumnType::Scalar || rhs == ColumnType::Scalar {
         return if is_nullable {
-            Ok(ColumnType::Scalar.to_nullable())
+            Ok(ColumnType::Scalar.into_nullable())
         } else {
             Ok(ColumnType::Scalar)
         };
@@ -73,12 +73,10 @@ pub fn try_add_subtract_column_types(
                     },
                 })
             })?;
-        let result_type = ColumnType::Decimal75(precision, scale);
-
         if is_nullable {
-            Ok(result_type.to_nullable())
+            Ok(ColumnType::Decimal75(precision, scale).into_nullable())
         } else {
-            Ok(result_type)
+            Ok(ColumnType::Decimal75(precision, scale))
         }
     }
 }
@@ -144,8 +142,8 @@ pub fn try_divide_column_types(
     {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
             operator: BinaryOperator::Division,
-            left_type: lhs.clone(),
-            right_type: rhs.clone(),
+            left_type: lhs,
+            right_type: rhs,
         });
     }
     if lhs.is_integer() && rhs.is_integer() {

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -973,6 +973,13 @@ mod test {
         let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(75).unwrap(), -13);
         assert_eq!(expected, actual);
+
+        // check if any of them are nullable
+        let lhs = ColumnType::Nullable(Box::new(ColumnType::SmallInt));
+        let rhs = ColumnType::Int;
+        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let expected = ColumnType::Nullable(Box::new(ColumnType::Int));
+        assert_eq!(expected, actual);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -97,3 +97,5 @@ mod filter_util_test;
 pub(crate) mod group_by_util;
 #[cfg(test)]
 mod group_by_util_test;
+mod nullable_column;
+mod owned_nullable_column;

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -1,0 +1,22 @@
+use crate::base::database::Column;
+use crate::base::scalar::Scalar;
+
+/// Represents a nullable column with values and an optional presence slice
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub struct NullableColumn<'a, T: Scalar> {
+    values: Column<'a, T>,
+    presence: Option<&'a [bool]>,
+}
+
+impl<'a, T: Scalar> NullableColumn<'a, T> {
+    /// Create a new nullable column
+    pub fn new(values: Column<'a, T>, presence: Option<&'a [bool]>) -> Self {
+        Self { values, presence }
+    }
+
+    /// Check if a specific value is null
+    pub fn is_null(&self, index: usize) -> bool {
+        self.presence
+            .map_or(false, |p| !p.get(index).map(|v| *v).unwrap_or_default())
+    }
+}

--- a/crates/proof-of-sql/src/base/database/nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/nullable_column.rs
@@ -4,8 +4,8 @@ use crate::base::scalar::Scalar;
 /// Represents a nullable column with values and an optional presence slice
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub struct NullableColumn<'a, T: Scalar> {
-    values: Column<'a, T>,
-    presence: Option<&'a [bool]>,
+    pub values: Column<'a, T>,
+    pub presence: Option<&'a [bool]>,
 }
 
 impl<'a, T: Scalar> NullableColumn<'a, T> {

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -208,6 +208,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 from_type: ColumnType::Scalar,
                 to_type: ColumnType::VarChar,
             }),
+            ColumnType::Nullable(val) => Self::try_from_scalars(scalars, *val),
         }
     }
 

--- a/crates/proof-of-sql/src/base/database/owned_nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_nullable_column.rs
@@ -4,8 +4,8 @@ use crate::base::scalar::Scalar;
 /// Represents a nullable column with values and an optional presence slice
 #[derive(Debug, PartialEq, Clone, Eq)]
 pub struct NullableOwnedColumn<T: Scalar> {
-    values: OwnedColumn<T>,
-    presence: Option<Vec<bool>>,
+    pub values: OwnedColumn<T>,
+    pub presence: Option<Vec<bool>>,
 }
 
 impl<T: Scalar> NullableOwnedColumn<T> {

--- a/crates/proof-of-sql/src/base/database/owned_nullable_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_nullable_column.rs
@@ -1,0 +1,23 @@
+use crate::base::database::OwnedColumn;
+use crate::base::scalar::Scalar;
+
+/// Represents a nullable column with values and an optional presence slice
+#[derive(Debug, PartialEq, Clone, Eq)]
+pub struct NullableOwnedColumn<T: Scalar> {
+    values: OwnedColumn<T>,
+    presence: Option<Vec<bool>>,
+}
+
+impl<T: Scalar> NullableOwnedColumn<T> {
+    /// Create a new nullable column
+    pub fn new(values: OwnedColumn<T>, presence: Option<Vec<bool>>) -> Self {
+        Self { values, presence }
+    }
+
+    /// Check if a specific value is null
+    pub fn is_null(&self, index: usize) -> bool {
+        self.presence
+            .as_ref()
+            .map_or(false, |p| !p.get(index).map(|v| *v).unwrap_or_default())
+    }
+}

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -131,7 +131,7 @@ fn we_can_access_the_commitments_of_table_columns() {
 
     let column = ColumnRef::new(table_ref_1, "b".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
-        accessor.get_commitment(column),
+        accessor.get_commitment(column.clone()),
         RistrettoPoint::compute_commitments(
             &[CommittableColumn::from(&[4i64, 5, 6][..])],
             0_usize,
@@ -144,7 +144,7 @@ fn we_can_access_the_commitments_of_table_columns() {
 
     let column = ColumnRef::new(table_ref_1, "a".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
-        accessor.get_commitment(column),
+        accessor.get_commitment(column.clone()),
         RistrettoPoint::compute_commitments(
             &[CommittableColumn::from(&[1i64, 2, 3][..])],
             0_usize,
@@ -154,7 +154,7 @@ fn we_can_access_the_commitments_of_table_columns() {
 
     let column = ColumnRef::new(table_ref_2, "b".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
-        accessor.get_commitment(column),
+        accessor.get_commitment(column.clone()),
         RistrettoPoint::compute_commitments(
             &[CommittableColumn::from(&[4i64, 5, 6, 5][..])],
             0_usize,
@@ -236,13 +236,13 @@ fn we_can_correctly_update_offsets() {
 
     let column = ColumnRef::new(table_ref, "a".parse().unwrap(), ColumnType::BigInt);
     assert_ne!(
-        accessor1.get_commitment(column),
-        accessor2.get_commitment(column)
+        accessor1.get_commitment(column.clone()),
+        accessor2.get_commitment(column.clone())
     );
     let column = ColumnRef::new(table_ref, "b".parse().unwrap(), ColumnType::BigInt);
     assert_ne!(
-        accessor1.get_commitment(column),
-        accessor2.get_commitment(column)
+        accessor1.get_commitment(column.clone()),
+        accessor2.get_commitment(column.clone())
     );
 
     assert_eq!(accessor1.get_offset(table_ref), 0);
@@ -252,13 +252,13 @@ fn we_can_correctly_update_offsets() {
 
     let column = ColumnRef::new(table_ref, "a".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
-        accessor1.get_commitment(column),
-        accessor2.get_commitment(column)
+        accessor1.get_commitment(column.clone()),
+        accessor2.get_commitment(column.clone())
     );
     let column = ColumnRef::new(table_ref, "b".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
-        accessor1.get_commitment(column),
-        accessor2.get_commitment(column)
+        accessor1.get_commitment(column.clone()),
+        accessor2.get_commitment(column.clone())
     );
 
     assert_eq!(accessor1.get_offset(table_ref), offset);

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -24,7 +24,7 @@ impl SchemaAccessor for TestSchemaAccessor {
             .get(&table_ref)
             .unwrap_or(&IndexMap::default())
             .iter()
-            .map(|(id, col)| (*id, *col))
+            .map(|(id, col)| (*id, col.clone()))
             .collect()
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -53,7 +53,7 @@ fn output_bit_table(
 /// # Arguments
 ///
 /// * `column_type` - The type of a committable column.
-const fn min_as_f(column_type: ColumnType) -> F {
+const fn min_as_f(column_type: &ColumnType) -> F {
     match column_type {
         ColumnType::SmallInt => MontFp!("-32768"),
         ColumnType::Int => MontFp!("-2147483648"),
@@ -63,6 +63,7 @@ const fn min_as_f(column_type: ColumnType) -> F {
         | ColumnType::Scalar
         | ColumnType::VarChar
         | ColumnType::Boolean => MontFp!("0"),
+        ColumnType::Nullable(val) => min_as_f(&(*val)),
     }
 }
 
@@ -104,7 +105,7 @@ pub fn modify_commits(
     for (i, column) in committable_columns.iter().enumerate() {
         let num_sub_commits = num_sub_commits(column, offset, num_matrix_commitment_columns);
         if column.column_type().is_signed() {
-            let min = min_as_f(column.column_type());
+            let min = min_as_f(&column.column_type());
             let offset_sub_commit_first = offset_sub_commits[0].mul(min);
             let offset_sub_commit_middle = offset_sub_commits[1].mul(min);
             let offset_sub_commit_last = offset_sub_commits[OFFSET_SIZE + i].mul(min);

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -71,11 +71,12 @@ impl DynProofExprBuilder<'_> {
         identifier: Identifier,
     ) -> Result<DynProofExpr<C>, ConversionError> {
         Ok(DynProofExpr::Column(ColumnExpr::new(
-            self.column_mapping.get(&identifier).ok_or(
-                ConversionError::MissingColumnWithoutTable {
+            self.column_mapping
+                .get(&identifier)
+                .ok_or(ConversionError::MissingColumnWithoutTable {
                     identifier: Box::new(identifier),
-                },
-            )?.clone(),
+                })?
+                .clone(),
         )))
     }
 

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -72,9 +72,12 @@ impl DynProofExprBuilder<'_> {
         identifier: Identifier,
     ) -> Result<DynProofExpr<C>, ConversionError> {
         Ok(DynProofExpr::Column(ColumnExpr::new(
-            *self.column_mapping.get(&identifier).ok_or(
-                ConversionError::MissingColumnWithoutTable(Box::new(identifier)),
-            )?,
+            self.column_mapping
+                .get(&identifier)
+                .ok_or(ConversionError::MissingColumnWithoutTable(Box::new(
+                    identifier,
+                )))?
+                .clone(),
         )))
     }
 

--- a/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
@@ -63,7 +63,7 @@ impl<C: Commitment> FilterExecBuilder<C> {
             for alias in self.column_mapping.keys().sorted() {
                 let column_ref = self.column_mapping.get(alias).unwrap();
                 self.filter_result_expr_list.push(AliasedDynProofExpr {
-                    expr: DynProofExpr::new_column(*column_ref),
+                    expr: DynProofExpr::new_column(column_ref.clone()),
                     alias: *alias,
                 });
             }

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -236,7 +236,7 @@ impl<C: Commitment> TryFrom<&QueryContext> for Option<GroupByExec<C>> {
                         Box::new(*expr),
                         Box::new(resource_id),
                     ))
-                    .map(|column_ref| ColumnExpr::<C>::new(*column_ref))
+                    .map(|column_ref| ColumnExpr::<C>::new(column_ref.clone()))
             })
             .collect::<Result<Vec<ColumnExpr<C>>, ConversionError>>()?;
         // For a query to be provable the result columns must be of one of three kinds below:

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -145,28 +145,27 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
     }
 }
 
+// TODO: rename
+fn handle_field_datatype<S: Scalar>(ty: ColumnType) -> OwnedColumn<S> {
+    match ty {
+        ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
+        ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
+        ColumnType::Int => OwnedColumn::Int(vec![]),
+        ColumnType::BigInt => OwnedColumn::BigInt(vec![]),
+        ColumnType::Int128 => OwnedColumn::Int128(vec![]),
+        ColumnType::Decimal75(precision, scale) => OwnedColumn::Decimal75(precision, scale, vec![]),
+        ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
+        ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
+        ColumnType::TimestampTZ(tu, tz) => OwnedColumn::TimestampTZ(tu, tz, vec![]),
+        ColumnType::Nullable(val) => handle_field_datatype(*val),
+    }
+}
+
 fn make_empty_query_result<S: Scalar>(result_fields: Vec<ColumnField>) -> QueryResult<S> {
     let table = OwnedTable::try_new(
         result_fields
             .iter()
-            .map(|field| {
-                (
-                    field.name(),
-                    match field.data_type() {
-                        ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
-                        ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
-                        ColumnType::Int => OwnedColumn::Int(vec![]),
-                        ColumnType::BigInt => OwnedColumn::BigInt(vec![]),
-                        ColumnType::Int128 => OwnedColumn::Int128(vec![]),
-                        ColumnType::Decimal75(precision, scale) => {
-                            OwnedColumn::Decimal75(precision, scale, vec![])
-                        }
-                        ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
-                        ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
-                        ColumnType::TimestampTZ(tu, tz) => OwnedColumn::TimestampTZ(tu, tz, vec![]),
-                    },
-                )
-            })
+            .map(|field| (field.name(), handle_field_datatype(field.data_type())))
             .collect(),
     )?;
     Ok(QueryData {

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -32,12 +32,15 @@ impl<C: Commitment> ColumnExpr<C> {
 
     /// Return the column referenced by this ColumnExpr
     pub fn get_column_reference(&self) -> ColumnRef {
-        self.column_ref
+        self.column_ref.clone()
     }
 
     /// Wrap the column output name and its type within the ColumnField
     pub fn get_column_field(&self) -> ColumnField {
-        ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
+        ColumnField::new(
+            self.column_ref.column_id(),
+            self.column_ref.column_type().clone(),
+        )
     }
 
     /// Get the column identifier
@@ -55,7 +58,7 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
 
     /// Get the data type of the expression
     fn data_type(&self) -> ColumnType {
-        *self.get_column_reference().column_type()
+        self.get_column_reference().column_type().clone()
     }
 
     /// Evaluate the column expression and
@@ -66,7 +69,7 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
         _alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let column = accessor.get_column(self.column_ref);
+        let column = accessor.get_column(self.column_ref.clone());
         assert_eq!(column.len(), table_length);
         column
     }
@@ -79,7 +82,7 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
         _alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let column = accessor.get_column(self.column_ref);
+        let column = accessor.get_column(self.column_ref.clone());
         builder.produce_anchored_mle(column);
         column
     }
@@ -91,7 +94,7 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
     ) -> Result<C::Scalar, ProofError> {
-        let col_commit = accessor.get_commitment(self.column_ref);
+        let col_commit = accessor.get_commitment(self.column_ref.clone());
         Ok(builder.consume_anchored_mle(col_commit))
     }
 
@@ -99,6 +102,6 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
     /// references in the BoolExpr or forwards the call to some
     /// subsequent bool_expr
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
-        columns.insert(self.column_ref);
+        columns.insert(self.column_ref.clone());
     }
 }


### PR DESCRIPTION
Part of: #183

I am confused with current flow of code.. so I could not understand why do we need `NullableColumn` and `NullableOwnedColumn`

I am not sure why `Column` needs serialization/deserialization, so ignoring the serde part,
here is the proposed change in `Column` itself which could help mark it nullable.

I edited `try_add_subtract_column_types` in [column_operation.](https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/crates/proof-of-sql/src/base/database/column_operation.rs) as an example.

ps: Sorry for not following the PR format

