### PR TITLE
refactor!: remove generic parameter from proof plans and exprs

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/mod.rs
+++ b/crates/proof-of-sql/benches/scaffold/mod.rs
@@ -27,7 +27,7 @@ fn scaffold<'a, CP: CommitmentEvaluationProof>(
     alloc: &'a Bump,
     accessor: &mut BenchmarkAccessor<'a, CP::Commitment>,
     rng: &mut impl Rng,
-) -> (QueryExpr<CP::Commitment>, VerifiableQueryResult<CP>) {
+) -> (QueryExpr, VerifiableQueryResult<CP>) {
     accessor.insert_table(
         "bench.table".parse().unwrap(),
         &generate_random_columns(alloc, rng, columns, size),

--- a/crates/proof-of-sql/examples/albums/main.rs
+++ b/crates/proof-of-sql/examples/albums/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "albums".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "albums".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/avocado-prices/main.rs
+++ b/crates/proof-of-sql/examples/avocado-prices/main.rs
@@ -8,8 +8,7 @@ use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{OwnedTable, OwnedTableTestAccessor},
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -41,12 +40,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "avocado".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "avocado".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/books/main.rs
+++ b/crates/proof-of-sql/examples/books/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "books".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "books".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/brands/main.rs
+++ b/crates/proof-of-sql/examples/brands/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "brands".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "brands".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/census/main.rs
+++ b/crates/proof-of-sql/examples/census/main.rs
@@ -11,8 +11,7 @@ use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{OwnedTable, OwnedTableTestAccessor},
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -44,12 +43,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "census".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "census".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/countries/main.rs
+++ b/crates/proof-of-sql/examples/countries/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "countries".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "countries".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/dinosaurs/main.rs
+++ b/crates/proof-of-sql/examples/dinosaurs/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "dinosaurs".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "dinosaurs".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql/examples/dog_breeds/main.rs
@@ -9,8 +9,7 @@ use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{OwnedTable, OwnedTableTestAccessor, TestAccessor},
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -34,7 +33,7 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
+    let query_plan = QueryExpr::try_new(
         sql.parse().unwrap(),
         "dog_breeds".parse().unwrap(),
         accessor,

--- a/crates/proof-of-sql/examples/plastics/main.rs
+++ b/crates/proof-of-sql/examples/plastics/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "plastics".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "plastics".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/programming_books/main.rs
+++ b/crates/proof-of-sql/examples/programming_books/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -34,7 +33,7 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
+    let query_plan = QueryExpr::try_new(
         sql.parse().unwrap(),
         "programming_books".parse().unwrap(),
         accessor,

--- a/crates/proof-of-sql/examples/rockets/main.rs
+++ b/crates/proof-of-sql/examples/rockets/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "rockets".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "rockets".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/space/main.rs
+++ b/crates/proof-of-sql/examples/space/main.rs
@@ -13,8 +13,7 @@ use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{OwnedTable, OwnedTableTestAccessor, TestAccessor},
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -46,12 +45,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "space".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "space".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/stocks/main.rs
+++ b/crates/proof-of-sql/examples/stocks/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "stocks".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "stocks".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/sushi/main.rs
+++ b/crates/proof-of-sql/examples/sushi/main.rs
@@ -8,8 +8,7 @@ use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{OwnedTable, OwnedTableTestAccessor, TestAccessor},
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, proof::QueryProof},
 };
@@ -30,12 +29,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "sushi".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "sushi".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
     // Generate the proof and result:
     print!("Generating proof...");

--- a/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
+++ b/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
@@ -9,8 +9,7 @@ use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{OwnedTable, OwnedTableTestAccessor},
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, proof::QueryProof},
 };
@@ -28,11 +27,7 @@ fn prove_and_verify_query(
 ) -> Result<(), Box<dyn Error>> {
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse()?,
-        "tech_gadget_prices".parse()?,
-        accessor,
-    )?;
+    let query_plan = QueryExpr::try_new(sql.parse()?, "tech_gadget_prices".parse()?, accessor)?;
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     print!("Generating proof...");

--- a/crates/proof-of-sql/examples/vehicles/main.rs
+++ b/crates/proof-of-sql/examples/vehicles/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,12 +36,8 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
-        sql.parse().unwrap(),
-        "vehicles".parse().unwrap(),
-        accessor,
-    )
-    .unwrap();
+    let query_plan =
+        QueryExpr::try_new(sql.parse().unwrap(), "vehicles".parse().unwrap(), accessor).unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Generate the proof and result:

--- a/crates/proof-of-sql/examples/wood_types/main.rs
+++ b/crates/proof-of-sql/examples/wood_types/main.rs
@@ -12,8 +12,7 @@ use proof_of_sql::{
         TestAccessor,
     },
     proof_primitive::dory::{
-        DynamicDoryCommitment, DynamicDoryEvaluationProof, ProverSetup, PublicParameters,
-        VerifierSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
 };
@@ -37,7 +36,7 @@ fn prove_and_verify_query(
     // Parse the query:
     println!("Parsing the query: {sql}...");
     let now = Instant::now();
-    let query_plan = QueryExpr::<DynamicDoryCommitment>::try_new(
+    let query_plan = QueryExpr::try_new(
         sql.parse().unwrap(),
         "wood_types".parse().unwrap(),
         accessor,

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -100,7 +100,7 @@ impl<'a, S: Scalar> Column<'a, S> {
 
     /// Generate a constant column from a literal value with a given length
     pub fn from_literal_with_length(
-        literal: &LiteralValue<S>,
+        literal: &LiteralValue,
         length: usize,
         alloc: &'a Bump,
     ) -> Self {
@@ -127,7 +127,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             LiteralValue::Decimal75(precision, scale, value) => Column::Decimal75(
                 *precision,
                 *scale,
-                alloc.alloc_slice_fill_copy(length, *value),
+                alloc.alloc_slice_fill_copy(length, value.into_scalar()),
             ),
             LiteralValue::TimeStampTZ(tu, tz, value) => {
                 Column::TimestampTZ(*tu, *tz, alloc.alloc_slice_fill_copy(length, *value))

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -122,7 +122,7 @@ impl<'a, S: Scalar> Column<'a, S> {
                 Column::Int128(alloc.alloc_slice_fill_copy(length, *value))
             }
             LiteralValue::Scalar(value) => {
-                Column::Scalar(alloc.alloc_slice_fill_copy(length, *value))
+                Column::Scalar(alloc.alloc_slice_fill_copy(length, (*value).into()))
             }
             LiteralValue::Decimal75(precision, scale, value) => Column::Decimal75(
                 *precision,

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -132,9 +132,9 @@ impl<'a, S: Scalar> Column<'a, S> {
             LiteralValue::TimeStampTZ(tu, tz, value) => {
                 Column::TimestampTZ(*tu, *tz, alloc.alloc_slice_fill_copy(length, *value))
             }
-            LiteralValue::VarChar((string, scalar)) => Column::VarChar((
+            LiteralValue::VarChar(string) => Column::VarChar((
                 alloc.alloc_slice_fill_with(length, |_| alloc.alloc_str(string) as &str),
-                alloc.alloc_slice_fill_copy(length, *scalar),
+                alloc.alloc_slice_fill_copy(length, S::from(string)),
             )),
         }
     }

--- a/crates/proof-of-sql/src/base/database/columnar_value.rs
+++ b/crates/proof-of-sql/src/base/database/columnar_value.rs
@@ -13,7 +13,7 @@ pub enum ColumnarValue<'a, S: Scalar> {
     /// A [ `ColumnarValue::Column` ] is a list of values.
     Column(Column<'a, S>),
     /// A [ `ColumnarValue::Literal` ] is a single value with indeterminate size.
-    Literal(LiteralValue<S>),
+    Literal(LiteralValue),
 }
 
 /// Errors from operations on [`ColumnarValue`]s.
@@ -30,6 +30,7 @@ pub enum ColumnarValueError {
 
 impl<'a, S: Scalar> ColumnarValue<'a, S> {
     /// Provides the column type associated with the column
+    #[must_use]
     pub fn column_type(&self) -> ColumnType {
         match self {
             Self::Column(column) => column.column_type(),
@@ -72,7 +73,7 @@ mod tests {
         let column = ColumnarValue::Column(Column::<TestScalar>::Int(&[1, 2, 3]));
         assert_eq!(column.column_type(), ColumnType::Int);
 
-        let column = ColumnarValue::Literal(LiteralValue::<TestScalar>::Boolean(true));
+        let column = ColumnarValue::<TestScalar>::Literal(LiteralValue::Boolean(true));
         assert_eq!(column.column_type(), ColumnType::Boolean);
     }
 
@@ -84,12 +85,12 @@ mod tests {
         let column = columnar_value.into_column(3, &bump).unwrap();
         assert_eq!(column, Column::Int(&[1, 2, 3]));
 
-        let columnar_value = ColumnarValue::Literal(LiteralValue::<TestScalar>::Boolean(false));
+        let columnar_value = ColumnarValue::<TestScalar>::Literal(LiteralValue::Boolean(false));
         let column = columnar_value.into_column(5, &bump).unwrap();
         assert_eq!(column, Column::Boolean(&[false; 5]));
 
         // Check whether it works if `num_rows` is 0
-        let columnar_value = ColumnarValue::Literal(LiteralValue::<TestScalar>::TinyInt(2));
+        let columnar_value = ColumnarValue::<TestScalar>::Literal(LiteralValue::TinyInt(2));
         let column = columnar_value.into_column(0, &bump).unwrap();
         assert_eq!(column, Column::TinyInt(&[]));
 

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,4 +1,8 @@
-use crate::base::{database::ColumnType, math::decimal::Precision, scalar::Scalar};
+use crate::base::{
+    database::ColumnType,
+    math::{decimal::Precision, i256::I256},
+    scalar::Scalar,
+};
 use alloc::string::String;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use serde::{Deserialize, Serialize};
@@ -10,7 +14,7 @@ use serde::{Deserialize, Serialize};
 /// a description of the native types used by Apache Ignite.
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-pub enum LiteralValue<S: Scalar> {
+pub enum LiteralValue {
     /// Boolean literals
     Boolean(bool),
     /// i8 literals
@@ -30,7 +34,7 @@ pub enum LiteralValue<S: Scalar> {
     Int128(i128),
     /// Decimal literals with a max width of 252 bits
     ///  - the backing store maps to the type [`crate::base::scalar::Curve25519Scalar`]
-    Decimal75(Precision, i8, S),
+    Decimal75(Precision, i8, I256),
     /// Scalar literals. The underlying `[u64; 4]` is the limbs of the canonical form of the literal
     Scalar([u64; 4]),
     /// `TimeStamp` defined over a unit (s, ms, ns, etc) and timezone with backing store
@@ -38,8 +42,9 @@ pub enum LiteralValue<S: Scalar> {
     TimeStampTZ(PoSQLTimeUnit, PoSQLTimeZone, i64),
 }
 
-impl<S: Scalar> LiteralValue<S> {
+impl LiteralValue {
     /// Provides the column type associated with the column
+    #[must_use]
     pub fn column_type(&self) -> ColumnType {
         match self {
             Self::Boolean(_) => ColumnType::Boolean,
@@ -56,7 +61,7 @@ impl<S: Scalar> LiteralValue<S> {
     }
 
     /// Converts the literal to a scalar
-    pub(crate) fn to_scalar(&self) -> S {
+    pub(crate) fn to_scalar<S: Scalar>(&self) -> S {
         match self {
             Self::Boolean(b) => b.into(),
             Self::TinyInt(i) => i.into(),
@@ -64,7 +69,7 @@ impl<S: Scalar> LiteralValue<S> {
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
             Self::VarChar(str) => str.into(),
-            Self::Decimal75(_, _, s) => *s,
+            Self::Decimal75(_, _, i) => i.into_scalar(),
             Self::Int128(i) => i.into(),
             Self::Scalar(limbs) => (*limbs).into(),
             Self::TimeStampTZ(_, _, time) => time.into(),

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -31,8 +31,8 @@ pub enum LiteralValue<S: Scalar> {
     /// Decimal literals with a max width of 252 bits
     ///  - the backing store maps to the type [`crate::base::scalar::Curve25519Scalar`]
     Decimal75(Precision, i8, S),
-    /// Scalar literals
-    Scalar(S),
+    /// Scalar literals. The underlying `[u64; 4]` is the limbs of the canonical form of the literal
+    Scalar([u64; 4]),
     /// `TimeStamp` defined over a unit (s, ms, ns, etc) and timezone with backing store
     /// mapped to i64, which is time units since unix epoch
     TimeStampTZ(PoSQLTimeUnit, PoSQLTimeZone, i64),
@@ -66,7 +66,7 @@ impl<S: Scalar> LiteralValue<S> {
             Self::VarChar(str) => str.into(),
             Self::Decimal75(_, _, s) => *s,
             Self::Int128(i) => i.into(),
-            Self::Scalar(scalar) => *scalar,
+            Self::Scalar(limbs) => (*limbs).into(),
             Self::TimeStampTZ(_, _, time) => time.into(),
         }
     }

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -25,7 +25,7 @@ pub enum LiteralValue<S: Scalar> {
     /// String literals
     ///  - the first element maps to the str value.
     ///  - the second element maps to the str hash (see [`crate::base::scalar::Scalar`]).
-    VarChar((String, S)),
+    VarChar(String),
     /// i128 literals
     Int128(i128),
     /// Decimal literals with a max width of 252 bits
@@ -63,7 +63,8 @@ impl<S: Scalar> LiteralValue<S> {
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),
             Self::BigInt(i) => i.into(),
-            Self::VarChar((_, s)) | Self::Decimal75(_, _, s) => *s,
+            Self::VarChar(str) => str.into(),
+            Self::Decimal75(_, _, s) => *s,
             Self::Int128(i) => i.into(),
             Self::Scalar(scalar) => *scalar,
             Self::TimeStampTZ(_, _, time) => time.into(),

--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -1,0 +1,268 @@
+use crate::base::scalar::Scalar;
+use ark_ff::BigInteger;
+use serde::{Deserialize, Serialize};
+
+/// A 256-bit data type with some conversions implemented that interpret it as a signed integer.
+///
+/// This should only implement conversions. If anything else is needed, we should strongly consider an alternative design.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Copy)]
+pub struct I256([u64; 4]);
+impl I256 {
+    /// Computes the wrapping negative of the value. This could perhaps be more efficient.
+    fn neg(self) -> Self {
+        let mut res = ark_ff::BigInt([0; 4]);
+        res.sub_with_borrow(&ark_ff::BigInt(self.0));
+        Self(res.0)
+    }
+    #[must_use]
+    /// Conversion into a [Scalar] type. The conversion handles negative values. In other words, `-1` maps to `-S::ONE`.
+    ///
+    /// NOTE: the behavior of this is undefined if the absolute value is larger than the modulus.
+    ///
+    /// NOTE: this is not a particularly efficient method. Please either refactor or avoid when performance matters.
+    pub fn into_scalar<S: Scalar>(self) -> S {
+        if self.0[3] & 0x8000_0000_0000_0000 == 0 {
+            self.0.into()
+        } else {
+            (Into::<S>::into(self.neg().0)).neg()
+        }
+    }
+
+    #[must_use]
+    /// Conversion from a [`num_bigint::BigInt`].
+    /// The conversion handles negative values and also wraps when the value is too large for an `I256`.
+    ///
+    /// NOTE: this is not a particularly efficient method. Please either refactor or avoid when performance matters.
+    pub fn from_num_bigint(value: &num_bigint::BigInt) -> Self {
+        let (sign, limbs_vec) = value.to_u64_digits();
+        let num_limbs = limbs_vec.len().min(4);
+        let mut limbs = [0u64; 4];
+        limbs[..num_limbs].copy_from_slice(&limbs_vec[..num_limbs]);
+        limbs[3] &= 0x7FFF_FFFF_FFFF_FFFF;
+        match sign {
+            num_bigint::Sign::Minus => Self(limbs).neg(),
+            num_bigint::Sign::Plus | num_bigint::Sign::NoSign => Self(limbs),
+        }
+    }
+}
+impl From<i32> for I256 {
+    fn from(value: i32) -> Self {
+        let abs = Self([value.unsigned_abs().into(), 0, 0, 0]);
+        if value >= 0 {
+            abs
+        } else {
+            abs.neg()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::I256;
+    use crate::base::scalar::{test_scalar::TestScalar, MontScalar, Scalar};
+    use ark_ff::MontFp;
+    use num_bigint::BigInt;
+    use rand::{thread_rng, Rng};
+
+    const ZERO: I256 = I256([0, 0, 0, 0]);
+    const ONE: I256 = I256([1, 0, 0, 0]);
+    const TWO: I256 = I256([2, 0, 0, 0]);
+    const NEG_ONE: I256 = I256([
+        0xFFFF_FFFF_FFFF_FFFF,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0xFFFF_FFFF_FFFF_FFFF,
+    ]);
+    const NEG_TWO: I256 = I256([
+        0xFFFF_FFFF_FFFF_FFFE,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0xFFFF_FFFF_FFFF_FFFF,
+    ]);
+    const A_STR: &str =
+        "57896044618658097705508390768957273162799202909612615603626436559492530307074";
+    const A: I256 = I256([2, 0, 0, 0x7FFF_FFFF_FFFF_FFFF]);
+    const NEG_A: I256 = I256([
+        0xFFFF_FFFF_FFFF_FFFE,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0x8000_0000_0000_0000,
+    ]);
+    const B_STR: &str =
+        "44514458406356786875149426309623179975904669798901350226660343085647800511238";
+    const B: I256 = I256([
+        0x12DE_4D02_71BF_2B06,
+        0x2686_80A2_B415_EE31,
+        0xBCF3_35CF_A69C_DBE3,
+        0x626A_4A65_275E_1D88,
+    ]);
+    const NEG_B: I256 = I256([
+        0xED21_B2FD_8E40_D4FA,
+        0xD979_7F5D_4BEA_11CE,
+        0x430C_CA30_5963_241C,
+        0x9D95_B59A_D8A1_E277,
+    ]);
+    const C_STR: &str =
+        "452312848583266388373324160190187140051835877600158453279131187530910662656";
+    const C_SCALAR: TestScalar = MontScalar(MontFp!(
+        "452312848583266388373324160190187140051835877600158453279131187530910662656"
+    ));
+    const C: I256 = I256([
+        0x0000_0000_0000_0000,
+        0x0000_0000_0000_0000,
+        0x0000_0000_0000_0000,
+        0x0100_0000_0000_0000,
+    ]);
+    const NEG_C: I256 = I256([
+        0x0000_0000_0000_0000,
+        0x0000_0000_0000_0000,
+        0x0000_0000_0000_0000,
+        0xFF00_0000_0000_0000,
+    ]);
+    const MODULUS_MINUS_ONE: I256 = I256([
+        0x5812_631A_5CF5_D3EC,
+        0x14DE_F9DE_A2F7_9CD6,
+        0x0000_0000_0000_0000,
+        0x1000_0000_0000_0000,
+    ]);
+    const NEG_MODULUS_PLUS_ONE: I256 = I256([
+        0xa7ed_9ce5_a30a_2c14,
+        0xEB21_0621_5D08_6329,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0xEFFF_FFFF_FFFF_FFFF,
+    ]);
+    const MODULUS_MINUS_TWO: I256 = I256([
+        0x5812_631A_5CF5_D3EB,
+        0x14DE_F9DE_A2F7_9CD6,
+        0x0000_0000_0000_0000,
+        0x1000_0000_0000_0000,
+    ]);
+    const NEG_MODULUS_PLUS_TWO: I256 = I256([
+        0xa7ed_9ce5_a30a_2c15,
+        0xEB21_0621_5D08_6329,
+        0xFFFF_FFFF_FFFF_FFFF,
+        0xEFFF_FFFF_FFFF_FFFF,
+    ]);
+
+    #[test]
+    fn we_can_compute_the_negative_of_i256() {
+        assert_eq!(ZERO.neg(), ZERO);
+        assert_eq!(ONE.neg(), NEG_ONE);
+        assert_eq!(NEG_ONE.neg(), ONE);
+        assert_eq!(TWO.neg(), NEG_TWO);
+        assert_eq!(NEG_TWO.neg(), TWO);
+        assert_eq!(A.neg(), NEG_A);
+        assert_eq!(NEG_A.neg(), A);
+        assert_eq!(B.neg(), NEG_B);
+        assert_eq!(NEG_B.neg(), B);
+        assert_eq!(C.neg(), NEG_C);
+        assert_eq!(NEG_C.neg(), C);
+        assert_eq!(MODULUS_MINUS_ONE.neg(), NEG_MODULUS_PLUS_ONE);
+        assert_eq!(NEG_MODULUS_PLUS_ONE.neg(), MODULUS_MINUS_ONE);
+        assert_eq!(MODULUS_MINUS_TWO.neg(), NEG_MODULUS_PLUS_TWO);
+        assert_eq!(NEG_MODULUS_PLUS_TWO.neg(), MODULUS_MINUS_TWO);
+
+        let mut rng = thread_rng();
+        for _ in 0..10 {
+            let x = I256([rng.gen(), rng.gen(), rng.gen(), rng.gen()]);
+            assert_eq!(x.neg().neg(), x);
+        }
+    }
+    #[test]
+    fn we_can_convert_i256_into_scalar() {
+        assert_eq!(ZERO.into_scalar::<TestScalar>(), TestScalar::ZERO);
+        assert_eq!(ONE.into_scalar::<TestScalar>(), TestScalar::ONE);
+        assert_eq!(NEG_ONE.into_scalar::<TestScalar>(), -TestScalar::ONE);
+        assert_eq!(TWO.into_scalar::<TestScalar>(), TestScalar::TWO);
+        assert_eq!(NEG_TWO.into_scalar::<TestScalar>(), -TestScalar::TWO);
+        assert_eq!(C.into_scalar::<TestScalar>(), C_SCALAR);
+        assert_eq!(NEG_C.into_scalar::<TestScalar>(), -C_SCALAR);
+        assert_eq!(
+            MODULUS_MINUS_ONE.into_scalar::<TestScalar>(),
+            -TestScalar::ONE
+        );
+        assert_eq!(
+            NEG_MODULUS_PLUS_ONE.into_scalar::<TestScalar>(),
+            TestScalar::ONE
+        );
+        assert_eq!(
+            MODULUS_MINUS_TWO.into_scalar::<TestScalar>(),
+            -TestScalar::TWO
+        );
+        assert_eq!(
+            NEG_MODULUS_PLUS_TWO.into_scalar::<TestScalar>(),
+            TestScalar::TWO
+        );
+
+        let mut rng = thread_rng();
+        for _ in 0..10 {
+            let x = I256([rng.gen(), rng.gen(), rng.gen(), rng.gen()]);
+            assert_eq!(
+                x.neg().into_scalar::<TestScalar>(),
+                -(x.into_scalar::<TestScalar>())
+            );
+        }
+    }
+    #[test]
+    fn we_can_convert_i256_from_num_bigint() {
+        assert_eq!(I256::from_num_bigint(&"0".parse().unwrap()), ZERO);
+        assert_eq!(I256::from_num_bigint(&"1".parse().unwrap()), ONE);
+        assert_eq!(I256::from_num_bigint(&"-1".parse().unwrap()), NEG_ONE);
+        assert_eq!(I256::from_num_bigint(&"2".parse().unwrap()), TWO);
+        assert_eq!(I256::from_num_bigint(&"-2".parse().unwrap()), NEG_TWO);
+        assert_eq!(I256::from_num_bigint(&A_STR.parse().unwrap()), A);
+        assert_eq!(
+            I256::from_num_bigint(&-A_STR.parse::<BigInt>().unwrap()),
+            NEG_A
+        );
+        assert_eq!(I256::from_num_bigint(&B_STR.parse().unwrap()), B);
+        assert_eq!(
+            I256::from_num_bigint(&-B_STR.parse::<BigInt>().unwrap()),
+            NEG_B
+        );
+        assert_eq!(I256::from_num_bigint(&C_STR.parse().unwrap()), C);
+        assert_eq!(
+            I256::from_num_bigint(&-C_STR.parse::<BigInt>().unwrap()),
+            NEG_C
+        );
+
+        let mut rng = thread_rng();
+        for _ in 0..10 {
+            let x =
+                (BigInt::from(rng.gen::<i128>().abs()) << 128) + BigInt::from(rng.gen::<u128>());
+            let y = &x + (BigInt::from(rng.gen::<u128>()) << 255);
+            assert_eq!(I256::from_num_bigint(&y), I256::from_num_bigint(&x));
+            assert_eq!(I256::from_num_bigint(&-&y), I256::from_num_bigint(&-x));
+            assert_eq!(I256::from_num_bigint(&y), I256::from_num_bigint(&-y).neg());
+        }
+    }
+    #[test]
+    fn we_can_convert_i256_from_i32() {
+        assert_eq!(I256::from(0), ZERO);
+        assert_eq!(I256::from(1), ONE);
+        assert_eq!(I256::from(-1), NEG_ONE);
+        assert_eq!(I256::from(2), TWO);
+        assert_eq!(I256::from(-2), NEG_TWO);
+    }
+    #[test]
+    fn we_can_convert_i256_between_type_compatibly() {
+        let mut rng = thread_rng();
+        for _ in 0..10 {
+            let int32: i32 = rng.gen();
+            let neg_int32 = -int32;
+            let scalar = TestScalar::from(int32);
+            let neg_scalar = -scalar;
+            let bigint = BigInt::from(int32);
+            let neg_bigint = -&bigint;
+            let int256_from_i32 = I256::from(int32);
+            let neg_int256_from_i32 = I256::from(neg_int32);
+            let int256_from_bigint = I256::from_num_bigint(&bigint);
+            let neg_int256_from_bigint = I256::from_num_bigint(&neg_bigint);
+            assert_eq!(int256_from_i32, int256_from_bigint);
+            assert_eq!(neg_int256_from_i32, neg_int256_from_bigint);
+            assert_eq!(neg_int256_from_i32, int256_from_i32.neg());
+            assert_eq!(int256_from_i32.into_scalar::<TestScalar>(), scalar);
+            assert_eq!(neg_int256_from_i32.into_scalar::<TestScalar>(), neg_scalar);
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/math/mod.rs
+++ b/crates/proof-of-sql/src/base/math/mod.rs
@@ -3,6 +3,8 @@
 pub mod decimal;
 #[cfg(test)]
 mod decimal_tests;
+/// Module containing [I256] type.
+pub mod i256;
 mod log;
 pub(crate) use log::log2_up;
 /// TODO: add docs

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -113,10 +113,7 @@ impl DynProofExprBuilder<'_> {
                     try_convert_intermediate_decimal_to_scalar(d, precision, scale)?,
                 )))
             }
-            Literal::VarChar(s) => Ok(DynProofExpr::new_literal(LiteralValue::VarChar((
-                s.clone(),
-                s.into(),
-            )))),
+            Literal::VarChar(s) => Ok(DynProofExpr::new_literal(LiteralValue::VarChar(s.clone()))),
             Literal::Timestamp(its) => {
                 let timestamp = match its.timeunit() {
                     PoSQLTimeUnit::Nanosecond => {

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -5,7 +5,8 @@ use crate::{
         database::{ColumnRef, LiteralValue},
         map::IndexMap,
         math::{
-            decimal::{try_convert_intermediate_decimal_to_scalar, DecimalError, Precision},
+            decimal::{DecimalError, Precision},
+            i256::I256,
             BigDecimalExt,
         },
     },
@@ -110,7 +111,9 @@ impl DynProofExprBuilder<'_> {
                 Ok(DynProofExpr::new_literal(LiteralValue::Decimal75(
                     precision,
                     scale,
-                    try_convert_intermediate_decimal_to_scalar(d, precision, scale)?,
+                    I256::from_num_bigint(
+                        &d.try_into_bigint_with_precision_and_scale(precision.value(), scale)?,
+                    ),
                 )))
             }
             Literal::VarChar(s) => Ok(DynProofExpr::new_literal(LiteralValue::VarChar(s.clone()))),

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -1,6 +1,6 @@
 use super::DynProofExprBuilder;
 use crate::{
-    base::{commitment::Commitment, database::ColumnRef, map::IndexMap},
+    base::{database::ColumnRef, map::IndexMap},
     sql::proof_exprs::DynProofExpr,
 };
 use alloc::boxed::Box;
@@ -13,14 +13,14 @@ use proof_of_sql_parser::{
 /// An enriched expression consists of an `proof_of_sql_parser::intermediate_ast::AliasedResultExpr`
 /// and an optional `DynProofExpr`.
 /// If the `DynProofExpr` is `None`, the `EnrichedExpr` is not provable.
-pub struct EnrichedExpr<C: Commitment> {
+pub struct EnrichedExpr {
     /// The remaining expression after the provable expression plan has been extracted.
     pub residue_expression: AliasedResultExpr,
     /// The extracted provable expression plan if it exists.
-    pub dyn_proof_expr: Option<DynProofExpr<C>>,
+    pub dyn_proof_expr: Option<DynProofExpr>,
 }
 
-impl<C: Commitment> EnrichedExpr<C> {
+impl EnrichedExpr {
     /// Create a new `EnrichedExpr` with a provable expression.
     ///
     /// If the expression is not provable, the `dyn_proof_expr` will be `None`.

--- a/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
@@ -1,7 +1,6 @@
 use super::{where_expr_builder::WhereExprBuilder, ConversionError, EnrichedExpr};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{ColumnRef, LiteralValue, TableRef},
         map::IndexMap,
     },
@@ -14,15 +13,15 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use itertools::Itertools;
 use proof_of_sql_parser::{intermediate_ast::Expression, Identifier};
 
-pub struct FilterExecBuilder<C: Commitment> {
+pub struct FilterExecBuilder {
     table_expr: Option<TableExpr>,
-    where_expr: Option<DynProofExpr<C>>,
-    filter_result_expr_list: Vec<AliasedDynProofExpr<C>>,
+    where_expr: Option<DynProofExpr>,
+    filter_result_expr_list: Vec<AliasedDynProofExpr>,
     column_mapping: IndexMap<Identifier, ColumnRef>,
 }
 
 // Public interface
-impl<C: Commitment> FilterExecBuilder<C> {
+impl FilterExecBuilder {
     pub fn new(column_mapping: IndexMap<Identifier, ColumnRef>) -> Self {
         Self {
             table_expr: None,
@@ -49,7 +48,7 @@ impl<C: Commitment> FilterExecBuilder<C> {
     ///
     /// Will panic if:
     /// - `self.column_mapping.get(alias)` returns `None`, which can occur if the alias is not found in the column mapping.
-    pub fn add_result_columns(mut self, columns: &[EnrichedExpr<C>]) -> Self {
+    pub fn add_result_columns(mut self, columns: &[EnrichedExpr]) -> Self {
         // If a column is provable, add it to the filter result expression list
         // If at least one column is non-provable, add all columns from the column mapping to the filter result expression list
         let mut has_nonprovable_column = false;
@@ -78,7 +77,7 @@ impl<C: Commitment> FilterExecBuilder<C> {
     }
 
     #[allow(clippy::missing_panics_doc)]
-    pub fn build(self) -> FilterExec<C> {
+    pub fn build(self) -> FilterExec {
         FilterExec::new(
             self.filter_result_expr_list,
             self.table_expr.expect("Table expr is required"),

--- a/crates/proof-of-sql/src/sql/parse/query_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr.rs
@@ -1,6 +1,6 @@
 use super::{EnrichedExpr, FilterExecBuilder, QueryContextBuilder};
 use crate::{
-    base::{commitment::Commitment, database::SchemaAccessor},
+    base::database::SchemaAccessor,
     sql::{
         parse::ConversionResult,
         postprocessing::{
@@ -17,14 +17,14 @@ use serde::{Deserialize, Serialize};
 #[derive(PartialEq, Serialize, Deserialize)]
 /// A `QueryExpr` represents a Proof of SQL query that can be executed against a database.
 /// It consists of a `DynProofPlan` for provable components and a vector of `OwnedTablePostprocessing` for the rest.
-pub struct QueryExpr<C: Commitment> {
-    proof_expr: DynProofPlan<C>,
+pub struct QueryExpr {
+    proof_expr: DynProofPlan,
     postprocessing: Vec<OwnedTablePostprocessing>,
 }
 
 // Implements fmt::Debug to aid in debugging QueryExpr.
 // Prints filter and postprocessing fields in a readable format.
-impl<C: Commitment> fmt::Debug for QueryExpr<C> {
+impl fmt::Debug for QueryExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -34,10 +34,10 @@ impl<C: Commitment> fmt::Debug for QueryExpr<C> {
     }
 }
 
-impl<C: Commitment> QueryExpr<C> {
+impl QueryExpr {
     /// Creates a new `QueryExpr` with the given `DynProofPlan` and `OwnedTablePostprocessing`.
     #[must_use]
-    pub fn new(proof_expr: DynProofPlan<C>, postprocessing: Vec<OwnedTablePostprocessing>) -> Self {
+    pub fn new(proof_expr: DynProofPlan, postprocessing: Vec<OwnedTablePostprocessing>) -> Self {
         Self {
             proof_expr,
             postprocessing,
@@ -82,7 +82,7 @@ impl<C: Commitment> QueryExpr<C> {
             ));
         }
         if context.has_agg() {
-            if let Some(group_by_expr) = Option::<GroupByExec<C>>::try_from(&context)? {
+            if let Some(group_by_expr) = Option::<GroupByExec>::try_from(&context)? {
                 Ok(Self {
                     proof_expr: DynProofPlan::GroupBy(group_by_expr),
                     postprocessing,
@@ -161,7 +161,7 @@ impl<C: Commitment> QueryExpr<C> {
 
     /// Immutable access to this query's provable filter expression.
     #[must_use]
-    pub fn proof_expr(&self) -> &DynProofPlan<C> {
+    pub fn proof_expr(&self) -> &DynProofPlan {
         &self.proof_expr
     }
 

--- a/crates/proof-of-sql/src/sql/parse/query_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr.rs
@@ -36,6 +36,7 @@ impl<C: Commitment> fmt::Debug for QueryExpr<C> {
 
 impl<C: Commitment> QueryExpr<C> {
     /// Creates a new `QueryExpr` with the given `DynProofPlan` and `OwnedTablePostprocessing`.
+    #[must_use]
     pub fn new(proof_expr: DynProofPlan<C>, postprocessing: Vec<OwnedTablePostprocessing>) -> Self {
         Self {
             proof_expr,
@@ -159,11 +160,13 @@ impl<C: Commitment> QueryExpr<C> {
     }
 
     /// Immutable access to this query's provable filter expression.
+    #[must_use]
     pub fn proof_expr(&self) -> &DynProofPlan<C> {
         &self.proof_expr
     }
 
     /// Immutable access to this query's post-proof result transform expression.
+    #[must_use]
     pub fn postprocessing(&self) -> &[OwnedTablePostprocessing] {
         &self.postprocessing
     }

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -1,7 +1,6 @@
 use super::{ConversionError, DynProofExprBuilder};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{ColumnRef, ColumnType},
         map::IndexMap,
     },
@@ -24,10 +23,10 @@ impl<'a> WhereExprBuilder<'a> {
     }
     /// Builds a `proof_of_sql::sql::proof_exprs::DynProofExpr` from a `proof_of_sql_parser::intermediate_ast::Expression` that is
     /// intended to be used as the where clause in a filter expression or group by expression.
-    pub fn build<C: Commitment>(
+    pub fn build(
         self,
         where_expr: Option<Box<Expression>>,
-    ) -> Result<Option<DynProofExpr<C>>, ConversionError> {
+    ) -> Result<Option<DynProofExpr>, ConversionError> {
         where_expr
             .map(|where_expr| {
                 let expr_plan = self.builder.build(&where_expr)?;

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use bigdecimal::BigDecimal;
 use core::str::FromStr;
-use curve25519_dalek::RistrettoPoint;
 use proof_of_sql_parser::{
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
     utility::*,
@@ -96,7 +95,7 @@ fn we_can_directly_check_whether_boolean_column_is_true() {
     let column_mapping = get_column_mappings_for_testing();
     let builder = WhereExprBuilder::new(&column_mapping);
     let expr_boolean = col("boolean_column");
-    assert!(builder.build::<RistrettoPoint>(Some(expr_boolean)).is_ok());
+    assert!(builder.build(Some(expr_boolean)).is_ok());
 }
 
 #[test]
@@ -104,7 +103,7 @@ fn we_can_directly_check_whether_boolean_literal_is_true() {
     let column_mapping = get_column_mappings_for_testing();
     let builder = WhereExprBuilder::new(&column_mapping);
     let expr_boolean = lit(false);
-    assert!(builder.build::<RistrettoPoint>(Some(expr_boolean)).is_ok());
+    assert!(builder.build(Some(expr_boolean)).is_ok());
 }
 
 #[test]
@@ -115,7 +114,7 @@ fn we_can_directly_check_nested_eq() {
         col("boolean_column"),
         equal(col("bigint_column"), col("int128_column")),
     );
-    assert!(builder.build::<RistrettoPoint>(Some(expr_nested)).is_ok());
+    assert!(builder.build(Some(expr_nested)).is_ok());
 }
 
 #[test]
@@ -123,9 +122,7 @@ fn we_can_directly_check_whether_boolean_columns_eq_boolean() {
     let column_mapping = get_column_mappings_for_testing();
     let builder = WhereExprBuilder::new(&column_mapping);
     let expr_boolean_to_boolean = equal(col("boolean_column"), lit(false));
-    assert!(builder
-        .build::<RistrettoPoint>(Some(expr_boolean_to_boolean))
-        .is_ok());
+    assert!(builder.build(Some(expr_boolean_to_boolean)).is_ok());
 }
 
 #[test]
@@ -133,9 +130,7 @@ fn we_can_directly_check_whether_integer_columns_eq_integer() {
     let column_mapping = get_column_mappings_for_testing();
     let builder = WhereExprBuilder::new(&column_mapping);
     let expr_integer_to_integer = equal(col("int128_column"), lit(12345_i128));
-    assert!(builder
-        .build::<RistrettoPoint>(Some(expr_integer_to_integer))
-        .is_ok());
+    assert!(builder.build(Some(expr_integer_to_integer)).is_ok());
 }
 
 #[test]
@@ -144,7 +139,7 @@ fn we_can_directly_check_whether_bigint_columns_ge_int128() {
     let builder = WhereExprBuilder::new(&column_mapping);
     let expr_integer_to_integer = ge(col("bigint_column"), lit(-12345_i128));
     let actual = builder
-        .build::<RistrettoPoint>(Some(expr_integer_to_integer))
+        .build(Some(expr_integer_to_integer))
         .unwrap()
         .unwrap();
     let expected = DynProofExpr::try_new_inequality(
@@ -166,7 +161,7 @@ fn we_can_directly_check_whether_bigint_columns_le_int128() {
     let builder = WhereExprBuilder::new(&column_mapping);
     let expr_integer_to_integer = le(col("bigint_column"), lit(-12345_i128));
     let actual = builder
-        .build::<RistrettoPoint>(Some(expr_integer_to_integer))
+        .build(Some(expr_integer_to_integer))
         .unwrap()
         .unwrap();
     let expected = DynProofExpr::try_new_inequality(
@@ -188,7 +183,7 @@ fn we_can_directly_check_whether_varchar_columns_eq_varchar() {
     // VarChar column with VarChar literal
     let expr = equal(col("varchar_column"), lit("test_string"));
     let builder = WhereExprBuilder::new(&column_mapping);
-    let result = builder.build::<RistrettoPoint>(Some(expr));
+    let result = builder.build(Some(expr));
     assert!(result.is_ok());
 }
 
@@ -198,7 +193,7 @@ fn we_can_check_non_decimal_columns_eq_integer_literals() {
     // Non-decimal column with integer literal
     let expr = equal(col("bigint_column"), lit(12345_i64));
     let builder = WhereExprBuilder::new(&column_mapping);
-    let result = builder.build::<RistrettoPoint>(Some(expr));
+    let result = builder.build(Some(expr));
     assert!(result.is_ok());
 }
 
@@ -208,7 +203,7 @@ fn we_can_check_scaled_integers_eq_correctly() {
     // Decimal column with integer literal that can be appropriately scaled
     let expr = equal(col("decimal_column"), lit(12345_i128));
     let builder = WhereExprBuilder::new(&column_mapping);
-    let result = builder.build::<RistrettoPoint>(Some(expr));
+    let result = builder.build(Some(expr));
     assert!(result.is_ok());
 }
 
@@ -221,7 +216,7 @@ fn we_can_check_exact_scale_and_precision_eq() {
         lit("123.45".parse::<BigDecimal>().unwrap()),
     );
     let builder = WhereExprBuilder::new(&column_mapping);
-    let result = builder.build::<RistrettoPoint>(Some(expr));
+    let result = builder.build(Some(expr));
     assert!(result.is_ok());
 }
 
@@ -234,7 +229,7 @@ fn we_can_check_varying_precision_eq_for_timestamp() {
         lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456789Z").unwrap()),
     );
     let builder = WhereExprBuilder::new(&column_mapping);
-    let result = builder.build::<RistrettoPoint>(Some(expr));
+    let result = builder.build(Some(expr));
     assert!(result.is_ok());
 
     let expr = equal(
@@ -242,7 +237,7 @@ fn we_can_check_varying_precision_eq_for_timestamp() {
         lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123456Z").unwrap()),
     );
     let builder = WhereExprBuilder::new(&column_mapping);
-    let result = builder.build::<RistrettoPoint>(Some(expr));
+    let result = builder.build(Some(expr));
     assert!(result.is_ok());
 
     let expr = equal(
@@ -250,7 +245,7 @@ fn we_can_check_varying_precision_eq_for_timestamp() {
         lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00.123Z").unwrap()),
     );
     let builder = WhereExprBuilder::new(&column_mapping);
-    let result = builder.build::<RistrettoPoint>(Some(expr));
+    let result = builder.build(Some(expr));
     assert!(result.is_ok());
 
     let expr = equal(
@@ -258,7 +253,7 @@ fn we_can_check_varying_precision_eq_for_timestamp() {
         lit(PoSQLTimestamp::try_from("1970-01-01T00:00:00Z").unwrap()),
     );
     let builder = WhereExprBuilder::new(&column_mapping);
-    let result = builder.build::<RistrettoPoint>(Some(expr));
+    let result = builder.build(Some(expr));
     assert!(result.is_ok());
 }
 
@@ -267,7 +262,7 @@ fn we_can_not_have_missing_column_as_where_clause() {
     let column_mapping = get_column_mappings_for_testing();
     let builder = WhereExprBuilder::new(&column_mapping);
     let expr_missing = col("not_a_column");
-    let res = builder.build::<RistrettoPoint>(Some(expr_missing));
+    let res = builder.build(Some(expr_missing));
     assert!(matches!(
         res,
         Result::Err(ConversionError::MissingColumnWithoutTable { .. })
@@ -281,7 +276,7 @@ fn we_can_not_have_non_boolean_column_as_where_clause() {
     let builder = WhereExprBuilder::new(&column_mapping);
 
     let expr_non_boolean = col("varchar_column");
-    let res = builder.build::<RistrettoPoint>(Some(expr_non_boolean));
+    let res = builder.build(Some(expr_non_boolean));
     assert!(matches!(
         res,
         Result::Err(ConversionError::NonbooleanWhereClause { .. })
@@ -295,7 +290,7 @@ fn we_can_not_have_non_boolean_literal_as_where_clause() {
     let builder = WhereExprBuilder::new(&column_mapping);
 
     let expr_non_boolean = lit(123_i128);
-    let res = builder.build::<RistrettoPoint>(Some(expr_non_boolean));
+    let res = builder.build(Some(expr_non_boolean));
     assert!(matches!(
         res,
         Result::Err(ConversionError::NonbooleanWhereClause { .. })
@@ -312,7 +307,7 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_eq_decimal() {
     });
 
     assert!(matches!(
-        QueryExpr::<RistrettoPoint>::try_new(
+        QueryExpr::try_new(
             SelectStatement::from_str("select * from sxt_tab where b = 123").unwrap(),
             t.schema_id(),
             &accessor,
@@ -331,7 +326,7 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_ge_decimal() {
     });
 
     assert!(matches!(
-        QueryExpr::<RistrettoPoint>::try_new(
+        QueryExpr::try_new(
             SelectStatement::from_str("select * from sxt_tab where b >= 123").unwrap(),
             t.schema_id(),
             &accessor,
@@ -349,7 +344,7 @@ fn we_do_not_expect_an_error_while_trying_to_check_int128_column_eq_decimal_with
         },
     });
 
-    assert!(QueryExpr::<RistrettoPoint>::try_new(
+    assert!(QueryExpr::try_new(
         SelectStatement::from_str("select * from sxt_tab where b = 123.000").unwrap(),
         t.schema_id(),
         &accessor,
@@ -366,7 +361,7 @@ fn we_do_not_expect_an_error_while_trying_to_check_bigint_column_eq_decimal_with
         },
     });
 
-    assert!(QueryExpr::<RistrettoPoint>::try_new(
+    assert!(QueryExpr::try_new(
         SelectStatement::from_str("select * from sxt_tab where b = 123.000").unwrap(),
         t.schema_id(),
         &accessor,

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -14,7 +14,7 @@ use bumpalo::Bump;
 use core::fmt::Debug;
 
 /// Provable nodes in the provable AST.
-pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scalar> {
+pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
     /// Count terms used within the Query's proof
     fn count(
         &self,
@@ -34,7 +34,7 @@ pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
     }
 
     /// Form components needed to verify and proof store into `VerificationBuilder`
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
@@ -51,9 +51,9 @@ pub trait ProofPlan<C: Commitment>: Debug + Send + Sync + ProverEvaluate<C::Scal
     fn get_table_references(&self) -> IndexSet<TableRef>;
 }
 
-pub trait ProverEvaluate<S: Scalar> {
+pub trait ProverEvaluate {
     /// Evaluate the query and modify `FirstRoundBuilder` to track the result of the query.
-    fn result_evaluate<'a>(
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         input_length: usize,
         alloc: &'a Bump,
@@ -69,7 +69,7 @@ pub trait ProverEvaluate<S: Scalar> {
     /// Intermediate values that are needed to form the proof are allocated into the arena
     /// allocator alloc. These intermediate values will persist through proof creation and
     /// will be bulk deallocated once the proof is formed.
-    fn final_round_evaluate<'a>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     base::{
         bit::BitDistribution,
-        commitment::{Commitment, CommitmentEvaluationProof},
+        commitment::CommitmentEvaluationProof,
         database::{Column, CommitmentAccessor, DataAccessor},
         math::log2_up,
         polynomial::{compute_evaluation_vector, CompositePolynomialInfo},
@@ -43,7 +43,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     /// Create a new `QueryProof`.
     #[tracing::instrument(name = "QueryProof::new", level = "debug", skip_all)]
     pub fn new(
-        expr: &(impl ProofPlan<CP::Commitment> + Serialize),
+        expr: &(impl ProofPlan + Serialize),
         accessor: &impl DataAccessor<CP::Scalar>,
         setup: &CP::ProverPublicSetup<'_>,
     ) -> (Self, ProvableQueryResult) {
@@ -145,7 +145,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     /// Verify a `QueryProof`. Note: This does NOT transform the result!
     pub fn verify(
         &self,
-        expr: &(impl ProofPlan<CP::Commitment> + Serialize),
+        expr: &(impl ProofPlan + Serialize),
         accessor: &impl CommitmentAccessor<CP::Commitment>,
         result: &ProvableQueryResult,
         setup: &CP::VerifierPublicSetup<'_>,
@@ -323,8 +323,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 /// This function returns a `merlin::Transcript`. The transcript is a record
 /// of all the operations and data involved in creating a proof.
 /// ```
-fn make_transcript<C: Commitment, T: Transcript>(
-    expr: &(impl ProofPlan<C> + Serialize),
+fn make_transcript<T: Transcript>(
+    expr: &(impl ProofPlan + Serialize),
     result: &ProvableQueryResult,
     table_length: usize,
     generator_offset: usize,

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -40,8 +40,8 @@ impl Default for TrivialTestProofPlan {
         }
     }
 }
-impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
-    fn result_evaluate<'a>(
+impl ProverEvaluate for TrivialTestProofPlan {
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         _input_length: usize,
         alloc: &'a Bump,
@@ -53,7 +53,7 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
-    fn final_round_evaluate<'a>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -68,7 +68,7 @@ impl<S: Scalar> ProverEvaluate<S> for TrivialTestProofPlan {
         vec![Column::BigInt(col)]
     }
 }
-impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
+impl ProofPlan for TrivialTestProofPlan {
     fn count(
         &self,
         builder: &mut CountBuilder,
@@ -86,7 +86,7 @@ impl<C: Commitment> ProofPlan<C> for TrivialTestProofPlan {
     fn get_offset(&self, _accessor: &dyn MetadataAccessor) -> usize {
         self.offset
     }
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         _accessor: &dyn CommitmentAccessor<C>,
@@ -200,8 +200,8 @@ impl Default for SquareTestProofPlan {
         }
     }
 }
-impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
-    fn result_evaluate<'a>(
+impl ProverEvaluate for SquareTestProofPlan {
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         _table_length: usize,
         alloc: &'a Bump,
@@ -213,7 +213,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
-    fn final_round_evaluate<'a>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -237,7 +237,7 @@ impl<S: Scalar> ProverEvaluate<S> for SquareTestProofPlan {
         vec![Column::BigInt(res)]
     }
 }
-impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
+impl ProofPlan for SquareTestProofPlan {
     fn count(
         &self,
         builder: &mut CountBuilder,
@@ -255,7 +255,7 @@ impl<C: Commitment> ProofPlan<C> for SquareTestProofPlan {
     fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize {
         accessor.get_offset("sxt.test".parse().unwrap())
     }
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
@@ -385,8 +385,8 @@ impl Default for DoubleSquareTestProofPlan {
         }
     }
 }
-impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
-    fn result_evaluate<'a>(
+impl ProverEvaluate for DoubleSquareTestProofPlan {
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         _input_length: usize,
         alloc: &'a Bump,
@@ -398,7 +398,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
 
-    fn final_round_evaluate<'a>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -435,7 +435,7 @@ impl<S: Scalar> ProverEvaluate<S> for DoubleSquareTestProofPlan {
         vec![Column::BigInt(res)]
     }
 }
-impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
+impl ProofPlan for DoubleSquareTestProofPlan {
     fn count(
         &self,
         builder: &mut CountBuilder,
@@ -453,7 +453,7 @@ impl<C: Commitment> ProofPlan<C> for DoubleSquareTestProofPlan {
     fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize {
         accessor.get_offset("sxt.test".parse().unwrap())
     }
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
@@ -600,8 +600,8 @@ fn verify_fails_the_result_doesnt_satisfy_an_intermediate_equation() {
 
 #[derive(Debug, Serialize)]
 struct ChallengeTestProofPlan {}
-impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
-    fn result_evaluate<'a>(
+impl ProverEvaluate for ChallengeTestProofPlan {
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         _input_length: usize,
         _alloc: &'a Bump,
@@ -614,7 +614,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         builder.request_post_result_challenges(2);
     }
 
-    fn final_round_evaluate<'a>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -640,7 +640,7 @@ impl<S: Scalar> ProverEvaluate<S> for ChallengeTestProofPlan {
         vec![Column::BigInt(&[9, 25])]
     }
 }
-impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
+impl ProofPlan for ChallengeTestProofPlan {
     fn count(
         &self,
         builder: &mut CountBuilder,
@@ -659,7 +659,7 @@ impl<C: Commitment> ProofPlan<C> for ChallengeTestProofPlan {
     fn get_offset(&self, accessor: &dyn MetadataAccessor) -> usize {
         accessor.get_offset("sxt.test".parse().unwrap())
     }
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -80,7 +80,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
     /// This function both computes the result of a query and constructs a proof of the results
     /// validity.
     pub fn new(
-        expr: &(impl ProofPlan<CP::Commitment> + Serialize),
+        expr: &(impl ProofPlan + Serialize),
         accessor: &impl DataAccessor<CP::Scalar>,
         setup: &CP::ProverPublicSetup<'_>,
     ) -> Self {
@@ -116,7 +116,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
     ///   - `self.provable_result.as_ref().unwrap()` is called but `self.provable_result` is `None`.
     pub fn verify(
         &self,
-        expr: &(impl ProofPlan<CP::Commitment> + Serialize),
+        expr: &(impl ProofPlan + Serialize),
         accessor: &impl CommitmentAccessor<CP::Commitment>,
         setup: &CP::VerifierPublicSetup<'_>,
     ) -> QueryResult<CP::Scalar> {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -24,8 +24,8 @@ pub(super) struct EmptyTestQueryExpr {
     pub(super) length: usize,
     pub(super) columns: usize,
 }
-impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
-    fn result_evaluate<'a>(
+impl ProverEvaluate for EmptyTestQueryExpr {
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         _input_length: usize,
         alloc: &'a Bump,
@@ -36,7 +36,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
         vec![Column::BigInt(res); self.columns]
     }
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
-    fn final_round_evaluate<'a>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -50,7 +50,7 @@ impl<S: Scalar> ProverEvaluate<S> for EmptyTestQueryExpr {
         vec![Column::BigInt(res); self.columns]
     }
 }
-impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
+impl ProofPlan for EmptyTestQueryExpr {
     fn count(
         &self,
         builder: &mut CountBuilder,
@@ -65,7 +65,7 @@ impl<C: Commitment> ProofPlan<C> for EmptyTestQueryExpr {
     fn get_offset(&self, _accessor: &dyn MetadataAccessor) -> usize {
         0
     }
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         _accessor: &dyn CommitmentAccessor<C>,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -26,7 +26,7 @@ use serde::Serialize;
 /// - `fake_accessor.update_offset` fails, causing a panic if it is designed to do so in the implementation.
 pub fn exercise_verification(
     res: &VerifiableQueryResult<InnerProductProof>,
-    expr: &(impl ProofPlan<RistrettoPoint> + Serialize),
+    expr: &(impl ProofPlan + Serialize),
     accessor: &impl TestAccessor<RistrettoPoint>,
     table_ref: TableRef,
 ) {
@@ -87,7 +87,7 @@ pub fn exercise_verification(
 
 fn tamper_no_result(
     res: &VerifiableQueryResult<InnerProductProof>,
-    expr: &(impl ProofPlan<RistrettoPoint> + Serialize),
+    expr: &(impl ProofPlan + Serialize),
     accessor: &impl CommitmentAccessor<RistrettoPoint>,
 ) {
     // add a result
@@ -110,7 +110,7 @@ fn tamper_no_result(
 
 fn tamper_empty_result(
     res: &VerifiableQueryResult<InnerProductProof>,
-    expr: &(impl ProofPlan<RistrettoPoint> + Serialize),
+    expr: &(impl ProofPlan + Serialize),
     accessor: &impl CommitmentAccessor<RistrettoPoint>,
 ) {
     // try to add a result
@@ -129,7 +129,7 @@ fn tamper_empty_result(
 ///   verification did not fail as expected after tampering.
 fn tamper_result(
     res: &VerifiableQueryResult<InnerProductProof>,
-    expr: &(impl ProofPlan<RistrettoPoint> + Serialize),
+    expr: &(impl ProofPlan + Serialize),
     accessor: &impl CommitmentAccessor<RistrettoPoint>,
 ) {
     if res.provable_result.is_none() {

--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -1,11 +1,10 @@
 use super::DynProofExpr;
-use crate::base::commitment::Commitment;
 use proof_of_sql_parser::Identifier;
 use serde::{Deserialize, Serialize};
 
 /// A `DynProofExpr` with an alias.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct AliasedDynProofExpr<C: Commitment> {
-    pub expr: DynProofExpr<C>,
+pub struct AliasedDynProofExpr {
+    pub expr: DynProofExpr,
     pub alias: Identifier,
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -5,29 +5,29 @@ use crate::{
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
         map::IndexSet,
         proof::ProofError,
+        scalar::Scalar,
     },
     sql::proof::{CountBuilder, FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
-use num_traits::One;
 use serde::{Deserialize, Serialize};
 
 /// Provable logical AND expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct AndExpr<C: Commitment> {
-    lhs: Box<DynProofExpr<C>>,
-    rhs: Box<DynProofExpr<C>>,
+pub struct AndExpr {
+    lhs: Box<DynProofExpr>,
+    rhs: Box<DynProofExpr>,
 }
 
-impl<C: Commitment> AndExpr<C> {
+impl AndExpr {
     /// Create logical AND expression
-    pub fn new(lhs: Box<DynProofExpr<C>>, rhs: Box<DynProofExpr<C>>) -> Self {
+    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
         Self { lhs, rhs }
     }
 }
 
-impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
+impl ProofExpr for AndExpr {
     fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
         self.lhs.count(builder)?;
         self.rhs.count(builder)?;
@@ -42,30 +42,28 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
     }
 
     #[tracing::instrument(name = "AndExpr::result_evaluate", level = "debug", skip_all)]
-    fn result_evaluate<'a>(
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         table_length: usize,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
-        let lhs_column: Column<'a, C::Scalar> =
-            self.lhs.result_evaluate(table_length, alloc, accessor);
-        let rhs_column: Column<'a, C::Scalar> =
-            self.rhs.result_evaluate(table_length, alloc, accessor);
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
+        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(table_length, alloc, accessor);
+        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(table_length, alloc, accessor);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         Column::Boolean(alloc.alloc_slice_fill_with(table_length, |i| lhs[i] && rhs[i]))
     }
 
     #[tracing::instrument(name = "AndExpr::prover_evaluate", level = "debug", skip_all)]
-    fn prover_evaluate<'a>(
+    fn prover_evaluate<'a, S: Scalar>(
         &self,
-        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
-        let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
-        let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
+        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, accessor);
+        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, accessor);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let n = lhs.len();
@@ -79,14 +77,14 @@ impl<C: Commitment> ProofExpr<C> for AndExpr<C> {
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
             vec![
-                (C::Scalar::one(), vec![Box::new(lhs_and_rhs)]),
-                (-C::Scalar::one(), vec![Box::new(lhs), Box::new(rhs)]),
+                (S::one(), vec![Box::new(lhs_and_rhs)]),
+                (-S::one(), vec![Box::new(lhs), Box::new(rhs)]),
             ],
         );
         Column::Boolean(lhs_and_rhs)
     }
 
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -2,6 +2,7 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        scalar::test_scalar::TestScalar,
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -10,7 +11,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use curve25519_dalek::ristretto::RistrettoPoint;
 use itertools::{multizip, MultiUnzip};
 use rand::{
     distributions::{Distribution, Uniform},
@@ -32,8 +32,11 @@ fn we_can_prove_a_simple_and_query() {
         cols_expr_plan(t, &["a", "d"], &accessor),
         tab(t),
         and(
-            equal(column(t, "b", &accessor), const_scalar(1)),
-            equal(column(t, "d", &accessor), const_scalar("t")),
+            equal(column(t, "b", &accessor), const_scalar::<TestScalar, _>(1)),
+            equal(
+                column(t, "d", &accessor),
+                const_scalar::<TestScalar, _>("t"),
+            ),
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
@@ -57,8 +60,11 @@ fn we_can_prove_a_simple_and_query_with_128_bits() {
         cols_expr_plan(t, &["a", "d"], &accessor),
         tab(t),
         and(
-            equal(column(t, "b", &accessor), const_scalar(1)),
-            equal(column(t, "d", &accessor), const_scalar("t")),
+            equal(column(t, "b", &accessor), const_scalar::<TestScalar, _>(1)),
+            equal(
+                column(t, "d", &accessor),
+                const_scalar::<TestScalar, _>("t"),
+            ),
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
@@ -155,7 +161,7 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
     ]);
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
-    let and_expr: DynProofExpr<RistrettoPoint> = and(
+    let and_expr: DynProofExpr = and(
         equal(column(t, "b", &accessor), const_int128(1)),
         equal(column(t, "d", &accessor), const_varchar("t")),
     );

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -203,7 +203,7 @@ pub(crate) fn scale_and_subtract_columnar_value<'a, S: Scalar>(
         }
         (ColumnarValue::Literal(lhs), ColumnarValue::Literal(rhs)) => {
             Ok(ColumnarValue::Literal(LiteralValue::Scalar(
-                scale_and_subtract_literal(&lhs, &rhs, lhs_scale, rhs_scale, is_equal)?,
+                scale_and_subtract_literal(&lhs, &rhs, lhs_scale, rhs_scale, is_equal)?.into(),
             )))
         }
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -39,8 +39,8 @@ fn unchecked_subtract_impl<'a, S: Scalar>(
 /// or if we have precision overflow issues.
 #[allow(clippy::cast_sign_loss)]
 pub fn scale_and_subtract_literal<S: Scalar>(
-    lhs: &LiteralValue<S>,
-    rhs: &LiteralValue<S>,
+    lhs: &LiteralValue,
+    rhs: &LiteralValue,
     lhs_scale: i8,
     rhs_scale: i8,
     is_equal: bool,
@@ -85,12 +85,12 @@ pub fn scale_and_subtract_literal<S: Scalar>(
     match lhs_scale.cmp(&rhs_scale) {
         Ordering::Less => {
             let upscale_factor = S::pow10(rhs_upscale as u8);
-            Ok(lhs.to_scalar() * upscale_factor - rhs.to_scalar())
+            Ok(lhs.to_scalar::<S>() * upscale_factor - rhs.to_scalar())
         }
-        Ordering::Equal => Ok(lhs.to_scalar() - rhs.to_scalar()),
+        Ordering::Equal => Ok(lhs.to_scalar::<S>() - rhs.to_scalar()),
         Ordering::Greater => {
             let upscale_factor = S::pow10(lhs_upscale as u8);
-            Ok(lhs.to_scalar() - rhs.to_scalar() * upscale_factor)
+            Ok(lhs.to_scalar::<S>() - rhs.to_scalar::<S>() * upscale_factor)
         }
     }
 }
@@ -203,7 +203,7 @@ pub(crate) fn scale_and_subtract_columnar_value<'a, S: Scalar>(
         }
         (ColumnarValue::Literal(lhs), ColumnarValue::Literal(rhs)) => {
             Ok(ColumnarValue::Literal(LiteralValue::Scalar(
-                scale_and_subtract_literal(&lhs, &rhs, lhs_scale, rhs_scale, is_equal)?.into(),
+                scale_and_subtract_literal::<S>(&lhs, &rhs, lhs_scale, rhs_scale, is_equal)?.into(),
             )))
         }
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -32,7 +32,7 @@ pub enum DynProofExpr<C: Commitment> {
     /// Provable logical NOT expression
     Not(NotExpr<C>),
     /// Provable CONST expression
-    Literal(LiteralExpr<C::Scalar>),
+    Literal(LiteralExpr),
     /// Provable AST expression for an equals expression
     Equals(EqualsExpr<C>),
     /// Provable AST expression for an inequality expression
@@ -67,7 +67,7 @@ impl<C: Commitment> DynProofExpr<C> {
         Ok(Self::Not(NotExpr::new(Box::new(expr))))
     }
     /// Create CONST expression
-    pub fn new_literal(value: LiteralValue<C::Scalar>) -> Self {
+    pub fn new_literal(value: LiteralValue) -> Self {
         Self::Literal(LiteralExpr::new(value))
     }
     /// Create a new equals expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -8,6 +8,7 @@ use crate::{
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
         map::IndexSet,
         proof::ProofError,
+        scalar::Scalar,
     },
     sql::{
         parse::{type_check_binary_operation, ConversionError, ConversionResult},
@@ -22,47 +23,47 @@ use serde::{Deserialize, Serialize};
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum DynProofExpr<C: Commitment> {
+pub enum DynProofExpr {
     /// Column
-    Column(ColumnExpr<C>),
+    Column(ColumnExpr),
     /// Provable logical AND expression
-    And(AndExpr<C>),
+    And(AndExpr),
     /// Provable logical OR expression
-    Or(OrExpr<C>),
+    Or(OrExpr),
     /// Provable logical NOT expression
-    Not(NotExpr<C>),
+    Not(NotExpr),
     /// Provable CONST expression
     Literal(LiteralExpr),
     /// Provable AST expression for an equals expression
-    Equals(EqualsExpr<C>),
+    Equals(EqualsExpr),
     /// Provable AST expression for an inequality expression
-    Inequality(InequalityExpr<C>),
+    Inequality(InequalityExpr),
     /// Provable numeric `+` / `-` expression
-    AddSubtract(AddSubtractExpr<C>),
+    AddSubtract(AddSubtractExpr),
     /// Provable numeric `*` expression
-    Multiply(MultiplyExpr<C>),
+    Multiply(MultiplyExpr),
     /// Provable aggregate expression
-    Aggregate(AggregateExpr<C>),
+    Aggregate(AggregateExpr),
 }
-impl<C: Commitment> DynProofExpr<C> {
+impl DynProofExpr {
     /// Create column expression
     pub fn new_column(column_ref: ColumnRef) -> Self {
         Self::Column(ColumnExpr::new(column_ref))
     }
     /// Create logical AND expression
-    pub fn try_new_and(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
+    pub fn try_new_and(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
         lhs.check_data_type(ColumnType::Boolean)?;
         rhs.check_data_type(ColumnType::Boolean)?;
         Ok(Self::And(AndExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical OR expression
-    pub fn try_new_or(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
+    pub fn try_new_or(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
         lhs.check_data_type(ColumnType::Boolean)?;
         rhs.check_data_type(ColumnType::Boolean)?;
         Ok(Self::Or(OrExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical NOT expression
-    pub fn try_new_not(expr: DynProofExpr<C>) -> ConversionResult<Self> {
+    pub fn try_new_not(expr: DynProofExpr) -> ConversionResult<Self> {
         expr.check_data_type(ColumnType::Boolean)?;
         Ok(Self::Not(NotExpr::new(Box::new(expr))))
     }
@@ -71,7 +72,7 @@ impl<C: Commitment> DynProofExpr<C> {
         Self::Literal(LiteralExpr::new(value))
     }
     /// Create a new equals expression
-    pub fn try_new_equals(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
+    pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(&lhs_datatype, &rhs_datatype, BinaryOperator::Equal) {
@@ -85,8 +86,8 @@ impl<C: Commitment> DynProofExpr<C> {
     }
     /// Create a new inequality expression
     pub fn try_new_inequality(
-        lhs: DynProofExpr<C>,
-        rhs: DynProofExpr<C>,
+        lhs: DynProofExpr,
+        rhs: DynProofExpr,
         is_lte: bool,
     ) -> ConversionResult<Self> {
         let lhs_datatype = lhs.data_type();
@@ -110,7 +111,7 @@ impl<C: Commitment> DynProofExpr<C> {
     }
 
     /// Create a new add expression
-    pub fn try_new_add(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
+    pub fn try_new_add(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(&lhs_datatype, &rhs_datatype, BinaryOperator::Add) {
@@ -128,7 +129,7 @@ impl<C: Commitment> DynProofExpr<C> {
     }
 
     /// Create a new subtract expression
-    pub fn try_new_subtract(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
+    pub fn try_new_subtract(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(&lhs_datatype, &rhs_datatype, BinaryOperator::Subtract) {
@@ -146,7 +147,7 @@ impl<C: Commitment> DynProofExpr<C> {
     }
 
     /// Create a new multiply expression
-    pub fn try_new_multiply(lhs: DynProofExpr<C>, rhs: DynProofExpr<C>) -> ConversionResult<Self> {
+    pub fn try_new_multiply(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(&lhs_datatype, &rhs_datatype, BinaryOperator::Multiply) {
@@ -163,7 +164,7 @@ impl<C: Commitment> DynProofExpr<C> {
     }
 
     /// Create a new aggregate expression
-    pub fn new_aggregate(op: AggregationOperator, expr: DynProofExpr<C>) -> Self {
+    pub fn new_aggregate(op: AggregationOperator, expr: DynProofExpr) -> Self {
         Self::Aggregate(AggregateExpr::new(op, Box::new(expr)))
     }
 
@@ -180,19 +181,19 @@ impl<C: Commitment> DynProofExpr<C> {
     }
 }
 
-impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
+impl ProofExpr for DynProofExpr {
     fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
         match self {
-            DynProofExpr::Column(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::And(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::Or(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::Not(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::Literal(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::Equals(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::Inequality(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::AddSubtract(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::Multiply(expr) => ProofExpr::<C>::count(expr, builder),
-            DynProofExpr::Aggregate(expr) => ProofExpr::<C>::count(expr, builder),
+            DynProofExpr::Column(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::And(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::Or(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::Not(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::Literal(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::Equals(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::Inequality(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::AddSubtract(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::Multiply(expr) => ProofExpr::count(expr, builder),
+            DynProofExpr::Aggregate(expr) => ProofExpr::count(expr, builder),
         }
     }
 
@@ -202,7 +203,7 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
             DynProofExpr::AddSubtract(expr) => expr.data_type(),
             DynProofExpr::Multiply(expr) => expr.data_type(),
             DynProofExpr::Aggregate(expr) => expr.data_type(),
-            DynProofExpr::Literal(expr) => ProofExpr::<C>::data_type(expr),
+            DynProofExpr::Literal(expr) => ProofExpr::data_type(expr),
             DynProofExpr::And(_)
             | DynProofExpr::Or(_)
             | DynProofExpr::Not(_)
@@ -211,95 +212,87 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
         }
     }
 
-    fn result_evaluate<'a>(
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         table_length: usize,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
         match self {
             DynProofExpr::Column(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::And(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::Or(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::Not(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::Literal(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::Equals(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::Inequality(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::AddSubtract(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::Multiply(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
             DynProofExpr::Aggregate(expr) => {
-                ProofExpr::<C>::result_evaluate(expr, table_length, alloc, accessor)
+                ProofExpr::result_evaluate(expr, table_length, alloc, accessor)
             }
         }
     }
 
-    fn prover_evaluate<'a>(
+    fn prover_evaluate<'a, S: Scalar>(
         &self,
-        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
         match self {
             DynProofExpr::Column(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::prover_evaluate(expr, builder, alloc, accessor)
             }
-            DynProofExpr::And(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
-            }
-            DynProofExpr::Or(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
-            }
-            DynProofExpr::Not(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
-            }
+            DynProofExpr::And(expr) => ProofExpr::prover_evaluate(expr, builder, alloc, accessor),
+            DynProofExpr::Or(expr) => ProofExpr::prover_evaluate(expr, builder, alloc, accessor),
+            DynProofExpr::Not(expr) => ProofExpr::prover_evaluate(expr, builder, alloc, accessor),
             DynProofExpr::Literal(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::prover_evaluate(expr, builder, alloc, accessor)
             }
             DynProofExpr::Equals(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::prover_evaluate(expr, builder, alloc, accessor)
             }
             DynProofExpr::Inequality(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::prover_evaluate(expr, builder, alloc, accessor)
             }
             DynProofExpr::AddSubtract(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::prover_evaluate(expr, builder, alloc, accessor)
             }
             DynProofExpr::Multiply(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::prover_evaluate(expr, builder, alloc, accessor)
             }
             DynProofExpr::Aggregate(expr) => {
-                ProofExpr::<C>::prover_evaluate(expr, builder, alloc, accessor)
+                ProofExpr::prover_evaluate(expr, builder, alloc, accessor)
             }
         }
     }
 
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,
     ) -> Result<C::Scalar, ProofError> {
         match self {
-            DynProofExpr::Column(expr) => {
-                ProofExpr::<C>::verifier_evaluate(expr, builder, accessor)
-            }
+            DynProofExpr::Column(expr) => ProofExpr::verifier_evaluate(expr, builder, accessor),
             DynProofExpr::And(expr) => expr.verifier_evaluate(builder, accessor),
             DynProofExpr::Or(expr) => expr.verifier_evaluate(builder, accessor),
             DynProofExpr::Not(expr) => expr.verifier_evaluate(builder, accessor),
@@ -314,16 +307,16 @@ impl<C: Commitment> ProofExpr<C> for DynProofExpr<C> {
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
         match self {
-            DynProofExpr::Column(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::And(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::Or(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::Not(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::Literal(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::Equals(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::Inequality(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::AddSubtract(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::Multiply(expr) => ProofExpr::<C>::get_column_references(expr, columns),
-            DynProofExpr::Aggregate(expr) => ProofExpr::<C>::get_column_references(expr, columns),
+            DynProofExpr::Column(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::And(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::Or(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::Not(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::Literal(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::Equals(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::Inequality(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::AddSubtract(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::Multiply(expr) => ProofExpr::get_column_references(expr, columns),
+            DynProofExpr::Aggregate(expr) => ProofExpr::get_column_references(expr, columns),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use curve25519_dalek::ristretto::RistrettoPoint;
 use itertools::{multizip, MultiUnzip};
 use rand::{
     distributions::{Distribution, Uniform},
@@ -407,9 +406,9 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
     ]);
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
-    let equals_expr: DynProofExpr<RistrettoPoint> = equal(
+    let equals_expr: DynProofExpr = equal(
         column(t, "e", &accessor),
-        const_scalar(Curve25519Scalar::ZERO),
+        const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ZERO),
     );
     let alloc = Bump::new();
     let res = equals_expr.result_evaluate(4, &alloc, &accessor);

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -15,7 +15,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use curve25519_dalek::RistrettoPoint;
 use itertools::{multizip, MultiUnzip};
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use rand::{
@@ -300,7 +299,7 @@ fn we_cannot_compare_columns_filtering_on_extreme_decimal_values() {
     assert!(matches!(
         DynProofExpr::try_new_inequality(
             column(t, "e", &accessor),
-            const_scalar::<RistrettoPoint, Curve25519Scalar>(Curve25519Scalar::ONE),
+            const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ONE),
             false
         ),
         Err(ConversionError::DataTypeMismatch { .. })
@@ -565,7 +564,7 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let t = "sxt.t".parse().unwrap();
     accessor.add_table(t, data, 0);
-    let lhs_expr: DynProofExpr<RistrettoPoint> = column(t, "a", &accessor);
+    let lhs_expr: DynProofExpr = column(t, "a", &accessor);
     let rhs_expr = column(t, "b", &accessor);
     let lte_expr = lte(lhs_expr, rhs_expr);
     let alloc = Bump::new();
@@ -580,7 +579,7 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let t = "sxt.t".parse().unwrap();
     accessor.add_table(t, data, 0);
-    let col_expr: DynProofExpr<RistrettoPoint> = column(t, "a", &accessor);
+    let col_expr: DynProofExpr = column(t, "a", &accessor);
     let lit_expr = const_bigint(1);
     let gte_expr = gte(col_expr, lit_expr);
     let alloc = Bump::new();

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -5,7 +5,6 @@ use crate::{
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
         map::IndexSet,
         proof::ProofError,
-        scalar::Scalar,
     },
     sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
@@ -24,18 +23,18 @@ use serde::{Deserialize, Serialize};
 /// such queries, it allows us to easily support projects with minimal code
 /// changes, and the performance is sufficient for present.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LiteralExpr<S: Scalar> {
-    value: LiteralValue<S>,
+pub struct LiteralExpr {
+    value: LiteralValue,
 }
 
-impl<S: Scalar> LiteralExpr<S> {
+impl LiteralExpr {
     /// Create literal expression
-    pub fn new(value: LiteralValue<S>) -> Self {
+    pub fn new(value: LiteralValue) -> Self {
         Self { value }
     }
 }
 
-impl<C: Commitment> ProofExpr<C> for LiteralExpr<C::Scalar> {
+impl<C: Commitment> ProofExpr<C> for LiteralExpr {
     fn count(&self, _builder: &mut CountBuilder) -> Result<(), ProofError> {
         Ok(())
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -5,6 +5,7 @@ use crate::{
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
         map::IndexSet,
         proof::ProofError,
+        scalar::Scalar,
     },
     sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
@@ -34,7 +35,7 @@ impl LiteralExpr {
     }
 }
 
-impl<C: Commitment> ProofExpr<C> for LiteralExpr {
+impl ProofExpr for LiteralExpr {
     fn count(&self, _builder: &mut CountBuilder) -> Result<(), ProofError> {
         Ok(())
     }
@@ -44,27 +45,27 @@ impl<C: Commitment> ProofExpr<C> for LiteralExpr {
     }
 
     #[tracing::instrument(name = "LiteralExpr::result_evaluate", level = "debug", skip_all)]
-    fn result_evaluate<'a>(
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         table_length: usize,
         alloc: &'a Bump,
-        _accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
+        _accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
         Column::from_literal_with_length(&self.value, table_length, alloc)
     }
 
     #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]
-    fn prover_evaluate<'a>(
+    fn prover_evaluate<'a, S: Scalar>(
         &self,
-        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        _accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
+        _accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
         let table_length = builder.table_length();
         Column::from_literal_with_length(&self.value, table_length, alloc)
     }
 
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         _accessor: &dyn CommitmentAccessor<C>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use curve25519_dalek::ristretto::RistrettoPoint;
 use rand::{
     distributions::{Distribution, Uniform},
     rngs::StdRng,
@@ -122,7 +121,7 @@ fn we_can_compute_the_correct_output_of_a_literal_expr_using_result_evaluate() {
     let data = owned_table([bigint("a", [123_i64, 456, 789, 1011])]);
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
-    let literal_expr: DynProofExpr<RistrettoPoint> = const_bool(true);
+    let literal_expr: DynProofExpr = const_bool(true);
     let alloc = Bump::new();
     let res = literal_expr.result_evaluate(4, &alloc, &accessor);
     let expected_res = Column::Boolean(&[true, true, true, true]);

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -8,6 +8,7 @@ use crate::{
         },
         map::IndexSet,
         proof::ProofError,
+        scalar::Scalar,
     },
     sql::{
         proof::{CountBuilder, FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
@@ -16,24 +17,23 @@ use crate::{
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
-use num_traits::One;
 use serde::{Deserialize, Serialize};
 
 /// Provable numerical * expression
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct MultiplyExpr<C: Commitment> {
-    lhs: Box<DynProofExpr<C>>,
-    rhs: Box<DynProofExpr<C>>,
+pub struct MultiplyExpr {
+    lhs: Box<DynProofExpr>,
+    rhs: Box<DynProofExpr>,
 }
 
-impl<C: Commitment> MultiplyExpr<C> {
+impl MultiplyExpr {
     /// Create numerical `*` expression
-    pub fn new(lhs: Box<DynProofExpr<C>>, rhs: Box<DynProofExpr<C>>) -> Self {
+    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
         Self { lhs, rhs }
     }
 }
 
-impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
+impl ProofExpr for MultiplyExpr {
     fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
         self.lhs.count(builder)?;
         self.rhs.count(builder)?;
@@ -48,16 +48,14 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
             .expect("Failed to multiply column types")
     }
 
-    fn result_evaluate<'a>(
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         table_length: usize,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
-        let lhs_column: Column<'a, C::Scalar> =
-            self.lhs.result_evaluate(table_length, alloc, accessor);
-        let rhs_column: Column<'a, C::Scalar> =
-            self.rhs.result_evaluate(table_length, alloc, accessor);
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
+        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(table_length, alloc, accessor);
+        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(table_length, alloc, accessor);
         let scalars = multiply_columns(&lhs_column, &rhs_column, alloc);
         Column::Scalar(scalars)
     }
@@ -67,34 +65,31 @@ impl<C: Commitment> ProofExpr<C> for MultiplyExpr<C> {
         level = "info",
         skip_all
     )]
-    fn prover_evaluate<'a>(
+    fn prover_evaluate<'a, S: Scalar>(
         &self,
-        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
-        let lhs_column: Column<'a, C::Scalar> = self.lhs.prover_evaluate(builder, alloc, accessor);
-        let rhs_column: Column<'a, C::Scalar> = self.rhs.prover_evaluate(builder, alloc, accessor);
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
+        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, accessor);
+        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, accessor);
 
         // lhs_times_rhs
-        let lhs_times_rhs: &'a [C::Scalar] = multiply_columns(&lhs_column, &rhs_column, alloc);
+        let lhs_times_rhs: &'a [S] = multiply_columns(&lhs_column, &rhs_column, alloc);
         builder.produce_intermediate_mle(lhs_times_rhs);
 
         // subpolynomial: lhs_times_rhs - lhs * rhs
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
             vec![
-                (C::Scalar::one(), vec![Box::new(lhs_times_rhs)]),
-                (
-                    -C::Scalar::one(),
-                    vec![Box::new(lhs_column), Box::new(rhs_column)],
-                ),
+                (S::one(), vec![Box::new(lhs_times_rhs)]),
+                (-S::one(), vec![Box::new(lhs_column), Box::new(rhs_column)]),
             ],
         );
         Column::Scalar(lhs_times_rhs)
     }
 
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -5,6 +5,7 @@ use crate::{
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
         map::IndexSet,
         proof::ProofError,
+        scalar::Scalar,
     },
     sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
@@ -14,18 +15,18 @@ use serde::{Deserialize, Serialize};
 
 /// Provable logical NOT expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct NotExpr<C: Commitment> {
-    expr: Box<DynProofExpr<C>>,
+pub struct NotExpr {
+    expr: Box<DynProofExpr>,
 }
 
-impl<C: Commitment> NotExpr<C> {
+impl NotExpr {
     /// Create logical NOT expression
-    pub fn new(expr: Box<DynProofExpr<C>>) -> Self {
+    pub fn new(expr: Box<DynProofExpr>) -> Self {
         Self { expr }
     }
 }
 
-impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
+impl ProofExpr for NotExpr {
     fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
         self.expr.count(builder)
     }
@@ -35,32 +36,30 @@ impl<C: Commitment> ProofExpr<C> for NotExpr<C> {
     }
 
     #[tracing::instrument(name = "NotExpr::result_evaluate", level = "debug", skip_all)]
-    fn result_evaluate<'a>(
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         table_length: usize,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
-        let expr_column: Column<'a, C::Scalar> =
-            self.expr.result_evaluate(table_length, alloc, accessor);
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
+        let expr_column: Column<'a, S> = self.expr.result_evaluate(table_length, alloc, accessor);
         let expr = expr_column.as_boolean().expect("expr is not boolean");
         Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]))
     }
 
     #[tracing::instrument(name = "NotExpr::prover_evaluate", level = "debug", skip_all)]
-    fn prover_evaluate<'a>(
+    fn prover_evaluate<'a, S: Scalar>(
         &self,
-        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar> {
-        let expr_column: Column<'a, C::Scalar> =
-            self.expr.prover_evaluate(builder, alloc, accessor);
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S> {
+        let expr_column: Column<'a, S> = self.expr.prover_evaluate(builder, alloc, accessor);
         let expr = expr_column.as_boolean().expect("expr is not boolean");
         Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]))
     }
 
-    fn verifier_evaluate(
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -2,6 +2,7 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
+        scalar::test_scalar::TestScalar,
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -10,7 +11,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use curve25519_dalek::ristretto::RistrettoPoint;
 use itertools::{multizip, MultiUnzip};
 use rand::{
     distributions::{Distribution, Uniform},
@@ -72,7 +72,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(t, "a", &accessor), const_bigint(filter_val_a)),
                 equal(
                     column(t, "b", &accessor),
-                    const_scalar(filter_val_b.as_str()),
+                    const_scalar::<TestScalar, _>(filter_val_b.as_str()),
                 ),
             )),
         );
@@ -117,8 +117,7 @@ fn we_can_compute_the_correct_output_of_a_not_expr_using_result_evaluate() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let t = "sxt.t".parse().unwrap();
     accessor.add_table(t, data, 0);
-    let not_expr: DynProofExpr<RistrettoPoint> =
-        not(equal(column(t, "b", &accessor), const_int128(1)));
+    let not_expr: DynProofExpr = not(equal(column(t, "b", &accessor), const_int128(1)));
     let alloc = Bump::new();
     let res = not_expr.result_evaluate(2, &alloc, &accessor);
     let expected_res = Column::Boolean(&[true, false]);

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -8,8 +8,8 @@ use core::cmp::Ordering;
 #[allow(clippy::cast_sign_loss)]
 /// Add or subtract two literals together.
 pub(crate) fn add_subtract_literals<S: Scalar>(
-    lhs: &LiteralValue<S>,
-    rhs: &LiteralValue<S>,
+    lhs: &LiteralValue,
+    rhs: &LiteralValue,
     lhs_scale: i8,
     rhs_scale: i8,
     is_subtract: bool,
@@ -17,12 +17,12 @@ pub(crate) fn add_subtract_literals<S: Scalar>(
     let (lhs_scaled, rhs_scaled) = match lhs_scale.cmp(&rhs_scale) {
         Ordering::Less => {
             let scaling_factor = S::pow10((rhs_scale - lhs_scale) as u8);
-            (lhs.to_scalar() * scaling_factor, rhs.to_scalar())
+            (lhs.to_scalar::<S>() * scaling_factor, rhs.to_scalar())
         }
         Ordering::Equal => (lhs.to_scalar(), rhs.to_scalar()),
         Ordering::Greater => {
             let scaling_factor = S::pow10((lhs_scale - rhs_scale) as u8);
-            (lhs.to_scalar(), rhs.to_scalar() * scaling_factor)
+            (lhs.to_scalar(), rhs.to_scalar::<S>() * scaling_factor)
         }
     };
     if is_subtract {
@@ -107,7 +107,7 @@ pub(crate) fn add_subtract_columnar_values<'a, S: Scalar>(
         }
         (ColumnarValue::Literal(lhs), ColumnarValue::Literal(rhs)) => {
             ColumnarValue::Literal(LiteralValue::Scalar(
-                add_subtract_literals(&lhs, &rhs, lhs_scale, rhs_scale, is_subtract).into(),
+                add_subtract_literals::<S>(&lhs, &rhs, lhs_scale, rhs_scale, is_subtract).into(),
             ))
         }
     }
@@ -146,7 +146,7 @@ pub(crate) fn multiply_columnar_values<'a, S: Scalar>(
             ColumnarValue::Column(Column::Scalar(multiply_columns(lhs, rhs, alloc)))
         }
         (ColumnarValue::Literal(lhs), ColumnarValue::Column(rhs)) => {
-            let lhs_scalar = lhs.to_scalar();
+            let lhs_scalar = lhs.to_scalar::<S>();
             let result =
                 alloc.alloc_slice_fill_with(rhs.len(), |i| lhs_scalar * rhs.scalar_at(i).unwrap());
             ColumnarValue::Column(Column::Scalar(result))
@@ -158,7 +158,7 @@ pub(crate) fn multiply_columnar_values<'a, S: Scalar>(
             ColumnarValue::Column(Column::Scalar(result))
         }
         (ColumnarValue::Literal(lhs), ColumnarValue::Literal(rhs)) => {
-            let result = lhs.to_scalar() * rhs.to_scalar();
+            let result = lhs.to_scalar::<S>() * rhs.to_scalar();
             ColumnarValue::Literal(LiteralValue::Scalar(result.into()))
         }
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -106,13 +106,9 @@ pub(crate) fn add_subtract_columnar_values<'a, S: Scalar>(
             )))
         }
         (ColumnarValue::Literal(lhs), ColumnarValue::Literal(rhs)) => {
-            ColumnarValue::Literal(LiteralValue::Scalar(add_subtract_literals(
-                &lhs,
-                &rhs,
-                lhs_scale,
-                rhs_scale,
-                is_subtract,
-            )))
+            ColumnarValue::Literal(LiteralValue::Scalar(
+                add_subtract_literals(&lhs, &rhs, lhs_scale, rhs_scale, is_subtract).into(),
+            ))
         }
     }
 }
@@ -163,7 +159,7 @@ pub(crate) fn multiply_columnar_values<'a, S: Scalar>(
         }
         (ColumnarValue::Literal(lhs), ColumnarValue::Literal(rhs)) => {
             let result = lhs.to_scalar() * rhs.to_scalar();
-            ColumnarValue::Literal(LiteralValue::Scalar(result))
+            ColumnarValue::Literal(LiteralValue::Scalar(result.into()))
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use curve25519_dalek::ristretto::RistrettoPoint;
 use itertools::{multizip, MultiUnzip};
 use rand::{
     distributions::{Distribution, Uniform},
@@ -179,7 +178,7 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let t = "sxt.t".parse().unwrap();
     accessor.add_table(t, data, 0);
-    let and_expr: DynProofExpr<RistrettoPoint> = or(
+    let and_expr: DynProofExpr = or(
         equal(column(t, "b", &accessor), const_int128(1)),
         equal(column(t, "d", &accessor), const_varchar("g")),
     );

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -4,6 +4,7 @@ use crate::{
         database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
         map::IndexSet,
         proof::ProofError,
+        scalar::Scalar,
     },
     sql::proof::{CountBuilder, FinalRoundBuilder, VerificationBuilder},
 };
@@ -11,7 +12,7 @@ use bumpalo::Bump;
 use core::fmt::Debug;
 
 /// Provable AST column expression that evaluates to a `Column`
-pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
+pub trait ProofExpr: Debug + Send + Sync {
     /// Count the number of proof terms needed for this expression
     fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError>;
 
@@ -21,26 +22,26 @@ pub trait ProofExpr<C: Commitment>: Debug + Send + Sync {
     /// This returns the result of evaluating the expression on the given table, and returns
     /// a column of values. This result slice is guarenteed to have length `table_length`.
     /// Implementations must ensure that the returned slice has length `table_length`.
-    fn result_evaluate<'a>(
+    fn result_evaluate<'a, S: Scalar>(
         &self,
         table_length: usize,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar>;
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S>;
 
     /// Evaluate the expression, add components needed to prove it, and return thet resulting column
     /// of values
-    fn prover_evaluate<'a>(
+    fn prover_evaluate<'a, S: Scalar>(
         &self,
-        builder: &mut FinalRoundBuilder<'a, C::Scalar>,
+        builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<C::Scalar>,
-    ) -> Column<'a, C::Scalar>;
+        accessor: &'a dyn DataAccessor<S>,
+    ) -> Column<'a, S>;
 
     /// Compute the evaluation of a multilinear extension from this expression
     /// at the random sumcheck point and adds components needed to verify the expression to
-    /// [`VerificationBuilder`]
-    fn verifier_evaluate(
+    /// [`VerificationBuilder<C>`]
+    fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
         accessor: &dyn CommitmentAccessor<C>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -4,7 +4,6 @@ use crate::base::{
     database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
 };
 use bumpalo::Bump;
-use curve25519_dalek::RistrettoPoint;
 
 #[test]
 fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluate() {
@@ -28,7 +27,7 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
     let t = "sxt.t".parse().unwrap();
     accessor.add_table(t, data, 0);
     // (a <= 5 || b == "g") && c != 3
-    let bool_expr: DynProofExpr<RistrettoPoint> = and(
+    let bool_expr: DynProofExpr = and(
         or(
             lte(column(t, "a", &accessor), const_bigint(5)),
             equal(column(t, "b", &accessor), const_varchar("g")),

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
@@ -243,7 +243,7 @@ fn prove_bit_decomposition<'a, S: Scalar>(
 ///
 /// This function checks the consistency of the bit evaluations with the expression evaluation.
 fn verify_bit_decomposition<C: Commitment>(
-    builder: &mut VerificationBuilder<'_, C>,
+    builder: &mut VerificationBuilder<C>,
     expr_eval: C::Scalar,
     bit_evals: &[C::Scalar],
     dist: &BitDistribution,

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -1,8 +1,8 @@
 use super::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr};
 use crate::base::{
-    commitment::Commitment,
     database::{ColumnRef, LiteralValue, SchemaAccessor, TableRef},
     math::{decimal::Precision, i256::I256},
+    scalar::Scalar,
 };
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 
@@ -19,11 +19,7 @@ pub fn col_ref(tab: TableRef, name: &str, accessor: &impl SchemaAccessor) -> Col
 /// Panics if:
 /// - `name.parse()` fails to parse the column name.
 /// - `accessor.lookup_column()` returns `None`, indicating the column is not found.
-pub fn column<C: Commitment>(
-    tab: TableRef,
-    name: &str,
-    accessor: &impl SchemaAccessor,
-) -> DynProofExpr<C> {
+pub fn column(tab: TableRef, name: &str, accessor: &impl SchemaAccessor) -> DynProofExpr {
     let name = name.parse().unwrap();
     let type_col = accessor.lookup_column(tab, name).unwrap();
     DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(tab, name, type_col)))
@@ -32,103 +28,99 @@ pub fn column<C: Commitment>(
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_equals()` returns an error.
-pub fn equal<C: Commitment>(left: DynProofExpr<C>, right: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn equal(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_equals(left, right).unwrap()
 }
 
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_inequality()` returns an error.
-pub fn lte<C: Commitment>(left: DynProofExpr<C>, right: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn lte(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_inequality(left, right, true).unwrap()
 }
 
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_inequality()` returns an error.
-pub fn gte<C: Commitment>(left: DynProofExpr<C>, right: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn gte(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_inequality(left, right, false).unwrap()
 }
 
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_not()` returns an error.
-pub fn not<C: Commitment>(expr: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn not(expr: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_not(expr).unwrap()
 }
 
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_and()` returns an error.
-pub fn and<C: Commitment>(left: DynProofExpr<C>, right: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn and(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_and(left, right).unwrap()
 }
 
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_or()` returns an error.
-pub fn or<C: Commitment>(left: DynProofExpr<C>, right: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn or(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_or(left, right).unwrap()
 }
 
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_add()` returns an error.
-pub fn add<C: Commitment>(left: DynProofExpr<C>, right: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn add(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_add(left, right).unwrap()
 }
 
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_subtract()` returns an error.
-pub fn subtract<C: Commitment>(left: DynProofExpr<C>, right: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn subtract(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_subtract(left, right).unwrap()
 }
 
 /// # Panics
 /// Panics if:
 /// - `DynProofExpr::try_new_multiply()` returns an error.
-pub fn multiply<C: Commitment>(left: DynProofExpr<C>, right: DynProofExpr<C>) -> DynProofExpr<C> {
+pub fn multiply(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_multiply(left, right).unwrap()
 }
 
-pub fn const_bool<C: Commitment>(val: bool) -> DynProofExpr<C> {
+pub fn const_bool(val: bool) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::Boolean(val))
 }
 
-pub fn const_smallint<C: Commitment>(val: i16) -> DynProofExpr<C> {
+pub fn const_smallint(val: i16) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::SmallInt(val))
 }
 
-pub fn const_int<C: Commitment>(val: i32) -> DynProofExpr<C> {
+pub fn const_int(val: i32) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::Int(val))
 }
 
-pub fn const_bigint<C: Commitment>(val: i64) -> DynProofExpr<C> {
+pub fn const_bigint(val: i64) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::BigInt(val))
 }
 
-pub fn const_int128<C: Commitment>(val: i128) -> DynProofExpr<C> {
+pub fn const_int128(val: i128) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::Int128(val))
 }
 
-pub fn const_varchar<C: Commitment>(val: &str) -> DynProofExpr<C> {
+pub fn const_varchar(val: &str) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::VarChar(val.to_string()))
 }
 
 /// Create a constant scalar value. Used if we don't want to specify column types.
-pub fn const_scalar<C: Commitment, T: Into<C::Scalar>>(val: T) -> DynProofExpr<C> {
+pub fn const_scalar<S: Scalar, T: Into<S>>(val: T) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::Scalar(val.into().into()))
 }
 
 /// # Panics
 /// Panics if:
 /// - `Precision::new(precision)` fails, meaning the provided precision is invalid.
-pub fn const_decimal75<C: Commitment, T: Into<I256>>(
-    precision: u8,
-    scale: i8,
-    val: T,
-) -> DynProofExpr<C> {
+pub fn const_decimal75<T: Into<I256>>(precision: u8, scale: i8, val: T) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::Decimal75(
         Precision::new(precision).unwrap(),
         scale,
@@ -143,7 +135,7 @@ pub fn tab(tab: TableRef) -> TableExpr {
 /// # Panics
 /// Panics if:
 /// - `alias.parse()` fails to parse the provided alias string.
-pub fn aliased_plan<C: Commitment>(expr: DynProofExpr<C>, alias: &str) -> AliasedDynProofExpr<C> {
+pub fn aliased_plan(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
     AliasedDynProofExpr {
         expr,
         alias: alias.parse().unwrap(),
@@ -154,14 +146,14 @@ pub fn aliased_plan<C: Commitment>(expr: DynProofExpr<C>, alias: &str) -> Aliase
 /// Panics if:
 /// - `old_name.parse()` or `new_name.parse()` fails to parse the provided column names.
 /// - `col_ref()` fails to find the referenced column, leading to a panic in the column accessor.
-pub fn aliased_col_expr_plan<C: Commitment>(
+pub fn aliased_col_expr_plan(
     tab: TableRef,
     old_name: &str,
     new_name: &str,
     accessor: &impl SchemaAccessor,
-) -> AliasedDynProofExpr<C> {
+) -> AliasedDynProofExpr {
     AliasedDynProofExpr {
-        expr: DynProofExpr::Column(ColumnExpr::<C>::new(col_ref(tab, old_name, accessor))),
+        expr: DynProofExpr::Column(ColumnExpr::new(col_ref(tab, old_name, accessor))),
         alias: new_name.parse().unwrap(),
     }
 }
@@ -170,52 +162,44 @@ pub fn aliased_col_expr_plan<C: Commitment>(
 /// Panics if:
 /// - `name.parse()` fails to parse the provided column name.
 /// - `col_ref()` fails to find the referenced column, leading to a panic in the column accessor.
-pub fn col_expr_plan<C: Commitment>(
+pub fn col_expr_plan(
     tab: TableRef,
     name: &str,
     accessor: &impl SchemaAccessor,
-) -> AliasedDynProofExpr<C> {
+) -> AliasedDynProofExpr {
     AliasedDynProofExpr {
-        expr: DynProofExpr::Column(ColumnExpr::<C>::new(col_ref(tab, name, accessor))),
+        expr: DynProofExpr::Column(ColumnExpr::new(col_ref(tab, name, accessor))),
         alias: name.parse().unwrap(),
     }
 }
 
-pub fn aliased_cols_expr_plan<C: Commitment>(
+pub fn aliased_cols_expr_plan(
     tab: TableRef,
     names: &[(&str, &str)],
     accessor: &impl SchemaAccessor,
-) -> Vec<AliasedDynProofExpr<C>> {
+) -> Vec<AliasedDynProofExpr> {
     names
         .iter()
         .map(|(old_name, new_name)| aliased_col_expr_plan(tab, old_name, new_name, accessor))
         .collect()
 }
 
-pub fn cols_expr_plan<C: Commitment>(
+pub fn cols_expr_plan(
     tab: TableRef,
     names: &[&str],
     accessor: &impl SchemaAccessor,
-) -> Vec<AliasedDynProofExpr<C>> {
+) -> Vec<AliasedDynProofExpr> {
     names
         .iter()
         .map(|name| col_expr_plan(tab, name, accessor))
         .collect()
 }
 
-pub fn col_expr<C: Commitment>(
-    tab: TableRef,
-    name: &str,
-    accessor: &impl SchemaAccessor,
-) -> ColumnExpr<C> {
-    ColumnExpr::<C>::new(col_ref(tab, name, accessor))
+pub fn col_expr(tab: TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnExpr {
+    ColumnExpr::new(col_ref(tab, name, accessor))
 }
 
-pub fn cols_expr<C: Commitment>(
-    tab: TableRef,
-    names: &[&str],
-    accessor: &impl SchemaAccessor,
-) -> Vec<ColumnExpr<C>> {
+pub fn cols_expr(tab: TableRef, names: &[&str], accessor: &impl SchemaAccessor) -> Vec<ColumnExpr> {
     names
         .iter()
         .map(|name| col_expr(tab, name, accessor))
@@ -225,7 +209,7 @@ pub fn cols_expr<C: Commitment>(
 /// # Panics
 /// Panics if:
 /// - `alias.parse()` fails to parse the provided alias string.
-pub fn sum_expr<C: Commitment>(expr: DynProofExpr<C>, alias: &str) -> AliasedDynProofExpr<C> {
+pub fn sum_expr(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
     AliasedDynProofExpr {
         expr: DynProofExpr::new_aggregate(AggregationOperator::Sum, expr),
         alias: alias.parse().unwrap(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -2,7 +2,7 @@ use super::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr};
 use crate::base::{
     commitment::Commitment,
     database::{ColumnRef, LiteralValue, SchemaAccessor, TableRef},
-    math::decimal::Precision,
+    math::{decimal::Precision, i256::I256},
 };
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 
@@ -124,7 +124,7 @@ pub fn const_scalar<C: Commitment, T: Into<C::Scalar>>(val: T) -> DynProofExpr<C
 /// # Panics
 /// Panics if:
 /// - `Precision::new(precision)` fails, meaning the provided precision is invalid.
-pub fn const_decimal75<C: Commitment, T: Into<C::Scalar>>(
+pub fn const_decimal75<C: Commitment, T: Into<I256>>(
     precision: u8,
     scale: i8,
     val: T,

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -113,10 +113,7 @@ pub fn const_int128<C: Commitment>(val: i128) -> DynProofExpr<C> {
 }
 
 pub fn const_varchar<C: Commitment>(val: &str) -> DynProofExpr<C> {
-    DynProofExpr::new_literal(LiteralValue::VarChar((
-        val.to_string(),
-        C::Scalar::from(val),
-    )))
+    DynProofExpr::new_literal(LiteralValue::VarChar(val.to_string()))
 }
 
 /// Create a constant scalar value. Used if we don't want to specify column types.

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -117,9 +117,8 @@ pub fn const_varchar<C: Commitment>(val: &str) -> DynProofExpr<C> {
 }
 
 /// Create a constant scalar value. Used if we don't want to specify column types.
-#[allow(dead_code)]
 pub fn const_scalar<C: Commitment, T: Into<C::Scalar>>(val: T) -> DynProofExpr<C> {
-    DynProofExpr::new_literal(LiteralValue::Scalar(val.into()))
+    DynProofExpr::new_literal(LiteralValue::Scalar(val.into().into()))
 }
 
 /// # Panics

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
-use curve25519_dalek::RistrettoPoint;
 use proof_of_sql_parser::{Identifier, ResourceId};
 
 #[test]
@@ -27,7 +26,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let b = Identifier::try_new("b").unwrap();
-    let provable_ast = FilterExec::<RistrettoPoint>::new(
+    let provable_ast = FilterExec::new(
         vec![
             aliased_plan(
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
@@ -93,7 +92,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
             ),
         ],
         TableExpr { table_ref },
-        not::<RistrettoPoint>(and(
+        not(and(
             or(
                 DynProofExpr::try_new_equals(
                     DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
@@ -188,8 +187,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
     let t = "sxt.t".parse().unwrap();
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(t, data, 0);
-    let where_clause: DynProofExpr<RistrettoPoint> =
-        equal(column(t, "a", &accessor), const_int128(999));
+    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(999));
     let expr = filter(
         cols_expr_plan(t, &["b", "c", "d", "e"], &accessor),
         tab(t),
@@ -235,8 +233,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
     let t = "sxt.t".parse().unwrap();
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(t, data, 0);
-    let where_clause: DynProofExpr<RistrettoPoint> =
-        equal(column(t, "a", &accessor), const_int128(999));
+    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(999));
     let expr = filter(
         cols_expr_plan(t, &["b", "c", "d", "e"], &accessor),
         tab(t),
@@ -282,8 +279,7 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
     let t = "sxt.t".parse().unwrap();
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(t, data, 0);
-    let where_clause: DynProofExpr<RistrettoPoint> =
-        equal(column(t, "a", &accessor), const_int128(5));
+    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
     let result_cols = expr.result_evaluate(5, &alloc, &accessor);
@@ -311,8 +307,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
     let t = "sxt.t".parse().unwrap();
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(t, data, 0);
-    let where_clause: DynProofExpr<RistrettoPoint> =
-        equal(column(t, "a", &accessor), const_int128(5));
+    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(
         cols_expr_plan(t, &["b", "c", "d", "e"], &accessor),
         tab(t),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -19,7 +19,6 @@ use crate::{
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
-use curve25519_dalek::RistrettoPoint;
 use proof_of_sql_parser::{Identifier, ResourceId};
 
 #[test]
@@ -27,7 +26,7 @@ fn we_can_correctly_fetch_the_query_result_schema() {
     let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let b = Identifier::try_new("b").unwrap();
-    let provable_ast = ProjectionExec::<RistrettoPoint>::new(
+    let provable_ast = ProjectionExec::new(
         vec![
             aliased_plan(
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
@@ -63,7 +62,7 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
     let table_ref = TableRef::new(ResourceId::try_new("sxt", "sxt_tab").unwrap());
     let a = Identifier::try_new("a").unwrap();
     let f = Identifier::try_new("f").unwrap();
-    let provable_ast = ProjectionExec::<RistrettoPoint>::new(
+    let provable_ast = ProjectionExec::new(
         vec![
             aliased_plan(
                 DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(
@@ -166,7 +165,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     let t = "sxt.t".parse().unwrap();
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(t, data, 0);
-    let expr: DynProofPlan<RistrettoPoint> =
+    let expr: DynProofPlan =
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
     let result_cols = expr.result_evaluate(0, &alloc, &accessor);
@@ -208,7 +207,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     let t = "sxt.t".parse().unwrap();
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(t, data, 0);
-    let expr: DynProofPlan<RistrettoPoint> = projection(cols_expr_plan(t, &[], &accessor), tab(t));
+    let expr: DynProofPlan = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
     let result_cols = expr.result_evaluate(5, &alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
@@ -235,7 +234,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
     let t = "sxt.t".parse().unwrap();
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(t, data, 0);
-    let expr: DynProofPlan<RistrettoPoint> = projection(
+    let expr: DynProofPlan = projection(
         vec![
             aliased_plan(add(column(t, "b", &accessor), const_bigint(1)), "b"),
             aliased_plan(

--- a/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
@@ -1,34 +1,28 @@
 use super::{DynProofPlan, FilterExec, GroupByExec, ProjectionExec};
-use crate::{
-    base::commitment::Commitment,
-    sql::proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
-};
+use crate::sql::proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr};
 
-pub fn projection<C: Commitment>(
-    results: Vec<AliasedDynProofExpr<C>>,
-    table: TableExpr,
-) -> DynProofPlan<C> {
+pub fn projection(results: Vec<AliasedDynProofExpr>, table: TableExpr) -> DynProofPlan {
     DynProofPlan::Projection(ProjectionExec::new(results, table))
 }
 
-pub fn filter<C: Commitment>(
-    results: Vec<AliasedDynProofExpr<C>>,
+pub fn filter(
+    results: Vec<AliasedDynProofExpr>,
     table: TableExpr,
-    where_clause: DynProofExpr<C>,
-) -> DynProofPlan<C> {
+    where_clause: DynProofExpr,
+) -> DynProofPlan {
     DynProofPlan::Filter(FilterExec::new(results, table, where_clause))
 }
 
 /// # Panics
 ///
 /// Will panic if `count_alias` cannot be parsed as a valid identifier.
-pub fn group_by<C: Commitment>(
-    group_by_exprs: Vec<ColumnExpr<C>>,
-    sum_expr: Vec<AliasedDynProofExpr<C>>,
+pub fn group_by(
+    group_by_exprs: Vec<ColumnExpr>,
+    sum_expr: Vec<AliasedDynProofExpr>,
     count_alias: &str,
     table: TableExpr,
-    where_clause: DynProofExpr<C>,
-) -> DynProofPlan<C> {
+    where_clause: DynProofExpr,
+) -> DynProofPlan {
     DynProofPlan::GroupBy(GroupByExec::new(
         group_by_exprs,
         sum_expr,

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "test")]
 #![cfg_attr(test, allow(clippy::missing_panics_doc))]
 use ark_std::test_rng;
-use curve25519_dalek::RistrettoPoint;
 #[cfg(feature = "blitzar")]
 use proof_of_sql::base::commitment::InnerProductProof;
 use proof_of_sql::{
@@ -10,7 +9,7 @@ use proof_of_sql::{
         scalar::Curve25519Scalar,
     },
     proof_primitive::dory::{
-        DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup,
+        DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup,
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{
@@ -298,7 +297,7 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
         owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 1, 2])]),
         0,
     );
-    let query = QueryExpr::<RistrettoPoint>::try_new(
+    let query = QueryExpr::try_new(
         "SELECT * FROM table WHERE b >= a + 1".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
@@ -330,7 +329,7 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
         owned_table([bigint("a", [1, -1, 3]), bigint("b", [0, 0, 2])]),
         0,
     );
-    let query = QueryExpr::<DoryCommitment>::try_new(
+    let query = QueryExpr::try_new(
         "SELECT * FROM table WHERE b > 1 - a;".parse().unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
@@ -431,7 +430,7 @@ fn decimal_type_issues_should_cause_provable_ast_to_fail() {
     let large_decimal = format!("0.{}", "1".repeat(75));
     let query_string = format!("SELECT d0 + {large_decimal} as res FROM table;");
     assert!(matches!(
-        QueryExpr::<RistrettoPoint>::try_new(
+        QueryExpr::try_new(
             query_string.parse().unwrap(),
             "sxt".parse().unwrap(),
             &accessor,

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -6,8 +6,8 @@ use proof_of_sql::base::commitment::InnerProductProof;
 use proof_of_sql::{
     base::database::{owned_table_utility::*, OwnedTableTestAccessor, TestAccessor},
     proof_primitive::dory::{
-        DoryCommitment, DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup,
-        ProverSetup, PublicParameters, VerifierSetup,
+        DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup,
+        PublicParameters, VerifierSetup,
     },
     sql::{
         parse::QueryExpr,
@@ -436,7 +436,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         ]),
         0,
     );
-    let query = QueryExpr::<DoryCommitment>::try_new(
+    let query = QueryExpr::try_new(
         "select *, a <= b as res from TABLE where a <= b"
             .parse()
             .unwrap(),


### PR DESCRIPTION
# Rationale for this change

The `DynProofPlan` type does not need to have a generic parameter. It only has one as a relic of past requirements.

# What changes are included in this PR?

The first four commits remove the generic `Scalar` parameter from `LiteralValue`. In order to not use `Scalar` as the underlying store for the `Decimal75` variant, an `I256` type is introduced. (This type could be extended to become the main 256-bit integer used in the crate, but this is left for later work.)

The next 3 commits are the bulk of the PR and remove the generic parameter from the `ProofPlan` and `ProofExpr` traits as well as all implementers of them, such as `DynProofPlan` and `DynProofExpr`.

# Are these changes tested?
Yes. This is a refactoring change, and existing test pass.
