### PR TITLE
ci: add `clippy::pedantic` linter to `proof-of-sql-parser`

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -132,6 +132,8 @@ jobs:
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Run clippy::pedantic for proof-of-sql-parser
+        run: cargo clippy --lib -p proof-of-sql-parser -- -D clippy::pedantic
 
   # Run cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
   format:


### PR DESCRIPTION
# Rationale for this change

We have added `clippy::pedantic` support for the `proof-of-sql-parser` crate. Therefore, we're introducing a Clippy check in the CI to enforce the `clippy::pedantic` linter. At this time, we won't include pedantic in the `.toml` file since the `proof-of-sql` library doesn't support it yet.
