### PR TITLE
feat: expose `OwnedTableTestAccessor` without `test` feature

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -67,9 +67,7 @@ pub use owned_and_arrow_conversions::OwnedArrowConversionError;
 #[cfg(all(test, feature = "arrow"))]
 mod owned_and_arrow_conversions_test;
 
-#[cfg(any(test, feature = "test"))]
 mod test_accessor;
-#[cfg(any(test, feature = "test"))]
 pub use test_accessor::TestAccessor;
 #[cfg(test)]
 pub(crate) use test_accessor::UnimplementedTestAccessor;
@@ -79,9 +77,7 @@ mod test_schema_accessor;
 #[cfg(test)]
 pub(crate) use test_schema_accessor::TestSchemaAccessor;
 
-#[cfg(any(test, feature = "test"))]
 mod owned_table_test_accessor;
-#[cfg(any(test, feature = "test"))]
 pub use owned_table_test_accessor::OwnedTableTestAccessor;
 #[cfg(all(test, feature = "blitzar"))]
 mod owned_table_test_accessor_test;

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -6,11 +6,12 @@ use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
     map::IndexMap,
 };
+use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
 use proof_of_sql_parser::Identifier;
 
 /// A test accessor that uses [`OwnedTable`] as the underlying table type.
-/// Note: this is not optimized for performance, so should not be used for benchmarks.
+/// Note: this is intended for testing and examples. It is not optimized for performance, so should not be used for benchmarks or production use-cases.
 pub struct OwnedTableTestAccessor<'a, CP: CommitmentEvaluationProof> {
     tables: IndexMap<TableRef, (OwnedTable<CP::Scalar>, usize)>,
     alloc: Bump,

--- a/crates/proof-of-sql/src/base/database/test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor.rs
@@ -3,10 +3,11 @@ use super::{
     SchemaAccessor, TableRef,
 };
 use crate::base::{commitment::Commitment, scalar::Curve25519Scalar};
+use alloc::vec::Vec;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use proof_of_sql_parser::Identifier;
 
-/// A trait that defines the interface for a combined metadata, schema, commitment, and data accessor for unit testing purposes.
+/// A trait that defines the interface for a combined metadata, schema, commitment, and data accessor for unit testing or example purposes.
 pub trait TestAccessor<C: Commitment>:
     Clone
     + Default


### PR DESCRIPTION
# Rationale for this change

The `test` feature is unwieldy and makes the repo difficult to use. This PR helps with this a bit.

# What changes are included in this PR?

The `test` feature no longer gates `OwnedTableTestAccessor`, which is helpful for examples and simple uses.

# Are these changes tested?
NA