### PR TITLE
ci: enable CI for merge queue

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Rationale for this change

Merge queues help improve merge velocity.

# What changes are included in this PR?

* The CI jobs now run on the merge queue

# Are these changes tested?

N/A
