### PR TITLE
refactor!: add `ScalarExt`

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -1,7 +1,7 @@
 use super::{LiteralValue, OwnedColumn, TableRef};
 use crate::base::{
-    math::decimal::{scale_scalar, Precision},
-    scalar::Scalar,
+    math::decimal::Precision,
+    scalar::{Scalar, ScalarExt},
     slice_ops::slice_cast_with,
 };
 use alloc::{sync::Arc, vec::Vec};
@@ -213,7 +213,7 @@ impl<'a, S: Scalar> Column<'a, S> {
     /// Convert a column to a vector of Scalar values with scaling
     #[allow(clippy::missing_panics_doc)]
     pub(crate) fn to_scalar_with_scaling(self, scale: i8) -> Vec<S> {
-        let scale_factor = scale_scalar(S::ONE, scale).expect("Invalid scale factor");
+        let scale_factor = S::pow10(u8::try_from(scale).expect("Upscale factor is nonnegative"));
         match self {
             Self::Boolean(col) => slice_cast_with(col, |b| S::from(b) * scale_factor),
             Self::Decimal75(_, _, col) => slice_cast_with(col, |s| *s * scale_factor),

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -3,7 +3,7 @@ use super::{ColumnOperationError, ColumnOperationResult};
 use crate::base::{
     database::ColumnType,
     math::decimal::{scale_scalar, DecimalError, Precision},
-    scalar::Scalar,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::{format, string::ToString, vec::Vec};
 use core::{cmp::Ordering, fmt::Debug};

--- a/crates/proof-of-sql/src/base/database/column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation.rs
@@ -2,7 +2,7 @@
 use super::{ColumnOperationError, ColumnOperationResult};
 use crate::base::{
     database::ColumnType,
-    math::decimal::{scale_scalar, DecimalError, Precision},
+    math::decimal::{DecimalError, Precision},
     scalar::{Scalar, ScalarExt},
 };
 use alloc::{format, string::ToString, vec::Vec};
@@ -548,7 +548,7 @@ where
                 .collect::<Vec<_>>()
         } else {
             let upscale_factor =
-                scale_scalar(S::ONE, upscale).expect("Upscale factor is nonnegative");
+                S::pow10(u8::try_from(upscale).expect("Upscale factor is nonnegative"));
             lhs.iter()
                 .zip(rhs.iter())
                 .map(|(l, r)| -> bool { Into::<S>::into(*l) * upscale_factor == *r })
@@ -569,7 +569,7 @@ where
                 .collect::<Vec<_>>()
         } else {
             let upscale_factor =
-                scale_scalar(S::ONE, upscale).expect("Upscale factor is nonnegative");
+                S::pow10(u8::try_from(upscale).expect("Upscale factor is nonnegative"));
             lhs.iter()
                 .zip(rhs.iter())
                 .map(|(l, r)| -> bool { Into::<S>::into(*l) == *r * upscale_factor })
@@ -624,7 +624,7 @@ where
                 .collect::<Vec<_>>()
         } else {
             let upscale_factor =
-                scale_scalar(S::ONE, upscale).expect("Upscale factor is nonnegative");
+                S::pow10(u8::try_from(upscale).expect("Upscale factor is nonnegative"));
             lhs.iter()
                 .zip(rhs.iter())
                 .map(|(l, r)| -> bool {
@@ -652,7 +652,7 @@ where
                 .collect::<Vec<_>>()
         } else {
             let upscale_factor =
-                scale_scalar(S::ONE, upscale).expect("Upscale factor is nonnegative");
+                S::pow10(u8::try_from(upscale).expect("Upscale factor is nonnegative"));
             lhs.iter()
                 .zip(rhs.iter())
                 .map(|(l, r)| -> bool {
@@ -709,7 +709,7 @@ where
                 .collect::<Vec<_>>()
         } else {
             let upscale_factor =
-                scale_scalar(S::ONE, upscale).expect("Upscale factor is nonnegative");
+                S::pow10(u8::try_from(upscale).expect("Upscale factor is nonnegative"));
             lhs.iter()
                 .zip(rhs.iter())
                 .map(|(l, r)| -> bool {
@@ -737,7 +737,7 @@ where
                 .collect::<Vec<_>>()
         } else {
             let upscale_factor =
-                scale_scalar(S::ONE, upscale).expect("Upscale factor is nonnegative");
+                S::pow10(u8::try_from(upscale).expect("Upscale factor is nonnegative"));
             lhs.iter()
                 .zip(rhs.iter())
                 .map(|(l, r)| -> bool {
@@ -786,13 +786,15 @@ where
             .expect("numeric columns have scale");
     // One of left_scale and right_scale is 0 so we can avoid scaling when unnecessary
     let scalars: Vec<S> = if left_upscale > 0 {
-        let upscale_factor = scale_scalar(S::ONE, left_upscale)?;
+        let upscale_factor =
+            S::pow10(u8::try_from(left_upscale).expect("Upscale factor is nonnegative"));
         lhs.iter()
             .zip(rhs)
             .map(|(l, r)| S::from(*l) * upscale_factor + S::from(*r))
             .collect()
     } else if right_upscale > 0 {
-        let upscale_factor = scale_scalar(S::ONE, right_upscale)?;
+        let upscale_factor =
+            S::pow10(u8::try_from(right_upscale).expect("Upscale factor is nonnegative"));
         lhs.iter()
             .zip(rhs)
             .map(|(l, r)| S::from(*l) + upscale_factor * S::from(*r))
@@ -846,13 +848,15 @@ where
             .expect("numeric columns have scale");
     // One of left_scale and right_scale is 0 so we can avoid scaling when unnecessary
     let scalars: Vec<S> = if left_upscale > 0 {
-        let upscale_factor = scale_scalar(S::ONE, left_upscale)?;
+        let upscale_factor =
+            S::pow10(u8::try_from(left_upscale).expect("Upscale factor is nonnegative"));
         lhs.iter()
             .zip(rhs)
             .map(|(l, r)| S::from(*l) * upscale_factor - S::from(*r))
             .collect()
     } else if right_upscale > 0 {
-        let upscale_factor = scale_scalar(S::ONE, right_upscale)?;
+        let upscale_factor =
+            S::pow10(u8::try_from(right_upscale).expect("Upscale factor is nonnegative"));
         lhs.iter()
             .zip(rhs)
             .map(|(l, r)| S::from(*l) - upscale_factor * S::from(*r))

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -3,7 +3,7 @@
 use crate::base::{
     database::{filter_util::filter_column_by_index, Column, OwnedColumn},
     if_rayon,
-    scalar::Scalar,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::vec::Vec;
 use bumpalo::Bump;
@@ -311,7 +311,7 @@ where
         indexes[start..index]
             .iter()
             .map(|i| S::from(&slice[*i]))
-            .max_by(super::super::scalar::Scalar::signed_cmp)
+            .max_by(super::super::scalar::ScalarExt::signed_cmp)
     }))
 }
 
@@ -352,7 +352,7 @@ where
         indexes[start..index]
             .iter()
             .map(|i| S::from(&slice[*i]))
-            .min_by(super::super::scalar::Scalar::signed_cmp)
+            .min_by(super::super::scalar::ScalarExt::signed_cmp)
     }))
 }
 

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -1,5 +1,5 @@
 //! Module for parsing an `IntermediateDecimal` into a `Decimal75`.
-use crate::base::scalar::{Scalar, ScalarConversionError};
+use crate::base::scalar::{Scalar, ScalarConversionError, ScalarExt};
 use alloc::{
     format,
     string::{String, ToString},
@@ -125,6 +125,7 @@ impl<S: Scalar> Decimal<S> {
         }
     }
 
+    #[allow(clippy::missing_panics_doc)]
     /// Scale the decimal to the new scale factor. Negative scaling and overflow error out.
     #[allow(clippy::cast_sign_loss)]
     pub fn with_precision_and_scale(
@@ -138,10 +139,12 @@ impl<S: Scalar> Decimal<S> {
                 error: "Scale factor must be non-negative".to_string(),
             });
         }
-        let scaled_value = scale_scalar(self.value, scale_factor)?;
+        let scaled_value =
+            self.value * S::pow10(u8::try_from(scale_factor).expect("scale_factor is nonnegative"));
         Ok(Decimal::new(scaled_value, new_precision, new_scale))
     }
 
+    #[allow(clippy::missing_panics_doc)]
     /// Get a decimal with given precision and scale from an i64
     #[allow(clippy::cast_sign_loss)]
     pub fn from_i64(value: i64, precision: Precision, scale: i8) -> DecimalResult<Self> {
@@ -157,10 +160,12 @@ impl<S: Scalar> Decimal<S> {
                 error: "Can not scale down a decimal".to_string(),
             });
         }
-        let scaled_value = scale_scalar(S::from(&value), scale)?;
+        let scaled_value =
+            S::from(&value) * S::pow10(u8::try_from(scale).expect("scale is nonnegative"));
         Ok(Decimal::new(scaled_value, precision, scale))
     }
 
+    #[allow(clippy::missing_panics_doc)]
     /// Get a decimal with given precision and scale from an i128
     #[allow(clippy::cast_sign_loss)]
     pub fn from_i128(value: i128, precision: Precision, scale: i8) -> DecimalResult<Self> {
@@ -176,7 +181,8 @@ impl<S: Scalar> Decimal<S> {
                 error: "Can not scale down a decimal".to_string(),
             });
         }
-        let scaled_value = scale_scalar(S::from(&value), scale)?;
+        let scaled_value =
+            S::from(&value) * S::pow10(u8::try_from(scale).expect("scale is nonnegative"));
         Ok(Decimal::new(scaled_value, precision, scale))
     }
 }
@@ -208,25 +214,6 @@ pub(crate) fn try_into_to_scalar<S: Scalar>(
         .map_err(|e: ScalarConversionError| DecimalError::InvalidDecimal {
             error: e.to_string(),
         })
-}
-
-/// Scale scalar by the given scale factor. Negative scaling is not allowed.
-/// Note that we do not check for overflow.
-pub(crate) fn scale_scalar<S: Scalar>(s: S, scale: i8) -> DecimalResult<S> {
-    match scale {
-        0 => Ok(s),
-        _ if scale < 0 => Err(DecimalError::RoundingError {
-            error: "Scale factor must be non-negative".to_string(),
-        }),
-        _ => {
-            let ten = S::from(10);
-            let mut res = s;
-            for _ in 0..scale {
-                res *= ten;
-            }
-            Ok(res)
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -1,5 +1,5 @@
 /// This module contains the definition of the `Scalar` trait, which is used to represent the scalar field used in Proof of SQL.
-pub mod scalar;
+mod scalar;
 pub use scalar::Scalar;
 mod error;
 pub use error::ScalarConversionError;
@@ -13,3 +13,6 @@ pub(crate) use mont_scalar::MontScalar;
 pub mod test_scalar;
 #[cfg(test)]
 mod test_scalar_test;
+
+mod scalar_ext;
+pub use scalar_ext::ScalarExt;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -430,6 +430,7 @@ impl super::Scalar for Curve25519Scalar {
     const ZERO: Self = Self(ark_ff::MontFp!("0"));
     const ONE: Self = Self(ark_ff::MontFp!("1"));
     const TWO: Self = Self(ark_ff::MontFp!("2"));
+    const TEN: Self = Self(ark_ff::MontFp!("10"));
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -4,7 +4,6 @@ use crate::base::{
 };
 use alloc::{format, string::ToString, vec::Vec};
 use byte_slice_cast::AsByteSlice;
-use core::cmp::Ordering;
 use num_bigint::BigInt;
 use num_traits::{Inv, One, Zero};
 use rand::{
@@ -359,20 +358,6 @@ fn the_one_scalar_is_the_multiplicative_identity() {
             Curve25519Scalar::one()
         );
     }
-}
-
-#[test]
-fn scalar_comparison_works() {
-    let zero = Curve25519Scalar::ZERO;
-    let one = Curve25519Scalar::ONE;
-    let two = Curve25519Scalar::TWO;
-    let max = Curve25519Scalar::MAX_SIGNED;
-    let min = max + one;
-    assert_eq!(max.signed_cmp(&one), Ordering::Greater);
-    assert_eq!(one.signed_cmp(&zero), Ordering::Greater);
-    assert_eq!(min.signed_cmp(&zero), Ordering::Less);
-    assert_eq!((two * max).signed_cmp(&zero), Ordering::Less);
-    assert_eq!(two * max + one, zero);
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -2,7 +2,7 @@
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
 use alloc::string::String;
-use core::{cmp::Ordering, ops::Sub};
+use core::ops::Sub;
 use num_bigint::BigInt;
 
 /// A trait for the scalar field used in Proof of SQL.
@@ -69,12 +69,4 @@ pub trait Scalar:
     const ONE: Self;
     /// 1 + 1
     const TWO: Self;
-    /// Compare two `Scalar`s as signed numbers.
-    fn signed_cmp(&self, other: &Self) -> Ordering {
-        match *self - *other {
-            x if x.is_zero() => Ordering::Equal,
-            x if x > Self::MAX_SIGNED => Ordering::Less,
-            _ => Ordering::Greater,
-        }
-    }
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -69,4 +69,6 @@ pub trait Scalar:
     const ONE: Self;
     /// 1 + 1
     const TWO: Self;
+    /// 2 + 2 + 2 + 2 + 2
+    const TEN: Self;
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -5,6 +5,10 @@ use core::cmp::Ordering;
 /// This trait is primarily to avoid cluttering the core `Scalar` implementation with default implemenentations
 /// and provides helper methods for `Scalar`.
 pub trait ScalarExt: Scalar {
+    /// Compute 10^exponent for the Scalar. Note that we do not check for overflow.
+    fn pow10(exponent: u8) -> Self {
+        itertools::repeat_n(Self::TEN, exponent as usize).product()
+    }
     /// Compare two `Scalar`s as signed numbers.
     fn signed_cmp(&self, other: &Self) -> Ordering {
         match *self - *other {
@@ -19,7 +23,7 @@ impl<S: Scalar> ScalarExt for S {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::scalar::Curve25519Scalar;
+    use crate::base::scalar::{test_scalar::TestScalar, Curve25519Scalar, MontScalar};
     #[test]
     fn scalar_comparison_works() {
         let zero = Curve25519Scalar::ZERO;
@@ -32,5 +36,20 @@ mod tests {
         assert_eq!(min.signed_cmp(&zero), Ordering::Less);
         assert_eq!((two * max).signed_cmp(&zero), Ordering::Less);
         assert_eq!(two * max + one, zero);
+    }
+    #[test]
+    fn we_can_compute_powers_of_10() {
+        for i in 0..=u128::MAX.ilog10() {
+            assert_eq!(
+                TestScalar::pow10(u8::try_from(i).unwrap()),
+                TestScalar::from(u128::pow(10, i))
+            );
+        }
+        assert_eq!(
+            TestScalar::pow10(76),
+            MontScalar(ark_ff::MontFp!(
+                "10000000000000000000000000000000000000000000000000000000000000000000000000000"
+            ))
+        );
     }
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -1,0 +1,36 @@
+use super::Scalar;
+use core::cmp::Ordering;
+
+/// Extention trait for blanket implementations for `Scalar` types.
+/// This trait is primarily to avoid cluttering the core `Scalar` implementation with default implemenentations
+/// and provides helper methods for `Scalar`.
+pub trait ScalarExt: Scalar {
+    /// Compare two `Scalar`s as signed numbers.
+    fn signed_cmp(&self, other: &Self) -> Ordering {
+        match *self - *other {
+            x if x.is_zero() => Ordering::Equal,
+            x if x > Self::MAX_SIGNED => Ordering::Less,
+            _ => Ordering::Greater,
+        }
+    }
+}
+impl<S: Scalar> ScalarExt for S {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::Curve25519Scalar;
+    #[test]
+    fn scalar_comparison_works() {
+        let zero = Curve25519Scalar::ZERO;
+        let one = Curve25519Scalar::ONE;
+        let two = Curve25519Scalar::TWO;
+        let max = Curve25519Scalar::MAX_SIGNED;
+        let min = max + one;
+        assert_eq!(max.signed_cmp(&one), Ordering::Greater);
+        assert_eq!(one.signed_cmp(&zero), Ordering::Greater);
+        assert_eq!(min.signed_cmp(&zero), Ordering::Less);
+        assert_eq!((two * max).signed_cmp(&zero), Ordering::Less);
+        assert_eq!(two * max + one, zero);
+    }
+}

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -13,6 +13,7 @@ impl Scalar for TestScalar {
     const ZERO: Self = Self(ark_ff::MontFp!("0"));
     const ONE: Self = Self(ark_ff::MontFp!("1"));
     const TWO: Self = Self(ark_ff::MontFp!("2"));
+    const TEN: Self = Self(ark_ff::MontFp!("10"));
 }
 
 pub struct TestMontConfig(pub ark_curve25519::FrConfig);

--- a/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
@@ -8,4 +8,5 @@ fn we_can_get_test_scalar_constants_from_z_p() {
     assert_eq!(TestScalar::from(2), TestScalar::TWO);
     // -1/2 == least upper bound
     assert_eq!(-TestScalar::TWO.inv().unwrap(), TestScalar::MAX_SIGNED);
+    assert_eq!(TestScalar::from(10), TestScalar::TEN);
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -45,6 +45,7 @@ impl Scalar for DoryScalar {
     const ZERO: Self = Self(ark_ff::MontFp!("0"));
     const ONE: Self = Self(ark_ff::MontFp!("1"));
     const TWO: Self = Self(ark_ff::MontFp!("2"));
+    const TEN: Self = Self(ark_ff::MontFp!("10"));
 }
 
 #[derive(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_test.rs
@@ -1,5 +1,5 @@
 use super::DoryScalar;
-use crate::base::scalar::{Scalar, ScalarConversionError};
+use crate::base::scalar::{Scalar, ScalarConversionError, ScalarExt};
 use core::cmp::Ordering;
 use num_bigint::BigInt;
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -5,8 +5,7 @@ use crate::{
             owned_table_utility::*, Column, LiteralValue, OwnedTable, OwnedTableTestAccessor,
             TestAccessor,
         },
-        math::decimal::scale_scalar,
-        scalar::{Curve25519Scalar, Scalar},
+        scalar::{Curve25519Scalar, Scalar, ScalarExt},
     },
     sql::{
         parse::ConversionError,
@@ -164,7 +163,7 @@ fn we_can_compare_columns_with_extreme_values() {
 
 #[test]
 fn we_can_compare_columns_with_small_decimal_values_without_scale() {
-    let scalar_pos = scale_scalar(Curve25519Scalar::ONE, 38).unwrap() - Curve25519Scalar::ONE;
+    let scalar_pos = Curve25519Scalar::pow10(38) - Curve25519Scalar::ONE;
     let scalar_neg = -scalar_pos;
     let data: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("a", [123, 25]),
@@ -192,7 +191,7 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
 
 #[test]
 fn we_can_compare_columns_with_small_decimal_values_with_scale() {
-    let scalar_pos = scale_scalar(Curve25519Scalar::ONE, 38).unwrap() - Curve25519Scalar::ONE;
+    let scalar_pos = Curve25519Scalar::pow10(38) - Curve25519Scalar::ONE;
     let scalar_neg = -scalar_pos;
     let data: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("a", [123, 25]),
@@ -222,7 +221,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
 
 #[test]
 fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
-    let scalar_pos = scale_scalar(Curve25519Scalar::ONE, 38).unwrap() - Curve25519Scalar::ONE;
+    let scalar_pos = Curve25519Scalar::pow10(38) - Curve25519Scalar::ONE;
     let scalar_neg = -scalar_pos;
     let data: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("a", [123, 25]),

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -1,4 +1,7 @@
-use crate::base::{database::Column, math::decimal::scale_scalar, scalar::Scalar};
+use crate::base::{
+    database::Column,
+    scalar::{Scalar, ScalarExt},
+};
 use bumpalo::Bump;
 
 #[allow(
@@ -65,10 +68,8 @@ pub(crate) fn scale_and_add_subtract_eval<S: Scalar>(
     is_subtract: bool,
 ) -> S {
     let max_scale = lhs_scale.max(rhs_scale);
-    let left_scaled_eval = scale_scalar(lhs_eval, max_scale - lhs_scale)
-        .expect("scaling factor should not be negative");
-    let right_scaled_eval = scale_scalar(rhs_eval, max_scale - rhs_scale)
-        .expect("scaling factor should not be negative");
+    let left_scaled_eval = lhs_eval * S::pow10(max_scale.abs_diff(lhs_scale));
+    let right_scaled_eval = rhs_eval * S::pow10(max_scale.abs_diff(rhs_scale));
     if is_subtract {
         left_scaled_eval - right_scaled_eval
     } else {


### PR DESCRIPTION
# Rationale for this change

Some helper code for `Scalar`s is scattered a bit. This PR clean this up.

# What changes are included in this PR?

* Moved signed_cmp to ScalarExt trait.
* Replaced scale_scalar with ScalarExt::pow10

# Are these changes tested?

Yes