### PR TITLE
test: improve sumcheck test coverage

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -6,6 +6,8 @@ use alloc::{rc::Rc, vec::Vec};
  * See third_party/license/arkworks.LICENSE
  */
 use core::cmp::max;
+#[cfg(test)]
+use core::iter;
 
 /// Stores a list of products of `DenseMultilinearExtension` that is meant to be added together.
 ///
@@ -84,6 +86,53 @@ impl<S: Scalar> CompositePolynomial<S> {
         }
         self.products.push((coefficient, indexed_product));
     }
+    /// Generate random `CompositePolnomial`.
+    #[cfg(test)]
+    pub fn rand(
+        num_variables: usize,
+        max_multiplicands: usize,
+        multiplicands_length: impl IntoIterator<Item = usize>,
+        products: impl IntoIterator<Item = impl IntoIterator<Item = usize>>,
+        rng: &mut (impl ark_std::rand::Rng + ?Sized),
+    ) -> Self {
+        let mut result = CompositePolynomial::new(num_variables);
+        result.max_multiplicands = max_multiplicands;
+        result.products = products
+            .into_iter()
+            .map(|p| (S::rand(rng), p.into_iter().collect()))
+            .collect();
+        result.flattened_ml_extensions = multiplicands_length
+            .into_iter()
+            .map(|length| Rc::new(iter::repeat_with(|| S::rand(rng)).take(length).collect()))
+            .collect();
+        result
+    }
+
+    /// Returns the sum of the evaluations of the `CompositePolynomial` on the boolean hypercube.
+    #[cfg(test)]
+    pub fn hypercube_sum(&self, length: usize) -> S {
+        self.products
+            .iter()
+            .map(|(coeff, terms)| {
+                (0..length)
+                    .map(|i| {
+                        *coeff
+                            * terms
+                                .iter()
+                                .copied()
+                                .map(|j| {
+                                    self.flattened_ml_extensions[j]
+                                        .get(i)
+                                        .copied()
+                                        .unwrap_or(S::ZERO)
+                                })
+                                .product::<S>()
+                    })
+                    .sum::<S>()
+            })
+            .sum::<S>()
+    }
+
     /// Evaluate the polynomial at point `point`
     #[cfg(test)]
     pub fn evaluate(&self, point: &[S]) -> S {

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -38,3 +38,36 @@ fn test_composite_polynomial_evaluation() {
     assert_eq!(prod01, calc01);
     assert_eq!(prod11, calc11);
 }
+
+#[allow(clippy::identity_op)]
+#[test]
+fn test_composite_polynomial_hypercube_sum() {
+    let a: Vec<Curve25519Scalar> = vec![
+        -Curve25519Scalar::from(7u32),
+        Curve25519Scalar::from(2u32),
+        -Curve25519Scalar::from(6u32),
+        Curve25519Scalar::from(17u32),
+    ];
+    let b: Vec<Curve25519Scalar> = vec![
+        Curve25519Scalar::from(2u32),
+        -Curve25519Scalar::from(8u32),
+        Curve25519Scalar::from(4u32),
+        Curve25519Scalar::from(1u32),
+    ];
+    let c: Vec<Curve25519Scalar> = vec![
+        Curve25519Scalar::from(1u32),
+        Curve25519Scalar::from(3u32),
+        -Curve25519Scalar::from(5u32),
+        -Curve25519Scalar::from(9u32),
+    ];
+    let mut prod = CompositePolynomial::new(2);
+    prod.add_product([Rc::new(a), Rc::new(b)], Curve25519Scalar::from(3u32));
+    prod.add_product([Rc::new(c)], Curve25519Scalar::from(2u32));
+    let sum = prod.hypercube_sum(4);
+    assert_eq!(
+        sum,
+        Curve25519Scalar::from(
+            3 * ((-7) * 2 + 2 * (-8) + (-6) * 4 + 17 * 1) + 2 * (1 + 3 + (-5) + (-9))
+        )
+    );
+}

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/mod.rs
@@ -11,3 +11,6 @@ pub use subclaim::Subclaim;
 
 mod prover_round;
 use prover_round::prove_round;
+
+#[cfg(test)]
+mod test_cases;

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/test_cases.rs
@@ -1,0 +1,96 @@
+use crate::base::{polynomial::CompositePolynomial, scalar::Scalar};
+use core::iter;
+use itertools::Itertools;
+
+pub struct SumcheckTestCase<S: Scalar> {
+    pub polynomial: CompositePolynomial<S>,
+    pub num_vars: usize,
+    pub max_multiplicands: usize,
+    pub sum: S,
+}
+
+impl<S: Scalar> SumcheckTestCase<S> {
+    fn rand(
+        num_vars: usize,
+        max_multiplicands: usize,
+        products: impl IntoIterator<Item = impl IntoIterator<Item = usize>>,
+        rng: &mut (impl ark_std::rand::Rng + ?Sized),
+    ) -> Self {
+        let length = 1 << num_vars;
+        let products_vec: Vec<Vec<usize>> = products
+            .into_iter()
+            .map(|p| p.into_iter().collect())
+            .collect();
+        let num_multiplicands = products_vec
+            .iter()
+            .map(|p| p.iter().max().copied().unwrap_or(0))
+            .max()
+            .unwrap_or(0)
+            + 1;
+        let polynomial = CompositePolynomial::<S>::rand(
+            num_vars,
+            max_multiplicands,
+            iter::repeat(length).take(num_multiplicands),
+            products_vec,
+            rng,
+        );
+        let sum = polynomial.hypercube_sum(length);
+        Self {
+            polynomial,
+            num_vars,
+            max_multiplicands,
+            sum,
+        }
+    }
+}
+
+pub fn sumcheck_test_cases<S: Scalar>(
+    rng: &mut (impl ark_std::rand::Rng + ?Sized),
+) -> impl Iterator<Item = SumcheckTestCase<S>> + '_ {
+    (1..=8)
+        .cartesian_product(1..=5)
+        .flat_map(|(num_vars, max_multiplicands)| {
+            [
+                Some(vec![]),
+                Some(vec![vec![]]),
+                (max_multiplicands >= 1).then_some(vec![vec![0]]),
+                (max_multiplicands >= 2).then_some(vec![vec![0, 1]]),
+                (max_multiplicands >= 3).then_some(vec![
+                    vec![0, 1, 2],
+                    vec![3, 4],
+                    vec![0],
+                    vec![],
+                ]),
+                (max_multiplicands >= 5).then_some(vec![
+                    vec![7, 0],
+                    vec![2, 4, 8, 5],
+                    vec![],
+                    vec![3],
+                    vec![1, 0, 8, 5, 0],
+                    vec![3, 6, 9, 9],
+                    vec![7, 8, 3],
+                    vec![4, 3, 2],
+                    vec![],
+                    vec![9, 8, 2],
+                ]),
+                (max_multiplicands >= 3).then_some(vec![
+                    vec![],
+                    vec![1, 0],
+                    vec![3, 6, 1],
+                    vec![],
+                    vec![],
+                    vec![1, 8],
+                    vec![1],
+                    vec![8],
+                    vec![6, 6],
+                    vec![4, 6, 7],
+                ]),
+            ]
+            .into_iter()
+            .flatten()
+            .map(move |products| (num_vars, max_multiplicands, products))
+        })
+        .map(|(num_vars, max_multiplicands, products)| {
+            SumcheckTestCase::rand(num_vars, max_multiplicands, products, rng)
+        })
+}


### PR DESCRIPTION
# Rationale for this change

The tests we have for sumcheck do not cover as many edge cases as they should. This PR adds many more tests cases.

# What changes are included in this PR?

See the individual commits.

* Added CompositePolynomial::rand and `CompositePolynomial::hypercube_sum` - These two methods are useful for generating test cases for sumcheck.
* Added `sumcheck::test_cases` module that enumerates a bunch of test cases that we should be testing. These test cases are intended to be re-used. In particular, 
* Added a test for all of these test cases.


# Are these changes tested?

Yes