### PR TITLE
chore: resolve `clippy::explicit_iter_loop`, `clippy::implicit_clone` and `clippy::uninlined_format_args` lints in `proof-of-sql`

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -39,7 +39,7 @@ impl BitDistribution {
 
     pub fn num_varying_bits(&self) -> usize {
         let mut res = 0_usize;
-        for xi in self.vary_mask.iter() {
+        for xi in &self.vary_mask {
             res += xi.count_ones() as usize;
         }
         res

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -7,7 +7,6 @@ use crate::base::{
     map::IndexSet,
 };
 use alloc::{
-    borrow::ToOwned,
     string::{String, ToString},
     vec,
     vec::Vec,
@@ -206,7 +205,7 @@ impl<C: Commitment> ColumnCommitments<C> {
             identifiers.into_iter().zip(committable_columns.iter()),
         );
 
-        self.column_metadata = self.column_metadata.to_owned().try_union(column_metadata)?;
+        self.column_metadata = self.column_metadata.clone().try_union(column_metadata)?;
 
         self.commitments
             .try_append_rows_with_offset(committable_columns, offset, setup)

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -423,7 +423,7 @@ impl TryFrom<DataType> for ColumnType {
                 ))
             }
             DataType::Utf8 => Ok(ColumnType::VarChar),
-            _ => Err(format!("Unsupported arrow data type {:?}", data_type)),
+            _ => Err(format!("Unsupported arrow data type {data_type:?}")),
         }
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -95,8 +95,7 @@ pub fn try_multiply_column_types(
             ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision {
                     error: format!(
-                        "Required precision {} is beyond what we can support",
-                        precision_value
+                        "Required precision {precision_value} is beyond what we can support"
                     ),
                 },
             }
@@ -242,7 +241,7 @@ where
         .map(|(l, r)| -> ColumnOperationResult<T> {
             l.checked_add(r)
                 .ok_or(ColumnOperationError::IntegerOverflow {
-                    error: format!("Overflow in integer addition {:?} + {:?}", l, r),
+                    error: format!("Overflow in integer addition {l:?} + {r:?}"),
                 })
         })
         .collect::<ColumnOperationResult<Vec<T>>>()
@@ -260,7 +259,7 @@ where
         .map(|(l, r)| -> ColumnOperationResult<T> {
             l.checked_sub(r)
                 .ok_or(ColumnOperationError::IntegerOverflow {
-                    error: format!("Overflow in integer subtraction {:?} - {:?}", l, r),
+                    error: format!("Overflow in integer subtraction {l:?} - {r:?}"),
                 })
         })
         .collect::<ColumnOperationResult<Vec<T>>>()
@@ -278,7 +277,7 @@ where
         .map(|(l, r)| -> ColumnOperationResult<T> {
             l.checked_mul(r)
                 .ok_or(ColumnOperationError::IntegerOverflow {
-                    error: format!("Overflow in integer multiplication {:?} * {:?}", l, r),
+                    error: format!("Overflow in integer multiplication {l:?} * {r:?}"),
                 })
         })
         .collect::<ColumnOperationResult<Vec<T>>>()
@@ -375,7 +374,7 @@ where
         .map(|(l, r)| -> ColumnOperationResult<LargerType> {
             Into::<LargerType>::into(*l).checked_add(r).ok_or(
                 ColumnOperationError::IntegerOverflow {
-                    error: format!("Overflow in integer addition {:?} + {:?}", l, r),
+                    error: format!("Overflow in integer addition {l:?} + {r:?}"),
                 },
             )
         })
@@ -398,7 +397,7 @@ where
         .map(|(l, r)| -> ColumnOperationResult<LargerType> {
             Into::<LargerType>::into(*l).checked_sub(r).ok_or(
                 ColumnOperationError::IntegerOverflow {
-                    error: format!("Overflow in integer subtraction {:?} - {:?}", l, r),
+                    error: format!("Overflow in integer subtraction {l:?} - {r:?}"),
                 },
             )
         })
@@ -421,7 +420,7 @@ where
         .map(|(l, r)| -> ColumnOperationResult<LargerType> {
             l.checked_sub(&Into::<LargerType>::into(*r)).ok_or(
                 ColumnOperationError::IntegerOverflow {
-                    error: format!("Overflow in integer subtraction {:?} - {:?}", l, r),
+                    error: format!("Overflow in integer subtraction {l:?} - {r:?}"),
                 },
             )
         })
@@ -445,7 +444,7 @@ where
         .map(|(l, r)| -> ColumnOperationResult<LargerType> {
             Into::<LargerType>::into(*l).checked_mul(r).ok_or(
                 ColumnOperationError::IntegerOverflow {
-                    error: format!("Overflow in integer multiplication {:?} * {:?}", l, r),
+                    error: format!("Overflow in integer multiplication {l:?} * {r:?}"),
                 },
             )
         })

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -19,7 +19,7 @@ impl<S: Scalar> OwnedTable<S> {
             Expression::Binary { op, left, right } => self.evaluate_binary_expr(*op, left, right),
             Expression::Unary { op, expr } => self.evaluate_unary_expr(*op, expr),
             _ => Err(ExpressionEvaluationError::Unsupported {
-                expression: format!("Expression {:?} is not supported yet", expr),
+                expression: format!("Expression {expr:?} is not supported yet"),
             }),
         }
     }

--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -71,7 +71,7 @@ pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
 
     // we keep reading until we find a byte with the MSB equal to zero,
     // which implies that we have read the whole varint number
-    for next_byte in buf.iter() {
+    for next_byte in buf {
         // we write the `next 7 bits` at the [shift_amount..shift_amount + 7)
         // bit positions of val u256 number
         match shift_amount.cmp(&126_u32) {

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -157,7 +157,7 @@ impl VarInt for u64 {
         let mut shift = 0;
 
         let mut success = false;
-        for b in src.iter() {
+        for b in src {
             let msb_dropped = b & DROP_MSB;
             result |= (msb_dropped as u64) << shift;
             shift += 7;

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -75,8 +75,7 @@ impl Precision {
         if value > MAX_SUPPORTED_PRECISION || value == 0 {
             Err(DecimalError::InvalidPrecision {
                 error: format!(
-                    "Failed to parse precision. Value of {} exceeds max supported precision of {}",
-                    value, MAX_SUPPORTED_PRECISION
+                    "Failed to parse precision. Value of {value} exceeds max supported precision of {MAX_SUPPORTED_PRECISION}"
                 ),
             })
         } else {

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -41,8 +41,7 @@ impl Permutation {
         if elements.len() < length {
             Err(PermutationError::InvalidPermutation {
                 error: format!(
-                    "Permutation can not have duplicate elements: {:?}",
-                    permutation
+                    "Permutation can not have duplicate elements: {permutation:?}"
                 ),
             })
         }
@@ -50,8 +49,7 @@ impl Permutation {
         else if permutation.iter().any(|&i| i >= length) {
             Err(PermutationError::InvalidPermutation {
                 error: format!(
-                    "Permutation can not have elements out of bounds: {:?}",
-                    permutation
+                    "Permutation can not have elements out of bounds: {permutation:?}"
                 ),
             })
         } else {

--- a/crates/proof-of-sql/src/base/math/permutation.rs
+++ b/crates/proof-of-sql/src/base/math/permutation.rs
@@ -40,17 +40,13 @@ impl Permutation {
         elements.dedup();
         if elements.len() < length {
             Err(PermutationError::InvalidPermutation {
-                error: format!(
-                    "Permutation can not have duplicate elements: {permutation:?}"
-                ),
+                error: format!("Permutation can not have duplicate elements: {permutation:?}"),
             })
         }
         // Check that no element is out of bounds
         else if permutation.iter().any(|&i| i >= length) {
             Err(PermutationError::InvalidPermutation {
-                error: format!(
-                    "Permutation can not have elements out of bounds: {permutation:?}"
-                ),
+                error: format!("Permutation can not have elements out of bounds: {permutation:?}"),
             })
         } else {
             Ok(Self { permutation })

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -381,7 +381,7 @@ where
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
-                error: format!("{} is too large to fit in an i8", value),
+                error: format!("{value} is too large to fit in an i8"),
             });
         }
         let val: i128 = sign * abs[0] as i128;
@@ -389,7 +389,7 @@ where
             0 => Ok(false),
             1 => Ok(true),
             _ => Err(ScalarConversionError::Overflow {
-                error: format!("{} is too large to fit in a bool", value),
+                error: format!("{value} is too large to fit in a bool"),
             }),
         }
     }
@@ -409,12 +409,12 @@ where
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
-                error: format!("{} is too large to fit in an i8", value),
+                error: format!("{value} is too large to fit in an i8"),
             });
         }
         let val: i128 = sign * abs[0] as i128;
         val.try_into().map_err(|_| ScalarConversionError::Overflow {
-            error: format!("{} is too large to fit in an i8", value),
+            error: format!("{value} is too large to fit in an i8"),
         })
     }
 }
@@ -433,12 +433,12 @@ where
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
-                error: format!("{} is too large to fit in an i16", value),
+                error: format!("{value} is too large to fit in an i16"),
             });
         }
         let val: i128 = sign * abs[0] as i128;
         val.try_into().map_err(|_| ScalarConversionError::Overflow {
-            error: format!("{} is too large to fit in an i16", value),
+            error: format!("{value} is too large to fit in an i16"),
         })
     }
 }
@@ -457,12 +457,12 @@ where
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
-                error: format!("{} is too large to fit in an i32", value),
+                error: format!("{value} is too large to fit in an i32"),
             });
         }
         let val: i128 = sign * abs[0] as i128;
         val.try_into().map_err(|_| ScalarConversionError::Overflow {
-            error: format!("{} is too large to fit in an i32", value),
+            error: format!("{value} is too large to fit in an i32"),
         })
     }
 }
@@ -481,12 +481,12 @@ where
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
-                error: format!("{} is too large to fit in an i64", value),
+                error: format!("{value} is too large to fit in an i64"),
             });
         }
         let val: i128 = sign * abs[0] as i128;
         val.try_into().map_err(|_| ScalarConversionError::Overflow {
-            error: format!("{} is too large to fit in an i64", value),
+            error: format!("{value} is too large to fit in an i64"),
         })
     }
 }
@@ -505,7 +505,7 @@ where
         };
         if abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
-                error: format!("{} is too large to fit in an i128", value),
+                error: format!("{value} is too large to fit in an i128"),
             });
         }
         let val: u128 = (abs[1] as u128) << 64 | (abs[0] as u128);
@@ -514,7 +514,7 @@ where
             (-1, v) if v <= i128::MAX as u128 => Ok(-(v as i128)),
             (-1, v) if v == i128::MAX as u128 + 1 => Ok(i128::MIN),
             _ => Err(ScalarConversionError::Overflow {
-                error: format!("{} is too large to fit in an i128", value),
+                error: format!("{value} is too large to fit in an i128"),
             }),
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -194,9 +194,7 @@ fn offset_column(
 ) {
     assert!(
         offset < num_matrix_commitment_columns,
-        "offset {} must be less than the number of columns {}",
-        offset,
-        num_matrix_commitment_columns
+        "offset {offset} must be less than the number of columns {num_matrix_commitment_columns}"
     );
 
     assert!(

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -215,9 +215,7 @@ impl DynProofExprBuilder<'_> {
                 ),
             }),
             _ => Err(ConversionError::Unprovable {
-                error: format!(
-                    "Aggregation operator {op:?} is not supported at this location"
-                ),
+                error: format!("Aggregation operator {op:?} is not supported at this location"),
             }),
         }
     }

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -62,7 +62,7 @@ impl DynProofExprBuilder<'_> {
             Expression::Unary { op, expr } => self.visit_unary_expr(*op, expr),
             Expression::Aggregation { op, expr } => self.visit_aggregate_expr(*op, expr),
             _ => Err(ConversionError::Unprovable {
-                error: format!("Expression {:?} is not supported yet", expr),
+                error: format!("Expression {expr:?} is not supported yet"),
             }),
         }
     }
@@ -189,7 +189,7 @@ impl DynProofExprBuilder<'_> {
                 DynProofExpr::try_new_multiply(left?, right?)
             }
             BinaryOperator::Division => Err(ConversionError::Unprovable {
-                error: format!("Binary operator {:?} is not supported at this location", op),
+                error: format!("Binary operator {op:?} is not supported at this location"),
             }),
         }
     }
@@ -211,14 +211,12 @@ impl DynProofExprBuilder<'_> {
             }
             (AggregationOperator::Sum, false) => Err(ConversionError::InvalidExpression {
                 expression: format!(
-                    "Aggregation operator {:?} doesn't work with non-numeric types",
-                    op
+                    "Aggregation operator {op:?} doesn't work with non-numeric types"
                 ),
             }),
             _ => Err(ConversionError::Unprovable {
                 error: format!(
-                    "Aggregation operator {:?} is not supported at this location",
-                    op
+                    "Aggregation operator {op:?} is not supported at this location"
                 ),
             }),
         }

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -99,12 +99,12 @@ impl<S: Scalar> CompositePolynomialBuilder<S> {
             ],
             One::one(),
         );
-        for (mult, terms) in self.fr_multiplicands_rest.iter() {
+        for (mult, terms) in &self.fr_multiplicands_rest {
             let fr_iter = iter::once(self.fr.clone());
             let terms_iter = terms.iter().cloned();
             res.add_product(fr_iter.chain(terms_iter), *mult);
         }
-        for (mult, terms) in self.zerosum_multiplicands.iter() {
+        for (mult, terms) in &self.zerosum_multiplicands {
             let terms_iter = terms.iter().cloned();
             res.add_product(terms_iter, *mult);
         }

--- a/crates/proof-of-sql/src/sql/proof/proof_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_builder.rs
@@ -146,7 +146,7 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
     )]
     pub fn evaluate_pcs_proof_mles(&self, evaluation_vec: &[S]) -> Vec<S> {
         let mut res = Vec::with_capacity(self.pcs_proof_mles.len());
-        for evaluator in self.pcs_proof_mles.iter() {
+        for evaluator in &self.pcs_proof_mles {
             res.push(evaluator.inner_product(evaluation_vec));
         }
         res

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -62,12 +62,12 @@ impl ProvableQueryResult {
     #[must_use]
     pub fn new<'a, S: Scalar>(indexes: &'a Indexes, columns: &'a [Column<'a, S>]) -> Self {
         let mut sz = 0;
-        for col in columns.iter() {
+        for col in columns {
             sz += col.num_bytes(indexes);
         }
         let mut data = vec![0u8; sz];
         let mut sz = 0;
-        for col in columns.iter() {
+        for col in columns {
             sz += col.write(&mut data[sz..], indexes);
         }
         ProvableQueryResult {

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -151,7 +151,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         assert!(num_sumcheck_variables > 0);
 
         // validate bit decompositions
-        for dist in self.bit_distributions.iter() {
+        for dist in &self.bit_distributions {
             if !dist.is_valid() {
                 Err(ProofError::VerificationError {
                     error: "invalid bit distributions",

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -45,7 +45,7 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
         composite_polynomial: &mut CompositePolynomialBuilder<S>,
         group_multiplier: S,
     ) {
-        for (mult, term) in self.terms.iter() {
+        for (mult, term) in &self.terms {
             match self.subpolynomial_type {
                 SumcheckSubpolynomialType::Identity => {
                     composite_polynomial.produce_fr_multiplicand(&(*mult * group_multiplier), term);

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
@@ -164,7 +164,7 @@ fn verifier_const_sign_evaluate<S: Scalar>(
 }
 
 fn prove_bits_are_binary<'a, S: Scalar>(builder: &mut ProofBuilder<'a, S>, bits: &[&'a [bool]]) {
-    for &seq in bits.iter() {
+    for &seq in bits {
         builder.produce_intermediate_mle(seq);
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
@@ -180,7 +180,7 @@ fn verify_bits_are_binary<C: Commitment>(
     builder: &mut VerificationBuilder<C>,
     bit_evals: &[C::Scalar],
 ) {
-    for bit_eval in bit_evals.iter() {
+    for bit_eval in bit_evals {
         builder.produce_sumcheck_subpolynomial_evaluation(
             SumcheckSubpolynomialType::Identity,
             *bit_eval - *bit_eval * *bit_eval,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -66,7 +66,7 @@ where
         _accessor: &dyn MetadataAccessor,
     ) -> Result<(), ProofError> {
         self.where_clause.count(builder)?;
-        for aliased_expr in self.aliased_results.iter() {
+        for aliased_expr in &self.aliased_results {
             aliased_expr.expr.count(builder)?;
             builder.count_result_columns(1);
         }
@@ -135,7 +135,7 @@ where
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         let mut columns = IndexSet::default();
 
-        for aliased_expr in self.aliased_results.iter() {
+        for aliased_expr in &self.aliased_results {
             aliased_expr.expr.get_column_references(&mut columns);
         }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -75,11 +75,11 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
         _accessor: &dyn MetadataAccessor,
     ) -> Result<(), ProofError> {
         self.where_clause.count(builder)?;
-        for expr in self.group_by_exprs.iter() {
+        for expr in &self.group_by_exprs {
             expr.count(builder)?;
             builder.count_result_columns(1);
         }
-        for aliased_expr in self.sum_expr.iter() {
+        for aliased_expr in &self.sum_expr {
             aliased_expr.expr.count(builder)?;
             builder.count_result_columns(1);
         }
@@ -194,10 +194,10 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         let mut columns = IndexSet::default();
 
-        for col in self.group_by_exprs.iter() {
+        for col in &self.group_by_exprs {
             columns.insert(col.get_column_reference());
         }
-        for aliased_expr in self.sum_expr.iter() {
+        for aliased_expr in &self.sum_expr {
             aliased_expr.expr.get_column_references(&mut columns);
         }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -47,7 +47,7 @@ impl<C: Commitment> ProofPlan<C> for ProjectionExec<C> {
         builder: &mut CountBuilder,
         _accessor: &dyn MetadataAccessor,
     ) -> Result<(), ProofError> {
-        for aliased_expr in self.aliased_results.iter() {
+        for aliased_expr in &self.aliased_results {
             aliased_expr.expr.count(builder)?;
             builder.count_result_columns(1);
         }


### PR DESCRIPTION
# Rationale for this change

We have cargo clippy running in our CI in order to enforce code quality. In order to increase our standards, we should enable the clippy::pedantic lint group.

# What changes are included in this PR?

This PR fixes `clippy::explicit_iter_loop`, `clippy::implicit_clone` and `clippy::uninlined_format_args` warnings for proof-of-sql lib.

# Are these changes tested?

Yes.