### PR TITLE
feat: add `ProofPlan::get_table_references`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -3,7 +3,7 @@ use crate::base::{
     commitment::Commitment,
     database::{
         Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
-        OwnedTable,
+        OwnedTable, TableRef,
     },
     map::IndexSet,
     proof::ProofError,
@@ -46,6 +46,9 @@ pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
 
     /// Return all the columns referenced in the Query
     fn get_column_references(&self) -> IndexSet<ColumnRef>;
+
+    /// Return all the tables referenced in the Query
+    fn get_table_references(&self) -> IndexSet<TableRef>;
 }
 
 pub trait ProverEvaluate<S: Scalar> {

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -7,7 +7,7 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            MetadataAccessor, OwnedTable, OwnedTableTestAccessor, TestAccessor,
+            MetadataAccessor, OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
             UnimplementedTestAccessor,
         },
         map::IndexSet,
@@ -107,6 +107,9 @@ impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        unimplemented!("no real usage for this function yet")
+    }
+    fn get_table_references(&self) -> IndexSet<TableRef> {
         unimplemented!("no real usage for this function yet")
     }
 }
@@ -276,6 +279,9 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        unimplemented!("no real usage for this function yet")
+    }
+    fn get_table_references(&self) -> IndexSet<TableRef> {
         unimplemented!("no real usage for this function yet")
     }
 }
@@ -481,6 +487,9 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         unimplemented!("no real usage for this function yet")
     }
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        unimplemented!("no real usage for this function yet")
+    }
 }
 
 fn verify_a_proof_with_an_intermediate_commitment_and_given_offset(offset_generators: usize) {
@@ -675,6 +684,9 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        unimplemented!("no real usage for this function yet")
+    }
+    fn get_table_references(&self) -> IndexSet<TableRef> {
         unimplemented!("no real usage for this function yet")
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -8,7 +8,7 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            MetadataAccessor, OwnedTable, TestAccessor, UnimplementedTestAccessor,
+            MetadataAccessor, OwnedTable, TableRef, TestAccessor, UnimplementedTestAccessor,
         },
         map::IndexSet,
         proof::ProofError,
@@ -86,6 +86,10 @@ impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        unimplemented!("no real usage for this function yet")
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
         unimplemented!("no real usage for this function yet")
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,6 +1,10 @@
 use super::{FilterExec, GroupByExec, ProjectionExec};
 use crate::{
-    base::{commitment::Commitment, database::Column, map::IndexSet},
+    base::{
+        commitment::Commitment,
+        database::{Column, TableRef},
+        map::IndexSet,
+    },
     sql::proof::{ProofPlan, ProverEvaluate},
 };
 use alloc::vec::Vec;
@@ -87,6 +91,14 @@ impl<C: Commitment> ProofPlan<C> for DynProofPlan<C> {
             DynProofPlan::Projection(expr) => expr.get_column_references(),
             DynProofPlan::GroupBy(expr) => expr.get_column_references(),
             DynProofPlan::Filter(expr) => expr.get_column_references(),
+        }
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        match self {
+            DynProofPlan::Projection(expr) => expr.get_table_references(),
+            DynProofPlan::GroupBy(expr) => expr.get_table_references(),
+            DynProofPlan::Filter(expr) => expr.get_table_references(),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -4,7 +4,7 @@ use crate::{
         commitment::Commitment,
         database::{
             filter_util::filter_columns, Column, ColumnField, ColumnRef, CommitmentAccessor,
-            DataAccessor, MetadataAccessor, OwnedTable,
+            DataAccessor, MetadataAccessor, OwnedTable, TableRef,
         },
         map::IndexSet,
         proof::ProofError,
@@ -138,6 +138,10 @@ where
         self.where_clause.get_column_references(&mut columns);
 
         columns
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        IndexSet::from_iter([self.table.table_ref])
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -153,6 +153,10 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
             )
         ])
     );
+
+    let ref_tables = provable_ast.get_table_references();
+
+    assert_eq!(ref_tables, IndexSet::from_iter([table_ref]));
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -7,7 +7,7 @@ use crate::{
                 aggregate_columns, compare_indexes_by_owned_columns, AggregatedColumns,
             },
             Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            MetadataAccessor, OwnedTable,
+            MetadataAccessor, OwnedTable, TableRef,
         },
         map::IndexSet,
         proof::ProofError,
@@ -201,6 +201,10 @@ impl<C: Commitment> ProofPlan<C> for GroupByExec<C> {
         self.where_clause.get_column_references(&mut columns);
 
         columns
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        IndexSet::from_iter([self.table.table_ref])
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -3,7 +3,7 @@ use crate::{
         commitment::Commitment,
         database::{
             Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
-            OwnedTable,
+            OwnedTable, TableRef,
         },
         map::IndexSet,
         proof::ProofError,
@@ -91,6 +91,10 @@ impl<C: Commitment> ProofPlan<C> for ProjectionExec<C> {
             aliased_expr.expr.get_column_references(&mut columns);
         });
         columns
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        IndexSet::from_iter([self.table.table_ref])
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -102,6 +102,10 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
             ),
         ])
     );
+
+    let ref_tables = provable_ast.get_table_references();
+
+    assert_eq!(ref_tables, IndexSet::from_iter([table_ref]));
 }
 
 #[test]


### PR DESCRIPTION
# Rationale for this change

An upstream crates needs to know what tables are being queried against from the proof plan.

# What changes are included in this PR?

`ProofPlan::get_table_references` is added

# Are these changes tested?

Yes