### PR TITLE
refactor!: generalize `ProverEvaluate::result_evaluate` and `final_round_evaluate` to multiple tables

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -52,7 +52,7 @@ pub trait ProverEvaluate<S: Scalar> {
     /// Evaluate the query and modify `FirstRoundBuilder` to track the result of the query.
     fn result_evaluate<'a>(
         &self,
-        input_length: usize,
+        input_lengths: &[usize],
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>>;
@@ -68,6 +68,7 @@ pub trait ProverEvaluate<S: Scalar> {
     /// will be bulk deallocated once the proof is formed.
     fn final_round_evaluate<'a>(
         &self,
+        input_lengths: &[usize],
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -55,7 +55,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let alloc = Bump::new();
 
         // Evaluate query result
-        let result_cols = expr.result_evaluate(table_length, &alloc, accessor);
+        let result_cols = expr.result_evaluate(&[table_length], &alloc, accessor);
         let output_length = result_cols.first().map_or(0, Column::len);
         let provable_result = ProvableQueryResult::new(output_length as u64, &result_cols);
 
@@ -79,7 +79,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         let mut builder =
             FinalRoundBuilder::new(table_length, num_sumcheck_variables, post_result_challenges);
-        expr.final_round_evaluate(&mut builder, &alloc, accessor);
+        expr.final_round_evaluate(&[table_length], &mut builder, &alloc, accessor);
 
         let num_sumcheck_variables = builder.num_sumcheck_variables();
         let table_length = builder.table_length();

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -43,7 +43,7 @@ impl Default for TrivialTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        _input_length: usize,
+        _input_lengths: &[usize],
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -55,11 +55,14 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
 
     fn final_round_evaluate<'a>(
         &self,
+        input_lengths: &[usize],
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
-        let col = alloc.alloc_slice_fill_copy(builder.table_length(), self.column_fill_value);
+        assert_eq!(input_lengths.len(), 1);
+        let input_length = input_lengths[0];
+        let col = alloc.alloc_slice_fill_copy(input_length, self.column_fill_value);
         builder.produce_intermediate_mle(col as &[_]);
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
@@ -200,7 +203,7 @@ impl Default for SquareTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        _table_length: usize,
+        _input_lengths: &[usize],
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -212,6 +215,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
 
     fn final_round_evaluate<'a>(
         &self,
+        _input_lengths: &[usize],
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
@@ -382,7 +386,7 @@ impl Default for DoubleSquareTestProofPlan {
 impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        _input_length: usize,
+        _input_lengths: &[usize],
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -394,6 +398,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
 
     fn final_round_evaluate<'a>(
         &self,
+        _input_lengths: &[usize],
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
@@ -594,7 +599,7 @@ struct ChallengeTestProofPlan {}
 impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
     fn result_evaluate<'a>(
         &self,
-        _input_length: usize,
+        _input_lengths: &[usize],
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -607,6 +612,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
 
     fn final_round_evaluate<'a>(
         &self,
+        _input_lengths: &[usize],
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -27,7 +27,7 @@ pub(super) struct EmptyTestQueryExpr {
 impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     fn result_evaluate<'a>(
         &self,
-        _input_length: usize,
+        _input_lengths: &[usize],
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -38,6 +38,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
     fn final_round_evaluate<'a>(
         &self,
+        _input_lengths: &[usize],
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -79,12 +79,17 @@ impl<C: Commitment> ProofExpr<C> for AddSubtractExpr<C> {
     )]
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
-        let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
+        let lhs_column: Column<'a, C::Scalar> =
+            self.lhs
+                .prover_evaluate(table_length, builder, alloc, accessor);
+        let rhs_column: Column<'a, C::Scalar> =
+            self.rhs
+                .prover_evaluate(table_length, builder, alloc, accessor);
         Column::Scalar(add_subtract_columns(
             lhs_column,
             rhs_column,

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -55,11 +55,13 @@ impl<C: Commitment> ProofExpr<C> for AggregateExpr<C> {
     #[tracing::instrument(name = "AggregateExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        self.expr.prover_evaluate(builder, alloc, accessor)
+        self.expr
+            .prover_evaluate(table_length, builder, alloc, accessor)
     }
 
     fn verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -60,12 +60,17 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
     #[tracing::instrument(name = "AndExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
-        let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
+        let lhs_column: Column<'a, C::Scalar> =
+            self.lhs
+                .prover_evaluate(table_length, builder, alloc, accessor);
+        let rhs_column: Column<'a, C::Scalar> =
+            self.rhs
+                .prover_evaluate(table_length, builder, alloc, accessor);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let n = lhs.len();

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -75,11 +75,13 @@ impl<C: Commitment> ProofExpr<C> for ColumnExpr<C> {
     /// add the components needed to prove the result
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         _alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
         let column = accessor.get_column(self.column_ref);
+        assert!(column.len() == table_length);
         builder.produce_anchored_mle(column);
         column
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -253,40 +253,41 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
 
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
         match self {
             DynProofExpr::Column(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::And(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::Or(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::Not(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::Literal(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::Equals(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::Inequality(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::AddSubtract(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::Multiply(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
             DynProofExpr::Aggregate(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::<C>::prover_evaluate(expr, table_length, builder, alloc, accessor)
             }
         }
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -59,12 +59,17 @@ impl<C: Commitment> ProofExpr<C> for EqualsExpr<C> {
     #[tracing::instrument(name = "EqualsExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let lhs_column = self.lhs.prover_evaluate(builder, alloc, accessor);
-        let rhs_column = self.rhs.prover_evaluate(builder, alloc, accessor);
+        let lhs_column = self
+            .lhs
+            .prover_evaluate(table_length, builder, alloc, accessor);
+        let rhs_column = self
+            .rhs
+            .prover_evaluate(table_length, builder, alloc, accessor);
         let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);
         let rhs_scale = self.rhs.data_type().scale().unwrap_or(0);
         let res = scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, true)

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -86,12 +86,17 @@ impl<C: Commitment> ProofExpr<C> for InequalityExpr<C> {
     #[tracing::instrument(name = "InequalityExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let lhs_column = self.lhs.prover_evaluate(builder, alloc, accessor);
-        let rhs_column = self.rhs.prover_evaluate(builder, alloc, accessor);
+        let lhs_column = self
+            .lhs
+            .prover_evaluate(table_length, builder, alloc, accessor);
+        let rhs_column = self
+            .rhs
+            .prover_evaluate(table_length, builder, alloc, accessor);
         let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);
         let rhs_scale = self.rhs.data_type().scale().unwrap_or(0);
         let diff = if self.is_lte {

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -57,11 +57,11 @@ impl<C: Commitment> ProofExpr<C> for LiteralExpr<C::Scalar> {
     #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
-        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
+        table_length: usize,
+        _builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let table_length = builder.table_length();
         Column::from_literal_with_length(&self.value, table_length, alloc)
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -69,12 +69,17 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
     )]
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
-        let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
+        let lhs_column: Column<'a, C::Scalar> =
+            self.lhs
+                .prover_evaluate(table_length, builder, alloc, accessor);
+        let rhs_column: Column<'a, C::Scalar> =
+            self.rhs
+                .prover_evaluate(table_length, builder, alloc, accessor);
 
         // lhs_times_rhs
         let lhs_times_rhs: &'a [C::Scalar] = multiply_columns(&lhs_column, &rhs_column, alloc);

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -50,12 +50,14 @@ impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
     #[tracing::instrument(name = "NotExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
         let expr_column: Column<'a, C::Scalar> =
-            self.expr.prover_evaluate(builder, alloc, accessor);
+            self.expr
+                .prover_evaluate(table_length, builder, alloc, accessor);
         let expr = expr_column.as_boolean().expect("expr is not boolean");
         Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]))
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -58,12 +58,17 @@ impl<C: Commitment> ProofExpr<C> for OrExpr<C> {
     #[tracing::instrument(name = "OrExpr::prover_evaluate", level = "debug", skip_all)]
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,
     ) -> Column<'a, C::Scalar> {
-        let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
-        let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
+        let lhs_column: Column<'a, C::Scalar> =
+            self.lhs
+                .prover_evaluate(table_length, builder, alloc, accessor);
+        let rhs_column: Column<'a, C::Scalar> =
+            self.rhs
+                .prover_evaluate(table_length, builder, alloc, accessor);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         Column::Boolean(prover_evaluate_or(builder, alloc, lhs, rhs))

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -32,6 +32,7 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
     /// of values
     fn prover_evaluate<'a>(
         &self,
+        table_length: usize,
         builder: &mut FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<C::Scalar>,

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -95,14 +95,14 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
     #[tracing::instrument(name = "DynProofPlan::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a>(
         &self,
-        input_length: usize,
+        input_lengths: &[usize],
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
         match self {
-            DynProofPlan::Projection(expr) => expr.result_evaluate(input_length, alloc, accessor),
-            DynProofPlan::GroupBy(expr) => expr.result_evaluate(input_length, alloc, accessor),
-            DynProofPlan::Filter(expr) => expr.result_evaluate(input_length, alloc, accessor),
+            DynProofPlan::Projection(expr) => expr.result_evaluate(input_lengths, alloc, accessor),
+            DynProofPlan::GroupBy(expr) => expr.result_evaluate(input_lengths, alloc, accessor),
+            DynProofPlan::Filter(expr) => expr.result_evaluate(input_lengths, alloc, accessor),
         }
     }
 
@@ -117,14 +117,21 @@ impl<C: Commitment> ProverEvaluate<C::Scalar> for DynProofPlan<C> {
     #[tracing::instrument(name = "DynProofPlan::final_round_evaluate", level = "debug", skip_all)]
     fn final_round_evaluate<'a>(
         &self,
+        input_lengths: &[usize],
         builder: &mut crate::sql::proof::FinalRoundBuilder<'a, C::Scalar>,
         alloc: &'a bumpalo::Bump,
         accessor: &'a dyn crate::base::database::DataAccessor<C::Scalar>,
     ) -> Vec<Column<'a, C::Scalar>> {
         match self {
-            DynProofPlan::Projection(expr) => expr.final_round_evaluate(builder, alloc, accessor),
-            DynProofPlan::GroupBy(expr) => expr.final_round_evaluate(builder, alloc, accessor),
-            DynProofPlan::Filter(expr) => expr.final_round_evaluate(builder, alloc, accessor),
+            DynProofPlan::Projection(expr) => {
+                expr.final_round_evaluate(input_lengths, builder, alloc, accessor)
+            }
+            DynProofPlan::GroupBy(expr) => {
+                expr.final_round_evaluate(input_lengths, builder, alloc, accessor)
+            }
+            DynProofPlan::Filter(expr) => {
+                expr.final_round_evaluate(input_lengths, builder, alloc, accessor)
+            }
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -192,7 +192,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(0, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&[0], &alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -239,7 +239,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&[5], &alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -282,7 +282,7 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
         equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&[5], &alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -315,7 +315,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&[5], &alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -165,7 +165,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     let expr: DynProofPlan<RistrettoPoint> =
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(0, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&[0], &alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -206,7 +206,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     accessor.add_table(t, data, 0);
     let expr: DynProofPlan<RistrettoPoint> = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&[5], &alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -244,7 +244,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         tab(t),
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&[5], &alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to complete #121 and #122 we need to allow `ProofPlan` composition and multiple table support. In particular we have to allow `ProofExpr::prover_evaluate` to accept `table_length`s that are not identical to `proof_builder.table_length` due to `ProofPlan` composition. This is the latest PR for this.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `table_length` to `ProofExpr::prover_evaluate`.
- generalize `ProverEvaluate::result_evaluate`.
- generalize `ProverEvaluate::final_round_evaluate`.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests should pass.