### PR TITLE
feat: add `base::database::ColumnarValue`

### DIFF
--- a/crates/proof-of-sql/src/base/database/columnar_value.rs
+++ b/crates/proof-of-sql/src/base/database/columnar_value.rs
@@ -1,0 +1,138 @@
+use crate::base::{
+    database::{Column, ColumnType, LiteralValue},
+    scalar::Scalar,
+};
+use bumpalo::Bump;
+use snafu::Snafu;
+
+/// The result of evaluating an expression.
+///
+/// Inspired by [`datafusion_expr_common::ColumnarValue`]
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum ColumnarValue<'a, S: Scalar> {
+    /// A [ `ColumnarValue::Column` ] is a list of values.
+    Column(Column<'a, S>),
+    /// A [ `ColumnarValue::Literal` ] is a single value with indeterminate size.
+    Literal(LiteralValue<S>),
+}
+
+/// Errors from operations on [`ColumnarValue`]s.
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum ColumnarValueError {
+    /// Attempt to convert a `[ColumnarValue::Column]` to a column of a different length
+    ColumnLengthMismatch {
+        /// The length of the `[ColumnarValue::Column]`
+        columnar_value_length: usize,
+        /// The length we attempted to convert the `[ColumnarValue::Column]` to
+        attempt_to_convert_length: usize,
+    },
+}
+
+impl<'a, S: Scalar> ColumnarValue<'a, S> {
+    /// Provides the column type associated with the column
+    pub fn column_type(&self) -> ColumnType {
+        match self {
+            Self::Column(column) => column.column_type(),
+            Self::Literal(literal) => literal.column_type(),
+        }
+    }
+
+    /// Converts the [`ColumnarValue`] to a [`Column`]
+    pub fn into_column(
+        &self,
+        num_rows: usize,
+        alloc: &'a Bump,
+    ) -> Result<Column<'a, S>, ColumnarValueError> {
+        match self {
+            Self::Column(column) => {
+                if column.len() == num_rows {
+                    Ok(*column)
+                } else {
+                    Err(ColumnarValueError::ColumnLengthMismatch {
+                        columnar_value_length: column.len(),
+                        attempt_to_convert_length: num_rows,
+                    })
+                }
+            }
+            Self::Literal(literal) => {
+                Ok(Column::from_literal_with_length(literal, num_rows, alloc))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::scalar::test_scalar::TestScalar;
+    use core::convert::Into;
+
+    #[test]
+    fn we_can_get_column_type_of_columnar_values() {
+        let column = ColumnarValue::Column(Column::<TestScalar>::Int(&[1, 2, 3]));
+        assert_eq!(column.column_type(), ColumnType::Int);
+
+        let column = ColumnarValue::Literal(LiteralValue::<TestScalar>::Boolean(true));
+        assert_eq!(column.column_type(), ColumnType::Boolean);
+    }
+
+    #[test]
+    fn we_can_transform_columnar_values_into_columns() {
+        let bump = Bump::new();
+
+        let columnar_value = ColumnarValue::Column(Column::<TestScalar>::Int(&[1, 2, 3]));
+        let column = columnar_value.into_column(3, &bump).unwrap();
+        assert_eq!(column, Column::Int(&[1, 2, 3]));
+
+        let columnar_value = ColumnarValue::Literal(LiteralValue::<TestScalar>::Boolean(false));
+        let column = columnar_value.into_column(5, &bump).unwrap();
+        assert_eq!(column, Column::Boolean(&[false; 5]));
+
+        // Check whether it works if `num_rows` is 0
+        let columnar_value = ColumnarValue::Literal(LiteralValue::<TestScalar>::TinyInt(2));
+        let column = columnar_value.into_column(0, &bump).unwrap();
+        assert_eq!(column, Column::TinyInt(&[]));
+
+        let columnar_value = ColumnarValue::Column(Column::<TestScalar>::SmallInt(&[]));
+        let column = columnar_value.into_column(0, &bump).unwrap();
+        assert_eq!(column, Column::SmallInt(&[]));
+    }
+
+    #[test]
+    fn we_cannot_transform_columnar_values_into_columns_of_different_length() {
+        let bump = Bump::new();
+
+        let columnar_value = ColumnarValue::Column(Column::<TestScalar>::Int(&[1, 2, 3]));
+        let res = columnar_value.into_column(2, &bump);
+        assert_eq!(
+            res,
+            Err(ColumnarValueError::ColumnLengthMismatch {
+                columnar_value_length: 3,
+                attempt_to_convert_length: 2,
+            })
+        );
+
+        let strings = ["a", "b", "c"];
+        let scalars: Vec<TestScalar> = strings.iter().map(Into::into).collect();
+        let columnar_value =
+            ColumnarValue::Column(Column::<TestScalar>::VarChar((&strings, &scalars)));
+        let res = columnar_value.into_column(0, &bump);
+        assert_eq!(
+            res,
+            Err(ColumnarValueError::ColumnLengthMismatch {
+                columnar_value_length: 3,
+                attempt_to_convert_length: 0,
+            })
+        );
+
+        let columnar_value = ColumnarValue::Column(Column::<TestScalar>::Boolean(&[]));
+        let res = columnar_value.into_column(1, &bump);
+        assert_eq!(
+            res,
+            Err(ColumnarValueError::ColumnLengthMismatch {
+                columnar_value_length: 0,
+                attempt_to_convert_length: 1,
+            })
+        );
+    }
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -15,6 +15,9 @@ pub use column_operation::{
 mod column_operation_error;
 pub use column_operation_error::{ColumnOperationError, ColumnOperationResult};
 
+mod columnar_value;
+pub use columnar_value::ColumnarValue;
+
 mod literal_value;
 pub use literal_value::LiteralValue;
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
We need to add `ColumnarValue` so that we can remove `table_length` from `ProofExpr::result_evaluate` which helps with `ProofPlan` composition.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `base::database::ColumnarValue `
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes