### PR TITLE
feat: add `commitment-utility`

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -59,7 +59,6 @@ zerocopy = { workspace = true }
 alloy-sol-types = { workspace = true }
 arrow-csv = { workspace = true }
 blitzar = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
 criterion = { workspace = true, features = ["html_reports"] }
 merlin = { workspace = true }
 opentelemetry = { workspace = true }
@@ -92,6 +91,11 @@ workspace = true
 [[bin]]
 name = "generate-parameters"
 path = "utils/generate-parameters/main.rs"
+required-features = [ "std", "blitzar"]
+
+[[bin]]
+name = "commitment-utility"
+path = "utils/commitment-utility/main.rs"
 required-features = [ "std", "blitzar"]
 
 [[example]]

--- a/crates/proof-of-sql/utils/commitment-utility/main.rs
+++ b/crates/proof-of-sql/utils/commitment-utility/main.rs
@@ -1,0 +1,135 @@
+//! Utility to deserialize and print a commitment from a file or stdin.
+use clap::{Parser, ValueEnum};
+use curve25519_dalek::ristretto::RistrettoPoint;
+use proof_of_sql::{
+    base::commitment::TableCommitment,
+    proof_primitive::dory::{DoryCommitment, DynamicDoryCommitment},
+};
+use snafu::Snafu;
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    path::PathBuf,
+};
+
+#[derive(ValueEnum, Clone, Debug)]
+/// Supported commitment schemes.
+enum CommitmentScheme {
+    /// Inner Product Argument (IPA) commitment scheme.
+    Ipa,
+    /// Dory commitment scheme.
+    Dory,
+    /// Dynamic Dory commitment scheme.
+    DynamicDory,
+}
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Input file (defaults to None which is stdin)
+    #[arg(short, long)]
+    input: Option<PathBuf>,
+
+    /// Output file (defaults to None which is stdout)
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Commitment scheme (e.g. `ipa`, `dynamic_dory`, `dory`)
+    #[arg(long, value_enum, default_value = "CommitmentScheme::DynamicDory")]
+    scheme: CommitmentScheme,
+}
+
+#[derive(Debug, Snafu)]
+enum CommitUtilityError {
+    #[snafu(display("Failed to open input file '{:?}'", filename))]
+    OpenInputFile { filename: PathBuf },
+
+    #[snafu(display("Failed to read from input file '{:?}'", filename))]
+    ReadInputFile { filename: PathBuf },
+
+    #[snafu(display("Failed to read from stdin"))]
+    ReadStdin,
+
+    #[snafu(display("Failed to create output file '{:?}'", filename))]
+    CreateOutputFile { filename: PathBuf },
+
+    #[snafu(display("Failed to write to output file '{:?}'", filename))]
+    WriteOutputFile { filename: PathBuf },
+
+    #[snafu(display("Failed to write to stdout"))]
+    WriteStdout,
+
+    #[snafu(display("Failed to deserialize commitment"))]
+    DeserializationError,
+}
+
+type CommitUtilityResult<T, E = CommitUtilityError> = std::result::Result<T, E>;
+
+fn main() -> CommitUtilityResult<()> {
+    let cli = Cli::parse();
+
+    // Read input data
+    let input_data = match &cli.input {
+        Some(input_file) => {
+            let mut file =
+                File::open(input_file).map_err(|_| CommitUtilityError::OpenInputFile {
+                    filename: input_file.clone(),
+                })?;
+            let mut buffer = Vec::new();
+            file.read_to_end(&mut buffer)
+                .map_err(|_| CommitUtilityError::ReadInputFile {
+                    filename: input_file.clone(),
+                })?;
+            buffer
+        }
+        None => {
+            let mut buffer = Vec::new();
+            io::stdin()
+                .read_to_end(&mut buffer)
+                .map_err(|_| CommitUtilityError::ReadStdin)?;
+            buffer
+        }
+    };
+
+    // Deserialize commitment based on the scheme
+    let human_readable = match cli.scheme {
+        CommitmentScheme::DynamicDory => {
+            let commitment: TableCommitment<DynamicDoryCommitment> =
+                postcard::from_bytes(&input_data)
+                    .map_err(|_| CommitUtilityError::DeserializationError)?;
+            format!("{commitment:#?}")
+        }
+        CommitmentScheme::Dory => {
+            let commitment: TableCommitment<DoryCommitment> = postcard::from_bytes(&input_data)
+                .map_err(|_| CommitUtilityError::DeserializationError)?;
+            format!("{commitment:#?}")
+        }
+        CommitmentScheme::Ipa => {
+            let commitment: TableCommitment<RistrettoPoint> = postcard::from_bytes(&input_data)
+                .map_err(|_| CommitUtilityError::DeserializationError)?;
+            format!("{commitment:#?}")
+        }
+    };
+
+    // Write output data
+    match &cli.output {
+        Some(output_file) => {
+            let mut file =
+                File::create(output_file).map_err(|_| CommitUtilityError::CreateOutputFile {
+                    filename: output_file.clone(),
+                })?;
+            file.write_all(human_readable.as_bytes()).map_err(|_| {
+                CommitUtilityError::WriteOutputFile {
+                    filename: output_file.clone(),
+                }
+            })?;
+        }
+        None => {
+            io::stdout()
+                .write_all(human_readable.as_bytes())
+                .map_err(|_| CommitUtilityError::WriteStdout)?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/proof-of-sql/utils/generate-parameters/round_trip_test.rs
+++ b/crates/proof-of-sql/utils/generate-parameters/round_trip_test.rs
@@ -19,6 +19,8 @@ fn we_can_generate_save_and_load_public_setups() {
     // Run the binary with nu = 4, mode = "pv", and target as the temp directory
     let output = Command::new("cargo")
         .arg("run")
+        .arg("--bin")
+        .arg("generate-parameters")
         .arg("--release")
         .arg("--")
         .arg("--nu")


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
It is nice for people to be able to inspect serialized commitments and table metadata from a commitments file.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `commitment-utility`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
It runs.