### PR TITLE
ci: update check-approver to trigger on pull request review submission

### DIFF
--- a/.github/workflows/check-approver.yaml
+++ b/.github/workflows/check-approver.yaml
@@ -1,8 +1,8 @@
 name: Check Approver
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize]
+  pull_request_review:
+    types: [submitted]
 
 permissions: read-all
 


### PR DESCRIPTION
Instead of triggering on pull request events, we'll now trigger on review submissions. This will handle the case where an approval was not immediately triggering the workflow.
