### PR TITLE
refact: remove Into<[u64; 4]>, From<[u64; 4]>, and RefInto<[u64; 4]> bounds for trait Scalar

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -52,7 +52,7 @@ zerocopy = { workspace = true }
 [dev-dependencies]
 alloy-sol-types = { workspace = true }
 arrow-csv = { workspace = true }
-blitzar = { workspace = true }
+#blitzar = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 criterion = { workspace = true, features = ["html_reports"] }
 merlin = { workspace = true }
@@ -74,7 +74,8 @@ default = ["arrow", "perf"]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
 test = ["dep:rand", "std"]
-perf = ["blitzar", "rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
+#perf = ["blitzar", "rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
+perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
 rayon = ["dep:rayon", "std"]
 std = ["snafu/std"]
 

--- a/crates/proof-of-sql/src/base/bit/abs_bit_mask.rs
+++ b/crates/proof-of-sql/src/base/bit/abs_bit_mask.rs
@@ -2,7 +2,7 @@ use crate::base::scalar::Scalar;
 
 pub fn make_abs_bit_mask<S: Scalar>(x: S) -> [u64; 4] {
     let (sign, x) = if S::MAX_SIGNED < x { (1, -x) } else { (0, x) };
-    let mut res: [u64; 4] = x.into();
+    let mut res: [u64; 4] = x.to_limbs();
     res[3] |= sign << 63;
     res
 }

--- a/crates/proof-of-sql/src/base/database/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/database/scalar_and_i256_conversions.rs
@@ -14,7 +14,7 @@ const MAX_SUPPORTED_I256: i256 = i256::from_parts(
 pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
     let is_negative = val > &S::MAX_SIGNED;
     let abs_scalar = if is_negative { -*val } else { *val };
-    let limbs: [u64; 4] = abs_scalar.into();
+    let limbs: [u64; 4] = abs_scalar.to_limbs();
 
     let low = (limbs[0] as u128) | ((limbs[1] as u128) << 64);
     let high = i128::from(limbs[2]) | (i128::from(limbs[3]) << 64);
@@ -46,7 +46,7 @@ pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
         ];
 
         // Convert limbs to Scalar and adjust for sign
-        let scalar: S = limbs.into();
+        let scalar: S = S::from_limbs(limbs);
         Some(if value.is_negative() { -scalar } else { scalar })
     }
 }

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -1,5 +1,5 @@
 use crate::base::scalar::MontScalar;
-use ark_ff::MontConfig;
+use ark_ff::{MontConfig, PrimeField};
 
 /// U256 represents an unsigned 256-bits integer number
 ///

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -1,5 +1,5 @@
 use super::Transcript;
-use crate::base::{ref_into::RefInto, scalar::Scalar};
+use crate::base::scalar::Scalar;
 use zerocopy::{AsBytes, FromBytes};
 
 /// A trait used to facilitate implementation of [Transcript](super::Transcript).
@@ -48,10 +48,10 @@ impl<T: TranscriptCore> Transcript for T {
         &mut self,
         messages: impl IntoIterator<Item = &'a S>,
     ) {
-        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(RefInto::ref_into));
+        self.extend_as_be::<[u64; 4]>(messages.into_iter().map(|s| s.to_limbs()));
     }
     fn scalar_challenge_as_be<S: Scalar>(&mut self) -> S {
-        receive_challenge_as_be::<[u64; 4]>(self).into()
+        S::from_limbs(receive_challenge_as_be::<[u64; 4]>(self))
     }
     fn challenge_as_le(&mut self) -> [u8; 32] {
         self.raw_challenge()

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -47,8 +47,6 @@ pub trait Scalar:
     + core::convert::TryInto <i32>
     + core::convert::TryInto <i64>
     + core::convert::TryInto <i128>
-    + core::convert::Into<[u64; 4]>
-    + core::convert::From<[u64; 4]>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
     + num_traits::Zero
@@ -57,7 +55,6 @@ pub trait Scalar:
     + ark_std::UniformRand //This enables us to get `Scalar`s as challenges from the transcript
     + num_traits::Inv<Output = Option<Self>> // Note: `inv` should return `None` exactly when the element is zero.
     + core::ops::SubAssign
-    + super::ref_into::RefInto<[u64; 4]>
     + for<'a> core::convert::From<&'a String>
     + super::encode::VarInt
     + core::convert::From<String>
@@ -87,4 +84,9 @@ pub trait Scalar:
             _ => Ordering::Greater,
         }
     }
+
+    fn from_limbs(val: [u64; 4]) -> Self;
+
+    fn to_limbs(&self) -> [u64; 4];
+
 }

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -229,11 +229,13 @@ impl<T: MontConfig<4>> TryFrom<BigInt> for MontScalar<T> {
 
         // Check if the number of digits exceeds the maximum precision allowed
         if digits.len() > MAX_SUPPORTED_PRECISION.into() {
-            return Err(ScalarConversionError::Overflow{ error: format!(
-                "Attempted to parse a number with {} digits, which exceeds the max supported precision of {}",
-                digits.len(),
-                MAX_SUPPORTED_PRECISION
-            )});
+            return Err(ScalarConversionError::Overflow {
+                error: format!(
+                    "Attempted to parse a number with {} digits, which exceeds the max supported precision of {}",
+                    digits.len(),
+                    MAX_SUPPORTED_PRECISION
+                )
+            });
         }
 
         // Continue with the previous logic
@@ -349,12 +351,6 @@ impl From<&Curve25519Scalar> for curve25519_dalek::scalar::Scalar {
     }
 }
 
-impl<T: MontConfig<4>> From<MontScalar<T>> for [u64; 4] {
-    fn from(value: MontScalar<T>) -> Self {
-        (&value).into()
-    }
-}
-
 impl<T: MontConfig<4>> From<&MontScalar<T>> for [u64; 4] {
     fn from(value: &MontScalar<T>) -> Self {
         value.0.into_bigint().0
@@ -433,6 +429,14 @@ impl super::Scalar for Curve25519Scalar {
     const ZERO: Self = Self(ark_ff::MontFp!("0"));
     const ONE: Self = Self(ark_ff::MontFp!("1"));
     const TWO: Self = Self(ark_ff::MontFp!("2"));
+
+    fn from_limbs(val: [u64; 4]) -> Self {
+        Self(Fp::new(ark_ff::BigInt(val)))
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
+    }
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool
@@ -443,9 +447,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -471,9 +475,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -495,9 +499,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -519,9 +523,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -543,9 +547,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -567,9 +571,9 @@ where
     type Error = ScalarConversionError;
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
-            (-1, (-value).into())
+            (-1, (-value).to_limbs())
         } else {
-            (1, value.into())
+            (1, value.to_limbs())
         };
         if abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
@@ -601,7 +605,7 @@ where
         } else {
             num_bigint::Sign::Plus
         };
-        let value_abs: [u64; 4] = (if is_negative { -value } else { value }).into();
+        let value_abs: [u64; 4] = (if is_negative { -value } else { value }).to_limbs();
         let bits: &[u8] = bytemuck::cast_slice(&value_abs);
         BigInt::from_bytes_le(sign, bits)
     }

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -1,5 +1,5 @@
 use super::{MontScalar, Scalar};
-use ark_ff::{Fp, MontBackend, MontConfig};
+use ark_ff::{Fp, MontBackend, MontConfig, PrimeField};
 
 /// An implementation of `Scalar` intended for use in testing when a concrete implementation is required.
 ///
@@ -13,6 +13,14 @@ impl Scalar for TestScalar {
     const ZERO: Self = Self(ark_ff::MontFp!("0"));
     const ONE: Self = Self(ark_ff::MontFp!("1"));
     const TWO: Self = Self(ark_ff::MontFp!("2"));
+
+    fn from_limbs(val: [u64; 4]) -> Self {
+        Self(Fp::new(ark_ff::BigInt(val)))
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
+    }
 }
 
 pub struct TestMontConfig(pub ark_curve25519::FrConfig);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -30,6 +30,7 @@ use crate::base::{
 };
 use alloc::vec::Vec;
 use ark_ec::pairing::PairingOutput;
+use ark_ff::{Fp, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::Mul;
 use derive_more::{AddAssign, Neg, Sub, SubAssign};
@@ -45,6 +46,14 @@ impl Scalar for DoryScalar {
     const ZERO: Self = Self(ark_ff::MontFp!("0"));
     const ONE: Self = Self(ark_ff::MontFp!("1"));
     const TWO: Self = Self(ark_ff::MontFp!("2"));
+
+    fn from_limbs(val: [u64; 4]) -> Self {
+        Self(Fp::new(ark_ff::BigInt(val)))
+    }
+
+    fn to_limbs(&self) -> [u64; 4] {
+        self.0.into_bigint().0
+    }
 }
 
 #[derive(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_vmv_helper.rs
@@ -1,13 +1,12 @@
 #[cfg(not(feature = "blitzar"))]
 use super::G1Projective;
-use super::{transpose, G1Affine, ProverSetup, F};
+use super::{G1Affine, ProverSetup, F};
 use crate::base::polynomial::compute_evaluation_vector;
 #[cfg(feature = "blitzar")]
 use crate::base::slice_ops::slice_cast;
 use alloc::{vec, vec::Vec};
 #[cfg(not(feature = "blitzar"))]
 use ark_ec::{AffineRepr, VariableBaseMSM};
-use ark_ff::{BigInt, MontBackend};
 #[cfg(feature = "blitzar")]
 use blitzar::compute::ElementP2;
 #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -22,6 +22,7 @@ where
     &'a T: Into<DoryScalar>,
     T: Sync,
 {
+    let a = column;
     let Gamma_1 = setup.Gamma_1.last().unwrap();
     let Gamma_2 = setup.Gamma_2.last().unwrap();
     let (first_row, _) = row_and_column_from_index(offset);

--- a/crates/proof-of-sql/src/sql/proof_exprs/bitwise_verification.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/bitwise_verification.rs
@@ -38,12 +38,12 @@ pub fn verify_constant_sign_decomposition<S: Scalar>(
             && !dist.has_varying_sign_bit()
     );
     let lhs = if dist.sign_bit() { -eval } else { eval };
-    let mut rhs = S::from(dist.constant_part()) * one_eval;
+    let mut rhs = S::from_limbs(dist.constant_part()) * one_eval;
     let mut vary_index = 0;
     dist.for_each_abs_varying_bit(|int_index: usize, bit_index: usize| {
         let mut mult = [0u64; 4];
         mult[int_index] = 1u64 << bit_index;
-        rhs += S::from(mult) * bit_evals[vary_index];
+        rhs += S::from_limbs(mult) * bit_evals[vary_index];
         vary_index += 1;
     });
     if lhs == rhs {
@@ -72,7 +72,7 @@ pub fn verify_constant_abs_decomposition<S: Scalar>(
             && dist.has_varying_sign_bit()
     );
     let t = one_eval - S::TWO * sign_eval;
-    if S::from(dist.constant_part()) * t == eval {
+    if S::from_limbs(dist.constant_part()) * t == eval {
         Ok(())
     } else {
         Err(ProofError::VerificationError {

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
@@ -10,7 +10,7 @@ fn decompose_scalar_to_words<'a, S: Scalar + 'a>(
     byte_counts: &mut [u64],
 ) {
     for (i, scalar) in scalars.iter().enumerate() {
-        let scalar_array: [u64; 4] = (*scalar).into(); // Convert scalar to u64 array
+        let scalar_array: [u64; 4] = (*scalar).to_limbs(); // Convert scalar to u64 array
         let scalar_bytes_full = cast_slice::<u64, u8>(&scalar_array); // Cast u64 array to u8 slice
         let scalar_bytes = &scalar_bytes_full[..31];
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
@@ -218,7 +218,7 @@ fn prove_bit_decomposition<'a, S: Scalar>(
     terms.push((S::one(), vec![Box::new(expr)]));
 
     // expr bit decomposition
-    let const_part = S::from(dist.constant_part());
+    let const_part = S::from_limbs(dist.constant_part());
     if !const_part.is_zero() {
         terms.push((-const_part, vec![Box::new(sign_mle)]));
     }
@@ -227,7 +227,7 @@ fn prove_bit_decomposition<'a, S: Scalar>(
         let mut mult = [0u64; 4];
         mult[int_index] = 1u64 << bit_index;
         terms.push((
-            -S::from(mult),
+            -S::from_limbs(mult),
             vec![Box::new(sign_mle), Box::new(bits[vary_index])],
         ));
         vary_index += 1;
@@ -249,12 +249,12 @@ fn verify_bit_decomposition<C: Commitment>(
     let sign_eval = bit_evals.last().unwrap();
     let sign_eval = builder.mle_evaluations.input_one_evaluation - C::Scalar::TWO * *sign_eval;
     let mut vary_index = 0;
-    eval -= sign_eval * C::Scalar::from(dist.constant_part());
+    eval -= sign_eval * C::Scalar::from_limbs(dist.constant_part());
     dist.for_each_abs_varying_bit(|int_index: usize, bit_index: usize| {
         let mut mult = [0u64; 4];
         mult[int_index] = 1u64 << bit_index;
         let bit_eval = bit_evals[vary_index];
-        eval -= C::Scalar::from(mult) * sign_eval * bit_eval;
+        eval -= C::Scalar::from_limbs(mult) * sign_eval * bit_eval;
         vary_index += 1;
     });
     builder.produce_sumcheck_subpolynomial_evaluation(SumcheckSubpolynomialType::Identity, eval);


### PR DESCRIPTION


# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# What changes are included in this PR?
* remove Into<[u64; 4]>, From<[u64; 4]>, and RefInto<[u64; 4]> bounds for trait Scalar


# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
