### PR TITLE
Feat/parquet to commitment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,12 @@ num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4.4", default-features = false }
 opentelemetry = { version = "0.23.0" }
 opentelemetry-jaeger = { version = "0.20.0" }
+parquet = { version = "51.0" }
 postcard = { version = "1.0" }
 proof-of-sql = { path = "crates/proof-of-sql" } # We automatically update this line during release. So do not modify it!
 proof-of-sql-parser = { path = "crates/proof-of-sql-parser" } # We automatically update this line during release. So do not modify it!
 rand = { version = "0.8", default-features = false }
+rand_chacha = { version = "0.3.1" }
 rand_core = { version = "0.6", default-features = false }
 rayon = { version = "1.5" }
 serde = { version = "1", default-features = false }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -38,9 +38,11 @@ itertools = { workspace = true }
 merlin = { workspace = true, optional = true }
 num-traits = { workspace = true }
 num-bigint = { workspace = true, default-features = false }
+parquet = { workspace = true }
 postcard = { workspace = true, features = ["alloc"] }
 proof-of-sql-parser = { workspace = true }
 rand = { workspace = true, default-features = false, optional = true }
+rand_chacha = { workspace = true }
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }

--- a/crates/proof-of-sql/src/lib.rs
+++ b/crates/proof-of-sql/src/lib.rs
@@ -8,6 +8,8 @@ extern crate alloc;
 pub mod base;
 pub mod proof_primitive;
 pub mod sql;
+/// Various utilities
+pub mod utils;
 
 #[cfg(test)]
 mod tests;

--- a/crates/proof-of-sql/src/utils/mod.rs
+++ b/crates/proof-of-sql/src/utils/mod.rs
@@ -1,4 +1,5 @@
 /// Utility for reading a parquet file and writing to a blob which represents a `TableCommitment`
+#[cfg(test)]
 pub mod parquet_to_commitment_blob;
 #[cfg(test)]
 mod parquet_to_commitment_blob_integration_tests;

--- a/crates/proof-of-sql/src/utils/mod.rs
+++ b/crates/proof-of-sql/src/utils/mod.rs
@@ -1,0 +1,4 @@
+/// Utility for reading a parquet file and writing to a blob which represents a `TableCommitment`
+pub mod parquet_to_commitment_blob;
+#[cfg(test)]
+mod parquet_to_commitment_blob_integration_tests;

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::commitment::{Commitment, TableCommitment},
-    proof_primitive::dory::{DoryCommitment, DoryProverPublicSetup, ProverSetup, PublicParameters},
+    proof_primitive::dory::{DoryCommitment, DoryProverPublicSetup, DynamicDoryCommitment, ProverSetup, PublicParameters},
 };
 use arrow::{array::RecordBatch, compute::concat_batches, error::ArrowError};
 use curve25519_dalek::RistrettoPoint;
@@ -46,6 +46,11 @@ pub fn read_parquet_file_to_commitment_as_blob(path: &str) {
         dory_prover_setup,
         "dory_commitment".to_string(),
     );
+    read_parquet_file_to_commitment_as_blob_and_write_to_file::<DynamicDoryCommitment>(
+        path_object,
+        &prover_setup,
+        "dynamic_dory_commitment".to_string(),
+    );
 }
 
 /// # Panics
@@ -73,8 +78,8 @@ fn read_parquet_file_to_commitment_as_blob_and_write_to_file<
     let commitment = TableCommitment::<C>::try_from_record_batch(&record_batch, &setup).unwrap();
     let bytes: Vec<u8> = to_allocvec(&commitment).unwrap();
     let path_base = path.file_stem().unwrap().to_str().unwrap();
-    let path_extension = path.extension().unwrap().to_str().unwrap();
+    let path_extension = "txt";
     let mut output_file =
-        File::create(format!("{path_base}_{output_file_suffix}_{path_extension}")).unwrap();
+        File::create(format!("{path_base}_{output_file_suffix}.{path_extension}")).unwrap();
     output_file.write_all(&bytes).unwrap();
 }

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
@@ -1,0 +1,80 @@
+use crate::{
+    base::commitment::{Commitment, TableCommitment},
+    proof_primitive::dory::{DoryCommitment, DoryProverPublicSetup, ProverSetup, PublicParameters},
+};
+use arrow::{array::RecordBatch, compute::concat_batches, error::ArrowError};
+use curve25519_dalek::RistrettoPoint;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use postcard::to_allocvec;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use serde::{Deserialize, Serialize};
+use std::{fs::File, io::Write, path::Path};
+
+/// Performs the following:
+/// Reads a parquet file into a `RecordBatch`,
+/// Calculates the `TableCommitment` for the `RecordBatch` using multiple commitment strategies,
+/// Serializes the commitment to a blob, which is saved in the same directory as the original parquet file
+///
+/// # Panics
+///
+/// Panics when fails any part of the process
+pub fn read_parquet_file_to_commitment_as_blob(path: &str) {
+    let path_object = Path::new(path);
+    read_parquet_file_to_commitment_as_blob_and_write_to_file::<RistrettoPoint>(
+        path_object,
+        (),
+        "ristretto_point".to_string(),
+    );
+    let setup_seed = "spaceandtime".to_string();
+    let mut rng = {
+        // Convert the seed string to bytes and create a seeded RNG
+        let seed_bytes = setup_seed
+            .bytes()
+            .chain(std::iter::repeat(0u8))
+            .take(32)
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("collection is guaranteed to contain 32 elements");
+        ChaCha20Rng::from_seed(seed_bytes) // Seed ChaChaRng
+    };
+    let public_parameters = PublicParameters::rand(4, &mut rng);
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    read_parquet_file_to_commitment_as_blob_and_write_to_file::<DoryCommitment>(
+        path_object,
+        dory_prover_setup,
+        "dory_commitment".to_string(),
+    );
+}
+
+/// # Panics
+///
+/// Panics when fails any part of the process
+fn read_parquet_file_to_commitment_as_blob_and_write_to_file<
+    C: Commitment + Serialize + for<'a> Deserialize<'a>,
+>(
+    path: &Path,
+    setup: C::PublicSetup<'_>,
+    output_file_suffix: String,
+) {
+    let file = File::open(path).unwrap();
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+        .unwrap()
+        .build()
+        .unwrap();
+    let record_batch_results: Vec<Result<RecordBatch, ArrowError>> = reader.collect();
+    let record_batches: Vec<RecordBatch> = record_batch_results
+        .into_iter()
+        .map(|record_batch_result| record_batch_result.unwrap())
+        .collect();
+    let schema = record_batches.first().unwrap().schema();
+    let record_batch: RecordBatch = concat_batches(&schema, &record_batches).unwrap();
+    let commitment = TableCommitment::<C>::try_from_record_batch(&record_batch, &setup).unwrap();
+    let bytes: Vec<u8> = to_allocvec(&commitment).unwrap();
+    let path_base = path.file_stem().unwrap().to_str().unwrap();
+    let path_extension = path.extension().unwrap().to_str().unwrap();
+    let mut output_file =
+        File::create(format!("{path_base}_{output_file_suffix}_{path_extension}")).unwrap();
+    output_file.write_all(&bytes).unwrap();
+}

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
@@ -24,7 +24,7 @@ use std::{fs::File, io::Write};
 /// # Panics
 ///
 /// Panics when fails any part of the process
-pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>) {
+pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>, output_path_prefix: &str) {
     let unsorted_record_batches_with_unmodified_schema: Vec<RecordBatch> = paths
         .iter()
         .map(|path| {
@@ -87,12 +87,12 @@ pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>) {
     read_parquet_file_to_commitment_as_blob_and_write_to_file::<DoryCommitment>(
         &record_batch,
         dory_prover_setup,
-        "dory_commitment".to_string(),
+        format!("{output_path_prefix}_dory_commitment"),
     );
     read_parquet_file_to_commitment_as_blob_and_write_to_file::<DynamicDoryCommitment>(
         &record_batch,
         &prover_setup,
-        "dynamic_dory_commitment".to_string(),
+        format!("{output_path_prefix}_dynamic_dory_commitment"),
     );
 }
 

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
@@ -5,8 +5,8 @@ use crate::{
     },
 };
 use arrow::{
-    array::RecordBatch,
-    compute::{concat_batches, sort_to_indices, take},
+    array::{Int32Array, RecordBatch},
+    compute::concat_batches,
     error::ArrowError,
 };
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -16,16 +16,22 @@ use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Write};
 
+pub static PARQUET_FILE_PROOF_ORDER_COLUMN: &str = "META_ROW_NUMBER";
+
 /// Performs the following:
-/// Reads a parquet file into a `RecordBatch`,
-/// Calculates the `TableCommitment` for the `RecordBatch` using multiple commitment strategies,
-/// Serializes the commitment to a blob, which is saved in the same directory as the original parquet file
+/// Reads a collection of parquet files which in aggregate represent a single table of data,
+/// Calculates the `TableCommitment` for the table using multiple commitment strategies,
+/// Serializes each commitment to a blob, which is saved in the same directory as the original parquet file
 ///
 /// # Panics
 ///
-/// Panics when fails any part of the process
+/// Panics when any part of the process fails
 pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>, output_path_prefix: &str) {
-    let unsorted_record_batches_with_unmodified_schema: Vec<RecordBatch> = paths
+    let mut offset: usize = 0;
+    let commitments: Vec<(
+        TableCommitment<DoryCommitment>,
+        TableCommitment<DynamicDoryCommitment>,
+    )> = paths
         .iter()
         .map(|path| {
             let file = File::open(path).unwrap();
@@ -39,72 +45,81 @@ pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>, output_path_pre
                 .map(|record_batch_result| record_batch_result.unwrap())
                 .collect();
             let schema = record_batches.first().unwrap().schema();
-            concat_batches(&schema, &record_batches).unwrap()
+            let mut record_batch = concat_batches(&schema, &record_batches).unwrap();
+            let meta_row_number_column = record_batch
+                .column_by_name(PARQUET_FILE_PROOF_ORDER_COLUMN)
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            let length = meta_row_number_column.len();
+            let new_offset = offset + length;
+            let range = ((offset + 1) as i32)..((new_offset + 1) as i32);
+            assert_eq!(
+                meta_row_number_column,
+                &Int32Array::from(range.collect::<Vec<_>>())
+            );
+            record_batch.remove_column(schema.index_of(PARQUET_FILE_PROOF_ORDER_COLUMN).unwrap());
+            let setup_seed = "spaceandtime".to_string();
+            let mut rng = {
+                // Convert the seed string to bytes and create a seeded RNG
+                let seed_bytes = setup_seed
+                    .bytes()
+                    .chain(std::iter::repeat(0u8))
+                    .take(32)
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("collection is guaranteed to contain 32 elements");
+                ChaCha20Rng::from_seed(seed_bytes) // Seed ChaChaRng
+            };
+            let public_parameters = PublicParameters::rand(12, &mut rng);
+            let prover_setup = ProverSetup::from(&public_parameters);
+            let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 20);
+            let dory_commitment =
+                TableCommitment::<DoryCommitment>::try_from_record_batch_with_offset(
+                    &record_batch,
+                    offset,
+                    &dory_prover_setup,
+                )
+                .unwrap();
+            let dynamic_dory_commitment =
+                TableCommitment::<DynamicDoryCommitment>::try_from_record_batch_with_offset(
+                    &record_batch,
+                    offset,
+                    &&prover_setup,
+                )
+                .unwrap();
+            offset = new_offset;
+            (dory_commitment, dynamic_dory_commitment)
         })
         .collect();
-    let schema = unsorted_record_batches_with_unmodified_schema
-        .first()
-        .unwrap()
-        .schema();
-    let unsorted_record_batch_with_unmodified_schema =
-        concat_batches(&schema, &unsorted_record_batches_with_unmodified_schema).unwrap();
-    let indices = sort_to_indices(
-        unsorted_record_batch_with_unmodified_schema
-            .column_by_name("SXTMETA_ROW_NUMBER")
-            .unwrap(),
-        None,
-        None,
-    )
-    .unwrap();
-    let index = schema.index_of("SXTMETA_ROW_NUMBER").unwrap();
-    let columns = unsorted_record_batch_with_unmodified_schema
-        .columns()
-        .iter()
-        .map(|c| take(c, &indices, None).unwrap())
-        .collect();
-    let mut record_batch = RecordBatch::try_new(
-        unsorted_record_batch_with_unmodified_schema.schema(),
-        columns,
-    )
-    .unwrap();
-    record_batch.remove_column(index);
-
-    let setup_seed = "spaceandtime".to_string();
-    let mut rng = {
-        // Convert the seed string to bytes and create a seeded RNG
-        let seed_bytes = setup_seed
-            .bytes()
-            .chain(std::iter::repeat(0u8))
-            .take(32)
-            .collect::<Vec<_>>()
-            .try_into()
-            .expect("collection is guaranteed to contain 32 elements");
-        ChaCha20Rng::from_seed(seed_bytes) // Seed ChaChaRng
-    };
-    let public_parameters = PublicParameters::rand(20, &mut rng);
-    let prover_setup = ProverSetup::from(&public_parameters);
-    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 12);
-    write_record_batch_to_blob::<DoryCommitment>(
-        &record_batch,
-        dory_prover_setup,
-        format!("{output_path_prefix}_dory_commitment"),
-    );
-    write_record_batch_to_blob::<DynamicDoryCommitment>(
-        &record_batch,
-        &prover_setup,
-        format!("{output_path_prefix}_dynamic_dory_commitment"),
+    let unzipped = commitments.into_iter().unzip();
+    aggregate_commitments_to_blob(unzipped.0, format!("{output_path_prefix}-dory-commitment"));
+    aggregate_commitments_to_blob(
+        unzipped.1,
+        format!("{output_path_prefix}-dynamic-dory-commitment"),
     );
 }
 
 /// # Panics
 ///
-/// Panics when fails any part of the process
-fn write_record_batch_to_blob<C: Commitment + Serialize + for<'a> Deserialize<'a>>(
-    record_batch: &RecordBatch,
-    setup: C::PublicSetup<'_>,
+/// Panics when any part of the process fails
+fn aggregate_commitments_to_blob<C: Commitment + Serialize + for<'a> Deserialize<'a>>(
+    commitments: Vec<TableCommitment<C>>,
     output_file_base: String,
 ) {
-    let commitment = TableCommitment::<C>::try_from_record_batch(record_batch, &setup).unwrap();
+    let commitment = commitments
+        .into_iter()
+        .fold(
+            None,
+            |aggregate_commitment: Option<TableCommitment<C>>, next_commitment| {
+                match aggregate_commitment {
+                    Some(agg) => Some(agg.try_add(next_commitment).unwrap()),
+                    None => Some(next_commitment),
+                }
+            },
+        )
+        .unwrap();
     let bytes: Vec<u8> = to_allocvec(&commitment).unwrap();
     let path_extension = "txt";
     let mut output_file = File::create(format!("{output_file_base}.{path_extension}")).unwrap();

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
@@ -84,12 +84,12 @@ pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>, output_path_pre
     let public_parameters = PublicParameters::rand(20, &mut rng);
     let prover_setup = ProverSetup::from(&public_parameters);
     let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 12);
-    read_parquet_file_to_commitment_as_blob_and_write_to_file::<DoryCommitment>(
+    write_record_batch_to_blob::<DoryCommitment>(
         &record_batch,
         dory_prover_setup,
         format!("{output_path_prefix}_dory_commitment"),
     );
-    read_parquet_file_to_commitment_as_blob_and_write_to_file::<DynamicDoryCommitment>(
+    write_record_batch_to_blob::<DynamicDoryCommitment>(
         &record_batch,
         &prover_setup,
         format!("{output_path_prefix}_dynamic_dory_commitment"),
@@ -99,7 +99,7 @@ pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>, output_path_pre
 /// # Panics
 ///
 /// Panics when fails any part of the process
-fn read_parquet_file_to_commitment_as_blob_and_write_to_file<
+fn write_record_batch_to_blob<
     C: Commitment + Serialize + for<'a> Deserialize<'a>,
 >(
     record_batch: &RecordBatch,

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
@@ -60,7 +60,7 @@ pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>, output_path_pre
     let columns = unsorted_record_batch_with_unmodified_schema
         .columns()
         .iter()
-        .map(|c| take(&*c, &indices, None).unwrap())
+        .map(|c| take(c, &indices, None).unwrap())
         .collect();
     let mut record_batch = RecordBatch::try_new(
         unsorted_record_batch_with_unmodified_schema.schema(),
@@ -104,7 +104,7 @@ fn write_record_batch_to_blob<C: Commitment + Serialize + for<'a> Deserialize<'a
     setup: C::PublicSetup<'_>,
     output_file_base: String,
 ) {
-    let commitment = TableCommitment::<C>::try_from_record_batch(&record_batch, &setup).unwrap();
+    let commitment = TableCommitment::<C>::try_from_record_batch(record_batch, &setup).unwrap();
     let bytes: Vec<u8> = to_allocvec(&commitment).unwrap();
     let path_extension = "txt";
     let mut output_file = File::create(format!("{output_file_base}.{path_extension}")).unwrap();

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
@@ -81,9 +81,9 @@ pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>, output_path_pre
             .expect("collection is guaranteed to contain 32 elements");
         ChaCha20Rng::from_seed(seed_bytes) // Seed ChaChaRng
     };
-    let public_parameters = PublicParameters::rand(4, &mut rng);
+    let public_parameters = PublicParameters::rand(20, &mut rng);
     let prover_setup = ProverSetup::from(&public_parameters);
-    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 12);
     read_parquet_file_to_commitment_as_blob_and_write_to_file::<DoryCommitment>(
         &record_batch,
         dory_prover_setup,

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob.rs
@@ -99,9 +99,7 @@ pub fn read_parquet_file_to_commitment_as_blob(paths: Vec<&str>, output_path_pre
 /// # Panics
 ///
 /// Panics when fails any part of the process
-fn write_record_batch_to_blob<
-    C: Commitment + Serialize + for<'a> Deserialize<'a>,
->(
+fn write_record_batch_to_blob<C: Commitment + Serialize + for<'a> Deserialize<'a>>(
     record_batch: &RecordBatch,
     setup: C::PublicSetup<'_>,
     output_file_base: String,

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob_integration_tests.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob_integration_tests.rs
@@ -54,7 +54,7 @@ fn calculate_dory_commitment(record_batch: &RecordBatch) -> TableCommitment<Dory
     let public_parameters = PublicParameters::rand(4, &mut rng);
     let prover_setup = ProverSetup::from(&public_parameters);
     let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
-    TableCommitment::<DoryCommitment>::try_from_record_batch(&record_batch, &dory_prover_setup)
+    TableCommitment::<DoryCommitment>::try_from_record_batch(record_batch, &dory_prover_setup)
         .unwrap()
 }
 
@@ -75,7 +75,7 @@ fn calculate_dynamic_dory_commitment(
     };
     let public_parameters = PublicParameters::rand(4, &mut rng);
     let prover_setup = ProverSetup::from(&public_parameters);
-    TableCommitment::<DynamicDoryCommitment>::try_from_record_batch(&record_batch, &&prover_setup)
+    TableCommitment::<DynamicDoryCommitment>::try_from_record_batch(record_batch, &&prover_setup)
         .unwrap()
 }
 
@@ -97,30 +97,29 @@ fn we_can_retrieve_commitments_and_save_to_file() {
     delete_file_if_exists(ristretto_point_path);
     delete_file_if_exists(dory_commitment_path);
     delete_file_if_exists(dynamic_dory_commitment_path);
-    let column_a_unsorted_1 = Int32Array::from(vec![2, 4]);
-    let column_b_unsorted_1 = Int32Array::from(vec![1, 4]);
-    let column_a_unsorted_2 = Int32Array::from(vec![1, 3]);
-    let column_b_unsorted_2 = Int32Array::from(vec![2, 3]);
-    let column_b_sorted = Int32Array::from(vec![2, 1, 3, 4]);
+    let proof_column_unsorted_1 = Int32Array::from(vec![2, 4]);
+    let column_unsorted_1 = Int32Array::from(vec![1, 4]);
+    let proof_column_unsorted_2 = Int32Array::from(vec![1, 3]);
+    let column_unsorted_2 = Int32Array::from(vec![2, 3]);
+    let column_sorted = Int32Array::from(vec![2, 1, 3, 4]);
     let record_batch_unsorted_1 = RecordBatch::try_from_iter(vec![
         (
             "SXTMETA_ROW_NUMBER",
-            Arc::new(column_a_unsorted_1) as ArrayRef,
+            Arc::new(proof_column_unsorted_1) as ArrayRef,
         ),
-        ("column", Arc::new(column_b_unsorted_1) as ArrayRef),
+        ("column", Arc::new(column_unsorted_1) as ArrayRef),
     ])
     .unwrap();
     let record_batch_unsorted_2 = RecordBatch::try_from_iter(vec![
         (
             "SXTMETA_ROW_NUMBER",
-            Arc::new(column_a_unsorted_2) as ArrayRef,
+            Arc::new(proof_column_unsorted_2) as ArrayRef,
         ),
-        ("column", Arc::new(column_b_unsorted_2) as ArrayRef),
+        ("column", Arc::new(column_unsorted_2) as ArrayRef),
     ])
     .unwrap();
     let record_batch_sorted =
-        RecordBatch::try_from_iter(vec![("column", Arc::new(column_b_sorted) as ArrayRef)])
-            .unwrap();
+        RecordBatch::try_from_iter(vec![("column", Arc::new(column_sorted) as ArrayRef)]).unwrap();
     create_mock_file_from_record_batch(parquet_path_1, &record_batch_unsorted_1);
     create_mock_file_from_record_batch(parquet_path_2, &record_batch_unsorted_2);
     read_parquet_file_to_commitment_as_blob(vec![parquet_path_1, parquet_path_2], "example");

--- a/crates/proof-of-sql/src/utils/parquet_to_commitment_blob_integration_tests.rs
+++ b/crates/proof-of-sql/src/utils/parquet_to_commitment_blob_integration_tests.rs
@@ -1,0 +1,85 @@
+use super::parquet_to_commitment_blob::read_parquet_file_to_commitment_as_blob;
+use crate::{
+    base::commitment::{Commitment, TableCommitment},
+    proof_primitive::dory::{DoryCommitment, DoryProverPublicSetup, ProverSetup, PublicParameters},
+};
+use arrow::array::{ArrayRef, Int32Array, RecordBatch};
+use parquet::{arrow::ArrowWriter, basic::Compression, file::properties::WriterProperties};
+use postcard::from_bytes;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::{self, File},
+    io::Read,
+    path::Path,
+    sync::Arc,
+};
+
+fn create_mock_file_from_record_batch(path: &str, record_batch: &RecordBatch) {
+    let parquet_file = File::create(path).unwrap();
+    let writer_properties = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+    let mut writer =
+        ArrowWriter::try_new(parquet_file, record_batch.schema(), Some(writer_properties)).unwrap();
+    writer.write(record_batch).unwrap();
+    writer.close().unwrap();
+}
+
+fn read_commitment_from_blob<C: Commitment + Serialize + for<'a> Deserialize<'a>>(
+    path: &str,
+) -> TableCommitment<C> {
+    let mut blob_file = File::open(path).unwrap();
+    let mut bytes: Vec<u8> = Vec::new();
+    blob_file.read_to_end(&mut bytes).unwrap();
+    from_bytes(&bytes).unwrap()
+}
+
+fn calculate_dory_commitment(record_batch: RecordBatch) -> TableCommitment<DoryCommitment> {
+    let setup_seed = "spaceandtime".to_string();
+    let mut rng = {
+        // Convert the seed string to bytes and create a seeded RNG
+        let seed_bytes = setup_seed
+            .bytes()
+            .chain(std::iter::repeat(0u8))
+            .take(32)
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("collection is guaranteed to contain 32 elements");
+        ChaCha20Rng::from_seed(seed_bytes) // Seed ChaChaRng
+    };
+    let public_parameters = PublicParameters::rand(4, &mut rng);
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let dory_prover_setup = DoryProverPublicSetup::new(&prover_setup, 3);
+    TableCommitment::<DoryCommitment>::try_from_record_batch(&record_batch, &dory_prover_setup)
+        .unwrap()
+}
+
+fn delete_file_if_exists(path: &str) {
+    if Path::new(path).exists() {
+        fs::remove_file(path).unwrap();
+    }
+}
+
+#[test]
+fn we_can_retrieve_commitments_and_save_to_file() {
+    let parquet_path = "example.parquet";
+    let ristretto_point_path = "example_ristretto_point.parquet";
+    let dory_commitment_path = "example_dory_commitment.parquet";
+    delete_file_if_exists(parquet_path);
+    delete_file_if_exists(ristretto_point_path);
+    delete_file_if_exists(dory_commitment_path);
+    let column = Int32Array::from(vec![1, 2, 3, 4]);
+    let record_batch =
+        RecordBatch::try_from_iter(vec![("id", Arc::new(column) as ArrayRef)]).unwrap();
+    create_mock_file_from_record_batch(parquet_path, &record_batch);
+    read_parquet_file_to_commitment_as_blob(parquet_path);
+    assert_eq!(
+        read_commitment_from_blob::<DoryCommitment>(dory_commitment_path),
+        calculate_dory_commitment(record_batch)
+    );
+    delete_file_if_exists(parquet_path);
+    delete_file_if_exists(ristretto_point_path);
+    delete_file_if_exists(dory_commitment_path);
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

There is a need to be able to compute the table commitments for tables from parquet files.

# What changes are included in this PR?

New utils directory with a script for calculating TableCommitments from parquet files and writing them to a file as a blob.

# Are these changes tested?
Yes.
