### PR TITLE
refactor!: modify `ProofExpr::result_evaluate` to return `ColumnarValue` and remove `table_length` as arg

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -1,7 +1,6 @@
 use crate::base::{database::ColumnType, math::decimal::DecimalError};
 use alloc::string::String;
 use core::result::Result;
-use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
 use snafu::Snafu;
 
 /// Errors from operations on columns.
@@ -19,8 +18,8 @@ pub enum ColumnOperationError {
     /// Incorrect `ColumnType` in binary operations
     #[snafu(display("{operator:?}(lhs: {left_type:?}, rhs: {right_type:?}) is not supported"))]
     BinaryOperationInvalidColumnType {
-        /// `BinaryOperator` that caused the error
-        operator: BinaryOperator,
+        /// Binary operator that caused the error
+        operator: String,
         /// `ColumnType` of left operand
         left_type: ColumnType,
         /// `ColumnType` of right operand
@@ -30,8 +29,8 @@ pub enum ColumnOperationError {
     /// Incorrect `ColumnType` in unary operations
     #[snafu(display("{operator:?}(operand: {operand_type:?}) is not supported"))]
     UnaryOperationInvalidColumnType {
-        /// `UnaryOperator` that caused the error
-        operator: UnaryOperator,
+        /// Unary operator that caused the error
+        operator: String,
         /// `ColumnType` of the operand
         operand_type: ColumnType,
     },

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -4,7 +4,6 @@ use crate::base::{
     math::decimal::{DecimalError, Precision},
 };
 use alloc::{format, string::ToString};
-use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 // For decimal type manipulation please refer to
 // https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-ver16
 
@@ -19,7 +18,6 @@ use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 pub fn try_add_subtract_column_types(
     lhs: ColumnType,
     rhs: ColumnType,
-    _operator: BinaryOperator,
 ) -> ColumnOperationResult<ColumnType> {
     if !lhs.is_numeric() || !rhs.is_numeric() {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
@@ -180,79 +178,79 @@ mod test {
         // lhs and rhs are integers with the same precision
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::TinyInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::TinyInt;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::SmallInt;
         assert_eq!(expected, actual);
 
         // lhs and rhs are integers with different precision
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::SmallInt;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Int;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Int;
         assert_eq!(expected, actual);
 
         // lhs is an integer and rhs is a scalar
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::Scalar;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Scalar;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Scalar;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Scalar;
         assert_eq!(expected, actual);
 
         // lhs is a decimal with nonnegative scale and rhs is an integer
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
         let rhs = ColumnType::TinyInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(11).unwrap(), 2);
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(11).unwrap(), 2);
         assert_eq!(expected, actual);
 
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = ColumnType::Decimal75(Precision::new(20).unwrap(), 3);
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(21).unwrap(), 3);
         assert_eq!(expected, actual);
 
         // lhs is an integer and rhs is a decimal with negative scale
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(13).unwrap(), 0);
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(13).unwrap(), 0);
         assert_eq!(expected, actual);
 
         // lhs and rhs are both decimals one of which has negative scale
         let lhs = ColumnType::Decimal75(Precision::new(40).unwrap(), -13);
         let rhs = ColumnType::Decimal75(Precision::new(15).unwrap(), 5);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(59).unwrap(), 5);
         assert_eq!(expected, actual);
 
@@ -260,7 +258,7 @@ mod test {
         // and with result having maximum precision
         let lhs = ColumnType::Decimal75(Precision::new(74).unwrap(), -13);
         let rhs = ColumnType::Decimal75(Precision::new(15).unwrap(), -14);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(75).unwrap(), -13);
         assert_eq!(expected, actual);
     }
@@ -270,21 +268,21 @@ mod test {
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
         let lhs = ColumnType::VarChar;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
     }
@@ -294,7 +292,7 @@ mod test {
         let lhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 4);
         let rhs = ColumnType::Decimal75(Precision::new(73).unwrap(), 4);
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision { .. }
             })
@@ -303,7 +301,7 @@ mod test {
         let lhs = ColumnType::Int;
         let rhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 10);
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Add),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision { .. }
             })
@@ -315,79 +313,79 @@ mod test {
         // lhs and rhs are integers with the same precision
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::TinyInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::TinyInt;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::SmallInt;
         assert_eq!(expected, actual);
 
         // lhs and rhs are integers with different precision
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::SmallInt;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Int;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Int;
         assert_eq!(expected, actual);
 
         // lhs is an integer and rhs is a scalar
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::Scalar;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Scalar;
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Scalar;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Scalar;
         assert_eq!(expected, actual);
 
         // lhs is a decimal and rhs is an integer
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
         let rhs = ColumnType::TinyInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(11).unwrap(), 2);
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
         let rhs = ColumnType::SmallInt;
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(11).unwrap(), 2);
         assert_eq!(expected, actual);
 
         // lhs and rhs are both decimals with nonnegative scale
         let lhs = ColumnType::Decimal75(Precision::new(20).unwrap(), 3);
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), 2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(21).unwrap(), 3);
         assert_eq!(expected, actual);
 
         // lhs is an integer and rhs is a decimal with negative scale
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(13).unwrap(), 0);
         assert_eq!(expected, actual);
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::Decimal75(Precision::new(10).unwrap(), -2);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(13).unwrap(), 0);
         assert_eq!(expected, actual);
 
         // lhs and rhs are both decimals one of which has negative scale
         let lhs = ColumnType::Decimal75(Precision::new(40).unwrap(), -13);
         let rhs = ColumnType::Decimal75(Precision::new(15).unwrap(), 5);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(59).unwrap(), 5);
         assert_eq!(expected, actual);
 
@@ -395,7 +393,7 @@ mod test {
         // and with result having maximum precision
         let lhs = ColumnType::Decimal75(Precision::new(61).unwrap(), -13);
         let rhs = ColumnType::Decimal75(Precision::new(73).unwrap(), -14);
-        let actual = try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract).unwrap();
+        let actual = try_add_subtract_column_types(lhs, rhs).unwrap();
         let expected = ColumnType::Decimal75(Precision::new(75).unwrap(), -13);
         assert_eq!(expected, actual);
     }
@@ -405,21 +403,21 @@ mod test {
         let lhs = ColumnType::TinyInt;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
         let lhs = ColumnType::SmallInt;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
 
         let lhs = ColumnType::VarChar;
         let rhs = ColumnType::VarChar;
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::BinaryOperationInvalidColumnType { .. })
         ));
     }
@@ -429,7 +427,7 @@ mod test {
         let lhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 0);
         let rhs = ColumnType::Decimal75(Precision::new(73).unwrap(), 1);
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision { .. }
             })
@@ -438,7 +436,7 @@ mod test {
         let lhs = ColumnType::Int128;
         let rhs = ColumnType::Decimal75(Precision::new(75).unwrap(), 12);
         assert!(matches!(
-            try_add_subtract_column_types(lhs, rhs, BinaryOperator::Subtract),
+            try_add_subtract_column_types(lhs, rhs),
             Err(ColumnOperationError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision { .. }
             })

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -19,11 +19,11 @@ use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 pub fn try_add_subtract_column_types(
     lhs: ColumnType,
     rhs: ColumnType,
-    operator: BinaryOperator,
+    _operator: BinaryOperator,
 ) -> ColumnOperationResult<ColumnType> {
     if !lhs.is_numeric() || !rhs.is_numeric() {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-            operator,
+            operator: "+/-".to_string(),
             left_type: lhs,
             right_type: rhs,
         });
@@ -77,7 +77,7 @@ pub fn try_multiply_column_types(
 ) -> ColumnOperationResult<ColumnType> {
     if !lhs.is_numeric() || !rhs.is_numeric() {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-            operator: BinaryOperator::Multiply,
+            operator: "*".to_string(),
             left_type: lhs,
             right_type: rhs,
         });
@@ -132,7 +132,7 @@ pub fn try_divide_column_types(
         || rhs == ColumnType::Scalar
     {
         return Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-            operator: BinaryOperator::Division,
+            operator: "/".to_string(),
             left_type: lhs,
             right_type: rhs,
         });

--- a/crates/proof-of-sql/src/base/database/columnar_value.rs
+++ b/crates/proof-of-sql/src/base/database/columnar_value.rs
@@ -39,15 +39,6 @@ impl<'a, S: Scalar> ColumnarValue<'a, S> {
         }
     }
 
-    /// Get default length of the [`ColumnarValue`]
-    #[must_use]
-    pub fn default_length(&self) -> usize {
-        match self {
-            Self::Column(column) => column.len(),
-            Self::Literal(_) => 1,
-        }
-    }
-
     /// Converts the [`ColumnarValue`] to a [`Column`]
     pub fn into_column(
         &self,

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -16,6 +16,7 @@ use crate::base::{
     },
     scalar::Scalar,
 };
+use alloc::string::ToString;
 use core::ops::{Add, Div, Mul, Sub};
 
 impl<S: Scalar> OwnedColumn<S> {

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -17,7 +17,6 @@ use crate::base::{
     scalar::Scalar,
 };
 use core::ops::{Add, Div, Mul, Sub};
-use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
 
 impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise NOT operation for a column
@@ -25,7 +24,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             Self::Boolean(values) => Ok(Self::Boolean(slice_not(values))),
             _ => Err(ColumnOperationError::UnaryOperationInvalidColumnType {
-                operator: UnaryOperator::Not,
+                operator: "NOT".to_string(),
                 operand_type: self.column_type(),
             }),
         }
@@ -42,7 +41,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match (self, rhs) {
             (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_and(lhs, rhs))),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::And,
+                operator: "AND".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -60,7 +59,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match (self, rhs) {
             (Self::Boolean(lhs), Self::Boolean(rhs)) => Ok(Self::Boolean(slice_or(lhs, rhs))),
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Or,
+                operator: "OR".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -242,7 +241,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 todo!("Implement equality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Equal,
+                operator: "=".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -423,7 +422,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 todo!("Implement inequality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::LessThanOrEqual,
+                operator: "<=".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -604,7 +603,7 @@ impl<S: Scalar> OwnedColumn<S> {
                 todo!("Implement inequality check for TimeStampTZ")
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::GreaterThanOrEqual,
+                operator: ">=".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -798,7 +797,7 @@ impl<S: Scalar> Add for OwnedColumn<S> {
                 Ok(Self::Decimal75(new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Add,
+                operator: "+".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -996,7 +995,7 @@ impl<S: Scalar> Sub for OwnedColumn<S> {
                 Ok(Self::Decimal75(new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Subtract,
+                operator: "-".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -1194,7 +1193,7 @@ impl<S: Scalar> Mul for OwnedColumn<S> {
                 Ok(Self::Decimal75(new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Multiply,
+                operator: "*".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),
@@ -1392,7 +1391,7 @@ impl<S: Scalar> Div for OwnedColumn<S> {
                 Ok(Self::Decimal75(new_precision, new_scale, new_values))
             }
             _ => Err(ColumnOperationError::BinaryOperationInvalidColumnType {
-                operator: BinaryOperator::Division,
+                operator: "/".to_string(),
                 left_type: self.column_type(),
                 right_type: rhs.column_type(),
             }),

--- a/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
@@ -13,7 +13,6 @@ use alloc::vec::Vec;
 use core::{cmp::Ordering, fmt::Debug};
 use num_bigint::BigInt;
 use num_traits::Zero;
-use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 /// Check whether a numerical slice is equal to a decimal one.
 ///
 /// Note that we do not check for length equality here.
@@ -273,8 +272,7 @@ where
     T0: Copy,
     T1: Copy,
 {
-    let new_column_type =
-        try_add_subtract_column_types(left_column_type, right_column_type, BinaryOperator::Add)?;
+    let new_column_type = try_add_subtract_column_types(left_column_type, right_column_type)?;
     let new_precision_value = new_column_type
         .precision_value()
         .expect("numeric columns have precision");
@@ -332,11 +330,7 @@ where
     T0: Copy,
     T1: Copy,
 {
-    let new_column_type = try_add_subtract_column_types(
-        left_column_type,
-        right_column_type,
-        BinaryOperator::Subtract,
-    )?;
+    let new_column_type = try_add_subtract_column_types(left_column_type, right_column_type)?;
     let new_precision_value = new_column_type
         .precision_value()
         .expect("numeric columns have precision");

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -305,12 +305,9 @@ pub(crate) fn type_check_binary_operation(
                         | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
                 )
         }
-        BinaryOperator::Add => {
-            try_add_subtract_column_types(*left_dtype, *right_dtype, BinaryOperator::Add).is_ok()
-        }
+        BinaryOperator::Add => try_add_subtract_column_types(*left_dtype, *right_dtype).is_ok(),
         BinaryOperator::Subtract => {
-            try_add_subtract_column_types(*left_dtype, *right_dtype, BinaryOperator::Subtract)
-                .is_ok()
+            try_add_subtract_column_types(*left_dtype, *right_dtype).is_ok()
         }
         BinaryOperator::Multiply => try_multiply_column_types(*left_dtype, *right_dtype).is_ok(),
         BinaryOperator::Division => left_dtype.is_numeric() && right_dtype.is_numeric(),

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -57,7 +57,6 @@ pub trait ProverEvaluate {
     /// Evaluate the query and modify `FirstRoundBuilder` to track the result of the query.
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        input_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>>;

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -55,7 +55,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let alloc = Bump::new();
 
         // Evaluate query result
-        let result_cols = expr.result_evaluate(table_length, &alloc, accessor);
+        let result_cols = expr.result_evaluate(&alloc, accessor);
         let output_length = result_cols.first().map_or(0, Column::len);
         let provable_result = ProvableQueryResult::new(output_length as u64, &result_cols);
 

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -43,7 +43,6 @@ impl Default for TrivialTestProofPlan {
 impl ProverEvaluate for TrivialTestProofPlan {
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        _input_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -203,7 +202,6 @@ impl Default for SquareTestProofPlan {
 impl ProverEvaluate for SquareTestProofPlan {
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        _table_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -388,7 +386,6 @@ impl Default for DoubleSquareTestProofPlan {
 impl ProverEvaluate for DoubleSquareTestProofPlan {
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        _input_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
@@ -603,7 +600,6 @@ struct ChallengeTestProofPlan {}
 impl ProverEvaluate for ChallengeTestProofPlan {
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        _input_length: usize,
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -27,7 +27,6 @@ pub(super) struct EmptyTestQueryExpr {
 impl ProverEvaluate for EmptyTestQueryExpr {
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        _input_length: usize,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
-use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
 
 /// Provable numerical `+` / `-` expression
@@ -44,12 +43,7 @@ impl ProofExpr for AddSubtractExpr {
     }
 
     fn data_type(&self) -> ColumnType {
-        let operator = if self.is_subtract {
-            BinaryOperator::Subtract
-        } else {
-            BinaryOperator::Add
-        };
-        try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type(), operator)
+        try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type())
             .expect("Failed to add/subtract column types")
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        database::{owned_table_utility::*, Column, ColumnarValue, OwnedTableTestAccessor},
         scalar::{test_scalar::TestScalar, Curve25519Scalar},
     },
     sql::{
@@ -319,11 +319,11 @@ fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_result_evalua
         subtract(column(t, "a", &accessor), const_bigint(1)),
     );
     let alloc = Bump::new();
-    let res = add_subtract_expr.result_evaluate(4, &alloc, &accessor);
+    let res = add_subtract_expr.result_evaluate(&alloc, &accessor);
     let expected_res_scalar = [0, 2, 2, 4]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
         .collect::<Vec<_>>();
-    let expected_res = Column::Scalar(&expected_res_scalar);
+    let expected_res = ColumnarValue::Column(Column::Scalar(&expected_res_scalar));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -2,7 +2,9 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnarValue, CommitmentAccessor, DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
@@ -46,11 +48,10 @@ impl ProofExpr for AggregateExpr {
     #[tracing::instrument(name = "AggregateExpr::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        table_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Column<'a, S> {
-        self.expr.result_evaluate(table_length, alloc, accessor)
+    ) -> ColumnarValue<'a, S> {
+        self.expr.result_evaluate(alloc, accessor)
     }
 
     #[tracing::instrument(name = "AggregateExpr::prover_evaluate", level = "debug", skip_all)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
-use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
 
 /// Provable logical AND expression
@@ -53,7 +52,7 @@ impl ProofExpr for AndExpr {
         let lhs_columnar_value: ColumnarValue<'a, S> = self.lhs.result_evaluate(alloc, accessor);
         let rhs_columnar_value: ColumnarValue<'a, S> = self.rhs.result_evaluate(alloc, accessor);
         lhs_columnar_value
-            .apply_boolean_binary_operator(&rhs_columnar_value, BinaryOperator::And, alloc)
+            .apply_boolean_binary_operator(&rhs_columnar_value, |l, r| *l && *r, alloc)
             .expect("Failed to apply boolean binary operator")
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        database::{owned_table_utility::*, Column, ColumnarValue, OwnedTableTestAccessor},
         scalar::test_scalar::TestScalar,
     },
     sql::{
@@ -166,7 +166,7 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
         equal(column(t, "d", &accessor), const_varchar("t")),
     );
     let alloc = Bump::new();
-    let res = and_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[false, true, false, false]);
+    let res = and_expr.result_evaluate(&alloc, &accessor);
+    let expected_res = ColumnarValue::Column(Column::Boolean(&[false, true, false, false]));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -2,7 +2,10 @@ use super::ProofExpr;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnField, ColumnRef, ColumnType, ColumnarValue, CommitmentAccessor,
+            DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
@@ -58,13 +61,11 @@ impl ProofExpr for ColumnExpr {
     /// add the result to the [`FirstRoundBuilder`](crate::sql::proof::FirstRoundBuilder)
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        table_length: usize,
         _alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Column<'a, S> {
+    ) -> ColumnarValue<'a, S> {
         let column = accessor.get_column(self.column_ref);
-        assert_eq!(column.len(), table_length);
-        column
+        ColumnarValue::Column(column)
     }
 
     /// Given the selected rows (as a slice of booleans), evaluate the column expression and

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -5,7 +5,10 @@ use super::{
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnarValue, CommitmentAccessor, DataAccessor,
+            LiteralValue,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -1,8 +1,14 @@
-use super::{scale_and_add_subtract_eval, scale_and_subtract, DynProofExpr, ProofExpr};
+use super::{
+    scale_and_add_subtract_eval, scale_and_subtract, scale_and_subtract_columnar_value,
+    DynProofExpr, ProofExpr,
+};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnarValue, CommitmentAccessor, DataAccessor,
+            LiteralValue,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
@@ -43,17 +49,34 @@ impl ProofExpr for EqualsExpr {
     #[tracing::instrument(name = "EqualsExpr::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        table_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Column<'a, S> {
-        let lhs_column = self.lhs.result_evaluate(table_length, alloc, accessor);
-        let rhs_column = self.rhs.result_evaluate(table_length, alloc, accessor);
+    ) -> ColumnarValue<'a, S> {
+        let lhs_columnar_value = self.lhs.result_evaluate(alloc, accessor);
+        let rhs_columnar_value = self.rhs.result_evaluate(alloc, accessor);
+        // If both sides are literals we should return a literal.
+        // Otherwise we return a column.
+        let is_literal = matches!(
+            (&lhs_columnar_value, &rhs_columnar_value),
+            (&ColumnarValue::Literal(_), &ColumnarValue::Literal(_))
+        );
         let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);
         let rhs_scale = self.rhs.data_type().scale().unwrap_or(0);
-        let res = scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, true)
-            .expect("Failed to scale and subtract");
-        Column::Boolean(result_evaluate_equals_zero(table_length, alloc, res))
+        let res = scale_and_subtract_columnar_value(
+            alloc,
+            lhs_columnar_value,
+            rhs_columnar_value,
+            lhs_scale,
+            rhs_scale,
+            true,
+        )
+        .expect("Failed to scale and subtract");
+        let raw_result = result_evaluate_equals_zero(res.len(), alloc, res);
+        if is_literal {
+            ColumnarValue::Literal(LiteralValue::Boolean(raw_result[0]))
+        } else {
+            ColumnarValue::Column(Column::Boolean(raw_result))
+        }
     }
 
     #[tracing::instrument(name = "EqualsExpr::prover_evaluate", level = "debug", skip_all)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -1,7 +1,9 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTable, OwnedTableTestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnarValue, OwnedTable, OwnedTableTestAccessor,
+        },
         scalar::{Curve25519Scalar, Scalar},
     },
     sql::{
@@ -411,7 +413,7 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
         const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ZERO),
     );
     let alloc = Bump::new();
-    let res = equals_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[true, false, true, false]);
+    let res = equals_expr.result_evaluate(&alloc, &accessor);
+    let expected_res = ColumnarValue::Column(Column::Boolean(&[true, false, true, false]));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -2,8 +2,8 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, Column, LiteralValue, OwnedTable, OwnedTableTestAccessor,
-            TestAccessor,
+            owned_table_utility::*, Column, ColumnarValue, LiteralValue, OwnedTable,
+            OwnedTableTestAccessor, TestAccessor,
         },
         scalar::{Curve25519Scalar, Scalar, ScalarExt},
     },
@@ -568,8 +568,8 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
     let rhs_expr = column(t, "b", &accessor);
     let lte_expr = lte(lhs_expr, rhs_expr);
     let alloc = Bump::new();
-    let res = lte_expr.result_evaluate(3, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[true, false, true]);
+    let res = lte_expr.result_evaluate(&alloc, &accessor);
+    let expected_res = ColumnarValue::Column(Column::Boolean(&[true, false, true]));
     assert_eq!(res, expected_res);
 }
 
@@ -583,7 +583,7 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
     let lit_expr = const_bigint(1);
     let gte_expr = gte(col_expr, lit_expr);
     let alloc = Bump::new();
-    let res = gte_expr.result_evaluate(3, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[false, true, true]);
+    let res = gte_expr.result_evaluate(&alloc, &accessor);
+    let expected_res = ColumnarValue::Column(Column::Boolean(&[false, true, true]));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -2,7 +2,10 @@ use super::ProofExpr;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnarValue, CommitmentAccessor, DataAccessor,
+            LiteralValue,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
@@ -47,11 +50,10 @@ impl ProofExpr for LiteralExpr {
     #[tracing::instrument(name = "LiteralExpr::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        table_length: usize,
-        alloc: &'a Bump,
+        _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) -> Column<'a, S> {
-        Column::from_literal_with_length(&self.value, table_length, alloc)
+    ) -> ColumnarValue<'a, S> {
+        ColumnarValue::Literal(self.value.clone())
     }
 
     #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -2,7 +2,7 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        database::{owned_table_utility::*, ColumnarValue, LiteralValue, OwnedTableTestAccessor},
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -123,7 +123,7 @@ fn we_can_compute_the_correct_output_of_a_literal_expr_using_result_evaluate() {
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
     let literal_expr: DynProofExpr = const_bool(true);
     let alloc = Bump::new();
-    let res = literal_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[true, true, true, true]);
+    let res = literal_expr.result_evaluate(&alloc, &accessor);
+    let expected_res = ColumnarValue::Literal(LiteralValue::Boolean(true));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -57,11 +57,12 @@ use not_expr::NotExpr;
 mod not_expr_test;
 
 mod comparison_util;
-pub(crate) use comparison_util::scale_and_subtract;
+pub(crate) use comparison_util::{scale_and_subtract, scale_and_subtract_columnar_value};
 
 mod numerical_util;
 pub(crate) use numerical_util::{
-    add_subtract_columns, multiply_columns, scale_and_add_subtract_eval,
+    add_subtract_columnar_values, add_subtract_columns, multiply_columnar_values, multiply_columns,
+    scale_and_add_subtract_eval,
 };
 
 mod equals_expr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor},
+        database::{owned_table_utility::*, Column, ColumnarValue, OwnedTableTestAccessor},
         scalar::{test_scalar::TestScalar, Curve25519Scalar},
     },
     sql::{
@@ -345,11 +345,11 @@ fn we_can_compute_the_correct_output_of_a_multiply_expr_using_result_evaluate() 
         subtract(column(t, "a", &accessor), const_decimal75(2, 1, 15)),
     );
     let alloc = Bump::new();
-    let res = arithmetic_expr.result_evaluate(4, &alloc, &accessor);
+    let res = arithmetic_expr.result_evaluate(&alloc, &accessor);
     let expected_res_scalar = [0, 5, 75, 25]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))
         .collect::<Vec<_>>();
-    let expected_res = Column::Scalar(&expected_res_scalar);
+    let expected_res = ColumnarValue::Column(Column::Scalar(&expected_res_scalar));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
-use proof_of_sql_parser::intermediate_ast::UnaryOperator;
 use serde::{Deserialize, Serialize};
 
 /// Provable logical NOT expression
@@ -46,7 +45,7 @@ impl ProofExpr for NotExpr {
     ) -> ColumnarValue<'a, S> {
         let expr_columnar_value: ColumnarValue<'a, S> = self.expr.result_evaluate(alloc, accessor);
         expr_columnar_value
-            .apply_boolean_unary_operator(UnaryOperator::Not, alloc)
+            .apply_boolean_unary_operator(|l| !*l, alloc)
             .expect("Failed to apply boolean unary operator")
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -1,7 +1,9 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnarValue, OwnedTableTestAccessor, TestAccessor,
+        },
         scalar::test_scalar::TestScalar,
     },
     sql::{
@@ -119,7 +121,7 @@ fn we_can_compute_the_correct_output_of_a_not_expr_using_result_evaluate() {
     accessor.add_table(t, data, 0);
     let not_expr: DynProofExpr = not(equal(column(t, "b", &accessor), const_int128(1)));
     let alloc = Bump::new();
-    let res = not_expr.result_evaluate(2, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[true, false]);
+    let res = not_expr.result_evaluate(&alloc, &accessor);
+    let expected_res = ColumnarValue::Column(Column::Boolean(&[true, false]));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -2,7 +2,9 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnarValue, CommitmentAccessor, DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
@@ -11,6 +13,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
+use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
 
 /// Provable logical OR expression
@@ -42,15 +45,14 @@ impl ProofExpr for OrExpr {
     #[tracing::instrument(name = "OrExpr::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        table_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Column<'a, S> {
-        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(table_length, alloc, accessor);
-        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(table_length, alloc, accessor);
-        let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
-        let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        Column::Boolean(result_evaluate_or(table_length, alloc, lhs, rhs))
+    ) -> ColumnarValue<'a, S> {
+        let lhs_columnar_value: ColumnarValue<'a, S> = self.lhs.result_evaluate(alloc, accessor);
+        let rhs_columnar_value: ColumnarValue<'a, S> = self.rhs.result_evaluate(alloc, accessor);
+        lhs_columnar_value
+            .apply_boolean_binary_operator(&rhs_columnar_value, BinaryOperator::Or, alloc)
+            .expect("Failed to apply boolean binary operator")
     }
 
     #[tracing::instrument(name = "OrExpr::prover_evaluate", level = "debug", skip_all)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
-use proof_of_sql_parser::intermediate_ast::BinaryOperator;
 use serde::{Deserialize, Serialize};
 
 /// Provable logical OR expression
@@ -51,7 +50,7 @@ impl ProofExpr for OrExpr {
         let lhs_columnar_value: ColumnarValue<'a, S> = self.lhs.result_evaluate(alloc, accessor);
         let rhs_columnar_value: ColumnarValue<'a, S> = self.rhs.result_evaluate(alloc, accessor);
         lhs_columnar_value
-            .apply_boolean_binary_operator(&rhs_columnar_value, BinaryOperator::Or, alloc)
+            .apply_boolean_binary_operator(&rhs_columnar_value, |l, r| *l || *r, alloc)
             .expect("Failed to apply boolean binary operator")
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -1,7 +1,9 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
+        database::{
+            owned_table_utility::*, Column, ColumnarValue, OwnedTableTestAccessor, TestAccessor,
+        },
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -183,7 +185,7 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
         equal(column(t, "d", &accessor), const_varchar("g")),
     );
     let alloc = Bump::new();
-    let res = and_expr.result_evaluate(4, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[false, true, true, true]);
+    let res = and_expr.result_evaluate(&alloc, &accessor);
+    let expected_res = ColumnarValue::Column(Column::Boolean(&[false, true, true, true]));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,7 +1,9 @@
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
+        database::{
+            Column, ColumnRef, ColumnType, ColumnarValue, CommitmentAccessor, DataAccessor,
+        },
         map::IndexSet,
         proof::ProofError,
         scalar::Scalar,
@@ -21,14 +23,12 @@ pub trait ProofExpr: Debug + Send + Sync {
     fn data_type(&self) -> ColumnType;
 
     /// This returns the result of evaluating the expression on the given table, and returns
-    /// a column of values. This result slice is guarenteed to have length `table_length`.
-    /// Implementations must ensure that the returned slice has length `table_length`.
+    /// a column of values.
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        table_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Column<'a, S>;
+    ) -> ColumnarValue<'a, S>;
 
     /// Evaluate the expression, add components needed to prove it, and return thet resulting column
     /// of values

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -1,7 +1,9 @@
 use super::{test_utility::*, DynProofExpr, ProofExpr};
 use crate::base::{
     commitment::InnerProductProof,
-    database::{owned_table_utility::*, Column, OwnedTableTestAccessor, TestAccessor},
+    database::{
+        owned_table_utility::*, Column, ColumnarValue, OwnedTableTestAccessor, TestAccessor,
+    },
 };
 use bumpalo::Bump;
 
@@ -35,10 +37,10 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
         not(equal(column(t, "c", &accessor), const_int128(3))),
     );
     let alloc = Bump::new();
-    let res = bool_expr.result_evaluate(17, &alloc, &accessor);
-    let expected_res = Column::Boolean(&[
+    let res = bool_expr.result_evaluate(&alloc, &accessor);
+    let expected_res = ColumnarValue::Column(Column::Boolean(&[
         false, true, false, true, false, true, false, true, false, true, false, true, false, true,
         false, false, false,
-    ]);
+    ]));
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -81,7 +81,6 @@ impl ProverEvaluate for EmptyExec {
     #[tracing::instrument(name = "EmptyExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        _input_length: usize,
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -152,14 +152,16 @@ impl ProverEvaluate for FilterExec {
     #[tracing::instrument(name = "FilterExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        input_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
+        let input_length = accessor.get_length(self.table.table_ref);
         // 1. selection
-        let selection_column: Column<'a, S> =
-            self.where_clause
-                .result_evaluate(input_length, alloc, accessor);
+        let selection_column: Column<'a, S> = self
+            .where_clause
+            .result_evaluate(alloc, accessor)
+            .into_column(input_length, alloc)
+            .expect("Failed to convert columnar value to column");
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
@@ -171,7 +173,9 @@ impl ProverEvaluate for FilterExec {
             .map(|aliased_expr| {
                 aliased_expr
                     .expr
-                    .result_evaluate(input_length, alloc, accessor)
+                    .result_evaluate(alloc, accessor)
+                    .into_column(input_length, alloc)
+                    .expect("Failed to convert columnar value to column")
             })
             .collect();
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -194,7 +194,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(0, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -240,7 +240,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -282,7 +282,7 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
     let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -314,7 +314,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -103,17 +103,19 @@ impl ProverEvaluate for ProjectionExec {
     #[tracing::instrument(name = "ProjectionExec::result_evaluate", level = "debug", skip_all)]
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        input_length: usize,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
     ) -> Vec<Column<'a, S>> {
+        let input_length = accessor.get_length(self.table.table_ref);
         let columns: Vec<_> = self
             .aliased_results
             .iter()
             .map(|aliased_expr| {
                 aliased_expr
                     .expr
-                    .result_evaluate(input_length, alloc, accessor)
+                    .result_evaluate(alloc, accessor)
+                    .into_column(input_length, alloc)
+                    .expect("Failed to convert columnar value to column")
             })
             .collect();
         columns

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -168,7 +168,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     let expr: DynProofPlan =
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(0, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -209,7 +209,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     accessor.add_table(t, data, 0);
     let expr: DynProofPlan = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
@@ -247,7 +247,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         tab(t),
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(5, &alloc, &accessor);
+    let result_cols = expr.result_evaluate(&alloc, &accessor);
     let output_length = result_cols.first().map_or(0, Column::len) as u64;
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to make `ProofPlan`s composable it is necessary to allow one or more `ProofPlan`s as the input to another. As such it is a great idea to remove `table_length` as an argument in `ProofPlan::result_evaluate` which in turn requires removal in `ProofExpr`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- Remove `table_length` from `ProofExpr::result_evaluate` and return `ColumnarValue`.
- Remove `table_length` from `ProofPlan::result_evaluate`.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
