### PR TITLE
chore: update blitzar 3.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ arrow-csv = { version = "51.0" }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3", default-features = false }
-blitzar = { version = "3.3.0" }
+blitzar = { version = "3.4.0" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
 byte-slice-cast = { version = "1.2.1", default-features = false }


### PR DESCRIPTION
# Rationale for this change

Upgrades blitzar to support loading an MSMHandle from a file

# What changes are included in this PR?

- [x] Cargo.toml blitzar uipdate

existing tests pass
