### PR TITLE
bench: jaeger benchmarks should be able to run the dynamic Dory evaluation proof

### DIFF
--- a/crates/proof-of-sql/benches/README.md
+++ b/crates/proof-of-sql/benches/README.md
@@ -11,7 +11,7 @@ To run benchmarks with Jaeger, you need to do the following
 2. Run a benchmark.
     ```bash
     cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof
-    cargo bench -p proof-of-sql --bench jaeger_benches Dory --features="test"
+    cargo bench -p proof-of-sql --bench jaeger_benches Dory
     ```
 3. Navigate to http://localhost:16686/ to see the results.
 4. To end the Jaeger service, run

--- a/crates/proof-of-sql/benches/README.md
+++ b/crates/proof-of-sql/benches/README.md
@@ -12,6 +12,7 @@ To run benchmarks with Jaeger, you need to do the following
     ```bash
     cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof
     cargo bench -p proof-of-sql --bench jaeger_benches Dory
+    cargo bench -p proof-of-sql --bench jaeger_benches DynamicDory
     ```
 3. Navigate to http://localhost:16686/ to see the results.
 4. To end the Jaeger service, run

--- a/crates/proof-of-sql/benches/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger_benches.rs
@@ -3,14 +3,12 @@
 //! ```bash
 //! docker run --rm -d --name jaeger -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:latest
 //! cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof
-//! cargo bench -p proof-of-sql --bench jaeger_benches Dory --features="test"
+//! cargo bench -p proof-of-sql --bench jaeger_benches Dory
 //! ```
 //! Then, navigate to <http://localhost:16686> to view the traces.
 
-#[cfg(feature = "test")]
 use ark_std::test_rng;
 use blitzar::{compute::init_backend, proof::InnerProductProof};
-#[cfg(feature = "test")]
 use proof_of_sql::proof_primitive::dory::{
     DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup,
     PublicParameters, VerifierSetup,
@@ -51,7 +49,6 @@ fn main() {
                 }
             }
         }
-        #[cfg(feature = "test")]
         "Dory" => {
             // Run 3 times to ensure that warm-up of the GPU has occurred.
             let pp = PublicParameters::test_rand(10, &mut test_rng());

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -38,7 +38,6 @@ impl PublicParameters {
     pub fn rand<R: CryptoRng + Rng + ?Sized>(max_nu: usize, rng: &mut R) -> Self {
         Self::rand_impl(max_nu, rng)
     }
-    #[cfg(any(test, feature = "test"))]
     /// Generate random public parameters for testing.
     pub fn test_rand<R: Rng + ?Sized>(max_nu: usize, rng: &mut R) -> Self {
         Self::rand_impl(max_nu, rng)


### PR DESCRIPTION
# Rationale for this change
It is important to be able to run benchmarks on the newly implemented dynamic Dory evaluation proof. This PR introduces Jaeger benchmarks that will run the dynamic Dory evaluation proof.

# What changes are included in this PR?
- Jaeger benchmarks are introduced that measure the dynamic Dory evaluation proof time.
- To simplify calling benchmarks, the `test` flag is removed from Dory `public_parameters` module when creating random test values.

# Are these changes tested?
Yes