### PR TITLE
feat: bump `lalrpop` to 0.22.0 and remove patch from the no std check in CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -57,10 +57,9 @@ jobs:
         run: cargo check -p proof-of-sql --no-default-features --features="perf"
       - name: Run cargo check (proof-of-sql) (just "std" feature)
         run: cargo check -p proof-of-sql --no-default-features --features="std"
-      - name: Run cargo check (proof-of-sql-parser) with no_std target. This requires a lalrpop patch.
+      - name: Run cargo check (proof-of-sql-parser) with no_std target.
         run: |
           rustup target add thumbv7em-none-eabi
-          printf '\n[patch.crates-io]\nlalrpop = { git = "https://github.com/lalrpop/lalrpop", rev = "173597c" }\nlalrpop-util = { git = "https://github.com/lalrpop/lalrpop", rev = "173597c" }\n' >> Cargo.toml
           cargo check -p proof-of-sql-parser --target thumbv7em-none-eabi
 
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ derive_more = { version = "0.99" }
 flexbuffers = { version = "2.0.0" }
 indexmap = { version = "2.1", default-features = false }
 itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }
-lalrpop = { version = "0.21.0" }
-lalrpop-util = { version = "0.21.0", default-features = false }
+lalrpop = { version = "0.22.0" }
+lalrpop-util = { version = "0.22.0", default-features = false }
 merlin = { version = "2" }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4.4", default-features = false }


### PR DESCRIPTION
# Rationale for this change
Bump `lalrpop` to support https://github.com/lalrpop/lalrpop/pull/957
<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
- Bump `lalrpop` to 0.22.0
- Remove patch from the no std check in CI
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
