### PR TITLE
feat: add helper methods to dynamic Dory structure (PROOF-919)

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_structure.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_structure.rs
@@ -64,9 +64,11 @@ pub(crate) fn index_from_row_and_column(row: usize, column: usize) -> Option<usi
 }
 
 /// Returns a matrix size, (height, width), that can hold the given number of data points being committed with respect to an offset.
+///
+/// Note: when data_len = 0 and offset = 0, this function returns an empty matrix with size (0, 0).
 #[allow(dead_code)]
 pub(crate) const fn matrix_size(data_len: usize, offset: usize) -> (usize, usize) {
-    if data_len == 0 {
+    if data_len == 0 && offset == 0 {
         return (0, 0);
     }
 
@@ -212,10 +214,9 @@ mod tests {
     #[test]
     fn we_can_produce_the_correct_matrix_size_with_offset() {
         // NOTE: returned tuple is (height, width).
-        for i in 0..100 {
-            assert_eq!(matrix_size(0, i), (0, 0));
-        }
-
+        assert_eq!(matrix_size(0, 0), (0, 0));
+        assert_eq!(matrix_size(0, 1), (1, 1));
+        assert_eq!(matrix_size(0, 2), (2, 2));
         assert_eq!(matrix_size(1, 1), (2, 2));
         assert_eq!(matrix_size(1, 2), (3, 2));
         assert_eq!(matrix_size(1, 3), (3, 2));

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_structure.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_structure.rs
@@ -31,16 +31,19 @@
 //! ```
 
 /// Sets the data to indicate if no index exists.
+#[allow(dead_code)]
 const fn no_index() -> usize {
     usize::MAX
 }
 
 /// Returns if the index exists.
+#[allow(dead_code)]
 pub(crate) const fn index_exists(index: usize) -> bool {
     index != no_index()
 }
 
 /// Returns the full width of a row in the matrix.
+#[allow(dead_code)]
 pub(crate) const fn full_width_of_row(row: usize) -> usize {
     ((2 * row + 4) / 3).next_power_of_two()
 }
@@ -63,6 +66,7 @@ pub(crate) const fn row_and_column_from_index(index: usize) -> (usize, usize) {
 }
 
 /// Returns the index of data where the (row, column) belongs.
+#[allow(dead_code)]
 pub(crate) const fn index_from_row_and_column(row: usize, column: usize) -> usize {
     let width_of_row = full_width_of_row(row);
 
@@ -75,6 +79,7 @@ pub(crate) const fn index_from_row_and_column(row: usize, column: usize) -> usiz
 }
 
 /// Returns a matrix size that can hold the given number of data points being committed with respect to an offset.
+#[allow(dead_code)]
 pub(crate) const fn matrix_size(data_len: usize, offset: usize) -> (usize, usize) {
     let (last_row, _) = row_and_column_from_index(offset + data_len - 1);
     let width_of_last_row = full_width_of_row(last_row);
@@ -162,9 +167,9 @@ mod tests {
     }
     #[test]
     fn we_can_correctly_identify_index_existence() {
-        assert_eq!(index_exists(0), true);
-        assert_eq!(index_exists(no_index()), false);
-        assert_eq!(index_exists(no_index() - 1), true);
+        assert!(index_exists(0));
+        assert!(!index_exists(no_index()));
+        assert!(index_exists(no_index() - 1));
     }
     #[test]
     fn we_can_find_the_full_width_of_row() {


### PR DESCRIPTION
# Rationale for this change
The GPU implementation of the dynamic Dory commitment computation requires a number of helper methods in the dynamic Dory structure. This PR implements methods that will be used by the GPU implementation.

# What changes are included in this PR?
- Add `index_from_row_and_column` method which is the inverse of `row_and_column_from_index` method. Given a `row` and `column` it will provide the `index` of the original data. The method also handles cases where `row` and `column` do not provide a valid `index`.
- Add `matrix_size` method which returns the width and height of the dynamic Dory matrix structure that will hold the given data.
- Made helper methods `const` for compile-time evaluation.
- Add temporary `#[allow(dead_code)]` to address `cargo clippy` warnings - these will be removed when the dynamic Dory commit computation is implemented for the GPU.

# Are these changes tested?
Yes