### PR TITLE
feat!: make public_parameters extendable

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -43,11 +43,11 @@ impl PublicParameters {
         Self::rand_impl(max_nu, rng)
     }
     fn rand_impl<R: Rng + ?Sized>(max_nu: usize, rng: &mut R) -> Self {
+        let (H_1, H_2) = (G1Affine::rand(rng), G2Affine::rand(rng));
+        let Gamma_2_fin = G2Affine::rand(rng);
         let (Gamma_1, Gamma_2) = iter::repeat_with(|| (G1Affine::rand(rng), G2Affine::rand(rng)))
             .take(1 << max_nu)
             .unzip();
-        let (H_1, H_2) = (G1Affine::rand(rng), G2Affine::rand(rng));
-        let Gamma_2_fin = G2Affine::rand(rng);
 
         Self {
             Gamma_1,


### PR DESCRIPTION
# Rationale for this change

The Dory public parameters should be compatible between various choices of `max_nu`. Currently, this is not the case.

# What changes are included in this PR?

Reorganize the generation of `PublicParameters` so that `max_nu` only extends it, instead of otherwise modifying it.

# Are these changes tested?
NA