### PR TITLE
refactor!: remove parser structs from `ColumnOperationError`

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -1,7 +1,6 @@
 use crate::base::{database::ColumnType, math::decimal::DecimalError};
 use alloc::string::String;
 use core::result::Result;
-use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
 use snafu::Snafu;
 
 /// Errors from operations on columns.
@@ -19,8 +18,8 @@ pub enum ColumnOperationError {
     /// Incorrect `ColumnType` in binary operations
     #[snafu(display("{operator:?}(lhs: {left_type:?}, rhs: {right_type:?}) is not supported"))]
     BinaryOperationInvalidColumnType {
-        /// `BinaryOperator` that caused the error
-        operator: BinaryOperator,
+        /// Binary operator that caused the error
+        operator: String,
         /// `ColumnType` of left operand
         left_type: ColumnType,
         /// `ColumnType` of right operand
@@ -30,8 +29,8 @@ pub enum ColumnOperationError {
     /// Incorrect `ColumnType` in unary operations
     #[snafu(display("{operator:?}(operand: {operand_type:?}) is not supported"))]
     UnaryOperationInvalidColumnType {
-        /// `UnaryOperator` that caused the error
-        operator: UnaryOperator,
+        /// Unary operator that caused the error
+        operator: String,
         /// `ColumnType` of the operand
         operand_type: ColumnType,
     },

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -4,7 +4,6 @@ use crate::base::{
     math::decimal::{DecimalError, Precision},
 };
 use alloc::{format, string::ToString};
-use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 // For decimal type manipulation please refer to
 // https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-ver16
 
@@ -19,7 +18,6 @@ use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 pub fn try_add_subtract_column_types(
     lhs: ColumnType,
     rhs: ColumnType,
-    _operator: BinaryOperator,
 ) -> ColumnOperationResult<ColumnType> {
     if !lhs.is_numeric() || !rhs.is_numeric() {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
@@ -180,79 +178,79 @@ mod test {
         // lhs and rhs are integers with the same precision
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::TinyInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::TinyInt;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::SmallInt;
         assert_eq!(expected, actual);
 
         // lhs and rhs are integers with different precision
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::SmallInt;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Int;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Int;
         assert_eq!(expected, actual);
 
         // lhs is an integer and rhs is a scalar
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::Scalar;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Scalar;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Scalar;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Scalar;
         assert_eq!(expected, actual);
 
         // lhs is a decimal with nonnegative scale and rhs is an integer
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
         let rhs = ColumnType::TinyInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(11).unwrap(), 2);
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(11).unwrap(), 2);
         assert_eq!(expected, actual);
 
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = ColumnType::Decimal75(Precision::new(20).unwrap(), 3);
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(21).unwrap(), 3);
         assert_eq!(expected, actual);
 
         // lhs is an integer and rhs is a decimal with negative scale
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(13).unwrap(), 0);
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(13).unwrap(), 0);
         assert_eq!(expected, actual);
 
         // lhs and rhs are both decimals one of which has negative scale
         let lhs = ColumnType::Decimal75(Precision::new(40).unwrap(), -13);
         let rhs = ColumnType::Decimal75(Precision::new(15).unwrap(), 5);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(59).unwrap(), 5);
         assert_eq!(expected, actual);
 
@@ -260,7 +258,7 @@ mod test {
         // and with result having maximum precision
         let lhs = ColumnType::Decimal75(Precision::new(74).unwrap(), -13);
         let rhs = ColumnType::Decimal75(Precision::new(15).unwrap(), -14);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(75).unwrap(), -13);
         assert_eq!(expected, actual);
     }
@@ -270,21 +268,21 @@ mod test {
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
         let lhs = ColumnType::VarChar;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
     }
@@ -294,7 +292,7 @@ mod test {
         let lhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 4);
         let rhs = ColumnType::Decimal75(Precision::new(73).unwrap(), 4);
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision { .. }
             })
@@ -303,7 +301,7 @@ mod test {
         let lhs = ColumnType::Int;
         let rhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 10);
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision { .. }
             })
@@ -315,79 +313,79 @@ mod test {
         // lhs and rhs are integers with the same precision
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::TinyInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::TinyInt;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::SmallInt;
         assert_eq!(expected, actual);
 
         // lhs and rhs are integers with different precision
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::SmallInt;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Int;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Int;
         assert_eq!(expected, actual);
 
         // lhs is an integer and rhs is a scalar
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::Scalar;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Scalar;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Scalar;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Scalar;
         assert_eq!(expected, actual);
 
         // lhs is a decimal and rhs is an integer
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
         let rhs = ColumnType::TinyInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(11).unwrap(), 2);
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(11).unwrap(), 2);
         assert_eq!(expected, actual);
 
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = ColumnType::Decimal75(Precision::new(20).unwrap(), 3);
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(21).unwrap(), 3);
         assert_eq!(expected, actual);
 
         // lhs is an integer and rhs is a decimal with negative scale
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(13).unwrap(), 0);
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(13).unwrap(), 0);
         assert_eq!(expected, actual);
 
         // lhs and rhs are both decimals one of which has negative scale
         let lhs = ColumnType::Decimal75(Precision::new(40).unwrap(), -13);
         let rhs = ColumnType::Decimal75(Precision::new(15).unwrap(), 5);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(59).unwrap(), 5);
         assert_eq!(expected, actual);
 
@@ -395,7 +393,7 @@ mod test {
         // and with result having maximum precision
         let lhs = ColumnType::Decimal75(Precision::new(61).unwrap(), -13);
         let rhs = ColumnType::Decimal75(Precision::new(73).unwrap(), -14);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(75).unwrap(), -13);
         assert_eq!(expected, actual);
     }
@@ -405,21 +403,21 @@ mod test {
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
         let lhs = ColumnType::VarChar;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
     }
@@ -429,7 +427,7 @@ mod test {
         let lhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 0);
         let rhs = ColumnType::Decimal75(Precision::new(73).unwrap(), 1);
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision { .. }
             })
@@ -438,7 +436,7 @@ mod test {
         let lhs = ColumnType::Int128;
         let rhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 12);
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision { .. }
             })

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -19,11 +19,11 @@ use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 pub fn try_add_subtract_column_types(
     lhs: ColumnType,
     rhs: ColumnType,
-    operator: BinaryOperator,
+    _operator: BinaryOperator,
 ) -> ColumnOperationResult<ColumnType> {
     if !lhs.is_numeric() || !rhs.is_numeric() {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-            operator,
+            operator: "+/-".to_string(),
             left_type: lhs,
             right_type: rhs,
         });
@@ -77,7 +77,7 @@ pub fn try_multiply_column_types(
 ) -> ColumnOperationResult<ColumnType> {
     if !lhs.is_numeric() || !rhs.is_numeric() {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-            operator: BinaryOperator::Multiply,
+            operator: "*".to_string(),
             left_type: lhs,
             right_type: rhs,
         });
@@ -132,7 +132,7 @@ pub fn try_divide_column_types(
         || rhs == ColumnType::Scalar
     {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-            operator: BinaryOperator::Division,
+            operator: "/".to_string(),
             left_type: lhs,
             right_type: rhs,
         });

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -16,6 +16,7 @@ use crate::base::{
     },
     scalar::Scalar,
 };
+use alloc::string::ToString;
 use core::ops::{Add, Div, Mul, Sub};
 
 impl<S: Scalar> OwnedColumn<S> {

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -17,7 +17,6 @@ use crate::base::{
     scalar::Scalar,
 };
 use core::ops::{Add, Div, Mul, Sub};
-use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
 
 impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise NOT operation for a column
@@ -25,7 +24,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             Self::Boolean(values) => Ok(Self::Boolean(slice_not(values))),
             _ => Err(ColumnOperationError::UnaryOperationInvalidColumnType {
-                operator: UnaryOperator::Not,
+                operator: "NOT".to_string(),
                 operand_type: self.column_type(),
             }),
         }
@@ -42,7 +41,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match (self, rhs) {
             (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_and(lhs, rhs))),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::And,
+                operator: "AND".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -60,7 +59,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match (self, rhs) {
             (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_or(lhs, rhs))),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Or,
+                operator: "OR".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -242,7 +241,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 todo!("Implement equality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Equal,
+                operator: "=".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -423,7 +422,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 todo!("Implement inequality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::LessThanOrEqual,
+                operator: "<=".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -604,7 +603,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 todo!("Implement inequality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::GreaterThanOrEqual,
+                operator: ">=".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -798,7 +797,7 @@ impl<S: Scalar> Add for OwnedColumn<S> {
                 Ok(Self::Decimal75(new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Add,
+                operator: "+".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -996,7 +995,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 Ok(Self::Decimal75(new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Subtract,
+                operator: "-".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -1194,7 +1193,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 Ok(Self::Decimal75(new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Multiply,
+                operator: "*".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -1392,7 +1391,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 Ok(Self::Decimal75(new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Division,
+                operator: "/".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),

--- a/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
@@ -13,7 +13,6 @@ use alloc::vec::Vec;
 use core::{cmp::Ordering, fmt::Debug};
 use num_bigint::BigInt;
 use num_traits::Zero;
-use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 /// Check whether a numerical slice is equal to a decimal one.
 ///
 /// Note that we do not check for length equality here.
@@ -273,8 +272,7 @@ where
     T0: Copy,
     T1: Copy,
 {
-    let new_column_type =
-        try_add_subtract_column_types(left_column_type, right_column_type, BinaryOperator::Add)?;
+    let new_column_type = try_add_subtract_column_types(left_column_type, right_column_type)?;
     let new_precision_value = new_column_type
         .precision_value()
         .expect("numeric columns have precision");
@@ -332,11 +330,7 @@ where
     T0: Copy,
     T1: Copy,
 {
-    let new_column_type = try_add_subtract_column_types(
-        left_column_type,
-        right_column_type,
-        BinaryOperator::Subtract,
-    )?;
+    let new_column_type = try_add_subtract_column_types(left_column_type, right_column_type)?;
     let new_precision_value = new_column_type
         .precision_value()
         .expect("numeric columns have precision");

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -305,12 +305,9 @@ pub(crate) fn type_check_binary_operation(
                         | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
                 )
         }
-        BinaryOperator::Add => {
-            try_add_subtract_column_types(*left_dtype, *right_dtype, BinaryOperator::Add).is_ok()
-        }
+        BinaryOperator::Add => try_add_subtract_column_types(*left_dtype, *right_dtype).is_ok(),
         BinaryOperator::Subtract => {
-            try_add_subtract_column_types(*left_dtype, *right_dtype, BinaryOperator::Subtract)
-                .is_ok()
+            try_add_subtract_column_types(*left_dtype, *right_dtype).is_ok()
         }
         BinaryOperator::Multiply => try_multiply_column_types(*left_dtype, *right_dtype).is_ok(),
         BinaryOperator::Division => left_dtype.is_numeric() && right_dtype.is_numeric(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
-use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
 
 /// Provable numerical `+` / `-` expression
@@ -44,12 +43,7 @@ impl ProofExpr for AddSubtractExpr {
     }
 
     fn data_type(&self) -> ColumnType {
-        let operator = if self.is_subtract {
-            BinaryOperator::Subtract
-        } else {
-            BinaryOperator::Add
-        };
-        try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type(), operator)
+        try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type())
             .expect("Failed to add/subtract column types")
     }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This change is made to simplify column operations partly in order to simplify `owned_column_operation.rs` and partly in preparation for the new version of provable arithmetic expressions.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- replace `BinaryOp` and `UnaryOp` in `ColumnOperationError` with strings
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests should pass