### PR TITLE
ci: the run_ci_checks shell script should not close the terminal if a failure occurs

### DIFF
--- a/scripts/run_ci_checks.sh
+++ b/scripts/run_ci_checks.sh
@@ -45,13 +45,19 @@ echo "$cargo_commands"
 echo "========================="
 
 # Execute the commands
+failed_tests=0
 while IFS= read -r cmd; do
     echo "Running command: $cmd"
     if ! eval "$cmd"; then
         echo "Error: Command failed - $cmd"
         echo "Stopping execution."
-        exit 1
+        failed_tests=$((failed_tests + 1))
     fi
 done <<< "$cargo_commands"
 
-echo "All CI checks (excluding tests and udeps) have completed successfully."
+# Print the results
+if [ "$failed_tests" -gt 0 ]; then
+    echo "Error: $failed_tests CI checks (excluding tests and udeps) have FAILED."
+else
+    echo "All CI checks (excluding tests and udeps) have completed successfully."
+fi


### PR DESCRIPTION
# Rationale for this change
The command `exit 1` is called if a failure occurs when executing the commands in the `scripts/run_ci_checks` shell script. The `exit 1` command closes the terminal in places like VSCode, the Ubuntu terminal, and Terminator. This makes debugging failures difficult since the tests results are not visible to the user.

# What changes are included in this PR?
- The `run_ci_checks.sh` shell script is updated to count the number of test failures when executing the commands and leave the terminal open after the script has run for users to see the test results.

# Are these changes tested?
Yes
