### PR TITLE
feat: wood_types example

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -116,6 +116,8 @@ jobs:
         run: cargo run --example space
       - name: Run dog breeds example
         run: cargo run --example dog_breeds
+      - name: Run wood types example
+        run: cargo run --example wood_types
       - name: Run posql_db example (With Blitzar)
         run: bash crates/proof-of-sql/examples/posql_db/run_example.sh
       - name: Run posql_db example (Without Blitzar)

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -99,6 +99,10 @@ required-features = [ "arrow" ]
 name = "dog_breeds"
 required-features = [ "arrow" ]
 
+[[example]]
+name = "wood_types"
+required-features = [ "arrow" ]
+
 [[bench]]
 name = "posql_benches"
 harness = false

--- a/crates/proof-of-sql/examples/wood_types/main.rs
+++ b/crates/proof-of-sql/examples/wood_types/main.rs
@@ -1,0 +1,132 @@
+//! This is a non-interactive example of using Proof of SQL with a wood types dataset.
+//! To run this, use `cargo run --release --example wood_types`.
+//!
+//! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
+//! you can run `cargo run --release --example wood_types --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
+
+use arrow::datatypes::SchemaRef;
+use arrow_csv::{infer_schema_from_files, ReaderBuilder};
+use proof_of_sql::{
+    base::database::{
+        arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
+        TestAccessor,
+    },
+    proof_primitive::dory::{
+        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
+        VerifierSetup,
+    },
+    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{fs::File, time::Instant};
+
+// We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
+// The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
+const DORY_SETUP_MAX_NU: usize = 8;
+// This should be a "nothing-up-my-sleeve" phrase or number.
+const DORY_SEED: [u8; 32] = *b"f3a8d12e6b7c4590a1f2e3d4b5c6a7b8";
+
+/// # Panics
+/// Will panic if the query does not parse or the proof fails to verify.
+fn prove_and_verify_query(
+    sql: &str,
+    accessor: &OwnedTableTestAccessor<DynamicDoryEvaluationProof>,
+    prover_setup: &ProverSetup,
+    verifier_setup: &VerifierSetup,
+) {
+    // Parse the query:
+    println!("Parsing the query: {sql}...");
+    let now = Instant::now();
+    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
+        sql.parse().unwrap(),
+        "wood_types".parse().unwrap(),
+        accessor,
+    )
+    .unwrap();
+    println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
+
+    // Generate the proof and result:
+    print!("Generating proof...");
+    let now = Instant::now();
+    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+        query_plan.proof_expr(),
+        accessor,
+        &prover_setup,
+    );
+    println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
+
+    // Verify the result with the proof:
+    print!("Verifying proof...");
+    let now = Instant::now();
+    let result = proof
+        .verify(
+            query_plan.proof_expr(),
+            accessor,
+            &provable_result,
+            &verifier_setup,
+        )
+        .unwrap();
+    let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
+    println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);
+
+    // Display the result
+    println!("Query Result:");
+    println!("{result:?}");
+}
+
+fn main() {
+    let mut rng = StdRng::from_seed(DORY_SEED);
+    let public_parameters = PublicParameters::rand(DORY_SETUP_MAX_NU, &mut rng);
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    let filename = "./crates/proof-of-sql/examples/wood_types/wood_types.csv";
+    let inferred_schema =
+        SchemaRef::new(infer_schema_from_files(&[filename.to_string()], b',', None, true).unwrap());
+    let posql_compatible_schema = get_posql_compatible_schema(&inferred_schema);
+
+    let wood_types_batch = ReaderBuilder::new(posql_compatible_schema)
+        .with_header(true)
+        .build(File::open(filename).unwrap())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap();
+
+    // Load the table into an "Accessor" so that the prover and verifier can access the data/commitments.
+    let mut accessor =
+        OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
+    accessor.add_table(
+        "wood_types.woods".parse().unwrap(),
+        OwnedTable::try_from(wood_types_batch).unwrap(),
+        0,
+    );
+
+    prove_and_verify_query(
+        "SELECT COUNT(*) AS total_wood_types FROM woods",
+        &accessor,
+        &prover_setup,
+        &verifier_setup,
+    );
+
+    prove_and_verify_query(
+        "SELECT common_use, SUM(density) as total_density, COUNT(*) as wood_count FROM woods GROUP BY common_use ORDER BY total_density DESC",
+        &accessor,
+        &prover_setup,
+        &verifier_setup,
+    );
+
+    prove_and_verify_query(
+        "SELECT common_use, COUNT(*) as c FROM woods GROUP BY common_use ORDER BY c DESC LIMIT 3",
+        &accessor,
+        &prover_setup,
+        &verifier_setup,
+    );
+
+    prove_and_verify_query(
+        "SELECT name, hardness FROM woods WHERE density > 0.7 ORDER BY hardness DESC",
+        &accessor,
+        &prover_setup,
+        &verifier_setup,
+    );
+}

--- a/crates/proof-of-sql/examples/wood_types/wood_types.csv
+++ b/crates/proof-of-sql/examples/wood_types/wood_types.csv
@@ -1,0 +1,11 @@
+id,name,hardness,density,color,common_use
+1,Oak,7.0,0.75,Light brown,Furniture
+2,Pine,3.5,0.55,Pale yellow,Construction
+3,Maple,6.5,0.70,Cream,Flooring
+4,Cherry,5.5,0.65,Reddish-brown,Cabinetry
+5,Walnut,6.0,0.68,Dark brown,Gunstocks
+6,Mahogany,4.5,0.60,Reddish,Musical instruments
+7,Birch,5.0,0.62,White,Plywood
+8,Cedar,2.5,0.45,Reddish,Outdoor furniture
+9,Teak,7.5,0.80,Golden brown,Boat building
+10,Ebony,9.0,1.10,Black,Piano keys

--- a/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
+++ b/crates/proof-of-sql/src/base/database/arrow_schema_utility.rs
@@ -25,7 +25,7 @@ pub fn get_posql_compatible_schema(schema: &SchemaRef) -> SchemaRef {
         .map(|field| {
             let new_data_type = match field.data_type() {
                 DataType::Float16 | DataType::Float32 | DataType::Float64 => {
-                    DataType::Decimal256(75, 30)
+                    DataType::Decimal256(20, 10)
                 }
                 _ => field.data_type().clone(),
             };

--- a/docs/SQLSyntaxSpecification.md
+++ b/docs/SQLSyntaxSpecification.md
@@ -57,3 +57,8 @@ It is far more efficient for the verifier to compute the actual division, while 
     - OFFSET clause
 
 [^1]: Currently, we do not support any string operations beyond = and !=.
+
+## Reserved keywords
+
+The following keywords may not be used as aliases:
+- `count`


### PR DESCRIPTION

# Rationale for this change

Add an additional wood_types example to help improve documentation.

# What changes are included in this PR?

wood_types example is added.

This patch includes a change to arrow_schema_utility::get_posql_compatible_schema to use a smaller precision and scale in order to allow for arithmetic on these columns (otherwise we will fail because we will overflow).

# Are these changes tested?
Yes.

```
Parsing the query: SELECT COUNT(*) AS total_wood_types FROM woods...
Done in 0.32695100000000005 ms.
Generating proof...Done in 29.766170000000002 ms.
Verifying proof...Verified in 13.525808 ms.
Query Result:
Ok(OwnedTable { table: {Identifier { name: "total_wood_types" }: BigInt([10])} })
Parsing the query: SELECT common_use, SUM(density) as total_density, COUNT(*) as wood_count FROM woods GROUP BY common_use ORDER BY total_density DESC...
Done in 0.591261 ms.
Generating proof...Done in 66.24345299999999 ms.
Verifying proof...Verified in 29.65461 ms.
Query Result:
Ok(OwnedTable { table: {Identifier { name: "common_use" }: VarChar(["Piano keys", "Boat building", "Furniture", "Flooring", "Gunstocks", "Cabinetry", "Plywood", "Musical instruments", "Construction", "Outdoor furniture"]), Identifier { name: "total_density" }: Decimal75(Precision(20), 10, [MontScalar(BigInt([11000000000, 0, 0, 0])), MontScalar(BigInt([8000000000, 0, 0, 0])), MontScalar(BigInt([7500000000, 0, 0, 0])), MontScalar(BigInt([7000000000, 0, 0, 0])), MontScalar(BigInt([6800000000, 0, 0, 0])), MontScalar(BigInt([6500000000, 0, 0, 0])), MontScalar(BigInt([6200000000, 0, 0, 0])), MontScalar(BigInt([6000000000, 0, 0, 0])), MontScalar(BigInt([5500000000, 0, 0, 0])), MontScalar(BigInt([4500000000, 0, 0, 0]))]), Identifier { name: "wood_count" }: BigInt([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])} })
Parsing the query: SELECT common_use, COUNT(*) as c FROM woods GROUP BY common_use ORDER BY c DESC LIMIT 3...
Done in 0.498162 ms.
Generating proof...Done in 37.722410999999994 ms.
Verifying proof...Verified in 16.769167000000003 ms.
Query Result:
Ok(OwnedTable { table: {Identifier { name: "common_use" }: VarChar(["Boat building", "Cabinetry", "Construction"]), Identifier { name: "c" }: BigInt([1, 1, 1])} })
Parsing the query: SELECT name, hardness FROM woods WHERE density > 0.7 ORDER BY hardness DESC...
Done in 0.602504 ms.
Generating proof...Done in 77.030322 ms.
Verifying proof...Verified in 18.318061 ms.
Query Result:
Ok(OwnedTable { table: {Identifier { name: "name" }: VarChar(["Ebony", "Teak", "Oak"]), Identifier { name: "hardness" }: Decimal75(Precision(20), 10, [MontScalar(BigInt([90000000000, 0, 0, 0])), MontScalar(BigInt([75000000000, 0, 0, 0])), MontScalar(BigInt([70000000000, 0, 0, 0]))])} })
```

