### PR TITLE
ci: add to config.toml and unify fmt customization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "/usr/bin/clang" # used to decrease build time
 rustflags = ["-Clink-arg=-fuse-ld=lld"] # used to decrease link time
+
+[alias]
+f = "fmt --all -- --config imports_granularity=Crate,group_imports=One"
+cl = "clippy --all-targets --all-features"

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo cl -- -D warnings
 
   coverage:
     name: Code Coverage
@@ -182,7 +182,7 @@ jobs:
       #   files: lcov.info
       #   fail_ci_if_error: true
         
-  # Run cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
+  # Run cargo f --check
   format:
     name: Format
     runs-on: ubuntu-latest
@@ -194,7 +194,7 @@ jobs:
           curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
           rustup component add rustfmt
       - name: Run cargo fmt
-        run: cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
+        run: cargo f --check
 
   udeps:
     name: Unused Dependencies


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
The rustfmt config used in CI is tedious to type hence it is helpful to add it as an alias to `config.toml`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `cargo f` and `cargo cl` aliases to `config.toml`
- remove fmt customization from CI to unify it
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes