### PR TITLE
refactor: remove `Commitment` references from `verifier_evaluate`

### DIFF
--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -28,6 +28,7 @@ macro_rules! indexset_macro {
     ($($value:expr),*) => {
         {
             const CAP: usize = <[()]>::len(&[$({ stringify!($value); }),*]);
+            #[allow(unused_mut)]
             let mut set = $crate::base::map::IndexSet::with_capacity_and_hasher(CAP, <_>::default());
             $(
                 set.insert($value);

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,10 +1,8 @@
 use super::{CountBuilder, FinalRoundBuilder, FirstRoundBuilder, VerificationBuilder};
 use crate::base::{
     commitment::Commitment,
-    database::{
-        Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, OwnedTable, TableRef,
-    },
-    map::IndexSet,
+    database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
+    map::{IndexMap, IndexSet},
     proof::ProofError,
     scalar::Scalar,
 };
@@ -22,7 +20,7 @@ pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
         result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError>;
 

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,6 +1,5 @@
 use super::{CountBuilder, FinalRoundBuilder, FirstRoundBuilder, VerificationBuilder};
 use crate::base::{
-    commitment::Commitment,
     database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
     map::{IndexMap, IndexSet},
     proof::ProofError,
@@ -17,12 +16,12 @@ pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
     fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError>;
 
     /// Form components needed to verify and proof store into `VerificationBuilder`
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-        result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError>;
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError>;
 
     /// Return all the result column fields
     fn get_column_result_fields(&self) -> Vec<ColumnField>;

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -265,7 +265,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             &sumcheck_random_scalars,
             &self.pcs_proof_evaluations,
         );
-        let mut builder = VerificationBuilder::<'_, CP::Commitment>::new(
+        let mut builder = VerificationBuilder::new(
             min_row_num,
             sumcheck_evaluations,
             &self.bit_distributions,

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::{
     base::{
-        commitment::{Commitment, InnerProductProof},
+        commitment::InnerProductProof,
         database::{
             owned_table_utility::{bigint, owned_table},
             Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable,
@@ -75,18 +75,18 @@ impl ProofPlan for TrivialTestProofPlan {
         builder.count_anchored_mles(self.anchored_mle_count);
         Ok(())
     }
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        _accessor: &IndexMap<ColumnRef, C::Scalar>,
-        _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
-        assert_eq!(builder.consume_intermediate_mle(), C::Scalar::ZERO);
+        builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
+        assert_eq!(builder.consume_intermediate_mle(), S::ZERO);
         builder.produce_sumcheck_subpolynomial_evaluation(
             &SumcheckSubpolynomialType::ZeroSum,
-            C::Scalar::from(self.evaluation),
+            S::from(self.evaluation),
         );
-        Ok(vec![C::Scalar::ZERO])
+        Ok(vec![S::ZERO])
     }
     ///
     /// # Panics
@@ -252,13 +252,13 @@ impl ProofPlan for SquareTestProofPlan {
         builder.count_subpolynomials(1);
         Ok(())
     }
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-        _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
-        let x_eval = C::Scalar::from(self.anchored_commit_multiplier)
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
+        let x_eval = S::from(self.anchored_commit_multiplier)
             * *accessor
                 .get(&ColumnRef::new(
                     "sxt.test".parse().unwrap(),
@@ -443,12 +443,12 @@ impl ProofPlan for DoubleSquareTestProofPlan {
         builder.count_subpolynomials(2);
         Ok(())
     }
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-        _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
         let x_eval = *accessor
             .get(&ColumnRef::new(
                 "sxt.test".parse().unwrap(),
@@ -642,12 +642,12 @@ impl ProofPlan for ChallengeTestProofPlan {
         builder.count_post_result_challenges(2);
         Ok(())
     }
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-        _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
         let alpha = builder.consume_post_result_challenge();
         let _beta = builder.consume_post_result_challenge();
         let x_eval = *accessor

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -6,10 +6,10 @@ use crate::{
         commitment::{Commitment, InnerProductProof},
         database::{
             owned_table_utility::{bigint, owned_table},
-            Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            OwnedTable, OwnedTableTestAccessor, TableRef,
+            Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable,
+            OwnedTableTestAccessor, TableRef,
         },
-        map::{indexset, IndexSet},
+        map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
         scalar::{Curve25519Scalar, Scalar},
     },
@@ -78,7 +78,7 @@ impl ProofPlan for TrivialTestProofPlan {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        _accessor: &dyn CommitmentAccessor<C>,
+        _accessor: &IndexMap<ColumnRef, C::Scalar>,
         _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
         assert_eq!(builder.consume_intermediate_mle(), C::Scalar::ZERO);
@@ -96,7 +96,7 @@ impl ProofPlan for TrivialTestProofPlan {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        unimplemented!("no real usage for this function yet")
+        indexset! {}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset! {TableRef::new("sxt.test".parse().unwrap())}
@@ -234,7 +234,6 @@ impl ProverEvaluate for SquareTestProofPlan {
             ColumnType::BigInt,
         ));
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        builder.produce_anchored_mle(x);
         builder.produce_intermediate_mle(res);
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
@@ -251,22 +250,22 @@ impl ProofPlan for SquareTestProofPlan {
         builder.count_degree(3);
         builder.count_intermediate_mles(1);
         builder.count_subpolynomials(1);
-        builder.count_anchored_mles(1);
         Ok(())
     }
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
         _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
-        let x_commit = C::Scalar::from(self.anchored_commit_multiplier)
-            * accessor.get_commitment(ColumnRef::new(
-                "sxt.test".parse().unwrap(),
-                "x".parse().unwrap(),
-                ColumnType::BigInt,
-            ));
-        let x_eval = builder.consume_anchored_mle(x_commit);
+        let x_eval = C::Scalar::from(self.anchored_commit_multiplier)
+            * *accessor
+                .get(&ColumnRef::new(
+                    "sxt.test".parse().unwrap(),
+                    "x".parse().unwrap(),
+                    ColumnType::BigInt,
+                ))
+                .unwrap();
         let res_eval = builder.consume_intermediate_mle();
         builder.produce_sumcheck_subpolynomial_evaluation(
             &SumcheckSubpolynomialType::Identity,
@@ -278,7 +277,11 @@ impl ProofPlan for SquareTestProofPlan {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        unimplemented!("no real usage for this function yet")
+        indexset! {ColumnRef::new(
+            "sxt.test".parse().unwrap(),
+            "x".parse().unwrap(),
+            ColumnType::BigInt,
+        )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset! {TableRef::new("sxt.test".parse().unwrap())}
@@ -410,7 +413,6 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
         ));
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         let z: &[_] = alloc.alloc_slice_copy(&self.z);
-        builder.produce_anchored_mle(x);
         builder.produce_intermediate_mle(z);
 
         // poly1
@@ -439,21 +441,21 @@ impl ProofPlan for DoubleSquareTestProofPlan {
         builder.count_degree(3);
         builder.count_intermediate_mles(2);
         builder.count_subpolynomials(2);
-        builder.count_anchored_mles(1);
         Ok(())
     }
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
         _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
-        let x_commit = accessor.get_commitment(ColumnRef::new(
-            "sxt.test".parse().unwrap(),
-            "x".parse().unwrap(),
-            ColumnType::BigInt,
-        ));
-        let x_eval = builder.consume_anchored_mle(x_commit);
+        let x_eval = *accessor
+            .get(&ColumnRef::new(
+                "sxt.test".parse().unwrap(),
+                "x".parse().unwrap(),
+                ColumnType::BigInt,
+            ))
+            .unwrap();
         let z_eval = builder.consume_intermediate_mle();
         let res_eval = builder.consume_intermediate_mle();
 
@@ -474,7 +476,11 @@ impl ProofPlan for DoubleSquareTestProofPlan {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        unimplemented!("no real usage for this function yet")
+        indexset! {ColumnRef::new(
+            "sxt.test".parse().unwrap(),
+            "x".parse().unwrap(),
+            ColumnType::BigInt,
+        )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset! {TableRef::new("sxt.test".parse().unwrap())}
@@ -617,7 +623,6 @@ impl ProverEvaluate for ChallengeTestProofPlan {
         let res: &[_] = alloc.alloc_slice_copy(&[9, 25]);
         let alpha = builder.consume_post_result_challenge();
         let _beta = builder.consume_post_result_challenge();
-        builder.produce_anchored_mle(x);
         builder.produce_intermediate_mle(res);
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
@@ -634,24 +639,24 @@ impl ProofPlan for ChallengeTestProofPlan {
         builder.count_degree(3);
         builder.count_intermediate_mles(1);
         builder.count_subpolynomials(1);
-        builder.count_anchored_mles(1);
         builder.count_post_result_challenges(2);
         Ok(())
     }
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
         _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
         let alpha = builder.consume_post_result_challenge();
         let _beta = builder.consume_post_result_challenge();
-        let x_commit = accessor.get_commitment(ColumnRef::new(
-            "sxt.test".parse().unwrap(),
-            "x".parse().unwrap(),
-            ColumnType::BigInt,
-        ));
-        let x_eval = builder.consume_anchored_mle(x_commit);
+        let x_eval = *accessor
+            .get(&ColumnRef::new(
+                "sxt.test".parse().unwrap(),
+                "x".parse().unwrap(),
+                ColumnType::BigInt,
+            ))
+            .unwrap();
         let res_eval = builder.consume_intermediate_mle();
         builder.produce_sumcheck_subpolynomial_evaluation(
             &SumcheckSubpolynomialType::Identity,
@@ -663,7 +668,11 @@ impl ProofPlan for ChallengeTestProofPlan {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        unimplemented!("no real usage for this function yet")
+        indexset! {ColumnRef::new(
+            "sxt.test".parse().unwrap(),
+            "x".parse().unwrap(),
+            ColumnType::BigInt,
+        )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
         indexset! {TableRef::new("sxt.test".parse().unwrap())}

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        commitment::{Commitment, InnerProductProof},
+        commitment::InnerProductProof,
         database::{
             owned_table_utility::{bigint, owned_table},
             Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable,
@@ -56,18 +56,18 @@ impl ProofPlan for EmptyTestQueryExpr {
         Ok(())
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        _accessor: &IndexMap<ColumnRef, C::Scalar>,
-        _result: Option<&OwnedTable<<C as Commitment>::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
         let _ = std::iter::repeat_with(|| {
-            assert_eq!(builder.consume_intermediate_mle(), C::Scalar::ZERO);
+            assert_eq!(builder.consume_intermediate_mle(), S::ZERO);
         })
         .take(self.columns)
         .collect::<Vec<_>>();
-        Ok(vec![C::Scalar::ZERO])
+        Ok(vec![S::ZERO])
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -7,10 +7,10 @@ use crate::{
         commitment::{Commitment, InnerProductProof},
         database::{
             owned_table_utility::{bigint, owned_table},
-            Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            OwnedTable, OwnedTableTestAccessor, TableRef,
+            Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable,
+            OwnedTableTestAccessor, TableRef,
         },
-        map::{indexset, IndexSet},
+        map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -59,7 +59,7 @@ impl ProofPlan for EmptyTestQueryExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        _accessor: &dyn CommitmentAccessor<C>,
+        _accessor: &IndexMap<ColumnRef, C::Scalar>,
         _result: Option<&OwnedTable<<C as Commitment>::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
         let _ = std::iter::repeat_with(|| {
@@ -77,7 +77,7 @@ impl ProofPlan for EmptyTestQueryExpr {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        unimplemented!("no real usage for this function yet")
+        indexset! {}
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {

--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -2,7 +2,6 @@ use super::{SumcheckMleEvaluations, VerificationBuilder};
 use crate::{base::scalar::Curve25519Scalar, sql::proof::SumcheckSubpolynomialType};
 use curve25519_dalek::ristretto::RistrettoPoint;
 use num_traits::Zero;
-use rand_core::OsRng;
 
 #[test]
 fn an_empty_sumcheck_polynomial_evaluates_to_zero() {
@@ -17,11 +16,9 @@ fn an_empty_sumcheck_polynomial_evaluates_to_zero() {
         &[][..],
         &[][..],
         &[][..],
-        &[][..],
         Vec::new(),
     );
     assert_eq!(builder.sumcheck_evaluation(), Curve25519Scalar::zero());
-    assert_eq!(builder.pcs_proof_commitments(), &[]);
     assert_eq!(builder.inner_product_multipliers(), &[]);
 }
 
@@ -39,7 +36,6 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
     let mut builder = VerificationBuilder::<RistrettoPoint>::new(
         0,
         mle_evaluations,
-        &[][..],
         &[][..],
         &subpolynomial_multipliers,
         &[][..],
@@ -70,28 +66,22 @@ fn we_build_up_the_folded_pcs_proof_commitment() {
         pcs_proof_evaluations: &pcs_proof_evaluations,
         ..Default::default()
     };
-    let mut rng = OsRng;
-    let commit1 = RistrettoPoint::random(&mut rng);
-    let commit2 = RistrettoPoint::random(&mut rng);
-    let intermediate_commitments = [commit2];
     let inner_product_multipliers = [
         Curve25519Scalar::from(10u64),
         Curve25519Scalar::from(100u64),
     ];
-    let mut builder = VerificationBuilder::new(
+    let mut builder = VerificationBuilder::<RistrettoPoint>::new(
         0,
         mle_evaluations,
         &[][..],
-        &intermediate_commitments,
         &[][..],
         &inner_product_multipliers,
         Vec::new(),
     );
-    let eval = builder.consume_anchored_mle(commit1);
+    let eval = builder.consume_anchored_mle();
     assert_eq!(eval, Curve25519Scalar::from(123u64));
     let eval = builder.consume_intermediate_mle();
     assert_eq!(eval, Curve25519Scalar::from(456u64));
-    assert_eq!(builder.pcs_proof_commitments(), &[commit1, commit2]);
     assert_eq!(
         builder.inner_product_multipliers(),
         &[inner_product_multipliers[0], inner_product_multipliers[1]]
@@ -110,7 +100,6 @@ fn we_can_consume_post_result_challenges_in_proof_builder() {
     let mut builder = VerificationBuilder::<RistrettoPoint>::new(
         0,
         SumcheckMleEvaluations::default(),
-        &[][..],
         &[][..],
         &[][..],
         &[][..],

--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -1,6 +1,5 @@
 use super::{SumcheckMleEvaluations, VerificationBuilder};
 use crate::{base::scalar::Curve25519Scalar, sql::proof::SumcheckSubpolynomialType};
-use curve25519_dalek::ristretto::RistrettoPoint;
 use num_traits::Zero;
 
 #[test]
@@ -10,7 +9,7 @@ fn an_empty_sumcheck_polynomial_evaluates_to_zero() {
         num_sumcheck_variables: 1,
         ..Default::default()
     };
-    let builder = VerificationBuilder::<RistrettoPoint>::new(
+    let builder = VerificationBuilder::<Curve25519Scalar>::new(
         0,
         mle_evaluations,
         &[][..],
@@ -33,7 +32,7 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
         Curve25519Scalar::from(10u64),
         Curve25519Scalar::from(100u64),
     ];
-    let mut builder = VerificationBuilder::<RistrettoPoint>::new(
+    let mut builder = VerificationBuilder::new(
         0,
         mle_evaluations,
         &[][..],
@@ -70,7 +69,7 @@ fn we_build_up_the_folded_pcs_proof_commitment() {
         Curve25519Scalar::from(10u64),
         Curve25519Scalar::from(100u64),
     ];
-    let mut builder = VerificationBuilder::<RistrettoPoint>::new(
+    let mut builder = VerificationBuilder::new(
         0,
         mle_evaluations,
         &[][..],
@@ -97,7 +96,7 @@ fn we_build_up_the_folded_pcs_proof_commitment() {
 
 #[test]
 fn we_can_consume_post_result_challenges_in_proof_builder() {
-    let mut builder = VerificationBuilder::<RistrettoPoint>::new(
+    let mut builder = VerificationBuilder::new(
         0,
         SumcheckMleEvaluations::default(),
         &[][..],

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -1,7 +1,6 @@
 use super::{add_subtract_columns, scale_and_add_subtract_eval, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{try_add_subtract_column_types, Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -85,11 +84,11 @@ impl ProofExpr for AddSubtractExpr {
         ))
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         let lhs_eval = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs_eval = self.rhs.verifier_evaluate(builder, accessor)?;
         let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -2,11 +2,8 @@ use super::{add_subtract_columns, scale_and_add_subtract_eval, DynProofExpr, Pro
 use crate::{
     base::{
         commitment::Commitment,
-        database::{
-            try_add_subtract_column_types, Column, ColumnRef, ColumnType, CommitmentAccessor,
-            DataAccessor,
-        },
-        map::IndexSet,
+        database::{try_add_subtract_column_types, Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -91,7 +88,7 @@ impl ProofExpr for AddSubtractExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         let lhs_eval = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs_eval = self.rhs.verifier_evaluate(builder, accessor)?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -2,8 +2,8 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -66,7 +66,7 @@ impl ProofExpr for AggregateExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         self.expr.verifier_evaluate(builder, accessor)
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -1,7 +1,6 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -63,11 +62,11 @@ impl ProofExpr for AggregateExpr {
         self.expr.prover_evaluate(builder, alloc, accessor)
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         self.expr.verifier_evaluate(builder, accessor)
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -2,8 +2,8 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -87,7 +87,7 @@ impl ProofExpr for AndExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         let lhs = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs = self.rhs.verifier_evaluate(builder, accessor)?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,7 +1,6 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -84,11 +83,11 @@ impl ProofExpr for AndExpr {
         Column::Boolean(lhs_and_rhs)
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         let lhs = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs = self.rhs.verifier_evaluate(builder, accessor)?;
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -1,7 +1,6 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnField, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -79,11 +78,11 @@ impl ProofExpr for ColumnExpr {
 
     /// Evaluate the column expression at the sumcheck's random point,
     /// add components needed to verify this column expression
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        _builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        _builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         Ok(*accessor
             .get(&self.column_ref)
             .ok_or(ProofError::VerificationError {

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -5,8 +5,8 @@ use super::{
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor, LiteralValue},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor, LiteralValue},
         map::{IndexMap, IndexSet},
         proof::ProofError,

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -1,7 +1,6 @@
 use super::{scale_and_add_subtract_eval, scale_and_subtract, DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -72,11 +71,11 @@ impl ProofExpr for EqualsExpr {
         Column::Boolean(prover_evaluate_equals_zero(builder, alloc, res))
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         let lhs_eval = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs_eval = self.rhs.verifier_evaluate(builder, accessor)?;
         let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);
@@ -145,10 +144,10 @@ pub fn prover_evaluate_equals_zero<'a, S: Scalar>(
     selection
 }
 
-pub fn verifier_evaluate_equals_zero<C: Commitment>(
-    builder: &mut VerificationBuilder<C>,
-    lhs_eval: C::Scalar,
-) -> C::Scalar {
+pub fn verifier_evaluate_equals_zero<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    lhs_eval: S,
+) -> S {
     // consume mle evaluations
     let lhs_pseudo_inv_eval = builder.consume_intermediate_mle();
     let selection_not_eval = builder.consume_intermediate_mle();

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -2,8 +2,8 @@ use super::{scale_and_add_subtract_eval, scale_and_subtract, DynProofExpr, Proof
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
         slice_ops,
@@ -75,7 +75,7 @@ impl ProofExpr for EqualsExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         let lhs_eval = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs_eval = self.rhs.verifier_evaluate(builder, accessor)?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -7,8 +7,8 @@ use super::{
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -122,7 +122,7 @@ impl ProofExpr for InequalityExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         let one_eval = builder.mle_evaluations.input_one_evaluation;
         let lhs_eval = self.lhs.verifier_evaluate(builder, accessor)?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -6,7 +6,6 @@ use super::{
 };
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -119,11 +118,11 @@ impl ProofExpr for InequalityExpr {
         Column::Boolean(prover_evaluate_or(builder, alloc, equals_zero, sign))
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         let one_eval = builder.mle_evaluations.input_one_evaluation;
         let lhs_eval = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs_eval = self.rhs.verifier_evaluate(builder, accessor)?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -1,7 +1,6 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor, LiteralValue},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -65,11 +64,11 @@ impl ProofExpr for LiteralExpr {
         Column::from_literal_with_length(&self.value, table_length, alloc)
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        _accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         let mut commitment = builder.mle_evaluations.input_one_evaluation;
         commitment *= self.value.to_scalar();
         Ok(commitment)

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -2,8 +2,8 @@ use super::ProofExpr;
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, LiteralValue},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor, LiteralValue},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -68,7 +68,7 @@ impl ProofExpr for LiteralExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        _accessor: &dyn CommitmentAccessor<C>,
+        _accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         let mut commitment = builder.mle_evaluations.input_one_evaluation;
         commitment *= self.value.to_scalar();

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -1,7 +1,6 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{try_multiply_column_types, Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -86,11 +85,11 @@ impl ProofExpr for MultiplyExpr {
         Column::Scalar(lhs_times_rhs)
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         let lhs = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs = self.rhs.verifier_evaluate(builder, accessor)?;
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -2,11 +2,8 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{
-            try_multiply_column_types, Column, ColumnRef, ColumnType, CommitmentAccessor,
-            DataAccessor,
-        },
-        map::IndexSet,
+        database::{try_multiply_column_types, Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -92,7 +89,7 @@ impl ProofExpr for MultiplyExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         let lhs = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs = self.rhs.verifier_evaluate(builder, accessor)?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -2,8 +2,8 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -62,7 +62,7 @@ impl ProofExpr for NotExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         let eval = self.expr.verifier_evaluate(builder, accessor)?;
         Ok(builder.mle_evaluations.input_one_evaluation - eval)

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -1,7 +1,6 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -59,11 +58,11 @@ impl ProofExpr for NotExpr {
         Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]))
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         let eval = self.expr.verifier_evaluate(builder, accessor)?;
         Ok(builder.mle_evaluations.input_one_evaluation - eval)
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -2,8 +2,8 @@ use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -70,7 +70,7 @@ impl ProofExpr for OrExpr {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError> {
         let lhs = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs = self.rhs.verifier_evaluate(builder, accessor)?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -1,7 +1,6 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -67,11 +66,11 @@ impl ProofExpr for OrExpr {
         Column::Boolean(prover_evaluate_or(builder, alloc, lhs, rhs))
     }
 
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError> {
         let lhs = self.lhs.verifier_evaluate(builder, accessor)?;
         let rhs = self.rhs.verifier_evaluate(builder, accessor)?;
 
@@ -129,11 +128,11 @@ pub fn prover_evaluate_or<'a, S: Scalar>(
     alloc.alloc_slice_fill_with(n, |i| lhs[i] || rhs[i])
 }
 
-pub fn verifier_evaluate_or<C: Commitment>(
-    builder: &mut VerificationBuilder<C>,
-    lhs: &C::Scalar,
-    rhs: &C::Scalar,
-) -> C::Scalar {
+pub fn verifier_evaluate_or<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    lhs: &S,
+    rhs: &S,
+) -> S {
     // lhs_and_rhs
     let lhs_and_rhs = builder.consume_intermediate_mle();
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,6 +1,5 @@
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnRef, ColumnType, DataAccessor},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -41,12 +40,12 @@ pub trait ProofExpr: Debug + Send + Sync {
 
     /// Compute the evaluation of a multilinear extension from this expression
     /// at the random sumcheck point and adds components needed to verify the expression to
-    /// [`VerificationBuilder<C>`]
-    fn verifier_evaluate<C: Commitment>(
+    /// [`VerificationBuilder<S>`]
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-    ) -> Result<C::Scalar, ProofError>;
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+    ) -> Result<S, ProofError>;
 
     /// Insert in the [`IndexSet`] `columns` all the column
     /// references in the `BoolExpr` or forwards the call to some

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,8 +1,8 @@
 use crate::{
     base::{
         commitment::Commitment,
-        database::{Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor},
-        map::IndexSet,
+        database::{Column, ColumnRef, ColumnType, DataAccessor},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -45,7 +45,7 @@ pub trait ProofExpr: Debug + Send + Sync {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
     ) -> Result<C::Scalar, ProofError>;
 
     /// Insert in the [`IndexSet`] `columns` all the column

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
@@ -67,7 +67,7 @@ fn we_can_verify_a_constant_decomposition() {
     let one_eval = sumcheck_evaluations.input_one_evaluation;
 
     let mut builder: VerificationBuilder<RistrettoPoint> =
-        VerificationBuilder::new(0, sumcheck_evaluations, &dists, &[], &[], &[], Vec::new());
+        VerificationBuilder::new(0, sumcheck_evaluations, &dists, &[], &[], Vec::new());
     let data_eval = (&data).evaluate_at_point(&evaluation_point);
     let eval = verifier_evaluate_sign(&mut builder, data_eval, one_eval).unwrap();
     assert_eq!(eval, Curve25519Scalar::zero());
@@ -91,7 +91,7 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
     let one_eval = sumcheck_evaluations.input_one_evaluation;
 
     let mut builder: VerificationBuilder<RistrettoPoint> =
-        VerificationBuilder::new(0, sumcheck_evaluations, &dists, &[], &[], &[], Vec::new());
+        VerificationBuilder::new(0, sumcheck_evaluations, &dists, &[], &[], Vec::new());
     let data_eval = Curve25519Scalar::from(2) * (&data).evaluate_at_point(&evaluation_point);
     assert!(verifier_evaluate_sign(&mut builder, data_eval, one_eval).is_err());
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
@@ -7,7 +7,6 @@ use crate::{
     },
 };
 use bumpalo::Bump;
-use curve25519_dalek::RistrettoPoint;
 use num_traits::Zero;
 
 #[test]
@@ -66,7 +65,7 @@ fn we_can_verify_a_constant_decomposition() {
     );
     let one_eval = sumcheck_evaluations.input_one_evaluation;
 
-    let mut builder: VerificationBuilder<RistrettoPoint> =
+    let mut builder =
         VerificationBuilder::new(0, sumcheck_evaluations, &dists, &[], &[], Vec::new());
     let data_eval = (&data).evaluate_at_point(&evaluation_point);
     let eval = verifier_evaluate_sign(&mut builder, data_eval, one_eval).unwrap();
@@ -90,7 +89,7 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
     );
     let one_eval = sumcheck_evaluations.input_one_evaluation;
 
-    let mut builder: VerificationBuilder<RistrettoPoint> =
+    let mut builder =
         VerificationBuilder::new(0, sumcheck_evaluations, &dists, &[], &[], Vec::new());
     let data_eval = Curve25519Scalar::from(2) * (&data).evaluate_at_point(&evaluation_point);
     assert!(verifier_evaluate_sign(&mut builder, data_eval, one_eval).is_err());

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -2,10 +2,8 @@ use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec};
 use crate::{
     base::{
         commitment::Commitment,
-        database::{
-            Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, OwnedTable, TableRef,
-        },
-        map::IndexSet,
+        database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,7 +1,6 @@
 use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
         map::{IndexMap, IndexSet},
         proof::ProofError,

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,6 +1,5 @@
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -40,12 +39,12 @@ impl ProofPlan for EmptyExec {
     }
 
     #[allow(unused_variables)]
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        _builder: &mut VerificationBuilder<C>,
-        _accessor: &IndexMap<ColumnRef, C::Scalar>,
-        _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
+        _builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
         Ok(Vec::new())
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,10 +1,8 @@
 use crate::{
     base::{
         commitment::Commitment,
-        database::{
-            Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, OwnedTable, TableRef,
-        },
-        map::IndexSet,
+        database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -45,7 +43,7 @@ impl ProofPlan for EmptyExec {
     fn verifier_evaluate<C: Commitment>(
         &self,
         _builder: &mut VerificationBuilder<C>,
-        _accessor: &dyn CommitmentAccessor<C>,
+        _accessor: &IndexMap<ColumnRef, C::Scalar>,
         _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
         Ok(Vec::new())

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -1,7 +1,6 @@
 use super::{fold_columns, fold_vals};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{
             filter_util::filter_columns, Column, ColumnField, ColumnRef, DataAccessor, OwnedTable,
             TableRef,
@@ -74,12 +73,12 @@ where
     }
 
     #[allow(unused_variables)]
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-        _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
         // 1. selection
         let selection_eval = self.where_clause.verifier_evaluate(builder, accessor)?;
         // 2. columns
@@ -218,13 +217,13 @@ impl ProverEvaluate for FilterExec {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn verify_filter<C: Commitment>(
-    builder: &mut VerificationBuilder<C>,
-    alpha: C::Scalar,
-    beta: C::Scalar,
-    c_evals: &[C::Scalar],
-    s_eval: C::Scalar,
-    d_evals: &[C::Scalar],
+fn verify_filter<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    c_evals: &[S],
+    s_eval: S,
+    d_evals: &[S],
 ) -> Result<(), ProofError> {
     let one_eval = builder.mle_evaluations.input_one_evaluation;
     let chi_eval = builder.mle_evaluations.output_one_evaluation;

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -3,10 +3,10 @@ use crate::{
     base::{
         commitment::Commitment,
         database::{
-            filter_util::filter_columns, Column, ColumnField, ColumnRef, CommitmentAccessor,
-            DataAccessor, OwnedTable, TableRef,
+            filter_util::filter_columns, Column, ColumnField, ColumnRef, DataAccessor, OwnedTable,
+            TableRef,
         },
-        map::IndexSet,
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
         slice_ops,
@@ -77,7 +77,7 @@ where
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
         _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
         // 1. selection

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -6,10 +6,9 @@ use crate::{
             group_by_util::{
                 aggregate_columns, compare_indexes_by_owned_columns, AggregatedColumns,
             },
-            Column, ColumnField, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor,
-            OwnedTable, TableRef,
+            Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable, TableRef,
         },
-        map::IndexSet,
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
         slice_ops,
@@ -92,7 +91,7 @@ impl ProofPlan for GroupByExec {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
         result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
         // 1. selection

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -1,7 +1,6 @@
 use super::{fold_columns, fold_vals};
 use crate::{
     base::{
-        commitment::Commitment,
         database::{
             group_by_util::{
                 aggregate_columns, compare_indexes_by_owned_columns, AggregatedColumns,
@@ -88,12 +87,12 @@ impl ProofPlan for GroupByExec {
     }
 
     #[allow(unused_variables)]
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-        result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
         // 1. selection
         let where_eval = self.where_clause.verifier_evaluate(builder, accessor)?;
         // 2. columns
@@ -311,12 +310,12 @@ impl ProverEvaluate for GroupByExec {
 }
 
 #[allow(clippy::unnecessary_wraps)]
-fn verify_group_by<C: Commitment>(
-    builder: &mut VerificationBuilder<C>,
-    alpha: C::Scalar,
-    beta: C::Scalar,
-    (g_in_evals, sum_in_evals, sel_in_eval): (Vec<C::Scalar>, Vec<C::Scalar>, C::Scalar),
-    (g_out_evals, sum_out_evals, count_out_eval): (Vec<C::Scalar>, Vec<C::Scalar>, C::Scalar),
+fn verify_group_by<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    (g_in_evals, sum_in_evals, sel_in_eval): (Vec<S>, Vec<S>, S),
+    (g_out_evals, sum_out_evals, count_out_eval): (Vec<S>, Vec<S>, S),
 ) -> Result<(), ProofError> {
     let one_eval = builder.mle_evaluations.input_one_evaluation;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -1,6 +1,5 @@
 use crate::{
     base::{
-        commitment::Commitment,
         database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -49,12 +48,12 @@ impl ProofPlan for ProjectionExec {
     }
 
     #[allow(unused_variables)]
-    fn verifier_evaluate<C: Commitment>(
+    fn verifier_evaluate<S: Scalar>(
         &self,
-        builder: &mut VerificationBuilder<C>,
-        accessor: &IndexMap<ColumnRef, C::Scalar>,
-        _result: Option<&OwnedTable<C::Scalar>>,
-    ) -> Result<Vec<C::Scalar>, ProofError> {
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+    ) -> Result<Vec<S>, ProofError> {
         self.aliased_results
             .iter()
             .map(|aliased_expr| aliased_expr.expr.verifier_evaluate(builder, accessor))

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -1,10 +1,8 @@
 use crate::{
     base::{
         commitment::Commitment,
-        database::{
-            Column, ColumnField, ColumnRef, CommitmentAccessor, DataAccessor, OwnedTable, TableRef,
-        },
-        map::IndexSet,
+        database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
+        map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
     },
@@ -54,7 +52,7 @@ impl ProofPlan for ProjectionExec {
     fn verifier_evaluate<C: Commitment>(
         &self,
         builder: &mut VerificationBuilder<C>,
-        accessor: &dyn CommitmentAccessor<C>,
+        accessor: &IndexMap<ColumnRef, C::Scalar>,
         _result: Option<&OwnedTable<C::Scalar>>,
     ) -> Result<Vec<C::Scalar>, ProofError> {
         self.aliased_results


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

Implementations of `verifier_evaluate` no longer rely on the commitment type.

# What changes are included in this PR?

All uses of a `Commitment` generic are removed from `verifier_evaluate`. See individual commits in this PR.

# Are these changes tested?
Yes, by existing tests.
