### PR TITLE
feat: proversetup fileio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ arrow-csv = { version = "51.0" }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3", default-features = false }
-blitzar = { version = "3.3.0" }
+blitzar = { version = "3.4.0" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
 byte-slice-cast = { version = "1.2.1", default-features = false }

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -18,6 +18,7 @@ use std::{
 /// Note: even though `H_1` and `H_2` are marked as blue, they are still needed.
 ///
 /// Note: `Gamma_1_fin` is unused, so we leave it out.
+#[derive(Clone)]
 pub struct PublicParameters {
     /// This is the vector of G1 elements that are used in the Dory protocol. That is, `Γ_1,0` in the Dory paper.
     pub(super) Gamma_1: Vec<G1Affine>,

--- a/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/public_parameters.rs
@@ -18,7 +18,6 @@ use std::{
 /// Note: even though `H_1` and `H_2` are marked as blue, they are still needed.
 ///
 /// Note: `Gamma_1_fin` is unused, so we leave it out.
-#[derive(Clone)]
 pub struct PublicParameters {
     /// This is the vector of G1 elements that are used in the Dory protocol. That is, `Γ_1,0` in the Dory paper.
     pub(super) Gamma_1: Vec<G1Affine>,

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -66,6 +66,41 @@ impl<'a> ProverSetup<'a> {
         }
     }
 
+    /// Create a new `ProverSetup` from the public parameters and blitzar handle
+    /// # Panics
+    /// Panics if the length of `Gamma_1` or `Gamma_2` is not equal to `2^max_nu`.
+    #[must_use]
+    #[cfg(feature = "blitzar")]
+    pub fn from_public_parameters_and_blitzar_handle(
+        public_parameters: &'a PublicParameters,
+        blitzar_handle: blitzar::compute::MsmHandle<
+            blitzar::compute::ElementP2<ark_bls12_381::g1::Config>,
+        >,
+    ) -> Self {
+        let Gamma_1: &'a [G1Affine] = &public_parameters.Gamma_1;
+        let Gamma_2: &'a [G2Affine] = &public_parameters.Gamma_2;
+        let H_1 = public_parameters.H_1;
+        let H_2 = public_parameters.H_2;
+        let Gamma_2_fin = public_parameters.Gamma_2_fin;
+        let max_nu = public_parameters.max_nu;
+        assert_eq!(Gamma_1.len(), 1 << max_nu);
+        assert_eq!(Gamma_2.len(), 1 << max_nu);
+
+        let (Gamma_1, Gamma_2): (Vec<_>, Vec<_>) = (0..=max_nu)
+            .map(|k| (&Gamma_1[..1 << k], &Gamma_2[..1 << k]))
+            .unzip();
+        ProverSetup {
+            Gamma_1,
+            Gamma_2,
+            H_1,
+            H_2,
+            Gamma_2_fin,
+            max_nu,
+            #[cfg(feature = "blitzar")]
+            blitzar_handle,
+        }
+    }
+
     #[cfg(feature = "blitzar")]
     #[tracing::instrument(name = "ProverSetup::blitzar_msm", level = "debug", skip_all)]
     pub(super) fn blitzar_msm(


### PR DESCRIPTION
# Rationale for this change

This PR adds support for a conversion from pre-generated public parameters and a blitzar handle into a ProverSetup. This helps skip an expensive step to generate parameters and should significantly decrease the amount of time to load the parameters. It serves as a step towards file i/o for the parameters.

# What changes are included in this PR?

- [x] convert public params and blitzar handle into a proversetup

# Are these changes tested?

existing tests pass. a round trip test is forthcoming in a future PR.
