### PR TITLE
chore: resolve `clippy::match_same_arms` lints in proof-of-sql

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -232,8 +232,8 @@ impl ColumnBounds {
             CommittableColumn::Boolean(_)
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
-            | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
-            CommittableColumn::RangeCheckWord(_) => ColumnBounds::NoOrder,
+            | CommittableColumn::VarChar(_)
+            | CommittableColumn::RangeCheckWord(_) => ColumnBounds::NoOrder,
         }
     }
 

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -53,13 +53,12 @@ impl<'a> CommittableColumn<'a> {
         match self {
             CommittableColumn::SmallInt(col) => col.len(),
             CommittableColumn::Int(col) => col.len(),
-            CommittableColumn::BigInt(col) => col.len(),
+            CommittableColumn::BigInt(col) | CommittableColumn::TimestampTZ(_, _, col) => col.len(),
             CommittableColumn::Int128(col) => col.len(),
-            CommittableColumn::Decimal75(_, _, col) => col.len(),
-            CommittableColumn::Scalar(col) => col.len(),
-            CommittableColumn::VarChar(col) => col.len(),
+            CommittableColumn::Decimal75(_, _, col)
+            | CommittableColumn::Scalar(col)
+            | CommittableColumn::VarChar(col) => col.len(),
             CommittableColumn::Boolean(col) => col.len(),
-            CommittableColumn::TimestampTZ(_, _, col) => col.len(),
             CommittableColumn::RangeCheckWord(col) => col.len(),
         }
     }
@@ -198,9 +197,9 @@ impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
             CommittableColumn::Int(ints) => Sequence::from(*ints),
             CommittableColumn::BigInt(ints) => Sequence::from(*ints),
             CommittableColumn::Int128(ints) => Sequence::from(*ints),
-            CommittableColumn::Decimal75(_, _, limbs) => Sequence::from(limbs),
-            CommittableColumn::Scalar(limbs) => Sequence::from(limbs),
-            CommittableColumn::VarChar(limbs) => Sequence::from(limbs),
+            CommittableColumn::Decimal75(_, _, limbs)
+            | CommittableColumn::Scalar(limbs)
+            | CommittableColumn::VarChar(limbs) => Sequence::from(limbs),
             CommittableColumn::Boolean(bools) => Sequence::from(*bools),
             CommittableColumn::TimestampTZ(_, _, times) => Sequence::from(*times),
             CommittableColumn::RangeCheckWord(words) => Sequence::from(*words),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -79,15 +79,13 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::Boolean(col) => col.len(),
             Self::SmallInt(col) => col.len(),
             Self::Int(col) => col.len(),
-            Self::BigInt(col) => col.len(),
+            Self::BigInt(col) | Self::TimestampTZ(_, _, col) => col.len(),
             Self::VarChar((col, scals)) => {
                 assert_eq!(col.len(), scals.len());
                 col.len()
             }
             Self::Int128(col) => col.len(),
-            Self::Scalar(col) => col.len(),
-            Self::Decimal75(_, _, col) => col.len(),
-            Self::TimestampTZ(_, _, col) => col.len(),
+            Self::Scalar(col) | Self::Decimal75(_, _, col) => col.len(),
         }
     }
     /// Returns `true` if the column has no elements.
@@ -177,12 +175,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::Boolean(col) => S::from(col[index]),
             Self::SmallInt(col) => S::from(col[index]),
             Self::Int(col) => S::from(col[index]),
-            Self::BigInt(col) => S::from(col[index]),
+            Self::BigInt(col) | Self::TimestampTZ(_, _, col) => S::from(col[index]),
             Self::Int128(col) => S::from(col[index]),
-            Self::Scalar(col) => col[index],
-            Self::Decimal75(_, _, col) => col[index],
+            Self::Scalar(col) | Self::Decimal75(_, _, col) => col[index],
             Self::VarChar((_, scals)) => scals[index],
-            Self::TimestampTZ(_, _, col) => S::from(col[index]),
         })
     }
 
@@ -309,8 +305,7 @@ impl ColumnType {
         match self {
             Self::SmallInt => Some(5_u8),
             Self::Int => Some(10_u8),
-            Self::BigInt => Some(19_u8),
-            Self::TimestampTZ(_, _) => Some(19_u8),
+            Self::BigInt | Self::TimestampTZ(_, _) => Some(19_u8),
             Self::Int128 => Some(39_u8),
             Self::Decimal75(precision, _) => Some(precision.value()),
             // Scalars are not in database & are only used for typeless comparisons for testing so we return 0

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -354,12 +354,11 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
             Column::Boolean(col) => col[i].cmp(&col[j]),
             Column::SmallInt(col) => col[i].cmp(&col[j]),
             Column::Int(col) => col[i].cmp(&col[j]),
-            Column::BigInt(col) => col[i].cmp(&col[j]),
+            Column::BigInt(col) | Column::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
             Column::Int128(col) => col[i].cmp(&col[j]),
             Column::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
-            Column::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)
@@ -380,12 +379,11 @@ pub(crate) fn compare_indexes_by_owned_columns<S: Scalar>(
             OwnedColumn::Boolean(col) => col[i].cmp(&col[j]),
             OwnedColumn::SmallInt(col) => col[i].cmp(&col[j]),
             OwnedColumn::Int(col) => col[i].cmp(&col[j]),
-            OwnedColumn::BigInt(col) => col[i].cmp(&col[j]),
+            OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
             OwnedColumn::Int128(col) => col[i].cmp(&col[j]),
             OwnedColumn::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
             OwnedColumn::Scalar(col) => col[i].cmp(&col[j]),
             OwnedColumn::VarChar(col) => col[i].cmp(&col[j]),
-            OwnedColumn::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -59,9 +59,8 @@ impl<S: Scalar> LiteralValue<S> {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar((_, s)) => *s,
+            Self::VarChar((_, s)) | Self::Decimal75(_, _, s) => *s,
             Self::Int128(i) => i.into(),
-            Self::Decimal75(_, _, s) => *s,
             Self::Scalar(scalar) => *scalar,
             Self::TimeStampTZ(_, _, time) => time.into(),
         }

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -52,12 +52,10 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Boolean(col) => col.len(),
             OwnedColumn::SmallInt(col) => col.len(),
             OwnedColumn::Int(col) => col.len(),
-            OwnedColumn::BigInt(col) => col.len(),
+            OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.len(),
             OwnedColumn::VarChar(col) => col.len(),
             OwnedColumn::Int128(col) => col.len(),
-            OwnedColumn::Decimal75(_, _, col) => col.len(),
-            OwnedColumn::Scalar(col) => col.len(),
-            OwnedColumn::TimestampTZ(_, _, col) => col.len(),
+            OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.len(),
         }
     }
 
@@ -107,12 +105,10 @@ impl<S: Scalar> OwnedColumn<S> {
             OwnedColumn::Boolean(col) => col.is_empty(),
             OwnedColumn::SmallInt(col) => col.is_empty(),
             OwnedColumn::Int(col) => col.is_empty(),
-            OwnedColumn::BigInt(col) => col.is_empty(),
+            OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.is_empty(),
             OwnedColumn::VarChar(col) => col.is_empty(),
             OwnedColumn::Int128(col) => col.is_empty(),
-            OwnedColumn::Scalar(col) => col.is_empty(),
-            OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
-            OwnedColumn::TimestampTZ(_, _, col) => col.is_empty(),
+            OwnedColumn::Scalar(col) | OwnedColumn::Decimal75(_, _, col) => col.is_empty(),
         }
     }
     /// Returns the type of the column.
@@ -320,12 +316,12 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
                 OwnedColumn::Boolean(col) => col[i].cmp(&col[j]),
                 OwnedColumn::SmallInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::Int(col) => col[i].cmp(&col[j]),
-                OwnedColumn::BigInt(col) => col[i].cmp(&col[j]),
+                OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {
+                    col[i].cmp(&col[j])
+                }
                 OwnedColumn::Int128(col) => col[i].cmp(&col[j]),
-                OwnedColumn::Decimal75(_, _, col) => col[i].cmp(&col[j]),
-                OwnedColumn::Scalar(col) => col[i].cmp(&col[j]),
+                OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col[i].cmp(&col[j]),
                 OwnedColumn::VarChar(col) => col[i].cmp(&col[j]),
-                OwnedColumn::TimestampTZ(_, _, col) => col[i].cmp(&col[j]),
             };
             match direction {
                 OrderByDirection::Asc => ordering,

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -100,56 +100,52 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
     fn inner_product(&self, evaluation_vec: &[S]) -> S {
         match self {
             Column::Boolean(c) => c.inner_product(evaluation_vec),
-            Column::Scalar(c) => c.inner_product(evaluation_vec),
+            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+                c.inner_product(evaluation_vec)
+            }
             Column::SmallInt(c) => c.inner_product(evaluation_vec),
             Column::Int(c) => c.inner_product(evaluation_vec),
-            Column::BigInt(c) => c.inner_product(evaluation_vec),
-            Column::VarChar((_, c)) => c.inner_product(evaluation_vec),
+            Column::BigInt(c) | Column::TimestampTZ(_, _, c) => c.inner_product(evaluation_vec),
             Column::Int128(c) => c.inner_product(evaluation_vec),
-            Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
-            Column::TimestampTZ(_, _, c) => c.inner_product(evaluation_vec),
         }
     }
 
     fn mul_add(&self, res: &mut [S], multiplier: &S) {
         match self {
             Column::Boolean(c) => c.mul_add(res, multiplier),
-            Column::Scalar(c) => c.mul_add(res, multiplier),
+            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+                c.mul_add(res, multiplier)
+            }
             Column::SmallInt(c) => c.mul_add(res, multiplier),
             Column::Int(c) => c.mul_add(res, multiplier),
-            Column::BigInt(c) => c.mul_add(res, multiplier),
-            Column::VarChar((_, c)) => c.mul_add(res, multiplier),
+            Column::BigInt(c) | Column::TimestampTZ(_, _, c) => c.mul_add(res, multiplier),
             Column::Int128(c) => c.mul_add(res, multiplier),
-            Column::Decimal75(_, _, c) => c.mul_add(res, multiplier),
-            Column::TimestampTZ(_, _, c) => c.mul_add(res, multiplier),
         }
     }
 
     fn to_sumcheck_term(&self, num_vars: usize) -> Rc<Vec<S>> {
         match self {
             Column::Boolean(c) => c.to_sumcheck_term(num_vars),
-            Column::Scalar(c) => c.to_sumcheck_term(num_vars),
+            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+                c.to_sumcheck_term(num_vars)
+            }
             Column::SmallInt(c) => c.to_sumcheck_term(num_vars),
             Column::Int(c) => c.to_sumcheck_term(num_vars),
-            Column::BigInt(c) => c.to_sumcheck_term(num_vars),
-            Column::VarChar((_, c)) => c.to_sumcheck_term(num_vars),
+            Column::BigInt(c) | Column::TimestampTZ(_, _, c) => c.to_sumcheck_term(num_vars),
             Column::Int128(c) => c.to_sumcheck_term(num_vars),
-            Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
-            Column::TimestampTZ(_, _, c) => c.to_sumcheck_term(num_vars),
         }
     }
 
     fn id(&self) -> *const c_void {
         match self {
             Column::Boolean(c) => MultilinearExtension::<S>::id(c),
-            Column::Scalar(c) => MultilinearExtension::<S>::id(c),
+            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+                MultilinearExtension::<S>::id(c)
+            }
             Column::SmallInt(c) => MultilinearExtension::<S>::id(c),
             Column::Int(c) => MultilinearExtension::<S>::id(c),
-            Column::BigInt(c) => MultilinearExtension::<S>::id(c),
-            Column::VarChar((_, c)) => MultilinearExtension::<S>::id(c),
+            Column::BigInt(c) | Column::TimestampTZ(_, _, c) => MultilinearExtension::<S>::id(c),
             Column::Int128(c) => MultilinearExtension::<S>::id(c),
-            Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
-            Column::TimestampTZ(_, _, c) => MultilinearExtension::<S>::id(c),
         }
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -39,15 +39,15 @@ fn compute_dory_commitment(
     setup: &ProverSetup,
 ) -> DynamicDoryCommitment {
     match committable_column {
-        CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::SmallInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::BigInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int128(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::Decimal75(_, _, column) => {
+        CommittableColumn::VarChar(column)
+        | CommittableColumn::Scalar(column)
+        | CommittableColumn::Decimal75(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
-        CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -396,7 +396,7 @@ pub fn bit_table_and_scalars_for_packed_msm(
                     num_matrix_commitment_columns,
                 );
             }
-            CommittableColumn::BigInt(column) => {
+            CommittableColumn::BigInt(column) | CommittableColumn::TimestampTZ(_, _, column) => {
                 pack_bit(
                     column,
                     &mut packed_scalars,
@@ -418,17 +418,6 @@ pub fn bit_table_and_scalars_for_packed_msm(
                     num_matrix_commitment_columns,
                 );
             }
-            CommittableColumn::TimestampTZ(_, _, column) => {
-                pack_bit(
-                    column,
-                    &mut packed_scalars,
-                    cumulative_bit_sum_table[i],
-                    offset,
-                    committable_columns[i].column_type().byte_size(),
-                    bit_table_full_sum_in_bytes,
-                    num_matrix_commitment_columns,
-                );
-            }
             CommittableColumn::Boolean(column) => {
                 pack_bit(
                     column,
@@ -440,29 +429,9 @@ pub fn bit_table_and_scalars_for_packed_msm(
                     num_matrix_commitment_columns,
                 );
             }
-            CommittableColumn::Decimal75(_, _, column) => {
-                pack_bit(
-                    column,
-                    &mut packed_scalars,
-                    cumulative_bit_sum_table[i],
-                    offset,
-                    committable_columns[i].column_type().byte_size(),
-                    bit_table_full_sum_in_bytes,
-                    num_matrix_commitment_columns,
-                );
-            }
-            CommittableColumn::Scalar(column) => {
-                pack_bit(
-                    column,
-                    &mut packed_scalars,
-                    cumulative_bit_sum_table[i],
-                    offset,
-                    committable_columns[i].column_type().byte_size(),
-                    bit_table_full_sum_in_bytes,
-                    num_matrix_commitment_columns,
-                );
-            }
-            CommittableColumn::VarChar(column) => {
+            CommittableColumn::Decimal75(_, _, column)
+            | CommittableColumn::Scalar(column)
+            | CommittableColumn::VarChar(column) => {
                 pack_bit(
                     column,
                     &mut packed_scalars,

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -112,9 +112,10 @@ impl ProvableQueryResult {
                     ColumnType::Int => decode_and_convert::<i32, S>(&self.data[offset..]),
                     ColumnType::BigInt => decode_and_convert::<i64, S>(&self.data[offset..]),
                     ColumnType::Int128 => decode_and_convert::<i128, S>(&self.data[offset..]),
-                    ColumnType::Decimal75(_, _) => decode_and_convert::<S, S>(&self.data[offset..]),
+                    ColumnType::Decimal75(_, _) | ColumnType::Scalar => {
+                        decode_and_convert::<S, S>(&self.data[offset..])
+                    }
 
-                    ColumnType::Scalar => decode_and_convert::<S, S>(&self.data[offset..]),
                     ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
                     ColumnType::TimestampTZ(_, _) => {
                         decode_and_convert::<i64, S>(&self.data[offset..])

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -37,12 +37,10 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Boolean(col) => col.num_bytes(selection),
             Column::SmallInt(col) => col.num_bytes(selection),
             Column::Int(col) => col.num_bytes(selection),
-            Column::BigInt(col) => col.num_bytes(selection),
+            Column::BigInt(col) | Column::TimestampTZ(_, _, col) => col.num_bytes(selection),
             Column::Int128(col) => col.num_bytes(selection),
-            Column::Decimal75(_, _, col) => col.num_bytes(selection),
-            Column::Scalar(col) => col.num_bytes(selection),
+            Column::Decimal75(_, _, col) | Column::Scalar(col) => col.num_bytes(selection),
             Column::VarChar((col, _)) => col.num_bytes(selection),
-            Column::TimestampTZ(_, _, col) => col.num_bytes(selection),
         }
     }
 
@@ -51,12 +49,10 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Boolean(col) => col.write(out, selection),
             Column::SmallInt(col) => col.write(out, selection),
             Column::Int(col) => col.write(out, selection),
-            Column::BigInt(col) => col.write(out, selection),
+            Column::BigInt(col) | Column::TimestampTZ(_, _, col) => col.write(out, selection),
             Column::Int128(col) => col.write(out, selection),
-            Column::Decimal75(_, _, col) => col.write(out, selection),
-            Column::Scalar(col) => col.write(out, selection),
+            Column::Decimal75(_, _, col) | Column::Scalar(col) => col.write(out, selection),
             Column::VarChar((col, _)) => col.write(out, selection),
-            Column::TimestampTZ(_, _, col) => col.write(out, selection),
         }
     }
 }


### PR DESCRIPTION
# Rationale for this change

We have cargo clippy running in our CI in order to enforce code quality. In order to increase our standards, we should enable the clippy::pedantic lint group.

# What changes are included in this PR?

This PR fixes `clippy::match_same_arms` warnings for proof-of-sql lib.

# Are these changes tested?

Yes.
