### PR TITLE
feat: add `EmptyExec`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,4 +1,4 @@
-use super::{FilterExec, GroupByExec, ProjectionExec};
+use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec};
 use crate::{
     base::{
         commitment::Commitment,
@@ -23,6 +23,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[enum_dispatch::enum_dispatch]
 pub enum DynProofPlan {
+    /// Source [`ProofPlan`] for (sub)queries without table source such as `SELECT "No table here" as msg;`
+    Empty(EmptyExec),
     /// Provable expressions for queries of the form
     /// ```ignore
     ///     SELECT <result_expr1>, ..., <result_exprN> FROM <table>

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,0 +1,103 @@
+use crate::{
+    base::{
+        commitment::Commitment,
+        database::{
+            Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor,
+            OwnedTable, TableRef,
+        },
+        map::IndexSet,
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        CountBuilder, FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
+        VerificationBuilder,
+    },
+};
+use alloc::vec::Vec;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+/// Source [`ProofPlan`] for (sub)queries without table source such as `SELECT "No table here" as msg;`
+/// Inspired by [`DataFusion EmptyExec`](https://docs.rs/datafusion/latest/datafusion/physical_plan/empty/struct.EmptyExec.html)
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct EmptyExec {}
+
+impl Default for EmptyExec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EmptyExec {
+    /// Creates a new empty plan.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ProofPlan for EmptyExec {
+    fn count(
+        &self,
+        _builder: &mut CountBuilder,
+        _accessor: &dyn MetadataAccessor,
+    ) -> Result<(), ProofError> {
+        Ok(())
+    }
+
+    fn get_length(&self, _accessor: &dyn MetadataAccessor) -> usize {
+        0
+    }
+
+    fn get_offset(&self, _accessor: &dyn MetadataAccessor) -> usize {
+        0
+    }
+
+    #[allow(unused_variables)]
+    fn verifier_evaluate<C: Commitment>(
+        &self,
+        _builder: &mut VerificationBuilder<C>,
+        _accessor: &dyn CommitmentAccessor<C>,
+        _result: Option<&OwnedTable<C::Scalar>>,
+    ) -> Result<Vec<C::Scalar>, ProofError> {
+        Ok(Vec::new())
+    }
+
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        Vec::new()
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        IndexSet::default()
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        IndexSet::default()
+    }
+}
+
+impl ProverEvaluate for EmptyExec {
+    #[tracing::instrument(name = "EmptyExec::result_evaluate", level = "debug", skip_all)]
+    fn result_evaluate<'a, S: Scalar>(
+        &self,
+        _input_length: usize,
+        _alloc: &'a Bump,
+        _accessor: &'a dyn DataAccessor<S>,
+    ) -> Vec<Column<'a, S>> {
+        Vec::new()
+    }
+
+    fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
+
+    #[tracing::instrument(name = "EmptyExec::final_round_evaluate", level = "debug", skip_all)]
+    #[allow(unused_variables)]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        _builder: &mut FinalRoundBuilder<'a, S>,
+        _alloc: &'a Bump,
+        _accessor: &'a dyn DataAccessor<S>,
+    ) -> Vec<Column<'a, S>> {
+        Vec::new()
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -1,4 +1,7 @@
 //! This module proves provable execution plans.
+mod empty_exec;
+pub use empty_exec::EmptyExec;
+
 mod projection_exec;
 pub(crate) use projection_exec::ProjectionExec;
 #[cfg(all(test, feature = "blitzar"))]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
The point of `EmptyExec` is to serve as a source `ProofPlan` (together with `TableExec` which I will add soon) so that composition of `ProofPlan`s is natural and so that we become more compatible with DataFusion.

Typical query using `EmptyExec`: `SELECT "I'm not from a table haha" as message` 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `EmptyExec`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
N/A