### PR TITLE
feat: updated the examples to use the `DynamicDoryEvaluationProof`

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -83,7 +83,7 @@ workspace = true
 
 [[example]]
 name = "hello_world"
-required-features = [ "blitzar", "test" ]
+required-features = [ "test" ]
 
 [[example]]
 name = "posql_db"

--- a/crates/proof-of-sql/examples/hello_world/main.rs
+++ b/crates/proof-of-sql/examples/hello_world/main.rs
@@ -1,8 +1,11 @@
 #![doc = include_str!("README.md")]
-
-use blitzar::{compute::init_backend, proof::InnerProductProof};
+use ark_std::test_rng;
+use blitzar::compute::init_backend;
 use proof_of_sql::{
     base::database::{owned_table_utility::*, OwnedTableTestAccessor, TestAccessor},
+    proof_primitive::dory::{
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    },
     sql::{parse::QueryExpr, proof::QueryProof},
 };
 use std::{
@@ -39,7 +42,11 @@ fn main() {
     init_backend();
     end_timer(timer);
     let timer = start_timer("Loading data");
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+    let mut accessor =
+        OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([
@@ -58,11 +65,19 @@ fn main() {
     .unwrap();
     end_timer(timer);
     let timer = start_timer("Generating Proof");
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let (proof, serialized_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &&prover_setup,
+    );
     end_timer(timer);
     let timer = start_timer("Verifying Proof");
-    let result = proof.verify(query.proof_expr(), &accessor, &serialized_result, &());
+    let result = proof.verify(
+        query.proof_expr(),
+        &accessor,
+        &serialized_result,
+        &&verifier_setup,
+    );
     end_timer(timer);
     match result {
         Ok(result) => {

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -5,20 +5,23 @@ mod commit_accessor;
 mod csv_accessor;
 /// TODO: add docs
 mod record_batch_accessor;
+use ark_std::rand::thread_rng;
 use arrow::{
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
-use blitzar::proof::InnerProductProof;
 use clap::{arg, Parser, Subcommand, ValueEnum};
 use commit_accessor::CommitAccessor;
 use csv_accessor::{read_record_batch_from_csv, CsvDataAccessor};
-use curve25519_dalek::RistrettoPoint;
 use itertools::Itertools;
 use proof_of_sql::{
     base::{
         commitment::TableCommitment,
         database::{SchemaAccessor, TableRef},
+    },
+    proof_primitive::dory::{
+        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
+        VerifierSetup,
     },
     sql::{parse::QueryExpr, proof::VerifiableQueryResult},
 };
@@ -149,6 +152,11 @@ fn main() {
     println!("Warming up GPU...");
     blitzar::compute::init_backend();
     println!("Done.");
+
+    let mut rng = thread_rng();
+    let public_parameters = PublicParameters::rand(5, &mut rng);
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
     match args.command {
         Commands::Create {
             table,
@@ -156,7 +164,7 @@ fn main() {
             data_types,
         } => {
             let commit_accessor =
-                CommitAccessor::<RistrettoPoint>::new(PathBuf::from(args.path.clone()));
+                CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let csv_accessor = CsvDataAccessor::new(PathBuf::from(args.path));
             let schema = Schema::new(
                 columns
@@ -166,7 +174,7 @@ fn main() {
                     .collect::<Vec<_>>(),
             );
             let batch = RecordBatch::new_empty(Arc::new(schema));
-            let table_commitment = TableCommitment::try_from_record_batch(&batch, &())
+            let table_commitment = TableCommitment::try_from_record_batch(&batch, &&prover_setup)
                 .expect("Failed to create table commitment.");
             commit_accessor
                 .write_commit(&table, &table_commitment)
@@ -180,7 +188,7 @@ fn main() {
             file: file_path,
         } => {
             let mut commit_accessor =
-                CommitAccessor::<RistrettoPoint>::new(PathBuf::from(args.path.clone()));
+                CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let csv_accessor = CsvDataAccessor::new(PathBuf::from(args.path));
             commit_accessor
                 .load_commit(table_name)
@@ -200,7 +208,7 @@ fn main() {
                 .expect("Failed to write batch");
             let timer = start_timer("Updating Commitment");
             table_commitment
-                .try_append_record_batch(&append_batch, &())
+                .try_append_record_batch(&append_batch, &&prover_setup)
                 .expect("Failed to append batch");
             end_timer(timer);
             commit_accessor
@@ -209,7 +217,7 @@ fn main() {
         }
         Commands::Prove { query, file } => {
             let mut commit_accessor =
-                CommitAccessor::<RistrettoPoint>::new(PathBuf::from(args.path.clone()));
+                CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let mut csv_accessor = CsvDataAccessor::new(PathBuf::from(args.path.clone()));
             let tables = query.get_table_references("example".parse().unwrap());
             for table in tables.into_iter().map(TableRef::new) {
@@ -230,10 +238,10 @@ fn main() {
             let query =
                 QueryExpr::try_new(query, "example".parse().unwrap(), &commit_accessor).unwrap();
             let timer = start_timer("Generating Proof");
-            let proof = VerifiableQueryResult::<InnerProductProof>::new(
+            let proof = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
                 query.proof_expr(),
                 &csv_accessor,
-                &(),
+                &&prover_setup,
             );
             end_timer(timer);
             fs::write(
@@ -244,7 +252,7 @@ fn main() {
         }
         Commands::Verify { query, file } => {
             let mut commit_accessor =
-                CommitAccessor::<RistrettoPoint>::new(PathBuf::from(args.path.clone()));
+                CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let table_refs = query.get_table_references("example".parse().unwrap());
             for table_ref in table_refs {
                 let table_name = TableRef::new(table_ref);
@@ -254,12 +262,13 @@ fn main() {
             }
             let query =
                 QueryExpr::try_new(query, "example".parse().unwrap(), &commit_accessor).unwrap();
-            let result: VerifiableQueryResult<InnerProductProof> =
+            let result: VerifiableQueryResult<DynamicDoryEvaluationProof> =
                 postcard::from_bytes(&fs::read(file).expect("Failed to read proof"))
                     .expect("Failed to deserialize proof");
+
             let timer = start_timer("Verifying Proof");
             let query_result = result
-                .verify(query.proof_expr(), &commit_accessor, &())
+                .verify(query.proof_expr(), &commit_accessor, &&verifier_setup)
                 .expect("Failed to verify proof");
             end_timer(timer);
             println!(

--- a/crates/proof-of-sql/examples/posql_db/run_example.sh
+++ b/crates/proof-of-sql/examples/posql_db/run_example.sh
@@ -1,5 +1,5 @@
 cd crates/proof-of-sql/examples/posql_db
-cargo run --features="arrow blitzar" --example posql_db create -t sxt.table -c a,b -d BIGINT,VARCHAR
-cargo run --features="arrow blitzar" --example posql_db append -t sxt.table -f hello_world.csv
-cargo run --features="arrow blitzar" --example posql_db prove -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
-cargo run --features="arrow blitzar" --example posql_db verify -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
+cargo run --features="arrow " --example posql_db create -t sxt.table -c a,b -d BIGINT,VARCHAR
+cargo run --features="arrow " --example posql_db append -t sxt.table -f hello_world.csv
+cargo run --features="arrow " --example posql_db prove -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
+cargo run --features="arrow " --example posql_db verify -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

To improve add the functionality of everyone to use non-GPU systems from the entry point 

 Closes #244 .
/claim #244 

 

# What changes are included in this PR?

Modified the examples completely to depend and run on `DynamicDoryEvaluationProof` . 

# Are these changes tested?

Yes, the existing test are enough with the same values 
