### PR TITLE
fix: dynamic Dory commitment computation should handle empty columns

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -322,11 +322,11 @@ fn we_can_compute_an_empty_dory_commitment() {
     let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);
     let setup = DoryProverPublicSetup::new(&prover_setup, 2);
-    let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 0])], 0, &setup);
+    let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 0, &setup);
     assert_eq!(res[0].0, GT::zero());
-    let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 0])], 5, &setup);
+    let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 5, &setup);
     assert_eq!(res[0].0, GT::zero());
-    let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0, 0])], 20, &setup);
+    let res = compute_dory_commitments(&[CommittableColumn::BigInt(&[0; 0])], 20, &setup);
     assert_eq!(res[0].0, GT::zero());
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -1,9 +1,10 @@
 use super::{
     dynamic_dory_structure::row_and_column_from_index, pairings, DoryScalar, DynamicDoryCommitment,
-    G1Affine, G1Projective, ProverSetup,
+    G1Affine, G1Projective, ProverSetup, GT,
 };
 use crate::base::commitment::CommittableColumn;
 use alloc::{vec, vec::Vec};
+use num_traits::Zero;
 
 #[tracing::instrument(name = "compute_dory_commitment_impl (cpu)", level = "debug", skip_all)]
 /// # Panics
@@ -71,6 +72,11 @@ pub(super) fn compute_dynamic_dory_commitments(
 ) -> Vec<DynamicDoryCommitment> {
     committable_columns
         .iter()
-        .map(|column| compute_dory_commitment(column, offset, setup))
+        .map(|column| {
+            column
+                .is_empty()
+                .then(|| DynamicDoryCommitment(GT::zero()))
+                .unwrap_or_else(|| compute_dory_commitment(column, offset, setup))
+        })
         .collect()
 }


### PR DESCRIPTION
# Rationale for this change
The dynamic Dory commitment computation does not currently handle empty columns as expected. This was uncovered after a test formatting error was discovered. Both the empty column case and formatting error are addressed.

# What changes are included in this PR?
- The empty column case is handled in the `dynamic_dory_commitment_helper_cpu` module. Tests for this function are in - https://github.com/spaceandtimelabs/sxt-proof-of-sql/pull/242
- Tests for empty Dory commitments are corrected.

# Are these changes tested?
Yes
