### PR TITLE
refactor!: add `get_table_references`,  `get_output_length` and modify `get_length`

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -72,6 +72,7 @@ mod test_accessor;
 #[cfg(any(test, feature = "test"))]
 pub use test_accessor::TestAccessor;
 #[cfg(test)]
+#[allow(unused_imports)]
 pub(crate) use test_accessor::UnimplementedTestAccessor;
 
 #[cfg(test)]

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -3,7 +3,7 @@ use crate::base::{
     commitment::Commitment,
     database::{
         Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
-        OwnedTable,
+        OwnedTable, TableRef,
     },
     map::IndexSet,
     proof::ProofError,
@@ -22,16 +22,8 @@ pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
         accessor: &dyn MetadataAccessor,
     ) -> Result<(), ProofError>;
 
-    /// The length of the input table
-    fn get_length(&self, accessor: &dyn MetadataAccessor) -> usize;
-
     /// The offset of the query, that is, how many rows to skip before starting to read the input table
     fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize;
-
-    /// Check if the input table is empty
-    fn is_empty(&self, accessor: &dyn MetadataAccessor) -> bool {
-        self.get_length(accessor) == 0
-    }
 
     /// Form components needed to verify and proof store into `VerificationBuilder`
     fn verifier_evaluate(
@@ -44,11 +36,36 @@ pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
     /// Return all the result column fields
     fn get_column_result_fields(&self) -> Vec<ColumnField>;
 
-    /// Return all the columns referenced in the Query
+    /// Return all the columns referenced in the query
     fn get_column_references(&self) -> IndexSet<ColumnRef>;
+
+    /// Return all the tables referenced in the query
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        self.get_column_references()
+            .iter()
+            .map(ColumnRef::table_ref)
+            .collect()
+    }
+
+    /// Check if the input tables are all empty
+    fn is_empty(&self, accessor: &dyn MetadataAccessor) -> bool {
+        self.get_table_references()
+            .iter()
+            .all(|table_ref| accessor.get_length(*table_ref) == 0)
+    }
 }
 
 pub trait ProverEvaluate<S: Scalar> {
+    /// Get the length of the input tables
+    fn get_input_lengths<'a>(
+        &self,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Vec<usize>;
+
+    /// Get the length of the output table
+    fn get_output_length<'a>(&self, alloc: &'a Bump, accessor: &'a dyn DataAccessor<S>) -> usize;
+
     /// Evaluate the query and modify `FirstRoundBuilder` to track the result of the query.
     fn result_evaluate<'a>(
         &self,

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -47,12 +47,12 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         accessor: &impl DataAccessor<CP::Scalar>,
         setup: &CP::ProverPublicSetup<'_>,
     ) -> (Self, ProvableQueryResult) {
-        let table_length = expr.get_length(accessor);
+        let alloc = Bump::new();
+        // TODO: Modify this to handle multiple tables
+        let table_length = expr.get_input_lengths(&alloc, accessor)[0];
         let num_sumcheck_variables = cmp::max(log2_up(table_length), 1);
         let generator_offset = expr.get_offset(accessor);
         assert!(num_sumcheck_variables > 0);
-
-        let alloc = Bump::new();
 
         // Evaluate query result
         let result_cols = expr.result_evaluate(table_length, &alloc, accessor);
@@ -150,7 +150,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         result: &ProvableQueryResult,
         setup: &CP::VerifierPublicSetup<'_>,
     ) -> QueryResult<CP::Scalar> {
-        let input_length = expr.get_length(accessor);
+        //TODO: Modify this when we have multiple tables
+        assert!(expr.get_table_references().len() == 1);
+        let input_length = accessor.get_length(*expr.get_table_references().first().unwrap());
         let output_length = result.table_length();
         let generator_offset = expr.get_offset(accessor);
         let num_sumcheck_variables = cmp::max(log2_up(input_length), 1);

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -8,7 +8,7 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            MetadataAccessor, OwnedTable, TestAccessor, UnimplementedTestAccessor,
+            MetadataAccessor, OwnedTable, OwnedTableTestAccessor, TableRef,
         },
         map::IndexSet,
         proof::ProofError,
@@ -25,6 +25,16 @@ pub(super) struct EmptyTestQueryExpr {
     pub(super) columns: usize,
 }
 impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
+    fn get_input_lengths<'a>(
+        &self,
+        _alloc: &'a Bump,
+        _accessor: &'a dyn DataAccessor<S>,
+    ) -> Vec<usize> {
+        vec![self.length]
+    }
+    fn get_output_length<'a>(&self, _alloc: &'a Bump, _accessor: &'a dyn DataAccessor<S>) -> usize {
+        self.length
+    }
     fn result_evaluate<'a>(
         &self,
         _input_length: usize,
@@ -59,9 +69,6 @@ impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
         builder.count_intermediate_mles(self.columns);
         Ok(())
     }
-    fn get_length(&self, _accessor: &dyn MetadataAccessor) -> usize {
-        self.length
-    }
     fn get_offset(&self, _accessor: &dyn MetadataAccessor) -> usize {
         0
     }
@@ -86,7 +93,15 @@ impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        unimplemented!("no real usage for this function yet")
+        (1..=self.columns)
+            .map(|i| {
+                ColumnRef::new(
+                    TableRef::new("sxt.test".parse().unwrap()),
+                    format!("a{i}").parse().unwrap(),
+                    ColumnType::BigInt,
+                )
+            })
+            .collect()
     }
 }
 
@@ -96,7 +111,13 @@ fn we_can_verify_queries_on_an_empty_table() {
         columns: 1,
         ..Default::default()
     };
-    let accessor = UnimplementedTestAccessor::new_empty();
+    let column: Vec<i64> = vec![0_i64; 0];
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        "sxt.test".parse().unwrap(),
+        owned_table([bigint("a1", column)]),
+        0,
+        (),
+    );
     let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
     let QueryData {
         verification_hash: _,
@@ -112,7 +133,13 @@ fn empty_verification_fails_if_the_result_contains_non_null_members() {
         columns: 1,
         ..Default::default()
     };
-    let accessor = UnimplementedTestAccessor::new_empty();
+    let column: Vec<i64> = vec![0_i64; 0];
+    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+        "sxt.test".parse().unwrap(),
+        owned_table([bigint("a1", column)]),
+        0,
+        (),
+    );
     let res = VerifiableQueryResult::<InnerProductProof> {
         provable_result: Some(ProvableQueryResult::default()),
         proof: None,

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -54,7 +54,6 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
 
     fn result_evaluate<'a>(
         &self,
-        table_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -23,10 +23,9 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
     /// Implementations must ensure that the returned slice has length `table_length`.
     fn result_evaluate<'a>(
         &self,
-        table_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar>;
+    ) -> ColumnarValue<'a, C::Scalar>;
 
     /// Evaluate the expression, add components needed to prove it, and return thet resulting column
     /// of values
@@ -35,7 +34,7 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar>;
+    ) -> ColumnarValue<'a, C::Scalar>;
 
     /// Compute the evaluation of a multilinear extension from this expression
     /// at the random sumcheck point and adds components needed to verify the expression to

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -44,14 +44,6 @@ impl<C: Commitment> ProofPlan<C> for DynProofPlan<C> {
         }
     }
 
-    fn get_length(&self, accessor: &dyn crate::base::database::MetadataAccessor) -> usize {
-        match self {
-            DynProofPlan::Projection(expr) => expr.get_length(accessor),
-            DynProofPlan::GroupBy(expr) => expr.get_length(accessor),
-            DynProofPlan::Filter(expr) => expr.get_length(accessor),
-        }
-    }
-
     fn get_offset(&self, accessor: &dyn crate::base::database::MetadataAccessor) -> usize {
         match self {
             DynProofPlan::Projection(expr) => expr.get_offset(accessor),
@@ -92,6 +84,30 @@ impl<C: Commitment> ProofPlan<C> for DynProofPlan<C> {
 }
 
 impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
+    fn get_input_lengths<'a>(
+        &self,
+        alloc: &'a bumpalo::Bump,
+        accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
+    ) -> Vec<usize> {
+        match self {
+            DynProofPlan::Projection(expr) => expr.get_input_lengths(alloc, accessor),
+            DynProofPlan::GroupBy(expr) => expr.get_input_lengths(alloc, accessor),
+            DynProofPlan::Filter(expr) => expr.get_input_lengths(alloc, accessor),
+        }
+    }
+
+    fn get_output_length<'a>(
+        &self,
+        alloc: &'a bumpalo::Bump,
+        accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
+    ) -> usize {
+        match self {
+            DynProofPlan::Projection(expr) => expr.get_output_length(alloc, accessor),
+            DynProofPlan::GroupBy(expr) => expr.get_output_length(alloc, accessor),
+            DynProofPlan::Filter(expr) => expr.get_output_length(alloc, accessor),
+        }
+    }
+
     #[tracing::instrument(name = "DynProofPlan::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -77,10 +77,6 @@ where
         Ok(())
     }
 
-    fn get_length(&self, accessor: &dyn MetadataAccessor) -> usize {
-        accessor.get_length(self.table.table_ref)
-    }
-
     fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize {
         accessor.get_offset(self.table.table_ref)
     }
@@ -145,6 +141,31 @@ where
 pub type FilterExec<C> = OstensibleFilterExec<C, HonestProver>;
 
 impl<C: Commitment> ProverEvaluate<C::Scalar> for FilterExec<C> {
+    fn get_input_lengths<'a>(
+        &self,
+        _alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<C::Scalar>,
+    ) -> Vec<usize> {
+        vec![accessor.get_length(self.table.table_ref)]
+    }
+
+    fn get_output_length<'a>(
+        &self,
+        alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<C::Scalar>,
+    ) -> usize {
+        let input_length = accessor.get_length(self.table.table_ref);
+        let selection_column: Column<'a, C::Scalar> =
+            self.where_clause
+                .result_evaluate(input_length, alloc, accessor);
+        selection_column
+            .as_boolean()
+            .expect("selection is not boolean")
+            .iter()
+            .filter(|&&b| b)
+            .count()
+    }
+
     #[tracing::instrument(name = "FilterExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -16,7 +16,7 @@ use crate::{
         proof_exprs::{AliasedDynProofExpr, ProofExpr, TableExpr},
     },
 };
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use bumpalo::Bump;
 use core::iter::repeat_with;
 use serde::{Deserialize, Serialize};
@@ -52,10 +52,6 @@ impl<C: Commitment> ProofPlan<C> for ProjectionExec<C> {
             builder.count_intermediate_mles(1);
         }
         Ok(())
-    }
-
-    fn get_length(&self, accessor: &dyn MetadataAccessor) -> usize {
-        accessor.get_length(self.table.table_ref)
     }
 
     fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize {
@@ -95,6 +91,22 @@ impl<C: Commitment> ProofPlan<C> for ProjectionExec<C> {
 }
 
 impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
+    fn get_input_lengths<'a>(
+        &self,
+        _alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<C::Scalar>,
+    ) -> Vec<usize> {
+        vec![accessor.get_length(self.table.table_ref)]
+    }
+
+    fn get_output_length<'a>(
+        &self,
+        _alloc: &'a Bump,
+        accessor: &'a dyn DataAccessor<C::Scalar>,
+    ) -> usize {
+        accessor.get_length(self.table.table_ref)
+    }
+
     #[tracing::instrument(name = "ProjectionExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to make `ProofPlan`s composable `get_length` has to depend on more than lengths of existing tables. Hence it is necessary to move it to `ProverEvaluate`. Moreover we want to support multiple tables. Hence let's add `get_table_references` and `get_input_lengths`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add  `ProverEvaluate::get_output_length`
- move `get_length` to `ProverEvaluate`, rename it to `get_input_lengths` and change its parameters
- add `ProofPlan::get_table_references`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes