### PR TITLE
feat: accessor function for bliztar msm handle

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -107,6 +107,13 @@ impl<'a> ProverSetup<'a> {
         }
     }
 
+    /// Gets the MSMHandle for this setup
+    pub fn get_handle(
+        self,
+    ) -> blitzar::compute::MsmHandle<blitzar::compute::ElementP2<ark_bls12_381::g1::Config>> {
+        self.blitzar_handle
+    }
+
     #[cfg(feature = "blitzar")]
     #[tracing::instrument(name = "ProverSetup::blitzar_msm", level = "debug", skip_all)]
     pub(super) fn blitzar_msm(

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -107,7 +107,9 @@ impl<'a> ProverSetup<'a> {
         }
     }
 
-    /// Gets the MSMHandle for this setup
+    /// Gets the `MSMHandle` for this setup
+    #[must_use]
+    #[cfg(feature = "blitzar")]
     pub fn get_handle(
         self,
     ) -> blitzar::compute::MsmHandle<blitzar::compute::ElementP2<ark_bls12_381::g1::Config>> {

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -110,7 +110,7 @@ impl<'a> ProverSetup<'a> {
     /// Gets the `MSMHandle` for this setup
     #[must_use]
     #[cfg(feature = "blitzar")]
-    pub fn get_handle(
+    pub fn blitzar_handle(
         self,
     ) -> blitzar::compute::MsmHandle<blitzar::compute::ElementP2<ark_bls12_381::g1::Config>> {
         self.blitzar_handle

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
@@ -1,6 +1,6 @@
 use super::{test_rng, ProverSetup, PublicParameters, VerifierSetup};
 use ark_ec::pairing::Pairing;
-use std::{fs, path::Path, time::Instant};
+use std::{fs, path::Path};
 
 #[test]
 fn we_can_create_and_manually_check_a_small_prover_setup() {
@@ -157,27 +157,5 @@ fn we_can_serialize_and_deserialize_verifier_setups() {
         let serialized = postcard::to_allocvec(&setup).unwrap();
         let deserialized: VerifierSetup = postcard::from_bytes(&serialized).unwrap();
         assert_eq!(setup, deserialized);
-    }
-}
-
-// generated setup of size 1 in 196.525603ms
-// generated setup of size 2 in 280.311185ms
-// generated setup of size 3 in 492.478225ms
-// generated setup of size 4 in 727.455531ms
-#[test]
-fn we_can_read_and_write_verifier_setups_with_various_sizes() {
-    for i in 1..=4 {
-        let mut rng = test_rng();
-        let pp = PublicParameters::test_rand(i, &mut rng);
-
-        let setup_start = Instant::now();
-        let v_setup = VerifierSetup::from(&pp);
-        let _setup_elapsed = Instant::elapsed(&setup_start);
-
-        v_setup.save_to_file(Path::new("setup.bin")).unwrap();
-        let setup = VerifierSetup::load_from_file(Path::new("setup.bin"));
-        assert!(setup.is_ok());
-
-        fs::remove_file(Path::new("setup.bin")).unwrap();
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup_test.rs
@@ -155,7 +155,6 @@ fn we_can_serialize_and_deserialize_verifier_setups() {
         let pp = PublicParameters::test_rand(nu, &mut rng);
         let setup = VerifierSetup::from(&pp);
         let serialized = postcard::to_allocvec(&setup).unwrap();
-        dbg!(serialized.len());
         let deserialized: VerifierSetup = postcard::from_bytes(&serialized).unwrap();
         assert_eq!(setup, deserialized);
     }
@@ -173,9 +172,7 @@ fn we_can_read_and_write_verifier_setups_with_various_sizes() {
 
         let setup_start = Instant::now();
         let v_setup = VerifierSetup::from(&pp);
-        let setup_elapsed = Instant::elapsed(&setup_start);
-
-        dbg!(setup_elapsed);
+        let _setup_elapsed = Instant::elapsed(&setup_start);
 
         v_setup.save_to_file(Path::new("setup.bin")).unwrap();
         let setup = VerifierSetup::load_from_file(Path::new("setup.bin"));


### PR DESCRIPTION
# Rationale for this change

Adds an accessor function for the blitzar MSM handle to allow for file loading of the handle

# What changes are included in this PR?

stated above

# Are these changes tested?

existing tests pass
