### PR TITLE
docs: Add lld as a pre-requisite to setup the dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,10 @@ To contribute to this project, you'll need to have Rust installed on your machin
      rustup component add rustfmt
      rustup component add clippy
      ```
+   - You will also need to install [lld](https://lld.llvm.org/) which will be required for running tests. For example on Debian based systems you can install it using the package manager:
+     ```bash
+     apt install lld
+     ```
 
 If you run into any issues, please refer to the [official Rust documentation](https://www.rust-lang.org/learn/get-started) for troubleshooting and more detailed installation instructions.
 


### PR DESCRIPTION

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [X] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

 I was going through this project and tried to run the tests locally but they failed because my machine was missing `lld`, so i added it as an instruction under the "Install Rust" section in `Contributing.md`


# What changes are included in this PR?

Adds one line to `CONTRIBUTING.md` telling the reader to install `lld`

# Are these changes tested?

Ran the CI checks script but it keeps killing my terminal, but I am making the PR anyway since I don't think a simple doc change would break anything
