### PR TITLE
chore: upgrade blitzar to 3.3.0 for send/sync on MsmHandle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ arrow-csv = { version = "51.0" }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3", default-features = false }
-blitzar = { version = "3.1.0" }
+blitzar = { version = "3.3.0" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
 byte-slice-cast = { version = "1.2.1", default-features = false }


### PR DESCRIPTION
# Rationale for this change

This PR upgrades blitzar to add support for Send and Sync via a default impl on MsmHandle.

# What changes are included in this PR?

Upgrades blitzar to 3.3.0

# Are these changes tested?

existing tests pass