### PR TITLE
refactor: move column operations to `ColumnOperation` trait

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -8,9 +8,7 @@ mod column;
 pub use column::{Column, ColumnField, ColumnRef, ColumnType};
 
 mod column_operation;
-pub use column_operation::{
-    try_add_subtract_column_types, try_divide_column_types, try_multiply_column_types,
-};
+pub use column_operation::ColumnOperation;
 
 mod column_operation_error;
 pub use column_operation_error::{ColumnOperationError, ColumnOperationResult};

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -1,9 +1,7 @@
 use super::{ConversionError, ConversionResult, QueryContext};
+use crate::base::database::ColumnOperation;
 use crate::base::{
-    database::{
-        try_add_subtract_column_types, try_multiply_column_types, ColumnRef, ColumnType,
-        SchemaAccessor, TableRef,
-    },
+    database::{ColumnRef, ColumnType, SchemaAccessor, TableRef},
     math::decimal::Precision,
 };
 use alloc::{boxed::Box, string::ToString, vec::Vec};
@@ -294,14 +292,15 @@ pub(crate) fn type_check_binary_operation(
                         | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
                 )
         }
-        BinaryOperator::Add => {
-            try_add_subtract_column_types(*left_dtype, *right_dtype, BinaryOperator::Add).is_ok()
-        }
-        BinaryOperator::Subtract => {
-            try_add_subtract_column_types(*left_dtype, *right_dtype, BinaryOperator::Subtract)
-                .is_ok()
-        }
-        BinaryOperator::Multiply => try_multiply_column_types(*left_dtype, *right_dtype).is_ok(),
+        BinaryOperator::Add => (*left_dtype)
+            .try_add_subtract_column_types(*right_dtype, BinaryOperator::Add)
+            .is_ok(),
+        BinaryOperator::Subtract => (*left_dtype)
+            .try_add_subtract_column_types(*right_dtype, BinaryOperator::Subtract)
+            .is_ok(),
+        BinaryOperator::Multiply => (*left_dtype)
+            .try_multiply_column_types(*right_dtype)
+            .is_ok(),
         BinaryOperator::Division => left_dtype.is_numeric() && right_dtype.is_numeric(),
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -1,11 +1,9 @@
 use super::{add_subtract_columns, scale_and_add_subtract_eval, DynProofExpr, ProofExpr};
+use crate::base::database::ColumnOperation;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, CommitmentAccessor,
-            DataAccessor,
-        },
+        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
         map::IndexSet,
         proof::ProofError,
     },
@@ -48,7 +46,9 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
         } else {
             BinaryOperator::Add
         };
-        try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type(), operator)
+        self.lhs
+            .data_type()
+            .try_add_subtract_column_types(self.rhs.data_type(), operator)
             .expect("Failed to add/subtract column types")
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -1,11 +1,9 @@
 use super::{DynProofExpr, ProofExpr};
+use crate::base::database::ColumnOperation;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{
-            try_multiply_column_types, Column, ColumnRef, ColumnType, CommitmentAccessor,
-            DataAccessor,
-        },
+        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
         map::IndexSet,
         proof::ProofError,
     },
@@ -44,7 +42,9 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
     }
 
     fn data_type(&self) -> ColumnType {
-        try_multiply_column_types(self.lhs.data_type(), self.rhs.data_type())
+        self.lhs
+            .data_type()
+            .try_multiply_column_types(self.rhs.data_type())
             .expect("Failed to multiply column types")
     }
 


### PR DESCRIPTION
# Rationale for this change

Now that we are including nullable column support in #183, the comment https://github.com/spaceandtimelabs/sxt-proof-of-sql/issues/183#issuecomment-2379341988 suggests creating new structs for nullable columns

This trait will help us with the easy implementation of methods

<!--
 Why are you proposing this change? If this is already explained clearly in the linked Jira ticket then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?

I introduced a trait `ColumnOperation` which contains the functions `try_add_subtract_column_types`, `try_multiply_column_types` and `try_divide_column_types`

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

The refactor does not affect any core logic, and changes made are covered under the tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->


PS: ext of #194