### PR TITLE
Remove inner product types from generic test. 

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -1,18 +1,18 @@
 use super::*;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::test_scalar::TestScalar;
 use num_traits::{One, Zero};
 
 #[test]
 fn we_can_compute_the_bit_distribution_of_an_empty_slice() {
     let data: Vec<i64> = vec![];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 0);
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::zero()
+        TestScalar::from(dist.constant_part()),
+        TestScalar::zero()
     );
 
     let mut cnt = 0;
@@ -38,14 +38,14 @@ fn we_can_compute_the_bit_distribution_of_an_empty_slice() {
 fn we_can_compute_the_bit_distribution_of_a_slice_with_a_single_element() {
     let val = (1 << 2) | (1 << 10);
     let data: Vec<i64> = vec![val];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 0);
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::from(val)
+        TestScalar::from(dist.constant_part()),
+        TestScalar::from(val)
     );
     assert_eq!(dist.most_significant_abs_bit(), 10);
 
@@ -73,14 +73,14 @@ fn we_can_compute_the_bit_distribution_of_a_slice_with_a_single_element() {
 #[test]
 fn we_can_compute_the_bit_distribution_of_a_slice_with_one_varying_bits() {
     let data: Vec<i64> = vec![(1 << 2) | (1 << 10), (1 << 2) | (1 << 10) | (1 << 21)];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 1);
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::from((1 << 10) | (1 << 2))
+        TestScalar::from(dist.constant_part()),
+        TestScalar::from((1 << 10) | (1 << 2))
     );
     assert_eq!(dist.most_significant_abs_bit(), 21);
 
@@ -116,14 +116,14 @@ fn we_can_compute_the_bit_distribution_of_a_slice_with_multiple_varying_bits() {
         (1 << 3) | (1 << 10) | (1 << 21),
         (1 << 10) | (1 << 21) | (1 << 50),
     ];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 4);
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::from(1 << 10)
+        TestScalar::from(dist.constant_part()),
+        TestScalar::from(1 << 10)
     );
     assert_eq!(dist.most_significant_abs_bit(), 50);
 
@@ -155,14 +155,14 @@ fn we_can_compute_the_bit_distribution_of_a_slice_with_multiple_varying_bits() {
 #[test]
 fn we_can_compute_the_bit_distribution_of_negative_values() {
     let data: Vec<i64> = vec![-1];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 0);
     assert!(!dist.has_varying_sign_bit());
     assert!(dist.sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::one()
+        TestScalar::from(dist.constant_part()),
+        TestScalar::one()
     );
     assert_eq!(dist.most_significant_abs_bit(), 0);
 
@@ -190,12 +190,12 @@ fn we_can_compute_the_bit_distribution_of_negative_values() {
 #[test]
 fn we_can_compute_the_bit_distribution_of_values_with_different_signs() {
     let data: Vec<i64> = vec![-1, 1];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 1);
     assert!(dist.has_varying_sign_bit());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::one()
+        TestScalar::from(dist.constant_part()),
+        TestScalar::one()
     );
     assert_eq!(dist.most_significant_abs_bit(), 0);
 
@@ -225,13 +225,13 @@ fn we_can_compute_the_bit_distribution_of_values_with_different_signs() {
 #[test]
 fn we_can_compute_the_bit_distribution_of_values_with_different_signs_and_values() {
     let data: Vec<i64> = vec![4, -1, 1];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 3);
     assert!(dist.has_varying_sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::zero()
+        TestScalar::from(dist.constant_part()),
+        TestScalar::zero()
     );
     assert_eq!(dist.most_significant_abs_bit(), 2);
 
@@ -261,14 +261,14 @@ fn we_can_compute_the_bit_distribution_of_values_with_different_signs_and_values
 fn we_can_compute_the_bit_distribution_of_values_larger_than_64_bit_integers() {
     let mut val = [0; 4];
     val[3] = 1 << 11;
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::from_bigint(val)];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::from_bigint(val)];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 0);
     assert!(!dist.has_varying_sign_bit());
     assert!(dist.is_valid());
     assert_eq!(
-        Curve25519Scalar::from(dist.constant_part()),
-        Curve25519Scalar::from_bigint(val)
+        TestScalar::from(dist.constant_part()),
+        TestScalar::from_bigint(val)
     );
     assert_eq!(dist.most_significant_abs_bit(), 64 * 3 + 11);
 

--- a/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution_test.rs
@@ -10,10 +10,7 @@ fn we_can_compute_the_bit_distribution_of_an_empty_slice() {
     assert!(!dist.has_varying_sign_bit());
     assert!(!dist.sign_bit());
     assert!(dist.is_valid());
-    assert_eq!(
-        TestScalar::from(dist.constant_part()),
-        TestScalar::zero()
-    );
+    assert_eq!(TestScalar::from(dist.constant_part()), TestScalar::zero());
 
     let mut cnt = 0;
     dist.for_each_abs_constant_bit(|_i: usize, _pos: usize| {
@@ -160,10 +157,7 @@ fn we_can_compute_the_bit_distribution_of_negative_values() {
     assert!(!dist.has_varying_sign_bit());
     assert!(dist.sign_bit());
     assert!(dist.is_valid());
-    assert_eq!(
-        TestScalar::from(dist.constant_part()),
-        TestScalar::one()
-    );
+    assert_eq!(TestScalar::from(dist.constant_part()), TestScalar::one());
     assert_eq!(dist.most_significant_abs_bit(), 0);
 
     let mut cnt = 0;
@@ -193,10 +187,7 @@ fn we_can_compute_the_bit_distribution_of_values_with_different_signs() {
     let dist = BitDistribution::new::<TestScalar, _>(&data);
     assert_eq!(dist.num_varying_bits(), 1);
     assert!(dist.has_varying_sign_bit());
-    assert_eq!(
-        TestScalar::from(dist.constant_part()),
-        TestScalar::one()
-    );
+    assert_eq!(TestScalar::from(dist.constant_part()), TestScalar::one());
     assert_eq!(dist.most_significant_abs_bit(), 0);
 
     let mut cnt = 0;
@@ -229,10 +220,7 @@ fn we_can_compute_the_bit_distribution_of_values_with_different_signs_and_values
     assert_eq!(dist.num_varying_bits(), 3);
     assert!(dist.has_varying_sign_bit());
     assert!(dist.is_valid());
-    assert_eq!(
-        TestScalar::from(dist.constant_part()),
-        TestScalar::zero()
-    );
+    assert_eq!(TestScalar::from(dist.constant_part()), TestScalar::zero());
     assert_eq!(dist.most_significant_abs_bit(), 2);
 
     let mut cnt = 0;

--- a/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
@@ -1,12 +1,12 @@
 use super::*;
-use crate::base::{bit::BitDistribution, scalar::Curve25519Scalar};
+use crate::base::{bit::BitDistribution, scalar::test_scalar::TestScalar};
 use bumpalo::Bump;
 use num_traits::{One, Zero};
 
 #[test]
 fn we_can_compute_the_bit_matrix_of_empty_data() {
-    let data: Vec<Curve25519Scalar> = vec![];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert!(matrix.is_empty());
@@ -14,8 +14,8 @@ fn we_can_compute_the_bit_matrix_of_empty_data() {
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_a_single_element() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::one()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::one()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert!(matrix.is_empty());
@@ -23,8 +23,8 @@ fn we_can_compute_the_bit_matrix_for_a_single_element() {
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_data_with_a_single_varying_bit() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::one(), Curve25519Scalar::zero()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::one(), TestScalar::zero()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 1);
@@ -34,8 +34,8 @@ fn we_can_compute_the_bit_matrix_for_data_with_a_single_varying_bit() {
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_data_with_a_varying_sign_bit() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::one(), -Curve25519Scalar::one()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::one(), -TestScalar::one()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 1);
@@ -45,8 +45,8 @@ fn we_can_compute_the_bit_matrix_for_data_with_a_varying_sign_bit() {
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_in_different_positions() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::from(2), Curve25519Scalar::one()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::from(2), TestScalar::one()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 2);
@@ -58,8 +58,8 @@ fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_in_different_positio
 
 #[test]
 fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_and_constant_bits() {
-    let data: Vec<Curve25519Scalar> = vec![Curve25519Scalar::from(3), Curve25519Scalar::from(-1)];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> = vec![TestScalar::from(3), TestScalar::from(-1)];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 2);
@@ -73,9 +73,9 @@ fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_and_constant_bits() 
 fn we_can_compute_the_bit_matrix_for_data_entries_bigger_than_64_bit_integers() {
     let mut val = [0; 4];
     val[3] = 1 << 2;
-    let data: Vec<Curve25519Scalar> =
-        vec![Curve25519Scalar::from_bigint(val), Curve25519Scalar::one()];
-    let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
+    let data: Vec<TestScalar> =
+        vec![TestScalar::from_bigint(val), TestScalar::one()];
+    let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);
     assert_eq!(matrix.len(), 2);

--- a/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_matrix_test.rs
@@ -73,8 +73,7 @@ fn we_can_compute_the_bit_matrix_for_data_with_varying_bits_and_constant_bits() 
 fn we_can_compute_the_bit_matrix_for_data_entries_bigger_than_64_bit_integers() {
     let mut val = [0; 4];
     val[3] = 1 << 2;
-    let data: Vec<TestScalar> =
-        vec![TestScalar::from_bigint(val), TestScalar::one()];
+    let data: Vec<TestScalar> = vec![TestScalar::from_bigint(val), TestScalar::one()];
     let dist = BitDistribution::new::<TestScalar, _>(&data);
     let alloc = Bump::new();
     let matrix = compute_varying_bit_matrix(&alloc, &data, &dist);

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
@@ -1,5 +1,10 @@
 use super::CommitmentEvaluationProof;
-use crate::base::{commitment::vec_commitment_ext::VecCommitmentExt, database::Column, commitment::test_evaluation_proof::TestEvaluationProof};
+use crate::base::{
+    commitment::{
+        test_evaluation_proof::TestEvaluationProof, vec_commitment_ext::VecCommitmentExt,
+    },
+    database::Column,
+};
 use ark_std::UniformRand;
 use merlin::Transcript;
 use num_traits::{One, Zero};

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof_test.rs
@@ -1,8 +1,6 @@
 use super::CommitmentEvaluationProof;
-use crate::base::{commitment::vec_commitment_ext::VecCommitmentExt, database::Column};
+use crate::base::{commitment::vec_commitment_ext::VecCommitmentExt, database::Column, commitment::test_evaluation_proof::TestEvaluationProof};
 use ark_std::UniformRand;
-#[cfg(feature = "blitzar")]
-use blitzar::proof::InnerProductProof;
 use merlin::Transcript;
 use num_traits::{One, Zero};
 
@@ -140,141 +138,141 @@ pub fn test_random_commitment_evaluation_proof<CP: CommitmentEvaluationProof>(
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_simple_ipa() {
-    test_simple_commitment_evaluation_proof::<InnerProductProof>(&(), &());
+    test_simple_commitment_evaluation_proof::<TestEvaluationProof>(&(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_1() {
-    test_commitment_evaluation_proof_with_length_1::<InnerProductProof>(&(), &());
+    test_commitment_evaluation_proof_with_length_1::<TestEvaluationProof>(&(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_128() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(128, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(128, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(128, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(128, 64, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(128, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(128, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(128, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(128, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(128, 64, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(128, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_100() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(100, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(100, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(100, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(100, 64, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(100, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(100, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(100, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(100, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(100, 64, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(100, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_64() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(64, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(64, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(64, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(64, 32, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(64, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(64, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(64, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(64, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(64, 32, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(64, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_50() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(50, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(50, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(50, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(50, 32, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(50, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(50, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(50, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(50, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(50, 32, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(50, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_32() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(32, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(32, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(32, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(32, 16, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(32, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(32, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(32, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(32, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(32, 16, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(32, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_20() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(20, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(20, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(20, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(20, 16, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(20, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(20, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(20, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(20, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(20, 16, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(20, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_16() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(16, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(16, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(16, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(16, 8, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(16, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(16, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(16, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(16, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(16, 8, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(16, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_10() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(10, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(10, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(10, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(10, 8, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(10, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(10, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(10, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(10, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(10, 8, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(10, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_8() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(8, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(8, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(8, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(8, 4, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(8, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(8, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(8, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(8, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(8, 4, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(8, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_5() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(5, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(5, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(5, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(5, 4, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(5, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(5, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(5, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(5, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(5, 4, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(5, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_4() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(4, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(4, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(4, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(4, 2, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(4, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(4, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(4, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(4, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(4, 2, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(4, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_3() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(3, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(3, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(3, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(3, 2, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(3, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(3, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(3, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(3, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(3, 2, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(3, 200, &(), &());
 }
 
 #[test]
 #[cfg(feature = "blitzar")]
 fn test_random_ipa_with_length_2() {
-    test_random_commitment_evaluation_proof::<InnerProductProof>(2, 0, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(2, 1, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(2, 10, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(2, 2, &(), &());
-    test_random_commitment_evaluation_proof::<InnerProductProof>(2, 200, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(2, 0, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(2, 1, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(2, 10, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(2, 2, &(), &());
+    test_random_commitment_evaluation_proof::<TestEvaluationProof>(2, 200, &(), &());
 }

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
@@ -4,7 +4,7 @@ use crate::base::{
         OwnedTable,
     },
     math::decimal::Precision,
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
 use proof_of_sql_parser::{
     intermediate_ast::Literal,
@@ -15,7 +15,7 @@ use proof_of_sql_parser::{
 
 #[test]
 fn we_can_evaluate_a_simple_literal() {
-    let table: OwnedTable<Curve25519Scalar> =
+    let table: OwnedTable<TestScalar> =
         owned_table([varchar("languages", ["en", "es", "pt", "fr", "ht"])]);
 
     // "Space and Time" in Hebrew
@@ -54,7 +54,7 @@ fn we_can_evaluate_a_simple_literal() {
 
 #[test]
 fn we_can_evaluate_a_simple_column() {
-    let table: OwnedTable<Curve25519Scalar> = owned_table([
+    let table: OwnedTable<TestScalar> = owned_table([
         bigint("bigints", [i64::MIN, -1, 0, 1, i64::MAX]),
         varchar("language", ["en", "es", "pt", "fr", "ht"]),
         varchar("john", ["John", "Juan", "João", "Jean", "Jean"]),
@@ -77,7 +77,7 @@ fn we_can_evaluate_a_simple_column() {
 
 #[test]
 fn we_can_not_evaluate_a_nonexisting_column() {
-    let table: OwnedTable<Curve25519Scalar> =
+    let table: OwnedTable<TestScalar> =
         owned_table([varchar("cats", ["Chloe", "Margaret", "Prudence", "Lucy"])]);
     // "not_a_column" is not a column in the table
     let expr = col("not_a_column");
@@ -89,7 +89,7 @@ fn we_can_not_evaluate_a_nonexisting_column() {
 
 #[test]
 fn we_can_evaluate_a_logical_expression() {
-    let table: OwnedTable<Curve25519Scalar> = owned_table([
+    let table: OwnedTable<TestScalar> = owned_table([
         varchar("en", ["Elizabeth", "John", "cat", "dog", "Munich"]),
         varchar("pl", ["Elżbieta", "Jan", "kot", "pies", "Monachium"]),
         varchar("cz", ["Alžběta", "Jan", "kočka", "pes", "Mnichov"]),
@@ -108,14 +108,14 @@ fn we_can_evaluate_a_logical_expression() {
     // Which Czech and Slovak words agree?
     let expr = equal(col("cz"), col("sk"));
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column: OwnedColumn<Curve25519Scalar> =
+    let expected_column: OwnedColumn<TestScalar> =
         OwnedColumn::Boolean(vec![false, false, false, true, false]);
     assert_eq!(actual_column, expected_column);
 
     // Find words shared among Slovak, Croatian and Slovenian
     let expr = and(equal(col("sk"), col("hr")), equal(col("hr"), col("sl")));
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column: OwnedColumn<Curve25519Scalar> =
+    let expected_column: OwnedColumn<TestScalar> =
         OwnedColumn::Boolean(vec![false, false, true, false, false]);
     assert_eq!(actual_column, expected_column);
 
@@ -125,7 +125,7 @@ fn we_can_evaluate_a_logical_expression() {
         not(equal(col("pl"), col("sl"))),
     );
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column: OwnedColumn<Curve25519Scalar> =
+    let expected_column: OwnedColumn<TestScalar> =
         OwnedColumn::Boolean(vec![false, true, false, false, false]);
     assert_eq!(actual_column, expected_column);
 
@@ -135,14 +135,14 @@ fn we_can_evaluate_a_logical_expression() {
         and(equal(col("hr"), col("sl")), equal(col("hr"), col("sk"))),
     );
     let actual_column = table.evaluate(&expr).unwrap();
-    let expected_column: OwnedColumn<Curve25519Scalar> =
+    let expected_column: OwnedColumn<TestScalar> =
         OwnedColumn::Boolean(vec![true, true, true, false, true]);
     assert_eq!(actual_column, expected_column);
 }
 
 #[test]
 fn we_can_evaluate_an_arithmetic_expression() {
-    let table: OwnedTable<Curve25519Scalar> = owned_table([
+    let table: OwnedTable<TestScalar> = owned_table([
         smallint("smallints", [-2_i16, -1, 0, 1, 2]),
         int("ints", [-4_i32, -2, 0, 2, 4]),
         bigint("bigints", [-8_i64, -4, 0, 4, 8]),
@@ -197,7 +197,7 @@ fn we_can_evaluate_an_arithmetic_expression() {
 
 #[test]
 fn we_cannot_evaluate_expressions_if_column_operation_errors_out() {
-    let table: OwnedTable<Curve25519Scalar> = owned_table([
+    let table: OwnedTable<TestScalar> = owned_table([
         bigint("bigints", [i64::MIN, -1, 0, 1, i64::MAX]),
         varchar("language", ["en", "es", "pt", "fr", "ht"]),
         varchar("sarah", ["Sarah", "Sara", "Sara", "Sarah", "Sarah"]),

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -8,8 +8,7 @@ use bumpalo::Bump;
 #[test]
 fn we_can_filter_columns() {
     let selection = vec![true, false, true, false, true];
-    let str_scalars: [TestScalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![
@@ -40,8 +39,7 @@ fn we_can_filter_columns() {
 #[test]
 fn we_can_filter_columns_with_empty_result() {
     let selection = vec![false, false, false, false, false];
-    let str_scalars: [TestScalar; 5] =
-        ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
+    let str_scalars: [TestScalar; 5] = ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let columns = vec![

--- a/crates/proof-of-sql/src/base/database/filter_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util_test.rs
@@ -1,14 +1,14 @@
 use crate::base::{
     database::{filter_util::*, Column},
     math::decimal::Precision,
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
 
 #[test]
 fn we_can_filter_columns() {
     let selection = vec![true, false, true, false, true];
-    let str_scalars: [Curve25519Scalar; 5] =
+    let str_scalars: [TestScalar; 5] =
         ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
@@ -40,7 +40,7 @@ fn we_can_filter_columns() {
 #[test]
 fn we_can_filter_columns_with_empty_result() {
     let selection = vec![false, false, false, false, false];
-    let str_scalars: [Curve25519Scalar; 5] =
+    let str_scalars: [TestScalar; 5] =
         ["1".into(), "2".into(), "3".into(), "4".into(), "5".into()];
     let scalars = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
     let decimals = [1.into(), 2.into(), 3.into(), 4.into(), 5.into()];
@@ -69,7 +69,7 @@ fn we_can_filter_columns_with_empty_result() {
 fn we_can_filter_empty_columns() {
     let selection = vec![];
     let columns = vec![
-        Column::<Curve25519Scalar>::BigInt(&[]),
+        Column::<TestScalar>::BigInt(&[]),
         Column::Int128(&[]),
         Column::VarChar((&[], &[])),
         Column::Scalar(&[]),

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         database::{group_by_util::*, Column, OwnedColumn},
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -10,7 +10,7 @@ use core::cmp::Ordering;
 
 #[test]
 fn we_can_aggregate_empty_columns() {
-    let column_a = Column::BigInt::<Curve25519Scalar>(&[]);
+    let column_a = Column::BigInt::<TestScalar>(&[]);
     let column_b = Column::VarChar((&[], &[]));
     let column_c = Column::Int128(&[]);
     let column_d = Column::Scalar(&[]);
@@ -33,7 +33,7 @@ fn we_can_aggregate_columns_with_empty_group_by_and_no_rows_selected() {
     let slice_c = &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
     let slice_d = &[200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211];
     let selection = &[false; 12];
-    let scals_d: Vec<Curve25519Scalar> = slice_d.iter().map(core::convert::Into::into).collect();
+    let scals_d: Vec<TestScalar> = slice_d.iter().map(core::convert::Into::into).collect();
     let column_c = Column::Int128(slice_c);
     let column_d = Column::Scalar(&scals_d);
     let group_by = &[];
@@ -69,7 +69,7 @@ fn we_can_aggregate_columns_with_empty_group_by() {
     let selection = &[
         false, true, true, true, true, true, true, true, true, true, true, true,
     ];
-    let scals_d: Vec<Curve25519Scalar> = slice_d.iter().map(core::convert::Into::into).collect();
+    let scals_d: Vec<TestScalar> = slice_d.iter().map(core::convert::Into::into).collect();
     let column_c = Column::Int128(slice_c);
     let column_d = Column::Scalar(&scals_d);
     let group_by = &[];
@@ -88,20 +88,20 @@ fn we_can_aggregate_columns_with_empty_group_by() {
     .expect("Aggregation should succeed");
     let expected_group_by_result = &[];
     let expected_sum_result = &[
-        &[Curve25519Scalar::from(
+        &[TestScalar::from(
             101 + 102 + 103 + 104 + 105 + 106 + 107 + 108 + 109 + 110 + 111,
         )],
-        &[Curve25519Scalar::from(
+        &[TestScalar::from(
             201 + 202 + 203 + 204 + 205 + 206 + 207 + 208 + 209 + 210 + 211,
         )],
     ];
     let expected_max_result = &[
-        &[Some(Curve25519Scalar::from(111))],
-        &[Some(Curve25519Scalar::from(211))],
+        &[Some(TestScalar::from(111))],
+        &[Some(TestScalar::from(211))],
     ];
     let expected_min_result = &[
-        &[Some(Curve25519Scalar::from(101))],
-        &[Some(Curve25519Scalar::from(201))],
+        &[Some(TestScalar::from(101))],
+        &[Some(TestScalar::from(201))],
     ];
     let expected_count_result = &[11];
     assert_eq!(aggregate_result.group_by_columns, expected_group_by_result);
@@ -122,8 +122,8 @@ fn we_can_aggregate_columns() {
     let selection = &[
         false, true, true, true, true, true, true, true, true, true, true, true,
     ];
-    let scals_b: Vec<Curve25519Scalar> = slice_b.iter().map(core::convert::Into::into).collect();
-    let scals_d: Vec<Curve25519Scalar> = slice_d.iter().map(core::convert::Into::into).collect();
+    let scals_b: Vec<TestScalar> = slice_b.iter().map(core::convert::Into::into).collect();
+    let scals_d: Vec<TestScalar> = slice_d.iter().map(core::convert::Into::into).collect();
     let column_a = Column::BigInt(slice_a);
     let column_b = Column::VarChar((slice_b, &scals_b));
     let column_c = Column::Int128(slice_c);
@@ -143,12 +143,12 @@ fn we_can_aggregate_columns() {
     )
     .expect("Aggregation should succeed");
     let scals_res = [
-        Curve25519Scalar::from("Cat"),
-        Curve25519Scalar::from("Dog"),
-        Curve25519Scalar::from("Cat"),
-        Curve25519Scalar::from("Dog"),
-        Curve25519Scalar::from("Cat"),
-        Curve25519Scalar::from("Dog"),
+        TestScalar::from("Cat"),
+        TestScalar::from("Dog"),
+        TestScalar::from("Cat"),
+        TestScalar::from("Dog"),
+        TestScalar::from("Cat"),
+        TestScalar::from("Dog"),
     ];
     let expected_group_by_result = &[
         Column::BigInt(&[1, 1, 2, 2, 3, 3]),
@@ -156,56 +156,56 @@ fn we_can_aggregate_columns() {
     ];
     let expected_sum_result = &[
         &[
-            Curve25519Scalar::from(105),
-            Curve25519Scalar::from(106),
-            Curve25519Scalar::from(103 + 107),
-            Curve25519Scalar::from(104 + 108),
-            Curve25519Scalar::from(101 + 109 + 111),
-            Curve25519Scalar::from(102 + 110),
+            TestScalar::from(105),
+            TestScalar::from(106),
+            TestScalar::from(103 + 107),
+            TestScalar::from(104 + 108),
+            TestScalar::from(101 + 109 + 111),
+            TestScalar::from(102 + 110),
         ],
         &[
-            Curve25519Scalar::from(205),
-            Curve25519Scalar::from(206),
-            Curve25519Scalar::from(203 + 207),
-            Curve25519Scalar::from(204 + 208),
-            Curve25519Scalar::from(201 + 209 + 211),
-            Curve25519Scalar::from(202 + 210),
+            TestScalar::from(205),
+            TestScalar::from(206),
+            TestScalar::from(203 + 207),
+            TestScalar::from(204 + 208),
+            TestScalar::from(201 + 209 + 211),
+            TestScalar::from(202 + 210),
         ],
     ];
     let expected_max_result = &[
         &[
-            Some(Curve25519Scalar::from(105)),
-            Some(Curve25519Scalar::from(106)),
-            Some(Curve25519Scalar::from(107)),
-            Some(Curve25519Scalar::from(108)),
-            Some(Curve25519Scalar::from(111)),
-            Some(Curve25519Scalar::from(110)),
+            Some(TestScalar::from(105)),
+            Some(TestScalar::from(106)),
+            Some(TestScalar::from(107)),
+            Some(TestScalar::from(108)),
+            Some(TestScalar::from(111)),
+            Some(TestScalar::from(110)),
         ],
         &[
-            Some(Curve25519Scalar::from(205)),
-            Some(Curve25519Scalar::from(206)),
-            Some(Curve25519Scalar::from(207)),
-            Some(Curve25519Scalar::from(208)),
-            Some(Curve25519Scalar::from(211)),
-            Some(Curve25519Scalar::from(210)),
+            Some(TestScalar::from(205)),
+            Some(TestScalar::from(206)),
+            Some(TestScalar::from(207)),
+            Some(TestScalar::from(208)),
+            Some(TestScalar::from(211)),
+            Some(TestScalar::from(210)),
         ],
     ];
     let expected_min_result = &[
         &[
-            Some(Curve25519Scalar::from(105)),
-            Some(Curve25519Scalar::from(106)),
-            Some(Curve25519Scalar::from(103)),
-            Some(Curve25519Scalar::from(104)),
-            Some(Curve25519Scalar::from(101)),
-            Some(Curve25519Scalar::from(102)),
+            Some(TestScalar::from(105)),
+            Some(TestScalar::from(106)),
+            Some(TestScalar::from(103)),
+            Some(TestScalar::from(104)),
+            Some(TestScalar::from(101)),
+            Some(TestScalar::from(102)),
         ],
         &[
-            Some(Curve25519Scalar::from(205)),
-            Some(Curve25519Scalar::from(206)),
-            Some(Curve25519Scalar::from(203)),
-            Some(Curve25519Scalar::from(204)),
-            Some(Curve25519Scalar::from(201)),
-            Some(Curve25519Scalar::from(202)),
+            Some(TestScalar::from(205)),
+            Some(TestScalar::from(206)),
+            Some(TestScalar::from(203)),
+            Some(TestScalar::from(204)),
+            Some(TestScalar::from(201)),
+            Some(TestScalar::from(202)),
         ],
     ];
     let expected_count_result = &[1, 1, 2, 2, 3, 2];
@@ -218,7 +218,7 @@ fn we_can_aggregate_columns() {
 
 #[test]
 fn we_can_compare_indexes_by_columns_with_no_columns() {
-    let columns: &[Column<Curve25519Scalar>; 0] = &[];
+    let columns: &[Column<TestScalar>; 0] = &[];
     assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Equal);
     assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Equal);
     assert_eq!(compare_indexes_by_columns(columns, 3, 2), Ordering::Equal);
@@ -258,7 +258,7 @@ fn we_can_compare_indexes_by_columns_for_mixed_columns() {
     let slice_a = &["55", "44", "66", "66", "66", "77", "66", "66", "66", "66"];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
-    let scals_a: Vec<Curve25519Scalar> = slice_a.iter().map(core::convert::Into::into).collect();
+    let scals_a: Vec<TestScalar> = slice_a.iter().map(core::convert::Into::into).collect();
     let column_a = Column::VarChar((slice_a, &scals_a));
     let column_b = Column::Int128(slice_b);
     let column_c = Column::BigInt(slice_c);
@@ -368,7 +368,7 @@ fn we_can_compare_indexes_by_columns_for_scalar_columns() {
     let slice_a = &[55, 44, 66, 66, 66, 77, 66, 66, 66, 66];
     let slice_b = &[22, 44, 11, 44, 33, 22, 22, 11, 22, 22];
     let slice_c = &[11, 55, 11, 44, 77, 11, 22, 55, 11, 22];
-    let scals_a: Vec<Curve25519Scalar> = slice_a.iter().map(core::convert::Into::into).collect();
+    let scals_a: Vec<TestScalar> = slice_a.iter().map(core::convert::Into::into).collect();
     let column_a = Column::Scalar(&scals_a);
     let column_b = Column::Int128(slice_b);
     let column_c = Column::BigInt(slice_c);
@@ -426,9 +426,9 @@ fn we_can_sum_aggregate_slice_by_counts_with_all_empty_groups() {
     ];
     let indexes = &[];
     let counts = &[0, 0, 0];
-    let expected = &[Curve25519Scalar::from(0); 3];
+    let expected = &[TestScalar::from(0); 3];
     let alloc = Bump::new();
-    let result: &[Curve25519Scalar] =
+    let result: &[TestScalar] =
         sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -441,12 +441,12 @@ fn we_can_sum_aggregate_slice_by_counts_with_some_empty_group() {
     let indexes = &[12, 11, 1, 10, 2, 3, 4];
     let counts = &[3, 4, 0];
     let expected = &[
-        Curve25519Scalar::from(112 + 111 + 101),
-        Curve25519Scalar::from(110 + 102 + 103 + 104),
-        Curve25519Scalar::from(0),
+        TestScalar::from(112 + 111 + 101),
+        TestScalar::from(110 + 102 + 103 + 104),
+        TestScalar::from(0),
     ];
     let alloc = Bump::new();
-    let result: &[Curve25519Scalar] =
+    let result: &[TestScalar] =
         sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -459,12 +459,12 @@ fn we_can_sum_aggregate_slice_by_counts_without_empty_groups() {
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4];
     let expected = &[
-        Curve25519Scalar::from(112 + 111 + 101),
-        Curve25519Scalar::from(110 + 102 + 103),
-        Curve25519Scalar::from(106 + 114 + 113 + 109),
+        TestScalar::from(112 + 111 + 101),
+        TestScalar::from(110 + 102 + 103),
+        TestScalar::from(106 + 114 + 113 + 109),
     ];
     let alloc = Bump::new();
-    let result: &[Curve25519Scalar] =
+    let result: &[TestScalar] =
         sum_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -493,16 +493,16 @@ fn we_can_sum_aggregate_columns_by_counts() {
     let slice_c = &[
         100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
     ];
-    let scals_c: Vec<Curve25519Scalar> = slice_c.iter().map(core::convert::Into::into).collect();
-    let column_a = Column::BigInt::<Curve25519Scalar>(slice_a);
-    let columns_b = Column::Int128::<Curve25519Scalar>(slice_b);
+    let scals_c: Vec<TestScalar> = slice_c.iter().map(core::convert::Into::into).collect();
+    let column_a = Column::BigInt::<TestScalar>(slice_a);
+    let columns_b = Column::Int128::<TestScalar>(slice_b);
     let columns_c = Column::Scalar(&scals_c);
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4];
     let expected = &[
-        Curve25519Scalar::from(112 + 111 + 101),
-        Curve25519Scalar::from(110 + 102 + 103),
-        Curve25519Scalar::from(106 + 114 + 113 + 109),
+        TestScalar::from(112 + 111 + 101),
+        TestScalar::from(110 + 102 + 103),
+        TestScalar::from(106 + 114 + 113 + 109),
     ];
     let alloc = Bump::new();
     let result = sum_aggregate_column_by_index_counts(&alloc, &column_a, counts, indexes);
@@ -547,7 +547,7 @@ fn we_can_max_aggregate_slice_by_counts_with_all_empty_groups() {
     let counts = &[0, 0, 0];
     let expected = &[None; 3];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -560,12 +560,12 @@ fn we_can_max_aggregate_slice_by_counts_with_some_empty_group() {
     let indexes = &[12, 11, 1, 10, 2, 3, 4];
     let counts = &[3, 4, 0];
     let expected = &[
-        Some(Curve25519Scalar::from(112)),
-        Some(Curve25519Scalar::from(110)),
+        Some(TestScalar::from(112)),
+        Some(TestScalar::from(110)),
         None,
     ];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -578,12 +578,12 @@ fn we_can_max_aggregate_slice_by_counts_without_empty_groups() {
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4];
     let expected = &[
-        Some(Curve25519Scalar::from(112)),
-        Some(Curve25519Scalar::from(110)),
-        Some(Curve25519Scalar::from(114)),
+        Some(TestScalar::from(112)),
+        Some(TestScalar::from(110)),
+        Some(TestScalar::from(114)),
     ];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         max_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -612,16 +612,16 @@ fn we_can_max_aggregate_columns_by_counts() {
     let slice_c = &[
         100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
     ];
-    let scals_c: Vec<Curve25519Scalar> = slice_c.iter().map(core::convert::Into::into).collect();
-    let column_a = Column::BigInt::<Curve25519Scalar>(slice_a);
-    let columns_b = Column::Int128::<Curve25519Scalar>(slice_b);
+    let scals_c: Vec<TestScalar> = slice_c.iter().map(core::convert::Into::into).collect();
+    let column_a = Column::BigInt::<TestScalar>(slice_a);
+    let columns_b = Column::Int128::<TestScalar>(slice_b);
     let columns_c = Column::Scalar(&scals_c);
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4, 0];
     let expected = &[
-        Some(Curve25519Scalar::from(112)),
-        Some(Curve25519Scalar::from(110)),
-        Some(Curve25519Scalar::from(114)),
+        Some(TestScalar::from(112)),
+        Some(TestScalar::from(110)),
+        Some(TestScalar::from(114)),
         None,
     ];
     let alloc = Bump::new();
@@ -667,7 +667,7 @@ fn we_can_min_aggregate_slice_by_counts_with_all_empty_groups() {
     let counts = &[0, 0, 0];
     let expected = &[None; 3];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -680,12 +680,12 @@ fn we_can_min_aggregate_slice_by_counts_with_some_empty_group() {
     let indexes = &[12, 11, 1, 10, 2, 3, 4];
     let counts = &[3, 4, 0];
     let expected = &[
-        Some(Curve25519Scalar::from(101)),
-        Some(Curve25519Scalar::from(102)),
+        Some(TestScalar::from(101)),
+        Some(TestScalar::from(102)),
         None,
     ];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -698,12 +698,12 @@ fn we_can_min_aggregate_slice_by_counts_without_empty_groups() {
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4];
     let expected = &[
-        Some(Curve25519Scalar::from(101)),
-        Some(Curve25519Scalar::from(102)),
-        Some(Curve25519Scalar::from(106)),
+        Some(TestScalar::from(101)),
+        Some(TestScalar::from(102)),
+        Some(TestScalar::from(106)),
     ];
     let alloc = Bump::new();
-    let result: &[Option<Curve25519Scalar>] =
+    let result: &[Option<TestScalar>] =
         min_aggregate_slice_by_index_counts(&alloc, slice_a, counts, indexes);
     assert_eq!(result, expected);
 }
@@ -732,16 +732,16 @@ fn we_can_min_aggregate_columns_by_counts() {
     let slice_c = &[
         100, -101, 102, -103, 104, -105, 106, -107, 108, -109, 110, -111, 112, -113, 114, -115,
     ];
-    let scals_c: Vec<Curve25519Scalar> = slice_c.iter().map(core::convert::Into::into).collect();
-    let column_a = Column::BigInt::<Curve25519Scalar>(slice_a);
-    let columns_b = Column::Int128::<Curve25519Scalar>(slice_b);
+    let scals_c: Vec<TestScalar> = slice_c.iter().map(core::convert::Into::into).collect();
+    let column_a = Column::BigInt::<TestScalar>(slice_a);
+    let columns_b = Column::Int128::<TestScalar>(slice_b);
     let columns_c = Column::Scalar(&scals_c);
     let indexes = &[12, 11, 1, 10, 2, 3, 6, 14, 13, 9];
     let counts = &[3, 3, 4, 0];
     let expected = &[
-        Some(Curve25519Scalar::from(-111)),
-        Some(Curve25519Scalar::from(-103)),
-        Some(Curve25519Scalar::from(-113)),
+        Some(TestScalar::from(-111)),
+        Some(TestScalar::from(-103)),
+        Some(TestScalar::from(-113)),
         None,
     ];
     let alloc = Bump::new();

--- a/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_and_arrow_conversions_test.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         database::{owned_table_utility::*, OwnedArrowConversionError},
         map::IndexMap,
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar,
     },
     record_batch,
 };
@@ -15,7 +15,7 @@ use arrow::{
 };
 
 fn we_can_convert_between_owned_column_and_array_ref_impl(
-    owned_column: OwnedColumn<Curve25519Scalar>,
+    owned_column: OwnedColumn<TestScalar>,
     array_ref: ArrayRef,
 ) {
     let ic_to_ar = ArrayRef::from(owned_column.clone());
@@ -26,19 +26,19 @@ fn we_can_convert_between_owned_column_and_array_ref_impl(
 }
 fn we_can_convert_between_boolean_owned_column_and_array_ref_impl(data: Vec<bool>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Boolean(data.clone()),
+        OwnedColumn::<TestScalar>::Boolean(data.clone()),
         Arc::new(BooleanArray::from(data)),
     );
 }
 fn we_can_convert_between_bigint_owned_column_and_array_ref_impl(data: Vec<i64>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::BigInt(data.clone()),
+        OwnedColumn::<TestScalar>::BigInt(data.clone()),
         Arc::new(Int64Array::from(data)),
     );
 }
 fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::Int128(data.clone()),
+        OwnedColumn::<TestScalar>::Int128(data.clone()),
         Arc::new(
             Decimal128Array::from(data)
                 .with_precision_and_scale(38, 0)
@@ -48,7 +48,7 @@ fn we_can_convert_between_int128_owned_column_and_array_ref_impl(data: Vec<i128>
 }
 fn we_can_convert_between_varchar_owned_column_and_array_ref_impl(data: Vec<String>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
-        OwnedColumn::<Curve25519Scalar>::VarChar(data.clone()),
+        OwnedColumn::<TestScalar>::VarChar(data.clone()),
         Arc::new(StringArray::from(data)),
     );
 }
@@ -75,13 +75,13 @@ fn we_get_an_unsupported_type_error_when_trying_to_convert_from_a_float32_array_
 ) {
     let array_ref: ArrayRef = Arc::new(Float32Array::from(vec![0.0]));
     assert!(matches!(
-        OwnedColumn::<Curve25519Scalar>::try_from(array_ref),
+        OwnedColumn::<TestScalar>::try_from(array_ref),
         Err(OwnedArrowConversionError::UnsupportedType { .. })
     ));
 }
 
 fn we_can_convert_between_owned_table_and_record_batch_impl(
-    owned_table: OwnedTable<Curve25519Scalar>,
+    owned_table: OwnedTable<TestScalar>,
     record_batch: RecordBatch,
 ) {
     let it_to_rb = RecordBatch::try_from(owned_table.clone()).unwrap();
@@ -93,7 +93,7 @@ fn we_can_convert_between_owned_table_and_record_batch_impl(
 #[test]
 fn we_can_convert_between_owned_table_and_record_batch() {
     we_can_convert_between_owned_table_and_record_batch_impl(
-        OwnedTable::<Curve25519Scalar>::try_new(IndexMap::default()).unwrap(),
+        OwnedTable::<TestScalar>::try_new(IndexMap::default()).unwrap(),
         RecordBatch::new_empty(Arc::new(Schema::empty())),
     );
     we_can_convert_between_owned_table_and_record_batch_impl(
@@ -136,7 +136,7 @@ fn we_cannot_convert_a_record_batch_if_it_has_repeated_column_names() {
         "A" => [0_i128; 0],
     );
     assert!(matches!(
-        OwnedTable::<Curve25519Scalar>::try_from(record_batch),
+        OwnedTable::<TestScalar>::try_from(record_batch),
         Err(OwnedArrowConversionError::DuplicateIdentifiers)
     ));
 }
@@ -144,6 +144,6 @@ fn we_cannot_convert_a_record_batch_if_it_has_repeated_column_names() {
 #[test]
 #[should_panic]
 fn we_panic_when_converting_an_owned_table_with_a_scalar_column() {
-    let owned_table = owned_table::<Curve25519Scalar>([scalar("a", [0; 0])]);
+    let owned_table = owned_table::<TestScalar>([scalar("a", [0; 0])]);
     let _ = RecordBatch::try_from(owned_table);
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{
         database::{owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableError},
         map::IndexMap,
-        scalar::Curve25519Scalar,
+        scalar::test_scalar::TestScalar
     },
     proof_primitive::dory::DoryScalar,
 };
@@ -13,7 +13,7 @@ use proof_of_sql_parser::{
 
 #[test]
 fn we_can_create_an_owned_table_with_no_columns() {
-    let table = OwnedTable::<Curve25519Scalar>::try_new(IndexMap::default()).unwrap();
+    let table = OwnedTable::<TestScalar>::try_new(IndexMap::default()).unwrap();
     assert_eq!(table.num_columns(), 0);
 }
 #[test]
@@ -121,7 +121,7 @@ fn we_can_create_an_owned_table_with_data() {
 }
 #[test]
 fn we_get_inequality_between_tables_with_differing_column_order() {
-    let owned_table_a: OwnedTable<Curve25519Scalar> = owned_table([
+    let owned_table_a: OwnedTable<TestScalar> = owned_table([
         bigint("a", [0; 0]),
         int128("b", [0; 0]),
         varchar("c", ["0"; 0]),
@@ -133,7 +133,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
             [0; 0],
         ),
     ]);
-    let owned_table_b: OwnedTable<Curve25519Scalar> = owned_table([
+    let owned_table_b: OwnedTable<TestScalar> = owned_table([
         boolean("d", [false; 0]),
         int128("b", [0; 0]),
         bigint("a", [0; 0]),
@@ -178,7 +178,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
 #[test]
 fn we_cannot_create_an_owned_table_with_differing_column_lengths() {
     assert!(matches!(
-        OwnedTable::<Curve25519Scalar>::try_from_iter([
+        OwnedTable::<TestScalar>::try_from_iter([
             ("a".parse().unwrap(), OwnedColumn::BigInt(vec![0])),
             ("b".parse().unwrap(), OwnedColumn::BigInt(vec![])),
         ]),

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -2,7 +2,7 @@ use crate::{
     base::{
         database::{owned_table_utility::*, OwnedColumn, OwnedTable, OwnedTableError},
         map::IndexMap,
-        scalar::test_scalar::TestScalar
+        scalar::test_scalar::TestScalar,
     },
     proof_primitive::dory::DoryScalar,
 };

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -5,15 +5,15 @@ use super::{
 use crate::base::{
     commitment::{Commitment, CommittableColumn},
     database::owned_table_utility::*,
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
+    commitment::test_evaluation_proof::TestEvaluationProof,
+    commitment::naive_commitment::NaiveCommitment
 };
-use blitzar::proof::InnerProductProof;
-use curve25519_dalek::ristretto::RistrettoPoint;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
 #[test]
 fn we_can_query_the_length_of_a_table() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
@@ -31,7 +31,7 @@ fn we_can_query_the_length_of_a_table() {
 
 #[test]
 fn we_can_access_the_columns_of_a_table() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
@@ -97,10 +97,10 @@ fn we_can_access_the_columns_of_a_table() {
         Column::Scalar(col) => assert_eq!(
             col.to_vec(),
             vec![
-                Curve25519Scalar::from(1),
-                Curve25519Scalar::from(2),
-                Curve25519Scalar::from(3),
-                Curve25519Scalar::from(4)
+                TestScalar::from(1),
+                TestScalar::from(2),
+                TestScalar::from(3),
+                TestScalar::from(4)
             ]
         ),
         _ => panic!("Invalid column type"),
@@ -125,7 +125,7 @@ fn we_can_access_the_columns_of_a_table() {
 
 #[test]
 fn we_can_access_the_commitments_of_table_columns() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
@@ -135,7 +135,7 @@ fn we_can_access_the_commitments_of_table_columns() {
     let column = ColumnRef::new(table_ref_1, "b".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
-        RistrettoPoint::compute_commitments(
+        NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[4i64, 5, 6][..])],
             0_usize,
             &()
@@ -148,7 +148,7 @@ fn we_can_access_the_commitments_of_table_columns() {
     let column = ColumnRef::new(table_ref_1, "a".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
-        RistrettoPoint::compute_commitments(
+        NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[1i64, 2, 3][..])],
             0_usize,
             &()
@@ -158,7 +158,7 @@ fn we_can_access_the_commitments_of_table_columns() {
     let column = ColumnRef::new(table_ref_2, "b".parse().unwrap(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
-        RistrettoPoint::compute_commitments(
+        NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[4i64, 5, 6, 5][..])],
             0_usize,
             &()
@@ -168,7 +168,7 @@ fn we_can_access_the_commitments_of_table_columns() {
 
 #[test]
 fn we_can_access_the_type_of_table_columns() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
@@ -209,7 +209,7 @@ fn we_can_access_the_type_of_table_columns() {
 
 #[test]
 fn we_can_access_schema_and_column_names() {
-    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref_1 = "sxt.test".parse().unwrap();
 
     let data1 = owned_table([bigint("a", [1, 2, 3]), varchar("b", ["x", "y", "z"])]);
@@ -227,14 +227,14 @@ fn we_can_access_schema_and_column_names() {
 
 #[test]
 fn we_can_correctly_update_offsets() {
-    let mut accessor1 = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor1 = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     let table_ref = "sxt.test".parse().unwrap();
 
     let data = owned_table([bigint("a", [1, 2, 3]), bigint("b", [123, 5, 123])]);
     accessor1.add_table(table_ref, data.clone(), 0_usize);
 
     let offset = 123;
-    let mut accessor2 = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let mut accessor2 = OwnedTableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
     accessor2.add_table(table_ref, data, offset);
 
     let column = ColumnRef::new(table_ref, "a".parse().unwrap(), ColumnType::BigInt);

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -3,11 +3,12 @@ use super::{
     OwnedTableTestAccessor, SchemaAccessor, TestAccessor,
 };
 use crate::base::{
-    commitment::{Commitment, CommittableColumn},
+    commitment::{
+        naive_commitment::NaiveCommitment, test_evaluation_proof::TestEvaluationProof, Commitment,
+        CommittableColumn,
+    },
     database::owned_table_utility::*,
     scalar::test_scalar::TestScalar,
-    commitment::test_evaluation_proof::TestEvaluationProof,
-    commitment::naive_commitment::NaiveCommitment
 };
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 

--- a/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
@@ -2,7 +2,7 @@ use super::scalar_varint::{
     read_scalar_varint, read_scalar_varints, scalar_varint_size, scalar_varints_size,
     write_scalar_varint, write_scalar_varints,
 };
-use crate::base::{encode::U256, scalar::test_scalar::TestScalar};
+use crate::base::{encode::U256, scalar::test_scalar::TestScalar, scalar::Curve25519Scalar};
 use alloc::vec;
 
 #[test]
@@ -195,7 +195,7 @@ fn valid_varint_encoded_input_that_map_to_curve25519_scalars_smaller_than_the_p_
     // buf represents the number 2^252 - 1
     // removing the varint encoding, we would have y = ((2^252 - 1) // 2 + 1) % p
     // since we want x, we would have x = -y
-    let expected_x = -TestScalar::from(&U256::from_words(
+    let expected_x = -Curve25519Scalar::from(&U256::from_words(
         0x0000_0000_0000_0000_0000_0000_0000_0000,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ));
@@ -216,7 +216,7 @@ fn valid_varint_encoded_input_that_map_to_curve25519_scalars_bigger_than_the_p_f
     // at this point, buf represents the number 2^256 - 2,
     // which has 256 bit-length, where 255 bits are set to 1
     // also, `expected_val` is simply x = ((2^256 - 2) >> 1) % p
-    let expected_val: TestScalar = (&U256::from_words(
+    let expected_val: Curve25519Scalar = (&U256::from_words(
         0x6de7_2ae9_8b3a_b623_977f_4a47_7547_3484,
         0x0fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
     ))

--- a/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
@@ -2,7 +2,10 @@ use super::scalar_varint::{
     read_scalar_varint, read_scalar_varints, scalar_varint_size, scalar_varints_size,
     write_scalar_varint, write_scalar_varints,
 };
-use crate::base::{encode::U256, scalar::test_scalar::TestScalar, scalar::Curve25519Scalar};
+use crate::base::{
+    encode::U256,
+    scalar::{test_scalar::TestScalar, Curve25519Scalar},
+};
 use alloc::vec;
 
 #[test]
@@ -264,8 +267,7 @@ fn write_read_and_compare_encoding(expected_scals: &[TestScalar]) {
     let total_bytes_read = write_scalar_varints(&mut buf_vec[..], expected_scals);
 
     let buf = &buf_vec[0..total_bytes_read];
-    let mut scals =
-        vec![TestScalar::from_le_bytes_mod_order(&[0_u8; 32]); expected_scals.len()];
+    let mut scals = vec![TestScalar::from_le_bytes_mod_order(&[0_u8; 32]); expected_scals.len()];
     read_scalar_varints(&mut scals[..], buf).unwrap();
 
     for (scal, expected_scal) in scals.iter().zip(expected_scals.iter()) {
@@ -276,10 +278,7 @@ fn write_read_and_compare_encoding(expected_scals: &[TestScalar]) {
 #[test]
 fn scalar_slices_are_correctly_encoded_and_decoded() {
     write_read_and_compare_encoding(&[TestScalar::from(0_u128)]);
-    write_read_and_compare_encoding(&[
-        TestScalar::from(1_u64),
-        TestScalar::from(4_u32),
-    ]);
+    write_read_and_compare_encoding(&[TestScalar::from(1_u64), TestScalar::from(4_u32)]);
     write_read_and_compare_encoding(&[
         TestScalar::from(1_u64),
         TestScalar::from(u128::MAX),

--- a/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint_test.rs
@@ -2,15 +2,15 @@ use super::scalar_varint::{
     read_scalar_varint, read_scalar_varints, scalar_varint_size, scalar_varints_size,
     write_scalar_varint, write_scalar_varints,
 };
-use crate::base::{encode::U256, scalar::Curve25519Scalar};
+use crate::base::{encode::U256, scalar::test_scalar::TestScalar};
 use alloc::vec;
 
 #[test]
 fn small_scalars_are_encoded_as_positive_varints_and_consume_few_bytes() {
-    assert!(scalar_varint_size(&Curve25519Scalar::from(0_u64)) == 1);
-    assert!(scalar_varint_size(&Curve25519Scalar::from(1_u64)) == 1);
-    assert!(scalar_varint_size(&Curve25519Scalar::from(2_u64)) == 1);
-    assert!(scalar_varint_size(&Curve25519Scalar::from(1000_u64)) == 2);
+    assert!(scalar_varint_size(&TestScalar::from(0_u64)) == 1);
+    assert!(scalar_varint_size(&TestScalar::from(1_u64)) == 1);
+    assert!(scalar_varint_size(&TestScalar::from(2_u64)) == 1);
+    assert!(scalar_varint_size(&TestScalar::from(1000_u64)) == 2);
 }
 
 #[test]
@@ -18,12 +18,12 @@ fn big_scalars_with_small_additive_inverses_are_encoded_as_negative_varints_and_
 {
     // x = p - 1 (p is the ristretto group order)
     // y = -x = 1
-    let val = -Curve25519Scalar::from(1_u64);
+    let val = -TestScalar::from(1_u64);
     assert!(scalar_varint_size(&val) == 1);
 
     // x = p - 1000 (p is the ristretto group order)
     // y = -x = 1000
-    let val = -Curve25519Scalar::from(1000_u64);
+    let val = -TestScalar::from(1000_u64);
     assert!(scalar_varint_size(&val) == 2);
 }
 
@@ -32,7 +32,7 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_posi
 ) {
     // x = (p - 1) / 10 (p is the ristretto group order)
     // y = -x = (p + 1) / 10
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x9baf_e5c9_76b2_5c7b_d59b_704f_6fb2_2eca,
         0x0199_9999_9999_9999_9999_9999_9999_9999,
     ))
@@ -45,7 +45,7 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
 ) {
     // x = (p + 1) / 10 (p is the ristretto group order)
     // y = -x = (p - 1) / 10
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x9baf_e5c9_76b2_5c7b_d59b_704f_6fb2_2ecb,
         0x0199_9999_9999_9999_9999_9999_9999_9999,
     ))
@@ -58,7 +58,7 @@ fn the_maximum_positive_and_negative_encoded_scalars_consume_the_maximum_amount_
     // maximum negative encoded scalar
     // x = (p + 1) / 2 (p is the ristretto group order)
     // y = -x = (p - 1) / 2
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f7,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ))
@@ -68,7 +68,7 @@ fn the_maximum_positive_and_negative_encoded_scalars_consume_the_maximum_amount_
     // maximum positive encoded scalar
     // x = (p - 1) / 2 (p is the ristretto group order)
     // y = -x = (p + 1) / 2
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f6,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ))
@@ -80,23 +80,23 @@ fn the_maximum_positive_and_negative_encoded_scalars_consume_the_maximum_amount_
 #[test]
 fn scalar_slices_consumes_the_correct_amount_of_bytes() {
     // x = (p - 1)
-    let val1 = -Curve25519Scalar::from(1_u64);
+    let val1 = -TestScalar::from(1_u64);
 
     // x = (p + 1) / 2
-    let val2: Curve25519Scalar = (&U256::from_words(
+    let val2: TestScalar = (&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f7,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ))
         .into();
 
-    assert!(scalar_varints_size(&[Curve25519Scalar::from(1000_u64)]) == 2);
+    assert!(scalar_varints_size(&[TestScalar::from(1000_u64)]) == 2);
 
     assert!(
         scalar_varints_size(&[
-            Curve25519Scalar::from(1000_u64),
-            Curve25519Scalar::from(0_u64),
+            TestScalar::from(1000_u64),
+            TestScalar::from(0_u64),
             val1,
-            Curve25519Scalar::from(2_u64),
+            TestScalar::from(2_u64),
             val2
         ]) == 42
     );
@@ -107,19 +107,19 @@ fn small_scalars_are_correctly_encoded_and_decoded_as_positive_varints() {
     let mut buf = [0_u8; 38];
 
     // x = 0, which is encoded as 2 * 0 = 0
-    assert!(write_scalar_varint(&mut buf[..], &Curve25519Scalar::from(0_u64)) == 1);
+    assert!(write_scalar_varint(&mut buf[..], &TestScalar::from(0_u64)) == 1);
     assert!(buf[0] == 0);
-    assert!(read_scalar_varint(&buf[..]).unwrap() == (Curve25519Scalar::from(0_u64), 1));
+    assert!(read_scalar_varint(&buf[..]).unwrap() == (TestScalar::from(0_u64), 1));
 
     // x = 1, which is encoded as 2 * 1 = 2
-    assert!(write_scalar_varint(&mut buf[..], &Curve25519Scalar::from(1_u64)) == 1);
+    assert!(write_scalar_varint(&mut buf[..], &TestScalar::from(1_u64)) == 1);
     assert!(buf[0] == 2);
-    assert!(read_scalar_varint(&buf[..]).unwrap() == (Curve25519Scalar::from(1_u64), 1));
+    assert!(read_scalar_varint(&buf[..]).unwrap() == (TestScalar::from(1_u64), 1));
 
     // x = 2, which is encoded as 2 * x = 4
-    assert!(write_scalar_varint(&mut buf[..], &Curve25519Scalar::from(2_u64)) == 1);
+    assert!(write_scalar_varint(&mut buf[..], &TestScalar::from(2_u64)) == 1);
     assert!(buf[0] == 4);
-    assert!(read_scalar_varint(&buf[..]).unwrap() == (Curve25519Scalar::from(2_u64), 1));
+    assert!(read_scalar_varint(&buf[..]).unwrap() == (TestScalar::from(2_u64), 1));
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn big_scalars_with_small_additive_inverses_are_correctly_encoded_and_decoded_as
     // x = p - 1 (p is the ristretto group order)
     // y = -x = 1
     // which is encoded as -y, or as 2 * y - 1 = 1
-    let val = -Curve25519Scalar::from(1u64);
+    let val = -TestScalar::from(1u64);
     assert!(write_scalar_varint(&mut buf[..], &val) == 1);
     assert!(buf[0] == 1);
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 1));
@@ -138,7 +138,7 @@ fn big_scalars_with_small_additive_inverses_are_correctly_encoded_and_decoded_as
     // x = p - 2 (p is the ristretto group order)
     // y = -x = 2
     // which is encoded as -y, or as 2 * y - 1 = 3
-    let val = -Curve25519Scalar::from(2u64);
+    let val = -TestScalar::from(2u64);
     assert!(write_scalar_varint(&mut buf[..], &val) == 1);
     assert!(buf[0] == 3);
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 1));
@@ -151,7 +151,7 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_correctly_encod
 
     // (p - 1) / 2 (p is the ristretto group order)
     // y = -x = (p + 1) / 2 (which is bigger than x)
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f6,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ))
@@ -160,7 +160,7 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_correctly_encod
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 37));
 
     // using a smaller buffer will fail
-    assert!((read_scalar_varint(&buf[..10]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..10]) as Option<(TestScalar, _)>).is_none());
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_correctly_e
 
     // x = (p + 1) / 2 (p is the group order)
     // y = -x = (p - 1) / 2 (which is smaller than x)
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f7,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ))
@@ -180,7 +180,7 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_correctly_e
     assert!(read_scalar_varint(&buf[..]).unwrap() == (val, 37));
 
     // using a smaller buffer will fail
-    assert!((read_scalar_varint(&buf[..10]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..10]) as Option<(TestScalar, _)>).is_none());
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn valid_varint_encoded_input_that_map_to_curve25519_scalars_smaller_than_the_p_
     // buf represents the number 2^252 - 1
     // removing the varint encoding, we would have y = ((2^252 - 1) // 2 + 1) % p
     // since we want x, we would have x = -y
-    let expected_x = -Curve25519Scalar::from(&U256::from_words(
+    let expected_x = -TestScalar::from(&U256::from_words(
         0x0000_0000_0000_0000_0000_0000_0000_0000,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ));
@@ -216,7 +216,7 @@ fn valid_varint_encoded_input_that_map_to_curve25519_scalars_bigger_than_the_p_f
     // at this point, buf represents the number 2^256 - 2,
     // which has 256 bit-length, where 255 bits are set to 1
     // also, `expected_val` is simply x = ((2^256 - 2) >> 1) % p
-    let expected_val: Curve25519Scalar = (&U256::from_words(
+    let expected_val: TestScalar = (&U256::from_words(
         0x6de7_2ae9_8b3a_b623_977f_4a47_7547_3484,
         0x0fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
     ))
@@ -240,7 +240,7 @@ fn varint_encoded_values_that_never_ends_will_make_the_read_scalar_to_error_out(
     let buf = [0b1111_1111_u8; 5];
 
     // varint numbers that do not terminate will fail out
-    assert!((read_scalar_varint(&buf[..]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..]) as Option<(TestScalar, _)>).is_none());
 }
 
 #[test]
@@ -251,21 +251,21 @@ fn valid_varint_encoded_input_that_has_length_bigger_than_259_bits_will_make_the
     // a varint with 260 bit-length will fail (260 bits = 37 * 7 + 1 as
     //  each byte can hold only 7 bits in the varint encoding)
     buf[37] = 0b0000_0001_u8;
-    assert!((read_scalar_varint(&buf[..37]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..37]) as Option<(TestScalar, _)>).is_none());
 
     // a varint with 266 bit-length will fail (266 bits = 38 * 7 as
     //  each byte can hold only 7 bits in the varint encoding)
     buf[37] = 0b0111_1111_u8;
-    assert!((read_scalar_varint(&buf[..38]) as Option<(Curve25519Scalar, _)>).is_none());
+    assert!((read_scalar_varint(&buf[..38]) as Option<(TestScalar, _)>).is_none());
 }
 
-fn write_read_and_compare_encoding(expected_scals: &[Curve25519Scalar]) {
+fn write_read_and_compare_encoding(expected_scals: &[TestScalar]) {
     let mut buf_vec = vec![0_u8; 37 * expected_scals.len()];
     let total_bytes_read = write_scalar_varints(&mut buf_vec[..], expected_scals);
 
     let buf = &buf_vec[0..total_bytes_read];
     let mut scals =
-        vec![Curve25519Scalar::from_le_bytes_mod_order(&[0_u8; 32]); expected_scals.len()];
+        vec![TestScalar::from_le_bytes_mod_order(&[0_u8; 32]); expected_scals.len()];
     read_scalar_varints(&mut scals[..], buf).unwrap();
 
     for (scal, expected_scal) in scals.iter().zip(expected_scals.iter()) {
@@ -275,30 +275,30 @@ fn write_read_and_compare_encoding(expected_scals: &[Curve25519Scalar]) {
 
 #[test]
 fn scalar_slices_are_correctly_encoded_and_decoded() {
-    write_read_and_compare_encoding(&[Curve25519Scalar::from(0_u128)]);
+    write_read_and_compare_encoding(&[TestScalar::from(0_u128)]);
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(4_u32),
+        TestScalar::from(1_u64),
+        TestScalar::from(4_u32),
     ]);
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(u128::MAX),
-        Curve25519Scalar::from(0_u128),
-        Curve25519Scalar::from(5_u16),
-        Curve25519Scalar::from(u128::MAX),
+        TestScalar::from(1_u64),
+        TestScalar::from(u128::MAX),
+        TestScalar::from(0_u128),
+        TestScalar::from(5_u16),
+        TestScalar::from(u128::MAX),
     ]);
 
     // x = p - 1 (where p is the ristretto group_order)
-    let val = -Curve25519Scalar::from(1_u64);
+    let val = -TestScalar::from(1_u64);
 
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(u128::MAX),
-        Curve25519Scalar::from(0_u64),
+        TestScalar::from(u128::MAX),
+        TestScalar::from(0_u64),
         val,
-        Curve25519Scalar::from(5_u16),
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from(u128::MAX),
+        TestScalar::from(5_u16),
+        TestScalar::from(1_u64),
+        TestScalar::from(0_u64),
+        TestScalar::from(u128::MAX),
     ]);
 
     // some random scalar
@@ -309,14 +309,14 @@ fn scalar_slices_are_correctly_encoded_and_decoded() {
     ];
 
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(u128::MAX),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from_le_bytes_mod_order(&bytes),
-        Curve25519Scalar::from(5_u16),
-        Curve25519Scalar::from_le_bytes_mod_order(&bytes),
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from(u128::MAX),
+        TestScalar::from(u128::MAX),
+        TestScalar::from(0_u64),
+        TestScalar::from_le_bytes_mod_order(&bytes),
+        TestScalar::from(5_u16),
+        TestScalar::from_le_bytes_mod_order(&bytes),
+        TestScalar::from(1_u64),
+        TestScalar::from(0_u64),
+        TestScalar::from(u128::MAX),
     ]);
 
     // some random scalar
@@ -327,13 +327,13 @@ fn scalar_slices_are_correctly_encoded_and_decoded() {
     ];
 
     write_read_and_compare_encoding(&[
-        Curve25519Scalar::from(u128::MAX),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from_le_bytes_mod_order(&bytes),
-        Curve25519Scalar::from(5_u16),
-        Curve25519Scalar::from_le_bytes_mod_order(&bytes),
-        Curve25519Scalar::from(1_u64),
-        Curve25519Scalar::from(0_u64),
-        Curve25519Scalar::from(u128::MAX),
+        TestScalar::from(u128::MAX),
+        TestScalar::from(0_u64),
+        TestScalar::from_le_bytes_mod_order(&bytes),
+        TestScalar::from(5_u16),
+        TestScalar::from_le_bytes_mod_order(&bytes),
+        TestScalar::from(1_u64),
+        TestScalar::from(0_u64),
+        TestScalar::from(u128::MAX),
     ]);
 }

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -1,5 +1,5 @@
 use super::VarInt;
-use crate::base::scalar::{ Scalar, Curve25519Scalar};
+use crate::base::scalar::{Curve25519Scalar, Scalar};
 use alloc::{vec, vec::Vec};
 use core::{
     fmt::Debug,

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -1,5 +1,5 @@
 use super::VarInt;
-use crate::base::scalar::{Curve25519Scalar, Scalar};
+use crate::base::scalar::{test_scalar::TestScalar, Scalar};
 use alloc::{vec, vec::Vec};
 use core::{
     fmt::Debug,
@@ -399,19 +399,19 @@ fn we_can_encode_and_decode_small_u128_values() {
 
 #[test]
 fn we_can_encode_and_decode_small_curve25519_scalar_values() {
-    test_small_signed_values_encode_and_decode_properly::<Curve25519Scalar>(Curve25519Scalar::ONE);
+    test_small_signed_values_encode_and_decode_properly::<TestScalar>(TestScalar::ONE);
 }
 
 #[test]
 fn we_can_encode_and_decode_i128_and_curve25519_scalar_the_same() {
     let mut rng = rand::thread_rng();
-    test_encode_and_decode_types_align::<i128, Curve25519Scalar>(
+    test_encode_and_decode_types_align::<i128, TestScalar>(
         &rng.gen::<[_; 32]>(),
         &[
-            Curve25519Scalar::from(i128::MAX) + Curve25519Scalar::one(),
-            Curve25519Scalar::from(i128::MIN) - Curve25519Scalar::one(),
-            Curve25519Scalar::from(i128::MAX) * Curve25519Scalar::from(1000),
-            Curve25519Scalar::from(i128::MIN) * Curve25519Scalar::from(1000),
+            TestScalar::from(i128::MAX) + TestScalar::one(),
+            TestScalar::from(i128::MIN) - TestScalar::one(),
+            TestScalar::from(i128::MAX) * TestScalar::from(1000),
+            TestScalar::from(i128::MIN) * TestScalar::from(1000),
         ],
         100,
     );

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -1,5 +1,5 @@
 use super::VarInt;
-use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+use crate::base::scalar::{ Scalar, Curve25519Scalar};
 use alloc::{vec, vec::Vec};
 use core::{
     fmt::Debug,
@@ -399,19 +399,19 @@ fn we_can_encode_and_decode_small_u128_values() {
 
 #[test]
 fn we_can_encode_and_decode_small_curve25519_scalar_values() {
-    test_small_signed_values_encode_and_decode_properly::<TestScalar>(TestScalar::ONE);
+    test_small_signed_values_encode_and_decode_properly::<Curve25519Scalar>(Curve25519Scalar::ONE);
 }
 
 #[test]
 fn we_can_encode_and_decode_i128_and_curve25519_scalar_the_same() {
     let mut rng = rand::thread_rng();
-    test_encode_and_decode_types_align::<i128, TestScalar>(
+    test_encode_and_decode_types_align::<i128, Curve25519Scalar>(
         &rng.gen::<[_; 32]>(),
         &[
-            TestScalar::from(i128::MAX) + TestScalar::one(),
-            TestScalar::from(i128::MIN) - TestScalar::one(),
-            TestScalar::from(i128::MAX) * TestScalar::from(1000),
-            TestScalar::from(i128::MIN) * TestScalar::from(1000),
+            Curve25519Scalar::from(i128::MAX) + Curve25519Scalar::one(),
+            Curve25519Scalar::from(i128::MIN) - Curve25519Scalar::one(),
+            Curve25519Scalar::from(i128::MAX) * Curve25519Scalar::from(1000),
+            Curve25519Scalar::from(i128::MIN) * Curve25519Scalar::from(1000),
         ],
         100,
     );

--- a/crates/proof-of-sql/src/base/encode/zigzag_test.rs
+++ b/crates/proof-of-sql/src/base/encode/zigzag_test.rs
@@ -1,32 +1,32 @@
 use crate::base::{
     encode::{ZigZag, U256},
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
 
 #[test]
 fn small_scalars_are_encoded_as_positive_zigzag_values() {
     // x = 0
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
-    assert!(Curve25519Scalar::from(0_u64).zigzag() == U256::from_words(0, 0));
+    assert!(TestScalar::from(0_u64).zigzag() == U256::from_words(0, 0));
 
     // x = 1
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
-    assert!(Curve25519Scalar::from(1_u8).zigzag() == U256::from_words(2, 0));
+    assert!(TestScalar::from(1_u8).zigzag() == U256::from_words(2, 0));
 
     // x = 2
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
-    assert!(Curve25519Scalar::from(2_u32).zigzag() == U256::from_words(4, 0));
+    assert!(TestScalar::from(2_u32).zigzag() == U256::from_words(4, 0));
 
     // x = u128::MAX
     // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
     assert!(
-        Curve25519Scalar::from(u128::MAX).zigzag()
+        TestScalar::from(u128::MAX).zigzag()
             == U256::from_words(0xffff_ffff_ffff_ffff_ffff_ffff_ffff_fffe, 0x1)
     );
 
     for x in 1..1000_u128 {
         // since x < y, where x + y = 0, the ZigZag value is encoded as 2 * x
-        assert!(Curve25519Scalar::from(x).zigzag() == U256::from_words(2 * x, 0));
+        assert!(TestScalar::from(x).zigzag() == U256::from_words(2 * x, 0));
     }
 }
 
@@ -35,16 +35,16 @@ fn big_scalars_with_small_additive_inverses_are_encoded_as_negative_zigzag_value
     // x = p - 1 (p = 2^252 + 27742317777372353535851937790883648493 is the ristretto group order)
     // the additive inverse of x is y = 1. Since y < x, the ZigZag encodes -y, which is
     // encoded as 2 * y - 1 = 1
-    assert!((-Curve25519Scalar::from(1_u32)).zigzag() == U256::from_words(1, 0));
+    assert!((-TestScalar::from(1_u32)).zigzag() == U256::from_words(1, 0));
 
     // x = p - 2 (p = 2^252 + 27742317777372353535851937790883648493 is the ristretto group order)
     // the additive inverse of x is y = 2. Since y < x, the ZigZag encodes -y, which is
     // encoded as 2 * y - 1 = 3
-    assert!((-Curve25519Scalar::from(2_u32)).zigzag() == U256::from_words(3, 0));
+    assert!((-TestScalar::from(2_u32)).zigzag() == U256::from_words(3, 0));
 
     for y in 1..1000_u128 {
         // since x > y, where x + y = 0, the ZigZag value is encoded as 2 * y - 1
-        assert!((-Curve25519Scalar::from(y)).zigzag() == U256::from_words(2 * y - 1, 0));
+        assert!((-TestScalar::from(y)).zigzag() == U256::from_words(2 * y - 1, 0));
     }
 }
 
@@ -52,7 +52,7 @@ fn big_scalars_with_small_additive_inverses_are_encoded_as_negative_zigzag_value
 fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_positive_zigzag_values()
 {
     // x = (p - 1) / 2 (p is the ristretto group order)
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f6,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ))
@@ -71,7 +71,7 @@ fn big_scalars_that_are_smaller_than_their_additive_inverses_are_encoded_as_posi
 fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_negative_zigzag_values(
 ) {
     // x = (p + 1) / 2 (p is the ristretto group order)
-    let val: Curve25519Scalar = (&U256::from_words(
+    let val: TestScalar = (&U256::from_words(
         0x0a6f_7cef_517b_ce6b_2c09_318d_2e7a_e9f7,
         0x0800_0000_0000_0000_0000_0000_0000_0000,
     ))
@@ -89,7 +89,7 @@ fn big_additive_inverses_that_are_smaller_than_the_input_scalars_are_encoded_as_
 
     // x = - U256 { low: 0, high: 0x1_u128 }
     // since x > y, where x + y = 0, the ZigZag value is encoded as 2 * y - 1
-    let val: Curve25519Scalar = (&U256 {
+    let val: TestScalar = (&U256 {
         low: 0x0_u128,
         high: 0x1_u128,
     })

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -1,38 +1,38 @@
 use super::CompositePolynomial;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::test_scalar::TestScalar;
 use alloc::rc::Rc;
 
 #[test]
 fn test_composite_polynomial_evaluation() {
-    let a: Vec<Curve25519Scalar> = vec![
-        -Curve25519Scalar::from(7u32),
-        Curve25519Scalar::from(2u32),
-        -Curve25519Scalar::from(6u32),
-        Curve25519Scalar::from(17u32),
+    let a: Vec<TestScalar> = vec![
+        -TestScalar::from(7u32),
+        TestScalar::from(2u32),
+        -TestScalar::from(6u32),
+        TestScalar::from(17u32),
     ];
-    let b: Vec<Curve25519Scalar> = vec![
-        Curve25519Scalar::from(2u32),
-        -Curve25519Scalar::from(8u32),
-        Curve25519Scalar::from(4u32),
-        Curve25519Scalar::from(1u32),
+    let b: Vec<TestScalar> = vec![
+        TestScalar::from(2u32),
+        -TestScalar::from(8u32),
+        TestScalar::from(4u32),
+        TestScalar::from(1u32),
     ];
-    let c: Vec<Curve25519Scalar> = vec![
-        Curve25519Scalar::from(1u32),
-        Curve25519Scalar::from(3u32),
-        -Curve25519Scalar::from(5u32),
-        -Curve25519Scalar::from(9u32),
+    let c: Vec<TestScalar> = vec![
+        TestScalar::from(1u32),
+        TestScalar::from(3u32),
+        -TestScalar::from(5u32),
+        -TestScalar::from(9u32),
     ];
     let mut prod = CompositePolynomial::new(2);
-    prod.add_product([Rc::new(a), Rc::new(b)], Curve25519Scalar::from(3u32));
-    prod.add_product([Rc::new(c)], Curve25519Scalar::from(2u32));
-    let prod00 = prod.evaluate(&[Curve25519Scalar::from(0u32), Curve25519Scalar::from(0u32)]);
-    let prod10 = prod.evaluate(&[Curve25519Scalar::from(1u32), Curve25519Scalar::from(0u32)]);
-    let prod01 = prod.evaluate(&[Curve25519Scalar::from(0u32), Curve25519Scalar::from(1u32)]);
-    let prod11 = prod.evaluate(&[Curve25519Scalar::from(1u32), Curve25519Scalar::from(1u32)]);
-    let calc00 = -Curve25519Scalar::from(40u32);
-    let calc10 = -Curve25519Scalar::from(42u32);
-    let calc01 = -Curve25519Scalar::from(82u32);
-    let calc11 = Curve25519Scalar::from(33u32);
+    prod.add_product([Rc::new(a), Rc::new(b)], TestScalar::from(3u32));
+    prod.add_product([Rc::new(c)], TestScalar::from(2u32));
+    let prod00 = prod.evaluate(&[TestScalar::from(0u32), TestScalar::from(0u32)]);
+    let prod10 = prod.evaluate(&[TestScalar::from(1u32), TestScalar::from(0u32)]);
+    let prod01 = prod.evaluate(&[TestScalar::from(0u32), TestScalar::from(1u32)]);
+    let prod11 = prod.evaluate(&[TestScalar::from(1u32), TestScalar::from(1u32)]);
+    let calc00 = -TestScalar::from(40u32);
+    let calc10 = -TestScalar::from(42u32);
+    let calc01 = -TestScalar::from(82u32);
+    let calc11 = TestScalar::from(33u32);
     assert_eq!(prod00, calc00);
     assert_eq!(prod10, calc10);
     assert_eq!(prod01, calc01);
@@ -42,31 +42,31 @@ fn test_composite_polynomial_evaluation() {
 #[allow(clippy::identity_op)]
 #[test]
 fn test_composite_polynomial_hypercube_sum() {
-    let a: Vec<Curve25519Scalar> = vec![
-        -Curve25519Scalar::from(7u32),
-        Curve25519Scalar::from(2u32),
-        -Curve25519Scalar::from(6u32),
-        Curve25519Scalar::from(17u32),
+    let a: Vec<TestScalar> = vec![
+        -TestScalar::from(7u32),
+        TestScalar::from(2u32),
+        -TestScalar::from(6u32),
+        TestScalar::from(17u32),
     ];
-    let b: Vec<Curve25519Scalar> = vec![
-        Curve25519Scalar::from(2u32),
-        -Curve25519Scalar::from(8u32),
-        Curve25519Scalar::from(4u32),
-        Curve25519Scalar::from(1u32),
+    let b: Vec<TestScalar> = vec![
+        TestScalar::from(2u32),
+        -TestScalar::from(8u32),
+        TestScalar::from(4u32),
+        TestScalar::from(1u32),
     ];
-    let c: Vec<Curve25519Scalar> = vec![
-        Curve25519Scalar::from(1u32),
-        Curve25519Scalar::from(3u32),
-        -Curve25519Scalar::from(5u32),
-        -Curve25519Scalar::from(9u32),
+    let c: Vec<TestScalar> = vec![
+        TestScalar::from(1u32),
+        TestScalar::from(3u32),
+        -TestScalar::from(5u32),
+        -TestScalar::from(9u32),
     ];
     let mut prod = CompositePolynomial::new(2);
-    prod.add_product([Rc::new(a), Rc::new(b)], Curve25519Scalar::from(3u32));
-    prod.add_product([Rc::new(c)], Curve25519Scalar::from(2u32));
+    prod.add_product([Rc::new(a), Rc::new(b)], TestScalar::from(3u32));
+    prod.add_product([Rc::new(c)], TestScalar::from(2u32));
     let sum = prod.hypercube_sum(4);
     assert_eq!(
         sum,
-        Curve25519Scalar::from(
+        TestScalar::from(
             3 * ((-7) * 2 + 2 * (-8) + (-6) * 4 + 17 * 1) + 2 * (1 + 3 + (-5) + (-9))
         )
     );

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -66,8 +66,6 @@ fn test_composite_polynomial_hypercube_sum() {
     let sum = prod.hypercube_sum(4);
     assert_eq!(
         sum,
-        TestScalar::from(
-            3 * ((-7) * 2 + 2 * (-8) + (-6) * 4 + 17 * 1) + 2 * (1 + 3 + (-5) + (-9))
-        )
+        TestScalar::from(3 * ((-7) * 2 + 2 * (-8) + (-6) * 4 + 17 * 1) + 2 * (1 + 3 + (-5) + (-9)))
     );
 }

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
@@ -1,65 +1,65 @@
 use super::compute_evaluation_vector;
-use crate::base::{scalar::Curve25519Scalar, slice_ops};
+use crate::base::{scalar::test_scalar::TestScalar, slice_ops};
 use ark_poly::MultilinearExtension;
 use num_traits::{One, Zero};
 
 #[test]
 fn we_compute_the_correct_evaluation_vector_for_a_small_example() {
-    let mut v = [Curve25519Scalar::zero(); 2];
-    compute_evaluation_vector(&mut v, &[Curve25519Scalar::from(3u64)]);
+    let mut v = [TestScalar::zero(); 2];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
     let expected_v = [
-        Curve25519Scalar::one() - Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(3u64),
+        TestScalar::one() - TestScalar::from(3u64),
+        TestScalar::from(3u64),
     ];
     assert_eq!(v, expected_v);
 
-    let mut v = [Curve25519Scalar::zero(); 4];
+    let mut v = [TestScalar::zero(); 4];
     compute_evaluation_vector(
         &mut v,
-        &[Curve25519Scalar::from(3u64), Curve25519Scalar::from(4u64)],
+        &[TestScalar::from(3u64), TestScalar::from(4u64)],
     );
     let expected_v = [
-        (Curve25519Scalar::one() - Curve25519Scalar::from(4u64))
-            * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64)),
-        (Curve25519Scalar::one() - Curve25519Scalar::from(4u64)) * Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(4u64) * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64)),
-        Curve25519Scalar::from(4u64) * Curve25519Scalar::from(3u64),
+        (TestScalar::one() - TestScalar::from(4u64))
+            * (TestScalar::one() - TestScalar::from(3u64)),
+        (TestScalar::one() - TestScalar::from(4u64)) * TestScalar::from(3u64),
+        TestScalar::from(4u64) * (TestScalar::one() - TestScalar::from(3u64)),
+        TestScalar::from(4u64) * TestScalar::from(3u64),
     ];
     assert_eq!(v, expected_v);
 }
 
 #[test]
 fn we_compute_the_evaluation_vectors_not_a_power_of_2() {
-    let mut v = [Curve25519Scalar::zero(); 1];
-    compute_evaluation_vector(&mut v, &[Curve25519Scalar::from(3u64)]);
-    let expected_v = [Curve25519Scalar::one() - Curve25519Scalar::from(3u64)];
+    let mut v = [TestScalar::zero(); 1];
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64)]);
+    let expected_v = [TestScalar::one() - TestScalar::from(3u64)];
     assert_eq!(v, expected_v);
 
-    let mut v = [Curve25519Scalar::zero(); 3];
+    let mut v = [TestScalar::zero(); 3];
     compute_evaluation_vector(
         &mut v,
-        &[Curve25519Scalar::from(3u64), Curve25519Scalar::from(4u64)],
+        &[TestScalar::from(3u64), TestScalar::from(4u64)],
     );
     let expected_v = [
-        (Curve25519Scalar::one() - Curve25519Scalar::from(4u64))
-            * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64)),
-        (Curve25519Scalar::one() - Curve25519Scalar::from(4u64)) * Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(4u64) * (Curve25519Scalar::one() - Curve25519Scalar::from(3u64)),
+        (TestScalar::one() - TestScalar::from(4u64))
+            * (TestScalar::one() - TestScalar::from(3u64)),
+        (TestScalar::one() - TestScalar::from(4u64)) * TestScalar::from(3u64),
+        TestScalar::from(4u64) * (TestScalar::one() - TestScalar::from(3u64)),
     ];
     assert_eq!(v, expected_v);
 }
 #[test]
 fn we_compute_the_evaluation_vectors_of_any_length() {
-    let mut full_vec = [Curve25519Scalar::zero(); 16];
+    let mut full_vec = [TestScalar::zero(); 16];
     let evaluation_point = [
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(5u64),
-        Curve25519Scalar::from(7u64),
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(5u64),
+        TestScalar::from(7u64),
     ];
     compute_evaluation_vector(&mut full_vec, &evaluation_point);
     for i in 0..16 {
-        let mut v = vec![Curve25519Scalar::zero(); i];
+        let mut v = vec![TestScalar::zero(); i];
         compute_evaluation_vector(&mut v, &evaluation_point);
         assert_eq!(v, &full_vec[..i]);
     }
@@ -67,39 +67,39 @@ fn we_compute_the_evaluation_vectors_of_any_length() {
 
 #[test]
 fn we_compute_the_evaluation_vector_for_an_empty_point() {
-    let mut v = [Curve25519Scalar::zero(); 1];
+    let mut v = [TestScalar::zero(); 1];
     compute_evaluation_vector(&mut v, &[]);
-    let expected_v = [Curve25519Scalar::one()];
+    let expected_v = [TestScalar::one()];
     assert_eq!(v, expected_v);
 }
 
 #[test]
 fn we_get_the_same_result_using_evaluation_vector_as_direct_evaluation() {
     let xs = [
-        Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(7u64),
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(9u64),
-        Curve25519Scalar::from(21u64),
-        Curve25519Scalar::from(10u64),
-        Curve25519Scalar::from(5u64),
-        Curve25519Scalar::from(92u64),
+        TestScalar::from(3u64),
+        TestScalar::from(7u64),
+        TestScalar::from(2u64),
+        TestScalar::from(9u64),
+        TestScalar::from(21u64),
+        TestScalar::from(10u64),
+        TestScalar::from(5u64),
+        TestScalar::from(92u64),
     ];
     let point = [
-        Curve25519Scalar::from(81u64),
-        Curve25519Scalar::from(33u64),
-        Curve25519Scalar::from(22u64),
+        TestScalar::from(81u64),
+        TestScalar::from(33u64),
+        TestScalar::from(22u64),
     ];
-    let mut v = [Curve25519Scalar::zero(); 8];
+    let mut v = [TestScalar::zero(); 8];
     compute_evaluation_vector(&mut v, &point);
     let eval = slice_ops::inner_product(&xs, &v);
 
     let poly = ark_poly::DenseMultilinearExtension::from_evaluations_slice(
         3,
-        &Curve25519Scalar::unwrap_slice(&xs),
+        &TestScalar::unwrap_slice(&xs),
     );
-    let expected_eval = Curve25519Scalar::new(
-        poly.evaluate(&Curve25519Scalar::unwrap_slice(&point))
+    let expected_eval = TestScalar::new(
+        poly.evaluate(&TestScalar::unwrap_slice(&point))
             .unwrap(),
     );
     assert_eq!(eval, expected_eval);

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
@@ -14,13 +14,9 @@ fn we_compute_the_correct_evaluation_vector_for_a_small_example() {
     assert_eq!(v, expected_v);
 
     let mut v = [TestScalar::zero(); 4];
-    compute_evaluation_vector(
-        &mut v,
-        &[TestScalar::from(3u64), TestScalar::from(4u64)],
-    );
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64), TestScalar::from(4u64)]);
     let expected_v = [
-        (TestScalar::one() - TestScalar::from(4u64))
-            * (TestScalar::one() - TestScalar::from(3u64)),
+        (TestScalar::one() - TestScalar::from(4u64)) * (TestScalar::one() - TestScalar::from(3u64)),
         (TestScalar::one() - TestScalar::from(4u64)) * TestScalar::from(3u64),
         TestScalar::from(4u64) * (TestScalar::one() - TestScalar::from(3u64)),
         TestScalar::from(4u64) * TestScalar::from(3u64),
@@ -36,13 +32,9 @@ fn we_compute_the_evaluation_vectors_not_a_power_of_2() {
     assert_eq!(v, expected_v);
 
     let mut v = [TestScalar::zero(); 3];
-    compute_evaluation_vector(
-        &mut v,
-        &[TestScalar::from(3u64), TestScalar::from(4u64)],
-    );
+    compute_evaluation_vector(&mut v, &[TestScalar::from(3u64), TestScalar::from(4u64)]);
     let expected_v = [
-        (TestScalar::one() - TestScalar::from(4u64))
-            * (TestScalar::one() - TestScalar::from(3u64)),
+        (TestScalar::one() - TestScalar::from(4u64)) * (TestScalar::one() - TestScalar::from(3u64)),
         (TestScalar::one() - TestScalar::from(4u64)) * TestScalar::from(3u64),
         TestScalar::from(4u64) * (TestScalar::one() - TestScalar::from(3u64)),
     ];
@@ -98,9 +90,6 @@ fn we_get_the_same_result_using_evaluation_vector_as_direct_evaluation() {
         3,
         &TestScalar::unwrap_slice(&xs),
     );
-    let expected_eval = TestScalar::new(
-        poly.evaluate(&TestScalar::unwrap_slice(&point))
-            .unwrap(),
-    );
+    let expected_eval = TestScalar::new(poly.evaluate(&TestScalar::unwrap_slice(&point)).unwrap());
     assert_eq!(eval, expected_eval);
 }

--- a/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
@@ -4,7 +4,7 @@
  * See third_party/license/arkworks.LICENSE
  */
 use super::interpolate::*;
-use crate::base::scalar::{test_scalar::TestScalar as S, test_scalar::TestScalar};
+use crate::base::scalar::test_scalar::{TestScalar as S, TestScalar};
 use ark_std::UniformRand;
 use core::iter;
 use num_traits::{Inv, Zero};

--- a/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate_test.rs
@@ -4,7 +4,7 @@
  * See third_party/license/arkworks.LICENSE
  */
 use super::interpolate::*;
-use crate::base::scalar::{Curve25519Scalar, Curve25519Scalar as S};
+use crate::base::scalar::{test_scalar::TestScalar as S, test_scalar::TestScalar};
 use ark_std::UniformRand;
 use core::iter;
 use num_traits::{Inv, Zero};
@@ -16,20 +16,20 @@ fn test_interpolate_uni_poly_for_random_polynomials() {
     let num_points = vec![0, 1, 2, 3, 4, 5, 10, 20, 32, 33, 64, 65];
 
     for n in num_points {
-        let poly = iter::repeat_with(|| Curve25519Scalar::rand(&mut prng))
+        let poly = iter::repeat_with(|| TestScalar::rand(&mut prng))
             .take(n)
             .collect::<Vec<_>>();
         let evals = (0..n)
             .map(|i| {
-                let x: Curve25519Scalar = (i as u64).into();
+                let x: TestScalar = (i as u64).into();
                 poly.iter().fold(Zero::zero(), |acc, &c| acc * x + c)
             })
             .collect::<Vec<_>>();
-        let query = Curve25519Scalar::rand(&mut prng);
+        let query = TestScalar::rand(&mut prng);
         let value = interpolate_uni_poly(&evals, query);
         let expected_value = poly
             .iter()
-            .fold(Curve25519Scalar::zero(), |acc, &c| acc * query + c);
+            .fold(TestScalar::zero(), |acc, &c| acc * query + c);
         assert_eq!(value, expected_value);
     }
 }
@@ -38,58 +38,58 @@ fn test_interpolate_uni_poly_for_random_polynomials() {
 fn interpolate_uni_poly_gives_zero_for_no_evaluations() {
     let evaluations = vec![];
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(10)),
-        Curve25519Scalar::from(0)
+        interpolate_uni_poly(&evaluations, TestScalar::from(10)),
+        TestScalar::from(0)
     );
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(100)),
-        Curve25519Scalar::from(0)
+        interpolate_uni_poly(&evaluations, TestScalar::from(100)),
+        TestScalar::from(0)
     );
 }
 
 #[test]
 fn interpolate_uni_poly_gives_constant_for_degree_0_polynomial() {
-    let evaluations = vec![Curve25519Scalar::from(77)];
+    let evaluations = vec![TestScalar::from(77)];
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(10)),
-        Curve25519Scalar::from(77)
+        interpolate_uni_poly(&evaluations, TestScalar::from(10)),
+        TestScalar::from(77)
     );
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(100)),
-        Curve25519Scalar::from(77)
+        interpolate_uni_poly(&evaluations, TestScalar::from(100)),
+        TestScalar::from(77)
     );
 }
 
 #[test]
 fn interpolate_uni_poly_gives_correct_result_for_linear_polynomial() {
     let evaluations = vec![
-        Curve25519Scalar::from(2),
-        Curve25519Scalar::from(3),
-        Curve25519Scalar::from(4),
+        TestScalar::from(2),
+        TestScalar::from(3),
+        TestScalar::from(4),
     ];
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(10)),
-        Curve25519Scalar::from(12)
+        interpolate_uni_poly(&evaluations, TestScalar::from(10)),
+        TestScalar::from(12)
     );
     assert_eq!(
-        interpolate_uni_poly(&evaluations, Curve25519Scalar::from(100)),
-        Curve25519Scalar::from(102)
+        interpolate_uni_poly(&evaluations, TestScalar::from(100)),
+        TestScalar::from(102)
     );
 }
 
 #[test]
 fn interpolate_uni_poly_gives_correct_value_for_known_evaluation() {
     let evaluations = vec![
-        Curve25519Scalar::from(777),
-        Curve25519Scalar::from(123),
-        Curve25519Scalar::from(2357),
-        Curve25519Scalar::from(1),
-        Curve25519Scalar::from(2),
-        Curve25519Scalar::from(3),
+        TestScalar::from(777),
+        TestScalar::from(123),
+        TestScalar::from(2357),
+        TestScalar::from(1),
+        TestScalar::from(2),
+        TestScalar::from(3),
     ];
     for i in 0..evaluations.len() {
         assert_eq!(
-            interpolate_uni_poly(&evaluations, Curve25519Scalar::from(i as u32)),
+            interpolate_uni_poly(&evaluations, TestScalar::from(i as u32)),
             evaluations[i]
         );
     }

--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
@@ -3,7 +3,7 @@ use crate::base::{
         compute_evaluation_vector, compute_truncated_lagrange_basis_inner_product,
         compute_truncated_lagrange_basis_sum,
     },
-    scalar::Curve25519Scalar,
+    scalar::test_scalar::TestScalar,
 };
 use ark_std::UniformRand;
 use core::iter;
@@ -11,144 +11,144 @@ use num_traits::Zero;
 
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_0_variables() {
-    let point: Vec<Curve25519Scalar> = vec![];
+    let point: Vec<TestScalar> = vec![];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        Curve25519Scalar::from(1u8)
+        TestScalar::from(1u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_1_variables() {
-    let point: Vec<Curve25519Scalar> = vec![Curve25519Scalar::from(2u8)];
+    let point: Vec<TestScalar> = vec![TestScalar::from(2u8)];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(2, &point),
-        Curve25519Scalar::from(1u8) // This is (1-2) + (2)
+        TestScalar::from(1u8) // This is (1-2) + (2)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        -Curve25519Scalar::from(1u8) // This is (1-2)
+        -TestScalar::from(1u8) // This is (1-2)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_2_variables() {
-    let point = vec![Curve25519Scalar::from(2u8), Curve25519Scalar::from(5u8)];
+    let point = vec![TestScalar::from(2u8), TestScalar::from(5u8)];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(4, &point),
-        Curve25519Scalar::from(1u8) // This is (1-2)(1-5)+(2)(1-5)+(1-2)(5)+(2)(5)
+        TestScalar::from(1u8) // This is (1-2)(1-5)+(2)(1-5)+(1-2)(5)+(2)(5)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(3, &point),
-        -Curve25519Scalar::from(9u8) // This is (1-2)(1-5)+(2)(1-5)+(1-2)(5)
+        -TestScalar::from(9u8) // This is (1-2)(1-5)+(2)(1-5)+(1-2)(5)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(2, &point),
-        -Curve25519Scalar::from(4u8) // This is (1-2)(1-5)+(2)(1-5)
+        -TestScalar::from(4u8) // This is (1-2)(1-5)+(2)(1-5)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        Curve25519Scalar::from(4u8) // This is (1-2)(1-5)
+        TestScalar::from(4u8) // This is (1-2)(1-5)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_3_variables() {
     let point = vec![
-        Curve25519Scalar::from(2u8),
-        Curve25519Scalar::from(5u8),
-        Curve25519Scalar::from(7u8),
+        TestScalar::from(2u8),
+        TestScalar::from(5u8),
+        TestScalar::from(7u8),
     ];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(8, &point),
-        Curve25519Scalar::from(1u8)
+        TestScalar::from(1u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(7, &point),
-        -Curve25519Scalar::from(69u8)
+        -TestScalar::from(69u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(6, &point),
-        -Curve25519Scalar::from(34u8)
+        -TestScalar::from(34u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(5, &point),
-        Curve25519Scalar::from(22u8)
+        TestScalar::from(22u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(4, &point),
-        -Curve25519Scalar::from(6u8)
+        -TestScalar::from(6u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(3, &point),
-        Curve25519Scalar::from(54u8)
+        TestScalar::from(54u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(2, &point),
-        Curve25519Scalar::from(24u8)
+        TestScalar::from(24u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        -Curve25519Scalar::from(24u8)
+        -TestScalar::from(24u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_3_variables_using_dalek_scalar() {
     let point = vec![
-        Curve25519Scalar::from(2u8),
-        Curve25519Scalar::from(5u8),
-        Curve25519Scalar::from(7u8),
+        TestScalar::from(2u8),
+        TestScalar::from(5u8),
+        TestScalar::from(7u8),
     ];
     assert_eq!(
         compute_truncated_lagrange_basis_sum(8, &point),
-        Curve25519Scalar::from(1u8)
+        TestScalar::from(1u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(7, &point),
-        -Curve25519Scalar::from(69u8)
+        -TestScalar::from(69u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(6, &point),
-        -Curve25519Scalar::from(34u8)
+        -TestScalar::from(34u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(5, &point),
-        Curve25519Scalar::from(22u8)
+        TestScalar::from(22u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(4, &point),
-        -Curve25519Scalar::from(6u8)
+        -TestScalar::from(6u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(3, &point),
-        Curve25519Scalar::from(54u8)
+        TestScalar::from(54u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(2, &point),
-        Curve25519Scalar::from(24u8)
+        TestScalar::from(24u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(1, &point),
-        -Curve25519Scalar::from(24u8)
+        -TestScalar::from(24u8)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_sum(0, &point),
-        Curve25519Scalar::from(0u8)
+        TestScalar::from(0u8)
     );
 }
 
@@ -168,82 +168,82 @@ fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_3_variables_us
 
 #[test]
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_0_variables() {
-    let a: Vec<Curve25519Scalar> = vec![];
+    let a: Vec<TestScalar> = vec![];
     let b = vec![];
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(1, &a, &b),
-        Curve25519Scalar::from(1u32)
+        TestScalar::from(1u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(0, &a, &b),
-        Curve25519Scalar::from(0u32)
+        TestScalar::from(0u32)
     );
 }
 #[test]
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_1_variables() {
-    let a = vec![Curve25519Scalar::from(2u8)];
-    let b = vec![Curve25519Scalar::from(3u8)];
+    let a = vec![TestScalar::from(2u8)];
+    let b = vec![TestScalar::from(3u8)];
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(2, &a, &b),
-        Curve25519Scalar::from(8u32) // This is (2-1)(3-1) + (2)(3)
+        TestScalar::from(8u32) // This is (2-1)(3-1) + (2)(3)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(1, &a, &b),
-        Curve25519Scalar::from(2u32) // This is (2-1)(3-1)
+        TestScalar::from(2u32) // This is (2-1)(3-1)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(0, &a, &b),
-        Curve25519Scalar::from(0u32)
+        TestScalar::from(0u32)
     );
 }
 
 #[test]
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_3_variables() {
     let a = vec![
-        Curve25519Scalar::from(2u8),
-        Curve25519Scalar::from(5u8),
-        Curve25519Scalar::from(7u8),
+        TestScalar::from(2u8),
+        TestScalar::from(5u8),
+        TestScalar::from(7u8),
     ];
     let b = vec![
-        Curve25519Scalar::from(3u8),
-        Curve25519Scalar::from(11u8),
-        Curve25519Scalar::from(13u8),
+        TestScalar::from(3u8),
+        TestScalar::from(11u8),
+        TestScalar::from(13u8),
     ];
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(8, &a, &b),
-        Curve25519Scalar::from(123_880_u32)
+        TestScalar::from(123_880_u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(7, &a, &b),
-        Curve25519Scalar::from(93850u32)
+        TestScalar::from(93850u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(6, &a, &b),
-        Curve25519Scalar::from(83840u32)
+        TestScalar::from(83840u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(5, &a, &b),
-        Curve25519Scalar::from(62000u32)
+        TestScalar::from(62000u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(4, &a, &b),
-        Curve25519Scalar::from(54720u32)
+        TestScalar::from(54720u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(3, &a, &b),
-        Curve25519Scalar::from(30960u32)
+        TestScalar::from(30960u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(2, &a, &b),
-        Curve25519Scalar::from(23040u32)
+        TestScalar::from(23040u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(1, &a, &b),
-        Curve25519Scalar::from(5760u32)
+        TestScalar::from(5760u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(0, &a, &b),
-        Curve25519Scalar::from(0u32)
+        TestScalar::from(0u32)
     );
 }
 
@@ -251,50 +251,50 @@ fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_3_va
 fn compute_truncated_lagrange_basis_inner_product_gives_correct_values_with_3_variables_using_dalek_scalar(
 ) {
     let a = vec![
-        Curve25519Scalar::from(2u8),
-        Curve25519Scalar::from(5u8),
-        Curve25519Scalar::from(7u8),
+        TestScalar::from(2u8),
+        TestScalar::from(5u8),
+        TestScalar::from(7u8),
     ];
     let b = vec![
-        Curve25519Scalar::from(3u8),
-        Curve25519Scalar::from(11u8),
-        Curve25519Scalar::from(13u8),
+        TestScalar::from(3u8),
+        TestScalar::from(11u8),
+        TestScalar::from(13u8),
     ];
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(8, &a, &b),
-        Curve25519Scalar::from(123_880_u32)
+        TestScalar::from(123_880_u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(7, &a, &b),
-        Curve25519Scalar::from(93850u32)
+        TestScalar::from(93850u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(6, &a, &b),
-        Curve25519Scalar::from(83840u32)
+        TestScalar::from(83840u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(5, &a, &b),
-        Curve25519Scalar::from(62000u32)
+        TestScalar::from(62000u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(4, &a, &b),
-        Curve25519Scalar::from(54720u32)
+        TestScalar::from(54720u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(3, &a, &b),
-        Curve25519Scalar::from(30960u32)
+        TestScalar::from(30960u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(2, &a, &b),
-        Curve25519Scalar::from(23040u32)
+        TestScalar::from(23040u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(1, &a, &b),
-        Curve25519Scalar::from(5760u32)
+        TestScalar::from(5760u32)
     );
     assert_eq!(
         compute_truncated_lagrange_basis_inner_product(0, &a, &b),
-        Curve25519Scalar::from(0u32)
+        TestScalar::from(0u32)
     );
 }
 
@@ -351,10 +351,10 @@ fn compute_truncated_lagrange_basis_sum_matches_sum_of_result_from_compute_evalu
     for _ in 0..20 {
         let variables = dist.sample(&mut rng);
         let length = Uniform::new((1 << (variables - 1)) + 1, 1 << variables).sample(&mut rng);
-        let point: Vec<_> = iter::repeat_with(|| Curve25519Scalar::rand(&mut rng))
+        let point: Vec<_> = iter::repeat_with(|| TestScalar::rand(&mut rng))
             .take(variables)
             .collect();
-        let mut eval_vec = vec![Curve25519Scalar::zero(); length];
+        let mut eval_vec = vec![TestScalar::zero(); length];
         compute_evaluation_vector(&mut eval_vec, &point);
         // ---------------- This is the actual test --------------------
         assert_eq!(
@@ -379,14 +379,14 @@ fn compute_truncated_lagrange_basis_inner_product_matches_inner_product_of_resul
     for _ in 0..20 {
         let variables = dist.sample(&mut rng);
         let length = Uniform::new((1 << (variables - 1)) + 1, 1 << variables).sample(&mut rng);
-        let a: Vec<_> = iter::repeat_with(|| Curve25519Scalar::rand(&mut rng))
+        let a: Vec<_> = iter::repeat_with(|| TestScalar::rand(&mut rng))
             .take(variables)
             .collect();
-        let b: Vec<_> = iter::repeat_with(|| Curve25519Scalar::rand(&mut rng))
+        let b: Vec<_> = iter::repeat_with(|| TestScalar::rand(&mut rng))
             .take(variables)
             .collect();
-        let mut eval_vec_a = vec![Curve25519Scalar::zero(); length];
-        let mut eval_vec_b = vec![Curve25519Scalar::zero(); length];
+        let mut eval_vec_a = vec![TestScalar::zero(); length];
+        let mut eval_vec_b = vec![TestScalar::zero(); length];
         compute_evaluation_vector(&mut eval_vec_a, &a);
         compute_evaluation_vector(&mut eval_vec_b, &b);
         // ---------------- This is the actual test --------------------

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,10 +1,10 @@
 use super::MultilinearExtension;
-use crate::base::{database::Column, scalar::Curve25519Scalar};
+use crate::base::{database::Column, scalar::test_scalar::TestScalar};
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_i64_slice() {
     let slice: &[i64] = &[2, 3, 4, 5, 6];
-    let evaluation_vec: Vec<Curve25519Scalar> =
+    let evaluation_vec: Vec<TestScalar> =
         vec![101.into(), 102.into(), 103.into(), 104.into(), 105.into()];
     assert_eq!(
         slice.inner_product(&evaluation_vec),
@@ -17,7 +17,7 @@ fn we_can_use_multilinear_extension_methods_for_i64_slice() {
         vec![121.into(), 132.into(), 143.into(), 154.into(), 165.into()]
     );
     assert_eq!(
-        *MultilinearExtension::<Curve25519Scalar>::to_sumcheck_term(&slice, 3),
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&slice, 3),
         vec![
             2.into(),
             3.into(),
@@ -30,15 +30,15 @@ fn we_can_use_multilinear_extension_methods_for_i64_slice() {
         ]
     );
     assert_ne!(
-        MultilinearExtension::<Curve25519Scalar>::id(&slice),
-        MultilinearExtension::<Curve25519Scalar>::id(&&evaluation_vec)
+        MultilinearExtension::<TestScalar>::id(&slice),
+        MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
 }
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_column() {
     let slice = Column::BigInt(&[2, 3, 4, 5, 6]);
-    let evaluation_vec: Vec<Curve25519Scalar> =
+    let evaluation_vec: Vec<TestScalar> =
         vec![101.into(), 102.into(), 103.into(), 104.into(), 105.into()];
     assert_eq!(
         slice.inner_product(&evaluation_vec),
@@ -51,7 +51,7 @@ fn we_can_use_multilinear_extension_methods_for_column() {
         vec![121.into(), 132.into(), 143.into(), 154.into(), 165.into()]
     );
     assert_eq!(
-        *MultilinearExtension::<Curve25519Scalar>::to_sumcheck_term(&slice, 3),
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&slice, 3),
         vec![
             2.into(),
             3.into(),
@@ -64,15 +64,15 @@ fn we_can_use_multilinear_extension_methods_for_column() {
         ]
     );
     assert_ne!(
-        MultilinearExtension::<Curve25519Scalar>::id(&slice),
-        MultilinearExtension::<Curve25519Scalar>::id(&&evaluation_vec)
+        MultilinearExtension::<TestScalar>::id(&slice),
+        MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
 }
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_i64_vec() {
     let slice: &Vec<i64> = &vec![2, 3, 4, 5, 6];
-    let evaluation_vec: Vec<Curve25519Scalar> =
+    let evaluation_vec: Vec<TestScalar> =
         vec![101.into(), 102.into(), 103.into(), 104.into(), 105.into()];
     assert_eq!(
         slice.inner_product(&evaluation_vec),
@@ -85,7 +85,7 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
         vec![121.into(), 132.into(), 143.into(), 154.into(), 165.into()]
     );
     assert_eq!(
-        *MultilinearExtension::<Curve25519Scalar>::to_sumcheck_term(&slice, 3),
+        *MultilinearExtension::<TestScalar>::to_sumcheck_term(&slice, 3),
         vec![
             2.into(),
             3.into(),
@@ -98,7 +98,7 @@ fn we_can_use_multilinear_extension_methods_for_i64_vec() {
         ]
     );
     assert_ne!(
-        MultilinearExtension::<Curve25519Scalar>::id(&slice),
-        MultilinearExtension::<Curve25519Scalar>::id(&&evaluation_vec)
+        MultilinearExtension::<TestScalar>::id(&slice),
+        MultilinearExtension::<TestScalar>::id(&&evaluation_vec)
     );
 }

--- a/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
@@ -1,5 +1,5 @@
 use super::{transcript_core::TranscriptCore, Keccak256Transcript as T, Transcript};
-use crate::base::scalar::Curve25519Scalar as S;
+use crate::base::scalar::test_scalar::TestScalar as S;
 use zerocopy::AsBytes;
 #[test]
 fn we_can_add_values_to_the_transcript_in_big_endian_form() {

--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse_test.rs
@@ -1,9 +1,9 @@
-use crate::base::{scalar::Curve25519Scalar, slice_ops};
+use crate::base::{scalar::test_scalar::TestScalar, slice_ops};
 use num_traits::{Inv, Zero};
 
 #[test]
 fn we_can_pseudo_invert_empty_arrays() {
-    let input: Vec<Curve25519Scalar> = Vec::new();
+    let input: Vec<TestScalar> = Vec::new();
     let mut res = Vec::new();
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
@@ -12,8 +12,8 @@ fn we_can_pseudo_invert_empty_arrays() {
 
 #[test]
 fn we_can_pseudo_invert_arrays_of_length_1_with_non_zero() {
-    let input = [Curve25519Scalar::from(2_u32)];
-    let mut res = vec![Curve25519Scalar::from(0_u32)];
+    let input = [TestScalar::from(2_u32)];
+    let mut res = vec![TestScalar::from(0_u32)];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
@@ -22,8 +22,8 @@ fn we_can_pseudo_invert_arrays_of_length_1_with_non_zero() {
 
 #[test]
 fn we_can_pseudo_invert_arrays_of_length_1_with_zero() {
-    let input = [Curve25519Scalar::from(0_u32)];
-    let mut res = vec![Curve25519Scalar::from(0_u32)];
+    let input = [TestScalar::from(0_u32)];
+    let mut res = vec![TestScalar::from(0_u32)];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
@@ -33,22 +33,22 @@ fn we_can_pseudo_invert_arrays_of_length_1_with_zero() {
 #[test]
 fn we_can_pseudo_invert_arrays_of_length_bigger_than_1_with_zeros_and_non_zeros() {
     let input = vec![
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(2_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
         (-33_i32).into(),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(45_u32),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(47_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(45_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(47_u32),
     ];
-    let mut res = vec![Curve25519Scalar::from(0_u32); input.len()];
+    let mut res = vec![TestScalar::from(0_u32); input.len()];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
 
     for (input_val, res_val) in input.iter().zip(res) {
-        if *input_val == Curve25519Scalar::zero() {
-            assert!(Curve25519Scalar::zero() == res_val);
+        if *input_val == TestScalar::zero() {
+            assert!(TestScalar::zero() == res_val);
         } else {
             assert!(input_val.inv().unwrap() == res_val);
         }
@@ -59,27 +59,27 @@ fn we_can_pseudo_invert_arrays_of_length_bigger_than_1_with_zeros_and_non_zeros(
 fn we_can_pseudo_invert_arrays_with_nonzero_count_bigger_than_min_chunking_size_with_zeros_and_non_zeros(
 ) {
     let input: Vec<_> = vec![
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(2_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
         (-33_i32).into(),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(45_u32),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(47_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(45_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(47_u32),
     ]
     .into_iter()
     .cycle()
     .take(slice_ops::MIN_RAYON_LEN * 10)
     .collect();
 
-    let mut res = vec![Curve25519Scalar::from(0_u32); input.len()];
+    let mut res = vec![TestScalar::from(0_u32); input.len()];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
 
     for (input_val, res_val) in input.iter().zip(res) {
-        if *input_val == Curve25519Scalar::zero() {
-            assert!(Curve25519Scalar::zero() == res_val);
+        if *input_val == TestScalar::zero() {
+            assert!(TestScalar::zero() == res_val);
         } else {
             assert!(input_val.inv().unwrap() == res_val);
         }
@@ -90,27 +90,27 @@ fn we_can_pseudo_invert_arrays_with_nonzero_count_bigger_than_min_chunking_size_
 fn we_can_pseudo_invert_arrays_with_nonzero_count_smaller_than_min_chunking_size_with_zeros_and_non_zeros(
 ) {
     let input: Vec<_> = vec![
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(2_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(2_u32),
         (-33_i32).into(),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(45_u32),
-        Curve25519Scalar::from(0_u32),
-        Curve25519Scalar::from(47_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(45_u32),
+        TestScalar::from(0_u32),
+        TestScalar::from(47_u32),
     ]
     .into_iter()
     .cycle()
     .take(slice_ops::MIN_RAYON_LEN - 1)
     .collect();
 
-    let mut res = vec![Curve25519Scalar::from(0_u32); input.len()];
+    let mut res = vec![TestScalar::from(0_u32); input.len()];
     assert_eq!(res.len(), input.len());
     res.copy_from_slice(&input[..]);
     slice_ops::batch_inversion(&mut res[..]);
 
     for (input_val, res_val) in input.iter().zip(res) {
-        if *input_val == Curve25519Scalar::zero() {
-            assert!(Curve25519Scalar::zero() == res_val);
+        if *input_val == TestScalar::zero() {
+            assert!(TestScalar::zero() == res_val);
         } else {
             assert!(input_val.inv().unwrap() == res_val);
         }

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -1,6 +1,5 @@
 use super::*;
-use crate::base::scalar::test_scalar::TestScalar;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::{test_scalar::TestScalar, Curve25519Scalar};
 
 #[test]
 fn test_inner_product() {

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::base::scalar::test_scalar::TestScalar;
 use crate::base::scalar::Curve25519Scalar;
 
 #[test]
@@ -19,21 +20,21 @@ fn test_inner_product_different_lengths() {
 /// test inner producr with scalar
 #[test]
 fn test_inner_product_scalar() {
-    let a = vec![Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
-    let b = vec![Curve25519Scalar::from(2u64), Curve25519Scalar::from(3u64)];
-    assert_eq!(Curve25519Scalar::from(8u64), inner_product(&a, &b));
+    let a = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
+    let b = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
 
 /// test uneven inner product with scalars
 #[test]
 fn test_inner_product_scalar_uneven() {
-    let a = vec![Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
+    let a = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
     let b = vec![
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(4u64),
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
+        TestScalar::from(4u64),
     ];
-    assert_eq!(Curve25519Scalar::from(8u64), inner_product(&a, &b));
+    assert_eq!(TestScalar::from(8u64), inner_product(&a, &b));
 }
 
 /// test inner product with curve25519scalar

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::base::scalar::test_scalar::TestScalar
+use crate::base::scalar::test_scalar::TestScalar;
 
 #[test]
 fn test_mul_add_assign() {

--- a/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mul_add_assign_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::base::scalar::Curve25519Scalar;
+use crate::base::scalar::test_scalar::TestScalar
 
 #[test]
 fn test_mul_add_assign() {
@@ -32,12 +32,12 @@ fn test_mul_add_assign_uneven_panic() {
 /// test [`mul_add_assign`] with curve25519scalar
 #[test]
 fn test_mul_add_assign_curve25519scalar() {
-    let mut a = vec![Curve25519Scalar::from(1u64), Curve25519Scalar::from(2u64)];
-    let b = vec![Curve25519Scalar::from(2u64), Curve25519Scalar::from(3u64)];
-    mul_add_assign(&mut a, Curve25519Scalar::from(10u64), &b);
+    let mut a = vec![TestScalar::from(1u64), TestScalar::from(2u64)];
+    let b = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    mul_add_assign(&mut a, TestScalar::from(10u64), &b);
     let c = vec![
-        Curve25519Scalar::from(1u64) + Curve25519Scalar::from(10u64) * Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(2u64) + Curve25519Scalar::from(10u64) * Curve25519Scalar::from(3u64),
+        TestScalar::from(1u64) + TestScalar::from(10u64) * TestScalar::from(2u64),
+        TestScalar::from(2u64) + TestScalar::from(10u64) * TestScalar::from(3u64),
     ];
     assert_eq!(a, c);
 }
@@ -46,16 +46,16 @@ fn test_mul_add_assign_curve25519scalar() {
 #[test]
 fn test_mul_add_assign_curve25519scalar_uneven() {
     let mut a = vec![
-        Curve25519Scalar::from(1u64),
-        Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(3u64),
+        TestScalar::from(1u64),
+        TestScalar::from(2u64),
+        TestScalar::from(3u64),
     ];
-    let b = vec![Curve25519Scalar::from(2u64), Curve25519Scalar::from(3u64)];
-    mul_add_assign(&mut a, Curve25519Scalar::from(10u64), &b);
+    let b = vec![TestScalar::from(2u64), TestScalar::from(3u64)];
+    mul_add_assign(&mut a, TestScalar::from(10u64), &b);
     let c = vec![
-        Curve25519Scalar::from(1u64) + Curve25519Scalar::from(10u64) * Curve25519Scalar::from(2u64),
-        Curve25519Scalar::from(2u64) + Curve25519Scalar::from(10u64) * Curve25519Scalar::from(3u64),
-        Curve25519Scalar::from(3u64),
+        TestScalar::from(1u64) + TestScalar::from(10u64) * TestScalar::from(2u64),
+        TestScalar::from(2u64) + TestScalar::from(10u64) * TestScalar::from(3u64),
+        TestScalar::from(3u64),
     ];
     assert_eq!(a, c);
 }

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::base::scalar::Curve25519Scalar;
+use create::base::scalar::test_scalar::TestScalar;
 use curve25519_dalek::scalar::Scalar;
 
 #[test]
@@ -87,7 +88,7 @@ fn test_slice_cast_mut_random() {
     use rand::Rng;
     let mut rng = rand::thread_rng();
     let a: Vec<u32> = (0..100).map(|_| rng.gen()).collect();
-    let mut b: Vec<Curve25519Scalar> = vec![Curve25519Scalar::default(); 100];
+    let mut b: Vec<TestScalar> = vec![TestScalar::default(); 100];
     slice_cast_mut(&a, &mut b);
     assert_eq!(b, slice_cast(&a));
 }

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
@@ -1,6 +1,5 @@
 use super::*;
-use crate::base::scalar::Curve25519Scalar;
-use crate::base::scalar::test_scalar::TestScalar;
+use crate::base::scalar::{test_scalar::TestScalar, Curve25519Scalar};
 use curve25519_dalek::scalar::Scalar;
 
 #[test]

--- a/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/slice_cast_test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::base::scalar::Curve25519Scalar;
-use create::base::scalar::test_scalar::TestScalar;
+use crate::base::scalar::test_scalar::TestScalar;
 use curve25519_dalek::scalar::Scalar;
 
 #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

The tests in the `base` directory was all modified with the updated from 


Curve25519Scalar -> TestScalar
RistrettoPoint -> NaiveCommitment
InnerProductProof -> TestEvaluationProof

## Notes 

During the previous commit , I accidentally modified the function which needs to be done in Curve25519Scalar , which was modified in the latest commit 

closes #230 
/claim #230 

# What changes are included in this PR?
all the test files, (unit tests) are modified. 

# Are these changes tested?
yes
