### PR TITLE
chore: resolve `clippy::must_use_candidate` and `clippy::range_plus_one` lints in `proof-of-sql`

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -221,7 +221,7 @@ impl ColumnBounds {
     /// Construct a [`ColumnBounds`] from a column by reference.
     ///
     /// If the column variant has order, only the minimum and maximum value will be copied.
-    pub fn from_column(column: &CommittableColumn) -> ColumnBounds {
+    #[must_use] pub fn from_column(column: &CommittableColumn) -> ColumnBounds {
         match column {
             CommittableColumn::SmallInt(ints) => ColumnBounds::SmallInt(Bounds::from_iter(*ints)),
             CommittableColumn::Int(ints) => ColumnBounds::Int(Bounds::from_iter(*ints)),

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -221,7 +221,8 @@ impl ColumnBounds {
     /// Construct a [`ColumnBounds`] from a column by reference.
     ///
     /// If the column variant has order, only the minimum and maximum value will be copied.
-    #[must_use] pub fn from_column(column: &CommittableColumn) -> ColumnBounds {
+    #[must_use]
+    pub fn from_column(column: &CommittableColumn) -> ColumnBounds {
         match column {
             CommittableColumn::SmallInt(ints) => ColumnBounds::SmallInt(Bounds::from_iter(*ints)),
             CommittableColumn::Int(ints) => ColumnBounds::Int(Bounds::from_iter(*ints)),

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -67,7 +67,8 @@ impl ColumnCommitmentMetadata {
     }
 
     /// Construct a [`ColumnCommitmentMetadata`] with widest possible bounds for the column type.
-    #[must_use] pub fn from_column_type_with_max_bounds(column_type: ColumnType) -> Self {
+    #[must_use]
+    pub fn from_column_type_with_max_bounds(column_type: ColumnType) -> Self {
         let bounds = match column_type {
             ColumnType::SmallInt => ColumnBounds::SmallInt(super::Bounds::Bounded(
                 BoundsInner::try_new(i16::MIN, i16::MAX)
@@ -100,17 +101,20 @@ impl ColumnCommitmentMetadata {
     }
 
     /// Immutable reference to this column's type.
-    #[must_use] pub fn column_type(&self) -> &ColumnType {
+    #[must_use]
+    pub fn column_type(&self) -> &ColumnType {
         &self.column_type
     }
 
     /// Immutable reference to this column's bounds.
-    #[must_use] pub fn bounds(&self) -> &ColumnBounds {
+    #[must_use]
+    pub fn bounds(&self) -> &ColumnBounds {
         &self.bounds
     }
 
     /// Contruct a [`ColumnCommitmentMetadata`] by analyzing a column.
-    #[must_use] pub fn from_column(column: &CommittableColumn) -> ColumnCommitmentMetadata {
+    #[must_use]
+    pub fn from_column(column: &CommittableColumn) -> ColumnCommitmentMetadata {
         ColumnCommitmentMetadata {
             column_type: column.column_type(),
             bounds: ColumnBounds::from_column(column),

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -67,7 +67,7 @@ impl ColumnCommitmentMetadata {
     }
 
     /// Construct a [`ColumnCommitmentMetadata`] with widest possible bounds for the column type.
-    pub fn from_column_type_with_max_bounds(column_type: ColumnType) -> Self {
+    #[must_use] pub fn from_column_type_with_max_bounds(column_type: ColumnType) -> Self {
         let bounds = match column_type {
             ColumnType::SmallInt => ColumnBounds::SmallInt(super::Bounds::Bounded(
                 BoundsInner::try_new(i16::MIN, i16::MAX)
@@ -100,17 +100,17 @@ impl ColumnCommitmentMetadata {
     }
 
     /// Immutable reference to this column's type.
-    pub fn column_type(&self) -> &ColumnType {
+    #[must_use] pub fn column_type(&self) -> &ColumnType {
         &self.column_type
     }
 
     /// Immutable reference to this column's bounds.
-    pub fn bounds(&self) -> &ColumnBounds {
+    #[must_use] pub fn bounds(&self) -> &ColumnBounds {
         &self.bounds
     }
 
     /// Contruct a [`ColumnCommitmentMetadata`] by analyzing a column.
-    pub fn from_column(column: &CommittableColumn) -> ColumnCommitmentMetadata {
+    #[must_use] pub fn from_column(column: &CommittableColumn) -> ColumnCommitmentMetadata {
         ColumnCommitmentMetadata {
             column_type: column.column_type(),
             bounds: ColumnBounds::from_column(column),

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -75,34 +75,34 @@ impl<C: Commitment> ColumnCommitments<C> {
     }
 
     /// Returns a reference to the stored commitments.
-    pub fn commitments(&self) -> &Vec<C> {
+    #[must_use] pub fn commitments(&self) -> &Vec<C> {
         &self.commitments
     }
 
     /// Returns a reference to the stored column metadata.
-    pub fn column_metadata(&self) -> &ColumnCommitmentMetadataMap {
+    #[must_use] pub fn column_metadata(&self) -> &ColumnCommitmentMetadataMap {
         &self.column_metadata
     }
 
     /// Returns the number of columns.
-    pub fn len(&self) -> usize {
+    #[must_use] pub fn len(&self) -> usize {
         self.column_metadata.len()
     }
 
     /// Returns true if there are no columns.
-    pub fn is_empty(&self) -> bool {
+    #[must_use] pub fn is_empty(&self) -> bool {
         self.column_metadata.is_empty()
     }
 
     /// Returns the commitment with the given identifier.
-    pub fn get_commitment(&self, identifier: &Identifier) -> Option<C> {
+    #[must_use] pub fn get_commitment(&self, identifier: &Identifier) -> Option<C> {
         self.column_metadata
             .get_index_of(identifier)
             .map(|index| self.commitments[index].clone())
     }
 
     /// Returns the metadata for the commitment with the given identifier.
-    pub fn get_metadata(&self, identifier: &Identifier) -> Option<&ColumnCommitmentMetadata> {
+    #[must_use] pub fn get_metadata(&self, identifier: &Identifier) -> Option<&ColumnCommitmentMetadata> {
         self.column_metadata.get(identifier)
     }
 

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -75,34 +75,40 @@ impl<C: Commitment> ColumnCommitments<C> {
     }
 
     /// Returns a reference to the stored commitments.
-    #[must_use] pub fn commitments(&self) -> &Vec<C> {
+    #[must_use]
+    pub fn commitments(&self) -> &Vec<C> {
         &self.commitments
     }
 
     /// Returns a reference to the stored column metadata.
-    #[must_use] pub fn column_metadata(&self) -> &ColumnCommitmentMetadataMap {
+    #[must_use]
+    pub fn column_metadata(&self) -> &ColumnCommitmentMetadataMap {
         &self.column_metadata
     }
 
     /// Returns the number of columns.
-    #[must_use] pub fn len(&self) -> usize {
+    #[must_use]
+    pub fn len(&self) -> usize {
         self.column_metadata.len()
     }
 
     /// Returns true if there are no columns.
-    #[must_use] pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
         self.column_metadata.is_empty()
     }
 
     /// Returns the commitment with the given identifier.
-    #[must_use] pub fn get_commitment(&self, identifier: &Identifier) -> Option<C> {
+    #[must_use]
+    pub fn get_commitment(&self, identifier: &Identifier) -> Option<C> {
         self.column_metadata
             .get_index_of(identifier)
             .map(|index| self.commitments[index].clone())
     }
 
     /// Returns the metadata for the commitment with the given identifier.
-    #[must_use] pub fn get_metadata(&self, identifier: &Identifier) -> Option<&ColumnCommitmentMetadata> {
+    #[must_use]
+    pub fn get_metadata(&self, identifier: &Identifier) -> Option<&ColumnCommitmentMetadata> {
         self.column_metadata.get(identifier)
     }
 

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -48,7 +48,8 @@ pub enum CommittableColumn<'a> {
 
 impl<'a> CommittableColumn<'a> {
     /// Returns the length of the column.
-    #[must_use] pub fn len(&self) -> usize {
+    #[must_use]
+    pub fn len(&self) -> usize {
         match self {
             CommittableColumn::SmallInt(col) => col.len(),
             CommittableColumn::Int(col) => col.len(),
@@ -64,12 +65,14 @@ impl<'a> CommittableColumn<'a> {
     }
 
     /// Returns true if the column is empty.
-    #[must_use] pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Returns the type of the column.
-    #[must_use] pub fn column_type(&self) -> ColumnType {
+    #[must_use]
+    pub fn column_type(&self) -> ColumnType {
         self.into()
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -48,7 +48,7 @@ pub enum CommittableColumn<'a> {
 
 impl<'a> CommittableColumn<'a> {
     /// Returns the length of the column.
-    pub fn len(&self) -> usize {
+    #[must_use] pub fn len(&self) -> usize {
         match self {
             CommittableColumn::SmallInt(col) => col.len(),
             CommittableColumn::Int(col) => col.len(),
@@ -64,12 +64,12 @@ impl<'a> CommittableColumn<'a> {
     }
 
     /// Returns true if the column is empty.
-    pub fn is_empty(&self) -> bool {
+    #[must_use] pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Returns the type of the column.
-    pub fn column_type(&self) -> ColumnType {
+    #[must_use] pub fn column_type(&self) -> ColumnType {
         self.into()
     }
 }

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -170,22 +170,26 @@ impl<C: Commitment> TableCommitment<C> {
     }
 
     /// Returns a reference to this type's internal [`ColumnCommitments`].
-    #[must_use] pub fn column_commitments(&self) -> &ColumnCommitments<C> {
+    #[must_use]
+    pub fn column_commitments(&self) -> &ColumnCommitments<C> {
         &self.column_commitments
     }
 
     /// Returns a reference to the range of rows this type commits to.
-    #[must_use] pub fn range(&self) -> &Range<usize> {
+    #[must_use]
+    pub fn range(&self) -> &Range<usize> {
         &self.range
     }
 
     /// Returns the number of columns in the committed table.
-    #[must_use] pub fn num_columns(&self) -> usize {
+    #[must_use]
+    pub fn num_columns(&self) -> usize {
         self.column_commitments.len()
     }
 
     /// Returns the number of rows that have been committed to.
-    #[must_use] pub fn num_rows(&self) -> usize {
+    #[must_use]
+    pub fn num_rows(&self) -> usize {
         self.range.len()
     }
 

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -170,22 +170,22 @@ impl<C: Commitment> TableCommitment<C> {
     }
 
     /// Returns a reference to this type's internal [`ColumnCommitments`].
-    pub fn column_commitments(&self) -> &ColumnCommitments<C> {
+    #[must_use] pub fn column_commitments(&self) -> &ColumnCommitments<C> {
         &self.column_commitments
     }
 
     /// Returns a reference to the range of rows this type commits to.
-    pub fn range(&self) -> &Range<usize> {
+    #[must_use] pub fn range(&self) -> &Range<usize> {
         &self.range
     }
 
     /// Returns the number of columns in the committed table.
-    pub fn num_columns(&self) -> usize {
+    #[must_use] pub fn num_columns(&self) -> usize {
         self.column_commitments.len()
     }
 
     /// Returns the number of rows that have been committed to.
-    pub fn num_rows(&self) -> usize {
+    #[must_use] pub fn num_rows(&self) -> usize {
         self.range.len()
     }
 

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -56,7 +56,7 @@ pub enum Column<'a, S: Scalar> {
 
 impl<'a, S: Scalar> Column<'a, S> {
     /// Provides the column type associated with the column
-    pub fn column_type(&self) -> ColumnType {
+    #[must_use] pub fn column_type(&self) -> ColumnType {
         match self {
             Self::Boolean(_) => ColumnType::Boolean,
             Self::SmallInt(_) => ColumnType::SmallInt,
@@ -72,7 +72,7 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
     /// Returns the length of the column.
-    pub fn len(&self) -> usize {
+    #[must_use] pub fn len(&self) -> usize {
         match self {
             Self::Boolean(col) => col.len(),
             Self::SmallInt(col) => col.len(),
@@ -89,7 +89,7 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
     /// Returns `true` if the column has no elements.
-    pub fn is_empty(&self) -> bool {
+    #[must_use] pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -238,7 +238,7 @@ pub enum ColumnType {
 
 impl ColumnType {
     /// Returns true if this column is numeric and false otherwise
-    pub fn is_numeric(&self) -> bool {
+    #[must_use] pub fn is_numeric(&self) -> bool {
         matches!(
             self,
             ColumnType::SmallInt
@@ -251,7 +251,7 @@ impl ColumnType {
     }
 
     /// Returns true if this column is an integer and false otherwise
-    pub fn is_integer(&self) -> bool {
+    #[must_use] pub fn is_integer(&self) -> bool {
         matches!(
             self,
             ColumnType::SmallInt | ColumnType::Int | ColumnType::BigInt | ColumnType::Int128
@@ -285,7 +285,7 @@ impl ColumnType {
     /// Returns the larger integer type of two ColumnTypes if they are both integers.
     ///
     /// If either of the columns is not an integer, return None.
-    pub fn max_integer_type(&self, other: &Self) -> Option<Self> {
+    #[must_use] pub fn max_integer_type(&self, other: &Self) -> Option<Self> {
         // If either of the columns is not an integer, return None
         if !self.is_integer() || !other.is_integer() {
             return None;
@@ -298,7 +298,7 @@ impl ColumnType {
     }
 
     /// Returns the precision of a ColumnType if it is converted to a decimal wrapped in Some(). If it can not be converted to a decimal, return None.
-    pub fn precision_value(&self) -> Option<u8> {
+    #[must_use] pub fn precision_value(&self) -> Option<u8> {
         match self {
             Self::SmallInt => Some(5_u8),
             Self::Int => Some(10_u8),
@@ -313,7 +313,7 @@ impl ColumnType {
         }
     }
     /// Returns scale of a ColumnType if it is convertible to a decimal wrapped in Some(). Otherwise return None.
-    pub fn scale(&self) -> Option<i8> {
+    #[must_use] pub fn scale(&self) -> Option<i8> {
         match self {
             Self::Decimal75(_, scale) => Some(*scale),
             Self::SmallInt | Self::Int | Self::BigInt | Self::Int128 | Self::Scalar => Some(0),
@@ -328,7 +328,7 @@ impl ColumnType {
     }
 
     /// Returns the byte size of the column type.
-    pub fn byte_size(&self) -> usize {
+    #[must_use] pub fn byte_size(&self) -> usize {
         match self {
             Self::Boolean => size_of::<bool>(),
             Self::SmallInt => size_of::<i16>(),
@@ -340,12 +340,12 @@ impl ColumnType {
     }
 
     /// Returns the bit size of the column type.
-    pub fn bit_size(&self) -> u32 {
+    #[must_use] pub fn bit_size(&self) -> u32 {
         self.byte_size() as u32 * 8
     }
 
     /// Returns if the column type supports signed values.
-    pub const fn is_signed(&self) -> bool {
+    #[must_use] pub const fn is_signed(&self) -> bool {
         match self {
             Self::SmallInt | Self::Int | Self::BigInt | Self::Int128 | Self::TimestampTZ(_, _) => {
                 true
@@ -452,7 +452,7 @@ pub struct ColumnRef {
 
 impl ColumnRef {
     /// Create a new `ColumnRef` from a table, column identifier and column type
-    pub fn new(table_ref: TableRef, column_id: Identifier, column_type: ColumnType) -> Self {
+    #[must_use] pub fn new(table_ref: TableRef, column_id: Identifier, column_type: ColumnType) -> Self {
         Self {
             column_id,
             column_type,
@@ -461,17 +461,17 @@ impl ColumnRef {
     }
 
     /// Returns the table reference of this column
-    pub fn table_ref(&self) -> TableRef {
+    #[must_use] pub fn table_ref(&self) -> TableRef {
         self.table_ref
     }
 
     /// Returns the column identifier of this column
-    pub fn column_id(&self) -> Identifier {
+    #[must_use] pub fn column_id(&self) -> Identifier {
         self.column_id
     }
 
     /// Returns the column type of this column
-    pub fn column_type(&self) -> &ColumnType {
+    #[must_use] pub fn column_type(&self) -> &ColumnType {
         &self.column_type
     }
 }
@@ -488,17 +488,17 @@ pub struct ColumnField {
 
 impl ColumnField {
     /// Create a new `ColumnField` from a name and a type
-    pub fn new(name: Identifier, data_type: ColumnType) -> ColumnField {
+    #[must_use] pub fn new(name: Identifier, data_type: ColumnType) -> ColumnField {
         ColumnField { name, data_type }
     }
 
     /// Returns the name of the column
-    pub fn name(&self) -> Identifier {
+    #[must_use] pub fn name(&self) -> Identifier {
         self.name
     }
 
     /// Returns the type of the column
-    pub fn data_type(&self) -> ColumnType {
+    #[must_use] pub fn data_type(&self) -> ColumnType {
         self.data_type
     }
 }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -56,7 +56,8 @@ pub enum Column<'a, S: Scalar> {
 
 impl<'a, S: Scalar> Column<'a, S> {
     /// Provides the column type associated with the column
-    #[must_use] pub fn column_type(&self) -> ColumnType {
+    #[must_use]
+    pub fn column_type(&self) -> ColumnType {
         match self {
             Self::Boolean(_) => ColumnType::Boolean,
             Self::SmallInt(_) => ColumnType::SmallInt,
@@ -72,7 +73,8 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
     /// Returns the length of the column.
-    #[must_use] pub fn len(&self) -> usize {
+    #[must_use]
+    pub fn len(&self) -> usize {
         match self {
             Self::Boolean(col) => col.len(),
             Self::SmallInt(col) => col.len(),
@@ -89,7 +91,8 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
     /// Returns `true` if the column has no elements.
-    #[must_use] pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
@@ -238,7 +241,8 @@ pub enum ColumnType {
 
 impl ColumnType {
     /// Returns true if this column is numeric and false otherwise
-    #[must_use] pub fn is_numeric(&self) -> bool {
+    #[must_use]
+    pub fn is_numeric(&self) -> bool {
         matches!(
             self,
             ColumnType::SmallInt
@@ -251,7 +255,8 @@ impl ColumnType {
     }
 
     /// Returns true if this column is an integer and false otherwise
-    #[must_use] pub fn is_integer(&self) -> bool {
+    #[must_use]
+    pub fn is_integer(&self) -> bool {
         matches!(
             self,
             ColumnType::SmallInt | ColumnType::Int | ColumnType::BigInt | ColumnType::Int128
@@ -285,7 +290,8 @@ impl ColumnType {
     /// Returns the larger integer type of two ColumnTypes if they are both integers.
     ///
     /// If either of the columns is not an integer, return None.
-    #[must_use] pub fn max_integer_type(&self, other: &Self) -> Option<Self> {
+    #[must_use]
+    pub fn max_integer_type(&self, other: &Self) -> Option<Self> {
         // If either of the columns is not an integer, return None
         if !self.is_integer() || !other.is_integer() {
             return None;
@@ -298,7 +304,8 @@ impl ColumnType {
     }
 
     /// Returns the precision of a ColumnType if it is converted to a decimal wrapped in Some(). If it can not be converted to a decimal, return None.
-    #[must_use] pub fn precision_value(&self) -> Option<u8> {
+    #[must_use]
+    pub fn precision_value(&self) -> Option<u8> {
         match self {
             Self::SmallInt => Some(5_u8),
             Self::Int => Some(10_u8),
@@ -313,7 +320,8 @@ impl ColumnType {
         }
     }
     /// Returns scale of a ColumnType if it is convertible to a decimal wrapped in Some(). Otherwise return None.
-    #[must_use] pub fn scale(&self) -> Option<i8> {
+    #[must_use]
+    pub fn scale(&self) -> Option<i8> {
         match self {
             Self::Decimal75(_, scale) => Some(*scale),
             Self::SmallInt | Self::Int | Self::BigInt | Self::Int128 | Self::Scalar => Some(0),
@@ -328,7 +336,8 @@ impl ColumnType {
     }
 
     /// Returns the byte size of the column type.
-    #[must_use] pub fn byte_size(&self) -> usize {
+    #[must_use]
+    pub fn byte_size(&self) -> usize {
         match self {
             Self::Boolean => size_of::<bool>(),
             Self::SmallInt => size_of::<i16>(),
@@ -340,12 +349,14 @@ impl ColumnType {
     }
 
     /// Returns the bit size of the column type.
-    #[must_use] pub fn bit_size(&self) -> u32 {
+    #[must_use]
+    pub fn bit_size(&self) -> u32 {
         self.byte_size() as u32 * 8
     }
 
     /// Returns if the column type supports signed values.
-    #[must_use] pub const fn is_signed(&self) -> bool {
+    #[must_use]
+    pub const fn is_signed(&self) -> bool {
         match self {
             Self::SmallInt | Self::Int | Self::BigInt | Self::Int128 | Self::TimestampTZ(_, _) => {
                 true
@@ -452,7 +463,8 @@ pub struct ColumnRef {
 
 impl ColumnRef {
     /// Create a new `ColumnRef` from a table, column identifier and column type
-    #[must_use] pub fn new(table_ref: TableRef, column_id: Identifier, column_type: ColumnType) -> Self {
+    #[must_use]
+    pub fn new(table_ref: TableRef, column_id: Identifier, column_type: ColumnType) -> Self {
         Self {
             column_id,
             column_type,
@@ -461,17 +473,20 @@ impl ColumnRef {
     }
 
     /// Returns the table reference of this column
-    #[must_use] pub fn table_ref(&self) -> TableRef {
+    #[must_use]
+    pub fn table_ref(&self) -> TableRef {
         self.table_ref
     }
 
     /// Returns the column identifier of this column
-    #[must_use] pub fn column_id(&self) -> Identifier {
+    #[must_use]
+    pub fn column_id(&self) -> Identifier {
         self.column_id
     }
 
     /// Returns the column type of this column
-    #[must_use] pub fn column_type(&self) -> &ColumnType {
+    #[must_use]
+    pub fn column_type(&self) -> &ColumnType {
         &self.column_type
     }
 }
@@ -488,17 +503,20 @@ pub struct ColumnField {
 
 impl ColumnField {
     /// Create a new `ColumnField` from a name and a type
-    #[must_use] pub fn new(name: Identifier, data_type: ColumnType) -> ColumnField {
+    #[must_use]
+    pub fn new(name: Identifier, data_type: ColumnType) -> ColumnField {
         ColumnField { name, data_type }
     }
 
     /// Returns the name of the column
-    #[must_use] pub fn name(&self) -> Identifier {
+    #[must_use]
+    pub fn name(&self) -> Identifier {
         self.name
     }
 
     /// Returns the type of the column
-    #[must_use] pub fn data_type(&self) -> ColumnType {
+    #[must_use]
+    pub fn data_type(&self) -> ColumnType {
         self.data_type
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -46,7 +46,7 @@ pub enum OwnedColumn<S: Scalar> {
 
 impl<S: Scalar> OwnedColumn<S> {
     /// Returns the length of the column.
-    pub fn len(&self) -> usize {
+    #[must_use] pub fn len(&self) -> usize {
         match self {
             OwnedColumn::Boolean(col) => col.len(),
             OwnedColumn::SmallInt(col) => col.len(),
@@ -80,7 +80,7 @@ impl<S: Scalar> OwnedColumn<S> {
     }
 
     /// Returns the sliced column.
-    pub fn slice(&self, start: usize, end: usize) -> Self {
+    #[must_use] pub fn slice(&self, start: usize, end: usize) -> Self {
         match self {
             OwnedColumn::Boolean(col) => OwnedColumn::Boolean(col[start..end].to_vec()),
             OwnedColumn::SmallInt(col) => OwnedColumn::SmallInt(col[start..end].to_vec()),
@@ -99,7 +99,7 @@ impl<S: Scalar> OwnedColumn<S> {
     }
 
     /// Returns true if the column is empty.
-    pub fn is_empty(&self) -> bool {
+    #[must_use] pub fn is_empty(&self) -> bool {
         match self {
             OwnedColumn::Boolean(col) => col.is_empty(),
             OwnedColumn::SmallInt(col) => col.is_empty(),
@@ -113,7 +113,7 @@ impl<S: Scalar> OwnedColumn<S> {
         }
     }
     /// Returns the type of the column.
-    pub fn column_type(&self) -> ColumnType {
+    #[must_use] pub fn column_type(&self) -> ColumnType {
         match self {
             OwnedColumn::Boolean(_) => ColumnType::Boolean,
             OwnedColumn::SmallInt(_) => ColumnType::SmallInt,

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -46,7 +46,8 @@ pub enum OwnedColumn<S: Scalar> {
 
 impl<S: Scalar> OwnedColumn<S> {
     /// Returns the length of the column.
-    #[must_use] pub fn len(&self) -> usize {
+    #[must_use]
+    pub fn len(&self) -> usize {
         match self {
             OwnedColumn::Boolean(col) => col.len(),
             OwnedColumn::SmallInt(col) => col.len(),
@@ -80,7 +81,8 @@ impl<S: Scalar> OwnedColumn<S> {
     }
 
     /// Returns the sliced column.
-    #[must_use] pub fn slice(&self, start: usize, end: usize) -> Self {
+    #[must_use]
+    pub fn slice(&self, start: usize, end: usize) -> Self {
         match self {
             OwnedColumn::Boolean(col) => OwnedColumn::Boolean(col[start..end].to_vec()),
             OwnedColumn::SmallInt(col) => OwnedColumn::SmallInt(col[start..end].to_vec()),
@@ -99,7 +101,8 @@ impl<S: Scalar> OwnedColumn<S> {
     }
 
     /// Returns true if the column is empty.
-    #[must_use] pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
         match self {
             OwnedColumn::Boolean(col) => col.is_empty(),
             OwnedColumn::SmallInt(col) => col.is_empty(),
@@ -113,7 +116,8 @@ impl<S: Scalar> OwnedColumn<S> {
         }
     }
     /// Returns the type of the column.
-    #[must_use] pub fn column_type(&self) -> ColumnType {
+    #[must_use]
+    pub fn column_type(&self) -> ColumnType {
         match self {
             OwnedColumn::Boolean(_) => ColumnType::Boolean,
             OwnedColumn::SmallInt(_) => ColumnType::SmallInt,

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -39,11 +39,11 @@ impl<S: Scalar> OwnedTable<S> {
         Self::try_new(IndexMap::from_iter(iter))
     }
     /// Number of columns in the table.
-    pub fn num_columns(&self) -> usize {
+    #[must_use] pub fn num_columns(&self) -> usize {
         self.table.len()
     }
     /// Number of rows in the table.
-    pub fn num_rows(&self) -> usize {
+    #[must_use] pub fn num_rows(&self) -> usize {
         if self.table.is_empty() {
             0
         } else {
@@ -51,15 +51,15 @@ impl<S: Scalar> OwnedTable<S> {
         }
     }
     /// Whether the table has no columns.
-    pub fn is_empty(&self) -> bool {
+    #[must_use] pub fn is_empty(&self) -> bool {
         self.table.is_empty()
     }
     /// Returns the columns of this table as an IndexMap
-    pub fn into_inner(self) -> IndexMap<Identifier, OwnedColumn<S>> {
+    #[must_use] pub fn into_inner(self) -> IndexMap<Identifier, OwnedColumn<S>> {
         self.table
     }
     /// Returns the columns of this table as an IndexMap
-    pub fn inner_table(&self) -> &IndexMap<Identifier, OwnedColumn<S>> {
+    #[must_use] pub fn inner_table(&self) -> &IndexMap<Identifier, OwnedColumn<S>> {
         &self.table
     }
     /// Returns the columns of this table as an Iterator

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -39,11 +39,13 @@ impl<S: Scalar> OwnedTable<S> {
         Self::try_new(IndexMap::from_iter(iter))
     }
     /// Number of columns in the table.
-    #[must_use] pub fn num_columns(&self) -> usize {
+    #[must_use]
+    pub fn num_columns(&self) -> usize {
         self.table.len()
     }
     /// Number of rows in the table.
-    #[must_use] pub fn num_rows(&self) -> usize {
+    #[must_use]
+    pub fn num_rows(&self) -> usize {
         if self.table.is_empty() {
             0
         } else {
@@ -51,15 +53,18 @@ impl<S: Scalar> OwnedTable<S> {
         }
     }
     /// Whether the table has no columns.
-    #[must_use] pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
         self.table.is_empty()
     }
     /// Returns the columns of this table as an IndexMap
-    #[must_use] pub fn into_inner(self) -> IndexMap<Identifier, OwnedColumn<S>> {
+    #[must_use]
+    pub fn into_inner(self) -> IndexMap<Identifier, OwnedColumn<S>> {
         self.table
     }
     /// Returns the columns of this table as an IndexMap
-    #[must_use] pub fn inner_table(&self) -> &IndexMap<Identifier, OwnedColumn<S>> {
+    #[must_use]
+    pub fn inner_table(&self) -> &IndexMap<Identifier, OwnedColumn<S>> {
         &self.table
     }
     /// Returns the columns of this table as an Iterator

--- a/crates/proof-of-sql/src/base/database/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/scalar_and_i256_conversions.rs
@@ -29,7 +29,7 @@ pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
 
 /// Converts an arrow i256 into limbed representation and then
 /// into a type implementing [Scalar]
-pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
+#[must_use] pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
     // Check if value is within the bounds
     if value < &MIN_SUPPORTED_I256 || value > &MAX_SUPPORTED_I256 {
         None

--- a/crates/proof-of-sql/src/base/database/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/scalar_and_i256_conversions.rs
@@ -29,7 +29,8 @@ pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
 
 /// Converts an arrow i256 into limbed representation and then
 /// into a type implementing [Scalar]
-#[must_use] pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
+#[must_use]
+pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
     // Check if value is within the bounds
     if value < &MIN_SUPPORTED_I256 || value > &MAX_SUPPORTED_I256 {
         None

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -14,22 +14,26 @@ pub struct TableRef {
 
 impl TableRef {
     /// Creates a new table reference from a resource id
-    #[must_use] pub fn new(resource_id: ResourceId) -> Self {
+    #[must_use]
+    pub fn new(resource_id: ResourceId) -> Self {
         Self { resource_id }
     }
 
     /// Returns the identifier of the schema
-    #[must_use] pub fn schema_id(&self) -> Identifier {
+    #[must_use]
+    pub fn schema_id(&self) -> Identifier {
         self.resource_id.schema()
     }
 
     /// Returns the identifier of the table
-    #[must_use] pub fn table_id(&self) -> Identifier {
+    #[must_use]
+    pub fn table_id(&self) -> Identifier {
         self.resource_id.object_name()
     }
 
     /// Returns the underlying resource id of the table
-    #[must_use] pub fn resource_id(&self) -> ResourceId {
+    #[must_use]
+    pub fn resource_id(&self) -> ResourceId {
         self.resource_id
     }
 }

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -14,22 +14,22 @@ pub struct TableRef {
 
 impl TableRef {
     /// Creates a new table reference from a resource id
-    pub fn new(resource_id: ResourceId) -> Self {
+    #[must_use] pub fn new(resource_id: ResourceId) -> Self {
         Self { resource_id }
     }
 
     /// Returns the identifier of the schema
-    pub fn schema_id(&self) -> Identifier {
+    #[must_use] pub fn schema_id(&self) -> Identifier {
         self.resource_id.schema()
     }
 
     /// Returns the identifier of the table
-    pub fn table_id(&self) -> Identifier {
+    #[must_use] pub fn table_id(&self) -> Identifier {
         self.resource_id.object_name()
     }
 
     /// Returns the underlying resource id of the table
-    pub fn resource_id(&self) -> ResourceId {
+    #[must_use] pub fn resource_id(&self) -> ResourceId {
         self.resource_id
     }
 }

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -85,7 +85,8 @@ impl Precision {
     }
 
     /// Gets the precision as a u8 for this decimal
-    #[must_use] pub fn value(&self) -> u8 {
+    #[must_use]
+    pub fn value(&self) -> u8 {
         self.0
     }
 }

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -85,7 +85,7 @@ impl Precision {
     }
 
     /// Gets the precision as a u8 for this decimal
-    pub fn value(&self) -> u8 {
+    #[must_use] pub fn value(&self) -> u8 {
         self.0
     }
 }

--- a/crates/proof-of-sql/src/lib.rs
+++ b/crates/proof-of-sql/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::missing_panics_doc)] // Fixed in Issue #163
 extern crate alloc;
 
 pub mod base;

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
@@ -10,18 +10,18 @@ impl<'a> DoryProverPublicSetup<'a> {
     /// Create a new public setup for the Dory PCS.
     /// public_parameters: The public parameters for the Dory protocol.
     /// sigma: A commitment with this setup is a matrix commitment with `1 << sigma` columns.
-    pub fn new(prover_setup: &'a ProverSetup<'a>, sigma: usize) -> Self {
+    #[must_use] pub fn new(prover_setup: &'a ProverSetup<'a>, sigma: usize) -> Self {
         Self {
             prover_setup,
             sigma,
         }
     }
     /// Returns sigma. A commitment with this setup is a matrix commitment with `1 << sigma` columns.
-    pub fn sigma(&self) -> usize {
+    #[must_use] pub fn sigma(&self) -> usize {
         self.sigma
     }
     /// The public setup for the Dory protocol.
-    pub fn prover_setup(&self) -> &ProverSetup {
+    #[must_use] pub fn prover_setup(&self) -> &ProverSetup {
         self.prover_setup
     }
 }
@@ -36,18 +36,18 @@ impl<'a> DoryVerifierPublicSetup<'a> {
     /// Create a new public setup for the Dory PCS.
     /// verifier_setup: The verifier's setup parameters for the Dory protocol.
     /// sigma: A commitment with this setup is a matrix commitment with `1 << sigma` columns.
-    pub fn new(verifier_setup: &'a VerifierSetup, sigma: usize) -> Self {
+    #[must_use] pub fn new(verifier_setup: &'a VerifierSetup, sigma: usize) -> Self {
         Self {
             verifier_setup,
             sigma,
         }
     }
     /// Returns sigma. A commitment with this setup is a matrix commitment with `1<<sigma` columns.
-    pub fn sigma(&self) -> usize {
+    #[must_use] pub fn sigma(&self) -> usize {
         self.sigma
     }
     /// The verifier's setup parameters for the Dory protocol.
-    pub fn verifier_setup(&self) -> &VerifierSetup {
+    #[must_use] pub fn verifier_setup(&self) -> &VerifierSetup {
         self.verifier_setup
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_public_setup.rs
@@ -10,18 +10,21 @@ impl<'a> DoryProverPublicSetup<'a> {
     /// Create a new public setup for the Dory PCS.
     /// public_parameters: The public parameters for the Dory protocol.
     /// sigma: A commitment with this setup is a matrix commitment with `1 << sigma` columns.
-    #[must_use] pub fn new(prover_setup: &'a ProverSetup<'a>, sigma: usize) -> Self {
+    #[must_use]
+    pub fn new(prover_setup: &'a ProverSetup<'a>, sigma: usize) -> Self {
         Self {
             prover_setup,
             sigma,
         }
     }
     /// Returns sigma. A commitment with this setup is a matrix commitment with `1 << sigma` columns.
-    #[must_use] pub fn sigma(&self) -> usize {
+    #[must_use]
+    pub fn sigma(&self) -> usize {
         self.sigma
     }
     /// The public setup for the Dory protocol.
-    #[must_use] pub fn prover_setup(&self) -> &ProverSetup {
+    #[must_use]
+    pub fn prover_setup(&self) -> &ProverSetup {
         self.prover_setup
     }
 }
@@ -36,18 +39,21 @@ impl<'a> DoryVerifierPublicSetup<'a> {
     /// Create a new public setup for the Dory PCS.
     /// verifier_setup: The verifier's setup parameters for the Dory protocol.
     /// sigma: A commitment with this setup is a matrix commitment with `1 << sigma` columns.
-    #[must_use] pub fn new(verifier_setup: &'a VerifierSetup, sigma: usize) -> Self {
+    #[must_use]
+    pub fn new(verifier_setup: &'a VerifierSetup, sigma: usize) -> Self {
         Self {
             verifier_setup,
             sigma,
         }
     }
     /// Returns sigma. A commitment with this setup is a matrix commitment with `1<<sigma` columns.
-    #[must_use] pub fn sigma(&self) -> usize {
+    #[must_use]
+    pub fn sigma(&self) -> usize {
         self.sigma
     }
     /// The verifier's setup parameters for the Dory protocol.
-    #[must_use] pub fn verifier_setup(&self) -> &VerifierSetup {
+    #[must_use]
+    pub fn verifier_setup(&self) -> &VerifierSetup {
         self.verifier_setup
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -49,7 +49,7 @@ impl<'a> ProverSetup<'a> {
         let blitzar_handle = blitzar::compute::MsmHandle::new(&Vec::from_iter(
             Gamma_1.iter().copied().map(Into::into),
         ));
-        let (Gamma_1, Gamma_2): (Vec<_>, Vec<_>) = (0..max_nu + 1)
+        let (Gamma_1, Gamma_2): (Vec<_>, Vec<_>) = (0..=max_nu)
             .map(|k| (&Gamma_1[..1 << k], &Gamma_2[..1 << k]))
             .unzip();
         ProverSetup {
@@ -151,8 +151,7 @@ impl VerifierSetup {
     ) -> Self {
         assert_eq!(Gamma_1_nu.len(), 1 << max_nu);
         assert_eq!(Gamma_2_nu.len(), 1 << max_nu);
-        let (Delta_1L_2L, Delta_1R, Delta_2R, chi): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) = (0..max_nu
-            + 1)
+        let (Delta_1L_2L, Delta_1R, Delta_2R, chi): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) = (0..=max_nu)
             .map(|k| {
                 if k == 0 {
                     (

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -87,7 +87,7 @@ impl<S: Scalar> SumcheckProof<S> {
             let start_index = round_index * (polynomial_info.max_multiplicands + 1);
             transcript.extend_scalars_as_be(
                 &self.coefficients
-                    [start_index..start_index + polynomial_info.max_multiplicands + 1],
+                    [start_index..=(start_index + polynomial_info.max_multiplicands)],
             );
             let round_evaluation_point = transcript.scalar_challenge_as_be();
             evaluation_point.push(round_evaluation_point);
@@ -95,7 +95,7 @@ impl<S: Scalar> SumcheckProof<S> {
             let mut actual_sum = round_evaluation
                 + self.coefficients[start_index + polynomial_info.max_multiplicands];
             for coefficient_index in
-                start_index + 1..start_index + polynomial_info.max_multiplicands + 1
+                (start_index + 1)..=(start_index + polynomial_info.max_multiplicands)
             {
                 round_evaluation *= round_evaluation_point;
                 round_evaluation += self.coefficients[coefficient_index];

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -86,8 +86,7 @@ impl<S: Scalar> SumcheckProof<S> {
         for round_index in 0..polynomial_info.num_variables {
             let start_index = round_index * (polynomial_info.max_multiplicands + 1);
             transcript.extend_scalars_as_be(
-                &self.coefficients
-                    [start_index..=(start_index + polynomial_info.max_multiplicands)],
+                &self.coefficients[start_index..=(start_index + polynomial_info.max_multiplicands)],
             );
             let round_evaluation_point = transcript.scalar_challenge_as_be();
             evaluation_point.push(round_evaluation_point);

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -169,17 +169,17 @@ impl GroupByPostprocessing {
     }
 
     /// Get group by identifiers
-    pub fn group_by(&self) -> &[Identifier] {
+    #[must_use] pub fn group_by(&self) -> &[Identifier] {
         &self.group_by_identifiers
     }
 
     /// Get remainder expressions for SELECT
-    pub fn remainder_exprs(&self) -> &[AliasedResultExpr] {
+    #[must_use] pub fn remainder_exprs(&self) -> &[AliasedResultExpr] {
         &self.remainder_exprs
     }
 
     /// Get aggregation expressions
-    pub fn aggregation_exprs(&self) -> &[(AggregationOperator, Expression, Identifier)] {
+    #[must_use] pub fn aggregation_exprs(&self) -> &[(AggregationOperator, Expression, Identifier)] {
         &self.aggregation_exprs
     }
 }

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -169,17 +169,20 @@ impl GroupByPostprocessing {
     }
 
     /// Get group by identifiers
-    #[must_use] pub fn group_by(&self) -> &[Identifier] {
+    #[must_use]
+    pub fn group_by(&self) -> &[Identifier] {
         &self.group_by_identifiers
     }
 
     /// Get remainder expressions for SELECT
-    #[must_use] pub fn remainder_exprs(&self) -> &[AliasedResultExpr] {
+    #[must_use]
+    pub fn remainder_exprs(&self) -> &[AliasedResultExpr] {
         &self.remainder_exprs
     }
 
     /// Get aggregation expressions
-    #[must_use] pub fn aggregation_exprs(&self) -> &[(AggregationOperator, Expression, Identifier)] {
+    #[must_use]
+    pub fn aggregation_exprs(&self) -> &[(AggregationOperator, Expression, Identifier)] {
         &self.aggregation_exprs
     }
 }

--- a/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
@@ -19,7 +19,8 @@ pub struct OrderByPostprocessing {
 
 impl OrderByPostprocessing {
     /// Create a new `OrderByPostprocessing` node.
-    #[must_use] pub fn new(by_exprs: Vec<OrderBy>) -> Self {
+    #[must_use]
+    pub fn new(by_exprs: Vec<OrderBy>) -> Self {
         Self { by_exprs }
     }
 }

--- a/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
@@ -19,7 +19,7 @@ pub struct OrderByPostprocessing {
 
 impl OrderByPostprocessing {
     /// Create a new `OrderByPostprocessing` node.
-    pub fn new(by_exprs: Vec<OrderBy>) -> Self {
+    #[must_use] pub fn new(by_exprs: Vec<OrderBy>) -> Self {
         Self { by_exprs }
     }
 }

--- a/crates/proof-of-sql/src/sql/postprocessing/owned_table_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/owned_table_postprocessing.rs
@@ -32,19 +32,19 @@ impl<S: Scalar> PostprocessingStep<S> for OwnedTablePostprocessing {
 
 impl OwnedTablePostprocessing {
     /// Create a new `OwnedTablePostprocessing` with the given `SlicePostprocessing`.
-    pub fn new_slice(slice_expr: SlicePostprocessing) -> Self {
+    #[must_use] pub fn new_slice(slice_expr: SlicePostprocessing) -> Self {
         Self::Slice(slice_expr)
     }
     /// Create a new `OwnedTablePostprocessing` with the given `OrderByPostprocessing`.
-    pub fn new_order_by(order_by_expr: OrderByPostprocessing) -> Self {
+    #[must_use] pub fn new_order_by(order_by_expr: OrderByPostprocessing) -> Self {
         Self::OrderBy(order_by_expr)
     }
     /// Create a new `OwnedTablePostprocessing` with the given `SelectPostprocessing`.
-    pub fn new_select(select_expr: SelectPostprocessing) -> Self {
+    #[must_use] pub fn new_select(select_expr: SelectPostprocessing) -> Self {
         Self::Select(select_expr)
     }
     /// Create a new `OwnedTablePostprocessing` with the given `GroupByPostprocessing`.
-    pub fn new_group_by(group_by_postprocessing: GroupByPostprocessing) -> Self {
+    #[must_use] pub fn new_group_by(group_by_postprocessing: GroupByPostprocessing) -> Self {
         Self::GroupBy(group_by_postprocessing)
     }
 }

--- a/crates/proof-of-sql/src/sql/postprocessing/owned_table_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/owned_table_postprocessing.rs
@@ -32,19 +32,23 @@ impl<S: Scalar> PostprocessingStep<S> for OwnedTablePostprocessing {
 
 impl OwnedTablePostprocessing {
     /// Create a new `OwnedTablePostprocessing` with the given `SlicePostprocessing`.
-    #[must_use] pub fn new_slice(slice_expr: SlicePostprocessing) -> Self {
+    #[must_use]
+    pub fn new_slice(slice_expr: SlicePostprocessing) -> Self {
         Self::Slice(slice_expr)
     }
     /// Create a new `OwnedTablePostprocessing` with the given `OrderByPostprocessing`.
-    #[must_use] pub fn new_order_by(order_by_expr: OrderByPostprocessing) -> Self {
+    #[must_use]
+    pub fn new_order_by(order_by_expr: OrderByPostprocessing) -> Self {
         Self::OrderBy(order_by_expr)
     }
     /// Create a new `OwnedTablePostprocessing` with the given `SelectPostprocessing`.
-    #[must_use] pub fn new_select(select_expr: SelectPostprocessing) -> Self {
+    #[must_use]
+    pub fn new_select(select_expr: SelectPostprocessing) -> Self {
         Self::Select(select_expr)
     }
     /// Create a new `OwnedTablePostprocessing` with the given `GroupByPostprocessing`.
-    #[must_use] pub fn new_group_by(group_by_postprocessing: GroupByPostprocessing) -> Self {
+    #[must_use]
+    pub fn new_group_by(group_by_postprocessing: GroupByPostprocessing) -> Self {
         Self::GroupBy(group_by_postprocessing)
     }
 }

--- a/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
@@ -17,7 +17,7 @@ pub struct SelectPostprocessing {
 
 impl SelectPostprocessing {
     /// Create a new `SelectPostprocessing` node.
-    pub fn new(aliased_result_exprs: Vec<AliasedResultExpr>) -> Self {
+    #[must_use] pub fn new(aliased_result_exprs: Vec<AliasedResultExpr>) -> Self {
         Self {
             aliased_result_exprs,
         }

--- a/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
@@ -17,7 +17,8 @@ pub struct SelectPostprocessing {
 
 impl SelectPostprocessing {
     /// Create a new `SelectPostprocessing` node.
-    #[must_use] pub fn new(aliased_result_exprs: Vec<AliasedResultExpr>) -> Self {
+    #[must_use]
+    pub fn new(aliased_result_exprs: Vec<AliasedResultExpr>) -> Self {
         Self {
             aliased_result_exprs,
         }

--- a/crates/proof-of-sql/src/sql/postprocessing/slice_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/slice_postprocessing.rs
@@ -21,7 +21,8 @@ pub struct SlicePostprocessing {
 
 impl SlicePostprocessing {
     /// Create a new `SlicePostprocessing` with the given `number_rows` and `offset`.
-    #[must_use] pub fn new(number_rows: Option<u64>, offset_value: Option<i64>) -> Self {
+    #[must_use]
+    pub fn new(number_rows: Option<u64>, offset_value: Option<i64>) -> Self {
         Self {
             number_rows,
             offset_value,

--- a/crates/proof-of-sql/src/sql/postprocessing/slice_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/slice_postprocessing.rs
@@ -21,7 +21,7 @@ pub struct SlicePostprocessing {
 
 impl SlicePostprocessing {
     /// Create a new `SlicePostprocessing` with the given `number_rows` and `offset`.
-    pub fn new(number_rows: Option<u64>, offset_value: Option<i64>) -> Self {
+    #[must_use] pub fn new(number_rows: Option<u64>, offset_value: Option<i64>) -> Self {
         Self {
             number_rows,
             offset_value,

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -21,11 +21,13 @@ pub struct ProvableQueryResult {
 
 impl ProvableQueryResult {
     /// The number of columns in the result
-    #[must_use] pub fn num_columns(&self) -> usize {
+    #[must_use]
+    pub fn num_columns(&self) -> usize {
         self.num_columns as usize
     }
     /// The indexes in the result.
-    #[must_use] pub fn indexes(&self) -> &Indexes {
+    #[must_use]
+    pub fn indexes(&self) -> &Indexes {
         &self.indexes
     }
     /// A mutable reference to a the indexes in the result. Because the struct is deserialized from untrusted data, it
@@ -57,7 +59,8 @@ impl ProvableQueryResult {
     }
 
     /// Form intermediate query result from index rows and result columns
-    #[must_use] pub fn new<'a, S: Scalar>(indexes: &'a Indexes, columns: &'a [Column<'a, S>]) -> Self {
+    #[must_use]
+    pub fn new<'a, S: Scalar>(indexes: &'a Indexes, columns: &'a [Column<'a, S>]) -> Self {
         let mut sz = 0;
         for col in columns.iter() {
             sz += col.num_bytes(indexes);

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -21,11 +21,11 @@ pub struct ProvableQueryResult {
 
 impl ProvableQueryResult {
     /// The number of columns in the result
-    pub fn num_columns(&self) -> usize {
+    #[must_use] pub fn num_columns(&self) -> usize {
         self.num_columns as usize
     }
     /// The indexes in the result.
-    pub fn indexes(&self) -> &Indexes {
+    #[must_use] pub fn indexes(&self) -> &Indexes {
         &self.indexes
     }
     /// A mutable reference to a the indexes in the result. Because the struct is deserialized from untrusted data, it
@@ -57,7 +57,7 @@ impl ProvableQueryResult {
     }
 
     /// Form intermediate query result from index rows and result columns
-    pub fn new<'a, S: Scalar>(indexes: &'a Indexes, columns: &'a [Column<'a, S>]) -> Self {
+    #[must_use] pub fn new<'a, S: Scalar>(indexes: &'a Indexes, columns: &'a [Column<'a, S>]) -> Self {
         let mut sz = 0;
         for col in columns.iter() {
             sz += col.num_bytes(indexes);


### PR DESCRIPTION
# Rationale for this change

We have cargo clippy running in our CI in order to enforce code quality. In order to increase our standards, we should enable the clippy::pedantic lint group.

# What changes are included in this PR?

This PR fixes  `clippy::must_use_candidate` and `clippy::range_plus_one` warnings for `proof-of-sql` lib.

# Are these changes tested?

Yes. In order to test individual lints, we can use the following command:

`cargo clippy --lib -p proof-of-sql -- -W clippy::lint_name`
