### PR TITLE
refactor!:  `proof_of_sql_parser::intermediate_ast::UnaryOp` with `sqlparser::ast::UnaryOp` in the proof-of-sql crate

### DIFF
--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -139,6 +139,13 @@ pub enum ConversionError {
         /// The underlying error
         error: String,
     },
+
+    #[snafu(display("Unsupported operator: {message}"))]
+    /// Unsupported operation
+    UnsupportedOperation {
+        /// The operator that is unsupported
+        message: String,
+    },
 }
 
 impl From<String> for ConversionError {

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -9,15 +9,15 @@ use crate::base::{
         BigDecimalExt,
     },
 };
-use alloc::{boxed::Box, string::ToString, vec::Vec};
+use alloc::{boxed::Box, format, string::ToString, vec::Vec};
 use proof_of_sql_parser::{
     intermediate_ast::{
         AggregationOperator, AliasedResultExpr, BinaryOperator, Expression, Literal, OrderBy,
-        SelectResultExpr, Slice, TableExpression, UnaryOperator,
+        SelectResultExpr, Slice, TableExpression,
     },
     Identifier, ResourceId,
 };
-
+use sqlparser::ast::UnaryOperator;
 pub struct QueryContextBuilder<'a> {
     context: QueryContext,
     schema_accessor: &'a dyn SchemaAccessor,
@@ -137,7 +137,7 @@ impl<'a> QueryContextBuilder<'a> {
             Expression::Wildcard => Ok(ColumnType::BigInt), // Since COUNT(*) = COUNT(1)
             Expression::Literal(literal) => self.visit_literal(literal),
             Expression::Column(_) => self.visit_column_expr(expr),
-            Expression::Unary { op, expr } => self.visit_unary_expr(*op, expr),
+            Expression::Unary { op, expr } => self.visit_unary_expr((*op).into(), expr),
             Expression::Binary { op, left, right } => self.visit_binary_expr(*op, left, right),
             Expression::Aggregation { op, expr } => self.visit_agg_expr(*op, expr),
         }
@@ -192,6 +192,10 @@ impl<'a> QueryContextBuilder<'a> {
                 }
                 Ok(ColumnType::Boolean)
             }
+            // Handle unsupported operators
+            _ => Err(ConversionError::UnsupportedOperation {
+                message: format!("{op:?}"),
+            }),
         }
     }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This PR addresses the need to replace the `proof_of_sql_parser::intermediate_ast::UnaryOp` with the `sqlparser::ast::UnaryOp` in the `proof-of-sql` crate as part of a larger transition toward integrating the `sqlparser` .

This change is a subtask of issue #235, with the main goal of streamlining the repository by switching to the `sqlparser` crate and gradually replacing intermediary constructs like `proof_of_sql_parser::intermediate_ast` with `sqlparser::ast`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- All instances of `proof_of_sql_parser::intermediate_ast::UnaryOp` have been replaced with `sqlparser::ast::UnaryOp`
-  Every usage of `UnaryOp` has been updated to maintain the original functionality, ensuring no changes to the logic or behavior.
-  Any unsupported `UnaryOp` variants from `sqlparser` have been appropriately handled using existing error handling mechanisms (i.e., the `Unsupported `variant in `ExpressionEvaluationError`).
 
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?

Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->

Part of #235 