### PR TITLE
refactor!: rename `ResultBuilder` to `FirstRoundBuilder`, `ProofBuilder` to `FinalRoundBuilder` && split first round proof out of `ProofPlan::result_evaluate`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -12,7 +12,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use num_traits::Zero;
 
 /// Track components used to form a query's proof
-pub struct ProofBuilder<'a, S: Scalar> {
+pub struct FinalRoundBuilder<'a, S: Scalar> {
     table_length: usize,
     num_sumcheck_variables: usize,
     bit_distributions: Vec<BitDistribution>,
@@ -29,7 +29,7 @@ pub struct ProofBuilder<'a, S: Scalar> {
     post_result_challenges: Vec<S>,
 }
 
-impl<'a, S: Scalar> ProofBuilder<'a, S> {
+impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
     pub fn new(
         table_length: usize,
         num_sumcheck_variables: usize,
@@ -96,7 +96,7 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
 
     /// Compute commitments of all the interemdiate MLEs used in sumcheck
     #[tracing::instrument(
-        name = "ProofBuilder::commit_intermediate_mles",
+        name = "FinalRoundBuilder::commit_intermediate_mles",
         level = "debug",
         skip_all
     )]
@@ -115,7 +115,7 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
     /// Given random multipliers, construct an aggregatated sumcheck polynomial from all
     /// the individual subpolynomials.
     #[tracing::instrument(
-        name = "ProofBuilder::make_sumcheck_polynomial",
+        name = "FinalRoundBuilder::make_sumcheck_polynomial",
         level = "debug",
         skip_all
     )]
@@ -140,7 +140,7 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
     /// Given the evaluation vector, compute evaluations of all the MLEs used in sumcheck except
     /// for those that correspond to result columns sent to the verifier.
     #[tracing::instrument(
-        name = "ProofBuilder::evaluate_pcs_proof_mles",
+        name = "FinalRoundBuilder::evaluate_pcs_proof_mles",
         level = "debug",
         skip_all
     )]
@@ -154,7 +154,11 @@ impl<'a, S: Scalar> ProofBuilder<'a, S> {
 
     /// Given random multipliers, multiply and add together all of the MLEs used in sumcheck except
     /// for those that correspond to result columns sent to the verifier.
-    #[tracing::instrument(name = "ProofBuilder::fold_pcs_proof_mles", level = "debug", skip_all)]
+    #[tracing::instrument(
+        name = "FinalRoundBuilder::fold_pcs_proof_mles",
+        level = "debug",
+        skip_all
+    )]
     pub fn fold_pcs_proof_mles(&self, multipliers: &[S]) -> Vec<S> {
         assert_eq!(multipliers.len(), self.pcs_proof_mles.len());
         let mut res = vec![Zero::zero(); self.table_length];

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -1,4 +1,4 @@
-use super::{ProofBuilder, ProvableQueryResult, SumcheckRandomScalars};
+use super::{FinalRoundBuilder, ProvableQueryResult, SumcheckRandomScalars};
 use crate::{
     base::{
         commitment::{Commitment, CommittableColumn},
@@ -22,7 +22,7 @@ use num_traits::{One, Zero};
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = ProofBuilder::<Curve25519Scalar>::new(2, 1, Vec::new());
+    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(2, 1, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 0_usize;
@@ -41,7 +41,7 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
 fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = ProofBuilder::<Curve25519Scalar>::new(2, 1, Vec::new());
+    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(2, 1, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 123_usize;
@@ -60,7 +60,7 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
 fn we_can_evaluate_pcs_proof_mles() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = ProofBuilder::new(2, 1, Vec::new());
+    let mut builder = FinalRoundBuilder::new(2, 1, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let evaluation_vec = [
@@ -80,7 +80,7 @@ fn we_can_form_an_aggregated_sumcheck_polynomial() {
     let mle1 = [1, 2, -1];
     let mle2 = [10i64, 20, 100, 30];
     let mle3 = [2000i64, 3000, 5000, 7000];
-    let mut builder = ProofBuilder::new(4, 2, Vec::new());
+    let mut builder = FinalRoundBuilder::new(4, 2, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     builder.produce_intermediate_mle(&mle3[..]);
@@ -170,7 +170,7 @@ fn we_can_form_the_provable_query_result() {
 fn we_can_fold_pcs_proof_mles() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = ProofBuilder::new(2, 1, Vec::new());
+    let mut builder = FinalRoundBuilder::new(2, 1, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let multipliers = [Curve25519Scalar::from(100u64), Curve25519Scalar::from(2u64)];
@@ -184,7 +184,7 @@ fn we_can_fold_pcs_proof_mles() {
 
 #[test]
 fn we_can_consume_post_result_challenges_in_proof_builder() {
-    let mut builder = ProofBuilder::new(
+    let mut builder = FinalRoundBuilder::new(
         0,
         0,
         vec![

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
@@ -1,5 +1,5 @@
 /// Track the result created by a query
-pub struct ResultBuilder {
+pub struct FirstRoundBuilder {
     result_table_length: usize,
 
     /// The number of challenges used in the proof.
@@ -9,13 +9,13 @@ pub struct ResultBuilder {
     num_post_result_challenges: usize,
 }
 
-impl Default for ResultBuilder {
+impl Default for FirstRoundBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ResultBuilder {
+impl FirstRoundBuilder {
     /// Create a new result builder for a table with the given length. For multi table queries, this will likely need to change.
     pub fn new() -> Self {
         Self {

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
@@ -1,7 +1,5 @@
 /// Track the result created by a query
 pub struct FirstRoundBuilder {
-    result_table_length: usize,
-
     /// The number of challenges used in the proof.
     /// Specifically, these are the challenges that the verifier sends to
     /// the prover after the prover sends the result, but before the prover
@@ -19,19 +17,8 @@ impl FirstRoundBuilder {
     /// Create a new result builder for a table with the given length. For multi table queries, this will likely need to change.
     pub fn new() -> Self {
         Self {
-            result_table_length: 0,
             num_post_result_challenges: 0,
         }
-    }
-
-    /// Get the length of the output table
-    pub fn result_table_length(&self) -> usize {
-        self.result_table_length
-    }
-
-    /// Set the length of the output table
-    pub fn set_result_table_length(&mut self, result_table_length: usize) {
-        self.result_table_length = result_table_length;
     }
 
     /// The number of challenges used in the proof.

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -68,5 +68,5 @@ pub(crate) use result_element_serialization::{
     decode_and_convert, decode_multiple_elements, ProvableResultElement,
 };
 
-mod result_builder;
-pub(crate) use result_builder::ResultBuilder;
+mod first_round_builder;
+pub(crate) use first_round_builder::FirstRoundBuilder;

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -2,10 +2,10 @@
 mod count_builder;
 pub(crate) use count_builder::CountBuilder;
 
-mod proof_builder;
-pub(crate) use proof_builder::ProofBuilder;
+mod final_round_builder;
+pub(crate) use final_round_builder::FinalRoundBuilder;
 #[cfg(all(test, feature = "blitzar"))]
-mod proof_builder_test;
+mod final_round_builder_test;
 
 mod composite_polynomial_builder;
 pub(crate) use composite_polynomial_builder::CompositePolynomialBuilder;

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -66,7 +66,7 @@ pub trait ProverEvaluate<S: Scalar> {
     /// Intermediate values that are needed to form the proof are allocated into the arena
     /// allocator alloc. These intermediate values will persist through proof creation and
     /// will be bulk deallocated once the proof is formed.
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,4 +1,4 @@
-use super::{CountBuilder, ProofBuilder, ResultBuilder, VerificationBuilder};
+use super::{CountBuilder, FirstRoundBuilder, ProofBuilder, VerificationBuilder};
 use crate::base::{
     commitment::Commitment,
     database::{
@@ -49,10 +49,10 @@ pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
 }
 
 pub trait ProverEvaluate<S: Scalar> {
-    /// Evaluate the query and modify `ResultBuilder` to track the result of the query.
+    /// Evaluate the query and modify `FirstRoundBuilder` to track the result of the query.
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>>;

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,4 +1,4 @@
-use super::{CountBuilder, FirstRoundBuilder, ProofBuilder, VerificationBuilder};
+use super::{CountBuilder, FinalRoundBuilder, FirstRoundBuilder, VerificationBuilder};
 use crate::base::{
     commitment::Commitment,
     database::{
@@ -57,7 +57,7 @@ pub trait ProverEvaluate<S: Scalar> {
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>>;
 
-    /// Evaluate the query and modify `ProofBuilder` to store an intermediate representation
+    /// Evaluate the query and modify `FinalRoundBuilder` to store an intermediate representation
     /// of the query result and track all the components needed to form the query's proof.
     ///
     /// Intermediate values that are needed to form the proof are allocated into the arena
@@ -65,7 +65,7 @@ pub trait ProverEvaluate<S: Scalar> {
     /// will be bulk deallocated once the proof is formed.
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, S>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>>;

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -52,10 +52,13 @@ pub trait ProverEvaluate<S: Scalar> {
     /// Evaluate the query and modify `FirstRoundBuilder` to track the result of the query.
     fn result_evaluate<'a>(
         &self,
-        builder: &mut FirstRoundBuilder,
+        input_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>>;
+
+    /// Evaluate the query and modify `FirstRoundBuilder` to form the query's proof.
+    fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder);
 
     /// Evaluate the query and modify `FinalRoundBuilder` to store an intermediate representation
     /// of the query result and track all the components needed to form the query's proof.

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -79,7 +79,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         let mut builder =
             FinalRoundBuilder::new(table_length, num_sumcheck_variables, post_result_challenges);
-        expr.prover_evaluate(&mut builder, &alloc, accessor);
+        expr.final_round_evaluate(&mut builder, &alloc, accessor);
 
         let num_sumcheck_variables = builder.num_sumcheck_variables();
         let table_length = builder.table_length();

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -1,5 +1,5 @@
 use super::{
-    CountBuilder, ProofBuilder, ProofCounts, ProofPlan, ProvableQueryResult, QueryResult,
+    CountBuilder, FinalRoundBuilder, ProofCounts, ProofPlan, ProvableQueryResult, QueryResult,
     SumcheckMleEvaluations, SumcheckRandomScalars, VerificationBuilder,
 };
 use crate::{
@@ -73,7 +73,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 .collect();
 
         let mut builder =
-            ProofBuilder::new(table_length, num_sumcheck_variables, post_result_challenges);
+            FinalRoundBuilder::new(table_length, num_sumcheck_variables, post_result_challenges);
         expr.prover_evaluate(&mut builder, &alloc, accessor);
 
         let num_sumcheck_variables = builder.num_sumcheck_variables();

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -12,7 +12,7 @@ use crate::{
         proof::{Keccak256Transcript, ProofError, Transcript},
     },
     proof_primitive::sumcheck::SumcheckProof,
-    sql::proof::{QueryData, ResultBuilder},
+    sql::proof::{FirstRoundBuilder, QueryData},
 };
 use alloc::{vec, vec::Vec};
 use bumpalo::Bump;
@@ -53,7 +53,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         assert!(num_sumcheck_variables > 0);
 
         let alloc = Bump::new();
-        let mut result_builder = ResultBuilder::new();
+        let mut result_builder = FirstRoundBuilder::new();
         let result_cols = expr.result_evaluate(&mut result_builder, &alloc, accessor);
         let provable_result =
             ProvableQueryResult::new(result_builder.result_table_length() as u64, &result_cols);

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -43,15 +43,15 @@ impl Default for TrivialTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut FirstRoundBuilder,
+        _input_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
-        let input_length = self.length;
-        let col = alloc.alloc_slice_fill_copy(input_length, self.column_fill_value);
-        builder.set_result_table_length(input_length);
+        let col = alloc.alloc_slice_fill_copy(self.length, self.column_fill_value);
         vec![Column::BigInt(col)]
     }
+
+    fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
     fn prover_evaluate<'a>(
         &self,
@@ -200,14 +200,15 @@ impl Default for SquareTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut FirstRoundBuilder,
+        _table_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        builder.set_result_table_length(2);
         vec![Column::BigInt(res)]
     }
+
+    fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
     fn prover_evaluate<'a>(
         &self,
@@ -381,14 +382,15 @@ impl Default for DoubleSquareTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut FirstRoundBuilder,
+        _input_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        builder.set_result_table_length(2);
         vec![Column::BigInt(res)]
     }
+
+    fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
     fn prover_evaluate<'a>(
         &self,
@@ -592,13 +594,15 @@ struct ChallengeTestProofPlan {}
 impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut FirstRoundBuilder,
+        _input_length: usize,
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
-        builder.request_post_result_challenges(2);
-        builder.set_result_table_length(2);
         vec![Column::BigInt(&[9, 25])]
+    }
+
+    fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder) {
+        builder.request_post_result_challenges(2);
     }
 
     fn prover_evaluate<'a>(

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -14,7 +14,7 @@ use crate::{
         proof::ProofError,
         scalar::{Curve25519Scalar, Scalar},
     },
-    sql::proof::{QueryData, ResultBuilder, SumcheckSubpolynomialType},
+    sql::proof::{FirstRoundBuilder, QueryData, SumcheckSubpolynomialType},
 };
 use bumpalo::Bump;
 use serde::Serialize;
@@ -43,7 +43,7 @@ impl Default for TrivialTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -200,7 +200,7 @@ impl Default for SquareTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -381,7 +381,7 @@ impl Default for DoubleSquareTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -592,7 +592,7 @@ struct ChallengeTestProofPlan {}
 impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    CountBuilder, ProofBuilder, ProofPlan, ProverEvaluate, QueryProof, VerificationBuilder,
+    CountBuilder, FinalRoundBuilder, ProofPlan, ProverEvaluate, QueryProof, VerificationBuilder,
 };
 use crate::{
     base::{
@@ -55,7 +55,7 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
 
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, S>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -211,7 +211,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
 
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, S>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -392,7 +392,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
 
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, S>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -603,7 +603,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
 
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, S>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -53,7 +53,7 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -210,7 +210,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -392,7 +392,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -605,7 +605,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         builder.request_post_result_challenges(2);
     }
 
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -14,7 +14,7 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{ProvableQueryResult, QueryData, ResultBuilder},
+    sql::proof::{FirstRoundBuilder, ProvableQueryResult, QueryData},
 };
 use bumpalo::Bump;
 use serde::Serialize;
@@ -27,7 +27,7 @@ pub(super) struct EmptyTestQueryExpr {
 impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -36,7 +36,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
         vec![Column::BigInt(res); self.columns]
     }
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -1,5 +1,5 @@
 use super::{
-    CountBuilder, ProofBuilder, ProofPlan, ProverEvaluate, VerifiableQueryResult,
+    CountBuilder, FinalRoundBuilder, ProofPlan, ProverEvaluate, VerifiableQueryResult,
     VerificationBuilder,
 };
 use crate::{
@@ -38,7 +38,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     }
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, S>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -27,15 +27,15 @@ pub(super) struct EmptyTestQueryExpr {
 impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     fn result_evaluate<'a>(
         &self,
-        builder: &mut FirstRoundBuilder,
+        _input_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
         let zeros = vec![0; self.length];
         let res: &[_] = alloc.alloc_slice_copy(&zeros);
-        builder.set_result_table_length(self.length);
         vec![Column::BigInt(res); self.columns]
     }
+    fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
     fn prover_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -9,7 +9,7 @@ use crate::{
         map::IndexSet,
         proof::ProofError,
     },
-    sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -79,7 +79,7 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
     )]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -6,7 +6,7 @@ use crate::{
         map::IndexSet,
         proof::ProofError,
     },
-    sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -55,7 +55,7 @@ impl<C: Commitment> ProofExpr<C> for AggregateExpr<C> {
     #[tracing::instrument(name = "AggregateExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -6,7 +6,7 @@ use crate::{
         map::IndexSet,
         proof::ProofError,
     },
-    sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
@@ -60,7 +60,7 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
     #[tracing::instrument(name = "AndExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -59,7 +59,7 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
     }
 
     /// Evaluate the column expression and
-    /// add the result to the [`ResultBuilder`](crate::sql::proof::ResultBuilder)
+    /// add the result to the [`FirstRoundBuilder`](crate::sql::proof::FirstRoundBuilder)
     fn result_evaluate<'a>(
         &self,
         table_length: usize,

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -6,7 +6,7 @@ use crate::{
         map::IndexSet,
         proof::ProofError,
     },
-    sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
 use core::marker::PhantomData;
@@ -75,7 +75,7 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
     /// add the components needed to prove the result
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         _alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     sql::{
         parse::{type_check_binary_operation, ConversionError, ConversionResult},
-        proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+        proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
     },
 };
 use alloc::{boxed::Box, string::ToString};
@@ -253,7 +253,7 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
 
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -8,7 +8,7 @@ use crate::{
         scalar::Scalar,
         slice_ops,
     },
-    sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
@@ -59,7 +59,7 @@ impl<C: Commitment> ProofExpr<C> for EqualsExpr<C> {
     #[tracing::instrument(name = "EqualsExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
@@ -105,7 +105,7 @@ pub fn result_evaluate_equals_zero<'a, S: Scalar>(
 }
 
 pub fn prover_evaluate_equals_zero<'a, S: Scalar>(
-    builder: &mut ProofBuilder<'a, S>,
+    builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     lhs: &'a [S],
 ) -> &'a [bool] {

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -11,7 +11,7 @@ use crate::{
         map::IndexSet,
         proof::ProofError,
     },
-    sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -86,7 +86,7 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
     #[tracing::instrument(name = "InequalityExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -7,7 +7,7 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
@@ -57,7 +57,7 @@ impl<C: Commitment> ProofExpr<C> for LiteralExpr<C::Scalar> {
     #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -10,7 +10,7 @@ use crate::{
         proof::ProofError,
     },
     sql::{
-        proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        proof::{CountBuilder, FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
         proof_exprs::multiply_columns,
     },
 };
@@ -69,7 +69,7 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
     )]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -6,7 +6,7 @@ use crate::{
         map::IndexSet,
         proof::ProofError,
     },
-    sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -50,7 +50,7 @@ impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
     #[tracing::instrument(name = "NotExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -7,7 +7,7 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{CountBuilder, ProofBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
@@ -58,7 +58,7 @@ impl<C: Commitment> ProofExpr<C> for OrExpr<C> {
     #[tracing::instrument(name = "OrExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
@@ -106,7 +106,7 @@ pub fn result_evaluate_or<'a>(
     reason = "lhs and rhs are guaranteed to have the same length, ensuring no panic occurs"
 )]
 pub fn prover_evaluate_or<'a, S: Scalar>(
-    builder: &mut ProofBuilder<'a, S>,
+    builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     lhs: &'a [bool],
     rhs: &'a [bool],

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -5,7 +5,7 @@ use crate::{
         map::IndexSet,
         proof::ProofError,
     },
-    sql::proof::{CountBuilder, ProofBuilder, VerificationBuilder},
+    sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
 use core::fmt::Debug;
@@ -32,7 +32,7 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
     /// of values
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar>;

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
@@ -10,7 +10,7 @@ use crate::{
         scalar::Scalar,
     },
     sql::proof::{
-        CountBuilder, ProofBuilder, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType,
+        CountBuilder, FinalRoundBuilder, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType,
         VerificationBuilder,
     },
 };
@@ -80,7 +80,7 @@ pub fn result_evaluate_sign<'a, S: Scalar>(
 /// Note: We can only prove the sign bit for non-zero scalars, and we restict
 /// the range of non-zero scalar so that there is a unique sign representation.
 pub fn prover_evaluate_sign<'a, S: Scalar>(
-    builder: &mut ProofBuilder<'a, S>,
+    builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     expr: &'a [S],
     #[cfg(test)] treat_column_of_zeros_as_negative: bool,
@@ -173,7 +173,10 @@ fn verifier_const_sign_evaluate<S: Scalar>(
     }
 }
 
-fn prove_bits_are_binary<'a, S: Scalar>(builder: &mut ProofBuilder<'a, S>, bits: &[&'a [bool]]) {
+fn prove_bits_are_binary<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    bits: &[&'a [bool]],
+) {
     for &seq in bits {
         builder.produce_intermediate_mle(seq);
         builder.produce_sumcheck_subpolynomial(
@@ -203,7 +206,7 @@ fn verify_bits_are_binary<C: Commitment>(
 ///
 /// This function generates subpolynomial terms for sumcheck, involving the scalar expression and its bit decomposition.
 fn prove_bit_decomposition<'a, S: Scalar>(
-    builder: &mut ProofBuilder<'a, S>,
+    builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     expr: &'a [S],
     bits: &[&'a [bool]],

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
@@ -2,7 +2,7 @@ use super::{count_sign, prover_evaluate_sign, result_evaluate_sign, verifier_eva
 use crate::{
     base::{bit::BitDistribution, polynomial::MultilinearExtension, scalar::Curve25519Scalar},
     sql::proof::{
-        CountBuilder, ProofBuilder, SumcheckMleEvaluations, SumcheckRandomScalars,
+        CountBuilder, FinalRoundBuilder, SumcheckMleEvaluations, SumcheckRandomScalars,
         VerificationBuilder,
     },
 };
@@ -16,7 +16,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_constant_column() {
     let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
     let alloc = Bump::new();
     let data: Vec<Curve25519Scalar> = data.into_iter().map(Curve25519Scalar::from).collect();
-    let mut builder = ProofBuilder::new(3, 2, Vec::new());
+    let mut builder = FinalRoundBuilder::new(3, 2, Vec::new());
     let sign = prover_evaluate_sign(&mut builder, &alloc, &data, false);
     assert_eq!(sign, [false; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
@@ -28,7 +28,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_negative_constant_colum
     let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
     let alloc = Bump::new();
     let data: Vec<Curve25519Scalar> = data.into_iter().map(Curve25519Scalar::from).collect();
-    let mut builder = ProofBuilder::new(3, 2, Vec::new());
+    let mut builder = FinalRoundBuilder::new(3, 2, Vec::new());
     let sign = prover_evaluate_sign(&mut builder, &alloc, &data, false);
     assert_eq!(sign, [true; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -114,17 +114,17 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
         }
     }
 
-    #[tracing::instrument(name = "DynProofPlan::prover_evaluate", level = "debug", skip_all)]
-    fn prover_evaluate<'a>(
+    #[tracing::instrument(name = "DynProofPlan::final_round_evaluate", level = "debug", skip_all)]
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut crate::sql::proof::FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
         match self {
-            DynProofPlan::Projection(expr) => expr.prover_evaluate(builder, alloc, accessor),
-            DynProofPlan::GroupBy(expr) => expr.prover_evaluate(builder, alloc, accessor),
-            DynProofPlan::Filter(expr) => expr.prover_evaluate(builder, alloc, accessor),
+            DynProofPlan::Projection(expr) => expr.final_round_evaluate(builder, alloc, accessor),
+            DynProofPlan::GroupBy(expr) => expr.final_round_evaluate(builder, alloc, accessor),
+            DynProofPlan::Filter(expr) => expr.final_round_evaluate(builder, alloc, accessor),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -95,7 +95,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
     #[tracing::instrument(name = "DynProofPlan::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut crate::sql::proof::ResultBuilder,
+        builder: &mut crate::sql::proof::FirstRoundBuilder,
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -95,14 +95,22 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
     #[tracing::instrument(name = "DynProofPlan::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut crate::sql::proof::FirstRoundBuilder,
+        input_length: usize,
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
         match self {
-            DynProofPlan::Projection(expr) => expr.result_evaluate(builder, alloc, accessor),
-            DynProofPlan::GroupBy(expr) => expr.result_evaluate(builder, alloc, accessor),
-            DynProofPlan::Filter(expr) => expr.result_evaluate(builder, alloc, accessor),
+            DynProofPlan::Projection(expr) => expr.result_evaluate(input_length, alloc, accessor),
+            DynProofPlan::GroupBy(expr) => expr.result_evaluate(input_length, alloc, accessor),
+            DynProofPlan::Filter(expr) => expr.result_evaluate(input_length, alloc, accessor),
+        }
+    }
+
+    fn first_round_evaluate(&self, builder: &mut crate::sql::proof::FirstRoundBuilder) {
+        match self {
+            DynProofPlan::Projection(expr) => expr.first_round_evaluate(builder),
+            DynProofPlan::GroupBy(expr) => expr.first_round_evaluate(builder),
+            DynProofPlan::Filter(expr) => expr.first_round_evaluate(builder),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -109,7 +109,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
     #[tracing::instrument(name = "DynProofPlan::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut crate::sql::proof::ProofBuilder<'a, C::Scalar>,
+        builder: &mut crate::sql::proof::FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -13,8 +13,8 @@ use crate::{
     },
     sql::{
         proof::{
-            CountBuilder, HonestProver, ProofBuilder, ProofPlan, ProverEvaluate,
-            ProverHonestyMarker, ResultBuilder, SumcheckSubpolynomialType, VerificationBuilder,
+            CountBuilder, FirstRoundBuilder, HonestProver, ProofBuilder, ProofPlan, ProverEvaluate,
+            ProverHonestyMarker, SumcheckSubpolynomialType, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
     },
@@ -148,7 +148,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for FilterExec<C> {
     #[tracing::instrument(name = "FilterExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -13,8 +13,8 @@ use crate::{
     },
     sql::{
         proof::{
-            CountBuilder, FirstRoundBuilder, HonestProver, ProofBuilder, ProofPlan, ProverEvaluate,
-            ProverHonestyMarker, SumcheckSubpolynomialType, VerificationBuilder,
+            CountBuilder, FinalRoundBuilder, FirstRoundBuilder, HonestProver, ProofPlan,
+            ProverEvaluate, ProverHonestyMarker, SumcheckSubpolynomialType, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
     },
@@ -183,7 +183,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for FilterExec<C> {
     #[allow(unused_variables)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
@@ -263,7 +263,7 @@ fn verify_filter<C: Commitment>(
 
 #[allow(clippy::too_many_arguments, clippy::many_single_char_names)]
 pub(super) fn prove_filter<'a, S: Scalar + 'a>(
-    builder: &mut ProofBuilder<'a, S>,
+    builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     alpha: S,
     beta: S,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -180,9 +180,9 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for FilterExec<C> {
         builder.request_post_result_challenges(2);
     }
 
-    #[tracing::instrument(name = "FilterExec::prover_evaluate", level = "debug", skip_all)]
+    #[tracing::instrument(name = "FilterExec::final_round_evaluate", level = "debug", skip_all)]
     #[allow(unused_variables)]
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     sql::{
         proof::{
-            exercise_verification, ProofPlan, ProvableQueryResult, ProverEvaluate, ResultBuilder,
-            VerifiableQueryResult,
+            exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
+            ProverEvaluate, VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, LiteralExpr, TableExpr},
     },
@@ -192,7 +192,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         where_clause,
     );
     let alloc = Bump::new();
-    let mut builder = ResultBuilder::new();
+    let mut builder = FirstRoundBuilder::new();
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
@@ -237,7 +237,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let mut builder = ResultBuilder::new();
+    let mut builder = FirstRoundBuilder::new();
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
@@ -278,7 +278,7 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
         equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
-    let mut builder = ResultBuilder::new();
+    let mut builder = FirstRoundBuilder::new();
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[];
     let res: OwnedTable<Curve25519Scalar> =
@@ -309,7 +309,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let mut builder = ResultBuilder::new();
+    let mut builder = FirstRoundBuilder::new();
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -2,8 +2,8 @@ use super::{test_utility::*, FilterExec};
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTable,
-            OwnedTableTestAccessor, TableRef, TestAccessor,
+            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType, LiteralValue,
+            OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
         },
         map::{IndexMap, IndexSet},
         math::decimal::Precision,
@@ -192,8 +192,10 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         where_clause,
     );
     let alloc = Bump::new();
+    let result_cols = expr.result_evaluate(0, &alloc, &accessor);
+    let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
-    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
+    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -204,7 +206,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(builder.result_table_length() as u64, &result_cols)
+        ProvableQueryResult::new(output_length as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -237,8 +239,10 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
+    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
-    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
+    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -249,7 +253,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(builder.result_table_length() as u64, &result_cols)
+        ProvableQueryResult::new(output_length as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -278,11 +282,13 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
         equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
+    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
-    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
+    expr.first_round_evaluate(&mut builder);
     let fields = &[];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(builder.result_table_length() as u64, &result_cols)
+        ProvableQueryResult::new(output_length as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
@@ -309,8 +315,10 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
+    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
-    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
+    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -321,7 +329,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(builder.result_table_length() as u64, &result_cols)
+        ProvableQueryResult::new(output_length as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -69,12 +69,12 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec<RistrettoPoint> {
     }
 
     #[tracing::instrument(
-        name = "DishonestFilterExec::prover_evaluate",
+        name = "DishonestFilterExec::final_round_evaluate",
         level = "debug",
         skip_all
     )]
     #[allow(unused_variables)]
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, Curve25519Scalar>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     sql::{
         proof::{
-            FirstRoundBuilder, ProofBuilder, ProverEvaluate, ProverHonestyMarker, QueryError,
+            FinalRoundBuilder, FirstRoundBuilder, ProverEvaluate, ProverHonestyMarker, QueryError,
             VerifiableQueryResult,
         },
         // Making this explicit to ensure that we don't accidentally use the
@@ -75,7 +75,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec<RistrettoPoint> {
     #[allow(unused_variables)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, Curve25519Scalar>,
+        builder: &mut FinalRoundBuilder<'a, Curve25519Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<Curve25519Scalar>,
     ) -> Vec<Column<'a, Curve25519Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     sql::{
         proof::{
-            ProofBuilder, ProverEvaluate, ProverHonestyMarker, QueryError, ResultBuilder,
+            FirstRoundBuilder, ProofBuilder, ProverEvaluate, ProverHonestyMarker, QueryError,
             VerifiableQueryResult,
         },
         // Making this explicit to ensure that we don't accidentally use the
@@ -37,7 +37,7 @@ impl ProverEvaluate<Curve25519Scalar> for DishonestFilterExec<RistrettoPoint> {
     )]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<Curve25519Scalar>,
     ) -> Vec<Column<'a, Curve25519Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     sql::{
         proof::{
-            CountBuilder, ProofBuilder, ProofPlan, ProverEvaluate, ResultBuilder,
+            CountBuilder, FirstRoundBuilder, ProofBuilder, ProofPlan, ProverEvaluate,
             SumcheckSubpolynomialType, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, ProofExpr, TableExpr},
@@ -208,7 +208,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
     #[tracing::instrument(name = "GroupByExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -256,9 +256,9 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
         builder.request_post_result_challenges(2);
     }
 
-    #[tracing::instrument(name = "GroupByExec::prover_evaluate", level = "debug", skip_all)]
+    #[tracing::instrument(name = "GroupByExec::final_round_evaluate", level = "debug", skip_all)]
     #[allow(unused_variables)]
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     sql::{
         proof::{
-            CountBuilder, FirstRoundBuilder, ProofBuilder, ProofPlan, ProverEvaluate,
+            CountBuilder, FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
             SumcheckSubpolynomialType, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, ProofExpr, TableExpr},
@@ -259,7 +259,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for GroupByExec<C> {
     #[allow(unused_variables)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
@@ -365,7 +365,7 @@ fn verify_group_by<C: Commitment>(
     reason = "alpha is guaranteed to not be zero in this context"
 )]
 pub fn prove_group_by<'a, S: Scalar>(
-    builder: &mut ProofBuilder<'a, S>,
+    builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     alpha: S,
     beta: S,

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     sql::{
         proof::{
-            CountBuilder, FirstRoundBuilder, ProofBuilder, ProofPlan, ProverEvaluate,
+            CountBuilder, FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
             VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, ProofExpr, TableExpr},
@@ -121,7 +121,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
     #[allow(unused_variables)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut ProofBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -98,11 +98,10 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
     #[tracing::instrument(name = "ProjectionExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut FirstRoundBuilder,
+        input_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
-        let input_length = accessor.get_length(self.table.table_ref);
         let columns: Vec<_> = self
             .aliased_results
             .iter()
@@ -112,10 +111,10 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
                     .result_evaluate(input_length, alloc, accessor)
             })
             .collect();
-        // For projection, the result table length is the same as the input table length
-        builder.set_result_table_length(input_length);
         columns
     }
+
+    fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
     #[tracing::instrument(name = "ProjectionExec::prover_evaluate", level = "debug", skip_all)]
     #[allow(unused_variables)]

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -116,9 +116,13 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
-    #[tracing::instrument(name = "ProjectionExec::prover_evaluate", level = "debug", skip_all)]
+    #[tracing::instrument(
+        name = "ProjectionExec::final_round_evaluate",
+        level = "debug",
+        skip_all
+    )]
     #[allow(unused_variables)]
-    fn prover_evaluate<'a>(
+    fn final_round_evaluate<'a>(
         &self,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     sql::{
         proof::{
-            CountBuilder, ProofBuilder, ProofPlan, ProverEvaluate, ResultBuilder,
+            CountBuilder, FirstRoundBuilder, ProofBuilder, ProofPlan, ProverEvaluate,
             VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, ProofExpr, TableExpr},
@@ -98,7 +98,7 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for ProjectionExec<C> {
     #[tracing::instrument(name = "ProjectionExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        builder: &mut ResultBuilder,
+        builder: &mut FirstRoundBuilder,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     sql::{
         proof::{
-            exercise_verification, ProofPlan, ProvableQueryResult, ProverEvaluate, ResultBuilder,
-            VerifiableQueryResult,
+            exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
+            ProverEvaluate, VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, TableExpr},
     },
@@ -165,7 +165,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     let expr: DynProofPlan<RistrettoPoint> =
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
-    let mut builder = ResultBuilder::new();
+    let mut builder = FirstRoundBuilder::new();
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
@@ -204,7 +204,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     accessor.add_table(t, data, 0);
     let expr: DynProofPlan<RistrettoPoint> = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
-    let mut builder = ResultBuilder::new();
+    let mut builder = FirstRoundBuilder::new();
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[];
     let res: OwnedTable<Curve25519Scalar> =
@@ -240,7 +240,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         tab(t),
     );
     let alloc = Bump::new();
-    let mut builder = ResultBuilder::new();
+    let mut builder = FirstRoundBuilder::new();
     let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -2,7 +2,7 @@ use super::{test_utility::*, DynProofPlan, ProjectionExec};
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, ColumnField, ColumnRef, ColumnType, OwnedTable,
+            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TestAccessor,
         },
         map::{IndexMap, IndexSet},
@@ -165,8 +165,10 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     let expr: DynProofPlan<RistrettoPoint> =
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
+    let result_cols = expr.result_evaluate(0, &alloc, &accessor);
+    let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
-    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
+    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -177,7 +179,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(builder.result_table_length() as u64, &result_cols)
+        ProvableQueryResult::new(output_length as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -204,11 +206,13 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     accessor.add_table(t, data, 0);
     let expr: DynProofPlan<RistrettoPoint> = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
+    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
-    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
+    expr.first_round_evaluate(&mut builder);
     let fields = &[];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(builder.result_table_length() as u64, &result_cols)
+        ProvableQueryResult::new(output_length as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
@@ -240,8 +244,10 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         tab(t),
     );
     let alloc = Bump::new();
+    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
-    let result_cols = expr.result_evaluate(&mut builder, &alloc, &accessor);
+    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("prod".parse().unwrap(), ColumnType::Int128),
@@ -252,7 +258,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(builder.result_table_length() as u64, &result_cols)
+        ProvableQueryResult::new(output_length as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
`ResultBuilder` isn't really needed for `result_evaluate` when all we need are input table lengths. However it is crucial in producing the query proof. Hence we need to remove it from the actual query result computation process (`expr.result_evaluate`). At the same time it should be correctly named as builder of the first round of the proof because that's what it is.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
The 4 commits are supposed to be reviewed individually.
- rename `ResultBuilder` to `FirstRoundBuilder`, `ProofBuilder` to `FinalRoundBuilder`.
- rename `proof-of-sql/src/sql/proof/result_builder.rs` to `first_round_builder.rs`,  `proof-of-sql/src/sql/proof/proof_builder.rs` to `final_round_builder.rs`.
- split out post result challenges into `ProofPlan::first_round_evaluate`
- replace `FirstRoundBuilder` in `result_evaluate` with `input_length`
- rename `ProverEvaluate::prover_evaluate` to `final_round_evaluate`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes