### PR TITLE
feat: add `Table` && `TableTestAccessor` && table utilities

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -95,6 +95,11 @@ pub use owned_table_test_accessor::OwnedTableTestAccessor;
 #[cfg(all(test, feature = "blitzar"))]
 mod owned_table_test_accessor_test;
 
+mod table_test_accessor;
+pub use table_test_accessor::TableTestAccessor;
+#[cfg(all(test, feature = "blitzar"))]
+mod table_test_accessor_test;
+
 /// TODO: add docs
 pub(crate) mod filter_util;
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -64,6 +64,14 @@ pub(crate) use owned_table::OwnedTableError;
 mod owned_table_test;
 pub mod owned_table_utility;
 
+mod table;
+pub use table::Table;
+#[cfg(test)]
+pub(crate) use table::TableError;
+#[cfg(test)]
+mod table_test;
+pub mod table_utility;
+
 /// TODO: add docs
 pub(crate) mod expression_evaluation;
 mod expression_evaluation_error;

--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -1,0 +1,97 @@
+use super::Column;
+use crate::base::{map::IndexMap, scalar::Scalar};
+use proof_of_sql_parser::Identifier;
+use snafu::Snafu;
+
+/// An error that occurs when working with tables.
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum TableError {
+    /// The columns have different lengths.
+    #[snafu(display("Columns have different lengths"))]
+    ColumnLengthMismatch,
+}
+/// A table of data, with schema included. This is simply a map from `Identifier` to `Column`,
+/// where columns order matters.
+/// This is primarily used as an internal result that is used before
+/// converting to the final result in either Arrow format or JSON.
+/// This is the analog of an arrow [`RecordBatch`](arrow::record_batch::RecordBatch).
+#[derive(Debug, Clone, Eq)]
+pub struct Table<'a, S: Scalar> {
+    table: IndexMap<Identifier, Column<'a, S>>,
+}
+impl<'a, S: Scalar> Table<'a, S> {
+    /// Creates a new [`Table`].
+    pub fn try_new(table: IndexMap<Identifier, Column<'a, S>>) -> Result<Self, TableError> {
+        if table.is_empty() {
+            return Ok(Self { table });
+        }
+        let num_rows = table[0].len();
+        if table.values().any(|column| column.len() != num_rows) {
+            Err(TableError::ColumnLengthMismatch)
+        } else {
+            Ok(Self { table })
+        }
+    }
+    /// Creates a new [`Table`].
+    pub fn try_from_iter<T: IntoIterator<Item = (Identifier, Column<'a, S>)>>(
+        iter: T,
+    ) -> Result<Self, TableError> {
+        Self::try_new(IndexMap::from_iter(iter))
+    }
+    /// Number of columns in the table.
+    #[must_use]
+    pub fn num_columns(&self) -> usize {
+        self.table.len()
+    }
+    /// Number of rows in the table.
+    #[must_use]
+    pub fn num_rows(&self) -> usize {
+        if self.table.is_empty() {
+            0
+        } else {
+            self.table[0].len()
+        }
+    }
+    /// Whether the table has no columns.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.table.is_empty()
+    }
+    /// Returns the columns of this table as an `IndexMap`
+    #[must_use]
+    pub fn into_inner(self) -> IndexMap<Identifier, Column<'a, S>> {
+        self.table
+    }
+    /// Returns the columns of this table as an `IndexMap`
+    #[must_use]
+    pub fn inner_table(&self) -> &IndexMap<Identifier, Column<'a, S>> {
+        &self.table
+    }
+    /// Returns the columns of this table as an Iterator
+    pub fn column_names(&self) -> impl Iterator<Item = &Identifier> {
+        self.table.keys()
+    }
+}
+
+// Note: we modify the default PartialEq for IndexMap to also check for column ordering.
+// This is to align with the behaviour of a `RecordBatch`.
+impl<S: Scalar> PartialEq for Table<'_, S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.table == other.table
+            && self
+                .table
+                .keys()
+                .zip(other.table.keys())
+                .all(|(a, b)| a == b)
+    }
+}
+
+#[cfg(test)]
+impl<'a, S: Scalar> core::ops::Index<&str> for Table<'a, S> {
+    type Output = Column<'a, S>;
+    fn index(&self, index: &str) -> &Self::Output {
+        self.table
+            .get(&index.parse::<Identifier>().unwrap())
+            .unwrap()
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -43,14 +43,10 @@ impl<'a, S: Scalar> Table<'a, S> {
     pub fn num_columns(&self) -> usize {
         self.table.len()
     }
-    /// Number of rows in the table.
+    /// Number of rows in the table. For an empty table, this will return `None`.
     #[must_use]
-    pub fn num_rows(&self) -> usize {
-        if self.table.is_empty() {
-            0
-        } else {
-            self.table[0].len()
-        }
+    pub fn num_rows(&self) -> Option<usize> {
+        (!self.table.is_empty()).then(|| self.table[0].len())
     }
     /// Whether the table has no columns.
     #[must_use]

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -21,11 +21,11 @@ fn we_can_create_a_table_with_no_columns() {
 fn we_can_create_an_empty_table() {
     let alloc = Bump::new();
     let borrowed_table = table::<DoryScalar>([
-        bigint("bigint", [0; 0], &alloc),
-        int128("decimal", [0; 0], &alloc),
-        varchar("varchar", ["0"; 0], &alloc),
-        scalar("scalar", [0; 0], &alloc),
-        boolean("boolean", [true; 0], &alloc),
+        borrowed_bigint("bigint", [0; 0], &alloc),
+        borrowed_int128("decimal", [0; 0], &alloc),
+        borrowed_varchar("varchar", ["0"; 0], &alloc),
+        borrowed_scalar("scalar", [0; 0], &alloc),
+        borrowed_boolean("boolean", [true; 0], &alloc),
     ]);
     let mut table = IndexMap::default();
     table.insert(Identifier::try_new("bigint").unwrap(), Column::BigInt(&[]));
@@ -47,28 +47,28 @@ fn we_can_create_a_table_with_data() {
     let alloc = Bump::new();
 
     let borrowed_table = table::<DoryScalar>([
-        bigint(
+        borrowed_bigint(
             "bigint",
             [0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
             &alloc,
         ),
-        int128(
+        borrowed_int128(
             "decimal",
             [0_i128, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX],
             &alloc,
         ),
-        varchar(
+        borrowed_varchar(
             "varchar",
             ["0", "1", "2", "3", "4", "5", "6", "7", "8"],
             &alloc,
         ),
-        scalar("scalar", [0, 1, 2, 3, 4, 5, 6, 7, 8], &alloc),
-        boolean(
+        borrowed_scalar("scalar", [0, 1, 2, 3, 4, 5, 6, 7, 8], &alloc),
+        borrowed_boolean(
             "boolean",
             [true, false, true, false, true, false, true, false, true],
             &alloc,
         ),
-        timestamptz(
+        borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -131,11 +131,11 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
     let alloc = Bump::new();
 
     let table_a: Table<'_, TestScalar> = table([
-        bigint("a", [0; 0], &alloc),
-        int128("b", [0; 0], &alloc),
-        varchar("c", ["0"; 0], &alloc),
-        boolean("d", [false; 0], &alloc),
-        timestamptz(
+        borrowed_bigint("a", [0; 0], &alloc),
+        borrowed_int128("b", [0; 0], &alloc),
+        borrowed_varchar("c", ["0"; 0], &alloc),
+        borrowed_boolean("d", [false; 0], &alloc),
+        borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -145,11 +145,11 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
     ]);
 
     let table_b: Table<'_, TestScalar> = table([
-        boolean("d", [false; 0], &alloc),
-        int128("b", [0; 0], &alloc),
-        bigint("a", [0; 0], &alloc),
-        varchar("c", ["0"; 0], &alloc),
-        timestamptz(
+        borrowed_boolean("d", [false; 0], &alloc),
+        borrowed_int128("b", [0; 0], &alloc),
+        borrowed_bigint("a", [0; 0], &alloc),
+        borrowed_varchar("c", ["0"; 0], &alloc),
+        borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -166,11 +166,11 @@ fn we_get_inequality_between_tables_with_differing_data() {
     let alloc = Bump::new();
 
     let table_a: Table<'_, DoryScalar> = table([
-        bigint("a", [0], &alloc),
-        int128("b", [0], &alloc),
-        varchar("c", ["0"], &alloc),
-        boolean("d", [true], &alloc),
-        timestamptz(
+        borrowed_bigint("a", [0], &alloc),
+        borrowed_int128("b", [0], &alloc),
+        borrowed_varchar("c", ["0"], &alloc),
+        borrowed_boolean("d", [true], &alloc),
+        borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -180,11 +180,11 @@ fn we_get_inequality_between_tables_with_differing_data() {
     ]);
 
     let table_b: Table<'_, DoryScalar> = table([
-        bigint("a", [1], &alloc),
-        int128("b", [0], &alloc),
-        varchar("c", ["0"], &alloc),
-        boolean("d", [true], &alloc),
-        timestamptz(
+        borrowed_bigint("a", [1], &alloc),
+        borrowed_int128("b", [0], &alloc),
+        borrowed_varchar("c", ["0"], &alloc),
+        borrowed_boolean("d", [true], &alloc),
+        borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -1,10 +1,7 @@
-use crate::{
-    base::{
-        database::{table_utility::*, Column, Table, TableError},
-        map::IndexMap,
-        scalar::test_scalar::TestScalar,
-    },
-    proof_primitive::dory::DoryScalar,
+use crate::base::{
+    database::{table_utility::*, Column, Table, TableError},
+    map::IndexMap,
+    scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
 use proof_of_sql_parser::{
@@ -16,11 +13,12 @@ use proof_of_sql_parser::{
 fn we_can_create_a_table_with_no_columns() {
     let table = Table::<TestScalar>::try_new(IndexMap::default()).unwrap();
     assert_eq!(table.num_columns(), 0);
+    assert_eq!(table.num_rows(), None);
 }
 #[test]
 fn we_can_create_an_empty_table() {
     let alloc = Bump::new();
-    let borrowed_table = table::<DoryScalar>([
+    let borrowed_table = table::<TestScalar>([
         borrowed_bigint("bigint", [0; 0], &alloc),
         borrowed_int128("decimal", [0; 0], &alloc),
         borrowed_varchar("varchar", ["0"; 0], &alloc),
@@ -46,7 +44,7 @@ fn we_can_create_an_empty_table() {
 fn we_can_create_a_table_with_data() {
     let alloc = Bump::new();
 
-    let borrowed_table = table::<DoryScalar>([
+    let borrowed_table = table::<TestScalar>([
         borrowed_bigint(
             "bigint",
             [0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
@@ -102,14 +100,14 @@ fn we_can_create_a_table_with_data() {
         .map(|&s| alloc.alloc_str(s) as &str)
         .collect();
     let varchar_str_slice = alloc.alloc_slice_clone(&varchar_data);
-    let varchar_scalars: Vec<DoryScalar> = varchar_data.iter().map(Into::into).collect();
+    let varchar_scalars: Vec<TestScalar> = varchar_data.iter().map(Into::into).collect();
     let varchar_scalars_slice = alloc.alloc_slice_clone(&varchar_scalars);
     expected_table.insert(
         Identifier::try_new("varchar").unwrap(),
         Column::VarChar((varchar_str_slice, varchar_scalars_slice)),
     );
 
-    let scalar_data: Vec<DoryScalar> = (0..=8).map(DoryScalar::from).collect();
+    let scalar_data: Vec<TestScalar> = (0..=8).map(TestScalar::from).collect();
     let scalar_slice = alloc.alloc_slice_copy(&scalar_data);
     expected_table.insert(
         Identifier::try_new("scalar").unwrap(),
@@ -165,7 +163,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
 fn we_get_inequality_between_tables_with_differing_data() {
     let alloc = Bump::new();
 
-    let table_a: Table<'_, DoryScalar> = table([
+    let table_a: Table<'_, TestScalar> = table([
         borrowed_bigint("a", [0], &alloc),
         borrowed_int128("b", [0], &alloc),
         borrowed_varchar("c", ["0"], &alloc),
@@ -179,7 +177,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
         ),
     ]);
 
-    let table_b: Table<'_, DoryScalar> = table([
+    let table_b: Table<'_, TestScalar> = table([
         borrowed_bigint("a", [1], &alloc),
         borrowed_int128("b", [0], &alloc),
         borrowed_varchar("c", ["0"], &alloc),

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -1,0 +1,208 @@
+use crate::{
+    base::{
+        database::{table_utility::*, Column, Table, TableError},
+        map::IndexMap,
+        scalar::test_scalar::TestScalar,
+    },
+    proof_primitive::dory::DoryScalar,
+};
+use bumpalo::Bump;
+use proof_of_sql_parser::{
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    Identifier,
+};
+
+#[test]
+fn we_can_create_a_table_with_no_columns() {
+    let table = Table::<TestScalar>::try_new(IndexMap::default()).unwrap();
+    assert_eq!(table.num_columns(), 0);
+}
+#[test]
+fn we_can_create_an_empty_table() {
+    let alloc = Bump::new();
+    let borrowed_table = table::<DoryScalar>([
+        bigint("bigint", [0; 0], &alloc),
+        int128("decimal", [0; 0], &alloc),
+        varchar("varchar", ["0"; 0], &alloc),
+        scalar("scalar", [0; 0], &alloc),
+        boolean("boolean", [true; 0], &alloc),
+    ]);
+    let mut table = IndexMap::default();
+    table.insert(Identifier::try_new("bigint").unwrap(), Column::BigInt(&[]));
+    table.insert(Identifier::try_new("decimal").unwrap(), Column::Int128(&[]));
+    table.insert(
+        Identifier::try_new("varchar").unwrap(),
+        Column::VarChar((&[], &[])),
+    );
+    table.insert(Identifier::try_new("scalar").unwrap(), Column::Scalar(&[]));
+    table.insert(
+        Identifier::try_new("boolean").unwrap(),
+        Column::Boolean(&[]),
+    );
+    assert_eq!(borrowed_table.into_inner(), table);
+}
+
+#[test]
+fn we_can_create_a_table_with_data() {
+    let alloc = Bump::new();
+
+    let borrowed_table = table::<DoryScalar>([
+        bigint(
+            "bigint",
+            [0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
+            &alloc,
+        ),
+        int128(
+            "decimal",
+            [0_i128, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX],
+            &alloc,
+        ),
+        varchar(
+            "varchar",
+            ["0", "1", "2", "3", "4", "5", "6", "7", "8"],
+            &alloc,
+        ),
+        scalar("scalar", [0, 1, 2, 3, 4, 5, 6, 7, 8], &alloc),
+        boolean(
+            "boolean",
+            [true, false, true, false, true, false, true, false, true],
+            &alloc,
+        ),
+        timestamptz(
+            "time_stamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            [0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
+            &alloc,
+        ),
+    ]);
+
+    let mut expected_table = IndexMap::default();
+
+    let time_stamp_data = alloc.alloc_slice_copy(&[0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]);
+    expected_table.insert(
+        Identifier::try_new("time_stamp").unwrap(),
+        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, time_stamp_data),
+    );
+
+    let bigint_data = alloc.alloc_slice_copy(&[0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]);
+    expected_table.insert(
+        Identifier::try_new("bigint").unwrap(),
+        Column::BigInt(bigint_data),
+    );
+
+    let decimal_data = alloc.alloc_slice_copy(&[0_i128, 1, 2, 3, 4, 5, 6, i128::MIN, i128::MAX]);
+    expected_table.insert(
+        Identifier::try_new("decimal").unwrap(),
+        Column::Int128(decimal_data),
+    );
+
+    let varchar_data: Vec<&str> = ["0", "1", "2", "3", "4", "5", "6", "7", "8"]
+        .iter()
+        .map(|&s| alloc.alloc_str(s) as &str)
+        .collect();
+    let varchar_str_slice = alloc.alloc_slice_clone(&varchar_data);
+    let varchar_scalars: Vec<DoryScalar> = varchar_data.iter().map(Into::into).collect();
+    let varchar_scalars_slice = alloc.alloc_slice_clone(&varchar_scalars);
+    expected_table.insert(
+        Identifier::try_new("varchar").unwrap(),
+        Column::VarChar((varchar_str_slice, varchar_scalars_slice)),
+    );
+
+    let scalar_data: Vec<DoryScalar> = (0..=8).map(DoryScalar::from).collect();
+    let scalar_slice = alloc.alloc_slice_copy(&scalar_data);
+    expected_table.insert(
+        Identifier::try_new("scalar").unwrap(),
+        Column::Scalar(scalar_slice),
+    );
+
+    let boolean_data =
+        alloc.alloc_slice_copy(&[true, false, true, false, true, false, true, false, true]);
+    expected_table.insert(
+        Identifier::try_new("boolean").unwrap(),
+        Column::Boolean(boolean_data),
+    );
+
+    assert_eq!(borrowed_table.into_inner(), expected_table);
+}
+
+#[test]
+fn we_get_inequality_between_tables_with_differing_column_order() {
+    let alloc = Bump::new();
+
+    let table_a: Table<'_, TestScalar> = table([
+        bigint("a", [0; 0], &alloc),
+        int128("b", [0; 0], &alloc),
+        varchar("c", ["0"; 0], &alloc),
+        boolean("d", [false; 0], &alloc),
+        timestamptz(
+            "time_stamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            [0_i64; 0],
+            &alloc,
+        ),
+    ]);
+
+    let table_b: Table<'_, TestScalar> = table([
+        boolean("d", [false; 0], &alloc),
+        int128("b", [0; 0], &alloc),
+        bigint("a", [0; 0], &alloc),
+        varchar("c", ["0"; 0], &alloc),
+        timestamptz(
+            "time_stamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            [0_i64; 0],
+            &alloc,
+        ),
+    ]);
+
+    assert_ne!(table_a, table_b);
+}
+
+#[test]
+fn we_get_inequality_between_tables_with_differing_data() {
+    let alloc = Bump::new();
+
+    let table_a: Table<'_, DoryScalar> = table([
+        bigint("a", [0], &alloc),
+        int128("b", [0], &alloc),
+        varchar("c", ["0"], &alloc),
+        boolean("d", [true], &alloc),
+        timestamptz(
+            "time_stamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            [1_625_072_400],
+            &alloc,
+        ),
+    ]);
+
+    let table_b: Table<'_, DoryScalar> = table([
+        bigint("a", [1], &alloc),
+        int128("b", [0], &alloc),
+        varchar("c", ["0"], &alloc),
+        boolean("d", [true], &alloc),
+        timestamptz(
+            "time_stamp",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            [1_625_076_000],
+            &alloc,
+        ),
+    ]);
+
+    assert_ne!(table_a, table_b);
+}
+
+#[test]
+fn we_cannot_create_a_table_with_differing_column_lengths() {
+    assert!(matches!(
+        Table::<TestScalar>::try_from_iter([
+            ("a".parse().unwrap(), Column::BigInt(&[0])),
+            ("b".parse().unwrap(), Column::BigInt(&[])),
+        ]),
+        Err(TableError::ColumnLengthMismatch)
+    ));
+}

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -111,7 +111,12 @@ impl<CP: CommitmentEvaluationProof> MetadataAccessor for TableTestAccessor<'_, C
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
     fn get_length(&self, table_ref: TableRef) -> usize {
-        self.tables.get(&table_ref).unwrap().0.num_rows()
+        self.tables
+            .get(&table_ref)
+            .unwrap()
+            .0
+            .num_rows()
+            .unwrap_or(0)
     }
     ///
     /// # Panics

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -1,0 +1,170 @@
+use super::{
+    Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor,
+    SchemaAccessor, Table, TableRef, TestAccessor,
+};
+use crate::base::{
+    commitment::{CommitmentEvaluationProof, VecCommitmentExt},
+    map::IndexMap,
+};
+use alloc::vec::Vec;
+use proof_of_sql_parser::Identifier;
+
+/// A test accessor that uses [`Table`] as the underlying table type.
+/// Note: this is intended for testing and examples. It is not optimized for performance, so should not be used for benchmarks or production use-cases.
+pub struct TableTestAccessor<'a, CP: CommitmentEvaluationProof> {
+    tables: IndexMap<TableRef, (Table<'a, CP::Scalar>, usize)>,
+    setup: Option<CP::ProverPublicSetup<'a>>,
+}
+
+impl<CP: CommitmentEvaluationProof> Default for TableTestAccessor<'_, CP> {
+    fn default() -> Self {
+        Self {
+            tables: IndexMap::default(),
+            setup: None,
+        }
+    }
+}
+
+impl<CP: CommitmentEvaluationProof> Clone for TableTestAccessor<'_, CP> {
+    fn clone(&self) -> Self {
+        Self {
+            tables: self.tables.clone(),
+            setup: self.setup,
+        }
+    }
+}
+
+impl<'a, CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment> for TableTestAccessor<'a, CP> {
+    type Table = Table<'a, CP::Scalar>;
+
+    fn new_empty() -> Self {
+        TableTestAccessor::default()
+    }
+
+    fn add_table(&mut self, table_ref: TableRef, data: Self::Table, table_offset: usize) {
+        self.tables.insert(table_ref, (data, table_offset));
+    }
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`, indicating
+    /// that an invalid reference was provided.
+    fn get_column_names(&self, table_ref: TableRef) -> Vec<&str> {
+        self.tables
+            .get(&table_ref)
+            .unwrap()
+            .0
+            .column_names()
+            .map(proof_of_sql_parser::Identifier::as_str)
+            .collect()
+    }
+
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
+    fn update_offset(&mut self, table_ref: TableRef, new_offset: usize) {
+        self.tables.get_mut(&table_ref).unwrap().1 = new_offset;
+    }
+}
+
+///
+/// # Panics
+///
+/// Will panic if the `column.table_ref()` is not found in `self.tables`, or if
+/// the `column.column_id()` is not found in the inner table for that reference,
+/// indicating that an invalid column reference was provided.
+impl<'a, CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for TableTestAccessor<'a, CP> {
+    fn get_column(&self, column: ColumnRef) -> Column<'a, CP::Scalar> {
+        *self
+            .tables
+            .get(&column.table_ref())
+            .unwrap()
+            .0
+            .inner_table()
+            .get(&column.column_id())
+            .unwrap()
+    }
+}
+
+///
+/// # Panics
+///
+/// Will panic if the `column.table_ref()` is not found in `self.tables`, or if the `column.column_id()` is not found in the inner table for that reference,indicating that an invalid column reference was provided.
+impl<CP: CommitmentEvaluationProof> CommitmentAccessor<CP::Commitment>
+    for TableTestAccessor<'_, CP>
+{
+    fn get_commitment(&self, column: ColumnRef) -> CP::Commitment {
+        let (table, offset) = self.tables.get(&column.table_ref()).unwrap();
+        let borrowed_column = table.inner_table().get(&column.column_id()).unwrap();
+        Vec::<CP::Commitment>::from_columns_with_offset(
+            [borrowed_column],
+            *offset,
+            self.setup.as_ref().unwrap(),
+        )[0]
+        .clone()
+    }
+}
+impl<CP: CommitmentEvaluationProof> MetadataAccessor for TableTestAccessor<'_, CP> {
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
+    fn get_length(&self, table_ref: TableRef) -> usize {
+        self.tables.get(&table_ref).unwrap().0.num_rows()
+    }
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
+    fn get_offset(&self, table_ref: TableRef) -> usize {
+        self.tables.get(&table_ref).unwrap().1
+    }
+}
+impl<CP: CommitmentEvaluationProof> SchemaAccessor for TableTestAccessor<'_, CP> {
+    fn lookup_column(&self, table_ref: TableRef, column_id: Identifier) -> Option<ColumnType> {
+        Some(
+            self.tables
+                .get(&table_ref)?
+                .0
+                .inner_table()
+                .get(&column_id)?
+                .column_type(),
+        )
+    }
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
+    fn lookup_schema(&self, table_ref: TableRef) -> Vec<(Identifier, ColumnType)> {
+        self.tables
+            .get(&table_ref)
+            .unwrap()
+            .0
+            .inner_table()
+            .iter()
+            .map(|(&id, col)| (id, col.column_type()))
+            .collect()
+    }
+}
+
+impl<'a, CP: CommitmentEvaluationProof> TableTestAccessor<'a, CP> {
+    /// Create a new empty test accessor with the given setup.
+    pub fn new_empty_with_setup(setup: CP::ProverPublicSetup<'a>) -> Self {
+        let mut res = Self::new_empty();
+        res.setup = Some(setup);
+        res
+    }
+
+    /// Create a new test accessor containing the provided table.
+    pub fn new_from_table(
+        table_ref: TableRef,
+        table: Table<'a, CP::Scalar>,
+        offset: usize,
+        setup: CP::ProverPublicSetup<'a>,
+    ) -> Self {
+        let mut res = Self::new_empty_with_setup(setup);
+        res.add_table(table_ref, table, offset);
+        res
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -21,16 +21,16 @@ fn we_can_query_the_length_of_a_table() {
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
     let data1 = table([
-        bigint("a", [1, 2, 3], &alloc),
-        bigint("b", [4, 5, 6], &alloc),
+        borrowed_bigint("a", [1, 2, 3], &alloc),
+        borrowed_bigint("b", [4, 5, 6], &alloc),
     ]);
     accessor.add_table(table_ref_1, data1, 0_usize);
 
     assert_eq!(accessor.get_length(table_ref_1), 3);
 
     let data2 = table([
-        bigint("a", [1, 2, 3, 4], &alloc),
-        bigint("b", [4, 5, 6, 5], &alloc),
+        borrowed_bigint("a", [1, 2, 3, 4], &alloc),
+        borrowed_bigint("b", [4, 5, 6, 5], &alloc),
     ]);
     accessor.add_table(table_ref_2, data2, 0_usize);
 
@@ -46,8 +46,8 @@ fn we_can_access_the_columns_of_a_table() {
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
     let data1 = table([
-        bigint("a", [1, 2, 3], &alloc),
-        bigint("b", [4, 5, 6], &alloc),
+        borrowed_bigint("a", [1, 2, 3], &alloc),
+        borrowed_bigint("b", [4, 5, 6], &alloc),
     ]);
     accessor.add_table(table_ref_1, data1, 0_usize);
 
@@ -58,13 +58,13 @@ fn we_can_access_the_columns_of_a_table() {
     };
 
     let data2 = table([
-        bigint("a", [1, 2, 3, 4], &alloc),
-        bigint("b", [4, 5, 6, 5], &alloc),
-        int128("c128", [1, 2, 3, 4], &alloc),
-        varchar("varchar", ["a", "bc", "d", "e"], &alloc),
-        scalar("scalar", [1, 2, 3, 4], &alloc),
-        boolean("boolean", [true, false, true, false], &alloc),
-        timestamptz(
+        borrowed_bigint("a", [1, 2, 3, 4], &alloc),
+        borrowed_bigint("b", [4, 5, 6, 5], &alloc),
+        borrowed_int128("c128", [1, 2, 3, 4], &alloc),
+        borrowed_varchar("varchar", ["a", "bc", "d", "e"], &alloc),
+        borrowed_scalar("scalar", [1, 2, 3, 4], &alloc),
+        borrowed_boolean("boolean", [true, false, true, false], &alloc),
+        borrowed_timestamptz(
             "time",
             PoSQLTimeUnit::Second,
             PoSQLTimeZone::Utc,
@@ -145,8 +145,8 @@ fn we_can_access_the_commitments_of_table_columns() {
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
     let data1 = table([
-        bigint("a", [1, 2, 3], &alloc),
-        bigint("b", [4, 5, 6], &alloc),
+        borrowed_bigint("a", [1, 2, 3], &alloc),
+        borrowed_bigint("b", [4, 5, 6], &alloc),
     ]);
     accessor.add_table(table_ref_1, data1, 0_usize);
 
@@ -161,8 +161,8 @@ fn we_can_access_the_commitments_of_table_columns() {
     );
 
     let data2 = table([
-        bigint("a", [1, 2, 3, 4], &alloc),
-        bigint("b", [4, 5, 6, 5], &alloc),
+        borrowed_bigint("a", [1, 2, 3, 4], &alloc),
+        borrowed_bigint("b", [4, 5, 6, 5], &alloc),
     ]);
     accessor.add_table(table_ref_2, data2, 0_usize);
 
@@ -195,8 +195,8 @@ fn we_can_access_the_type_of_table_columns() {
     let table_ref_2 = "sxt.test2".parse().unwrap();
 
     let data1 = table([
-        bigint("a", [1, 2, 3], &alloc),
-        bigint("b", [4, 5, 6], &alloc),
+        borrowed_bigint("a", [1, 2, 3], &alloc),
+        borrowed_bigint("b", [4, 5, 6], &alloc),
     ]);
     accessor.add_table(table_ref_1, data1, 0_usize);
 
@@ -212,8 +212,8 @@ fn we_can_access_the_type_of_table_columns() {
         .is_none());
 
     let data2 = table([
-        bigint("a", [1, 2, 3, 4], &alloc),
-        bigint("b", [4, 5, 6, 5], &alloc),
+        borrowed_bigint("a", [1, 2, 3, 4], &alloc),
+        borrowed_bigint("b", [4, 5, 6, 5], &alloc),
     ]);
     accessor.add_table(table_ref_2, data2, 0_usize);
 
@@ -242,8 +242,8 @@ fn we_can_access_schema_and_column_names() {
     let table_ref_1 = "sxt.test".parse().unwrap();
 
     let data1 = table([
-        bigint("a", [1, 2, 3], &alloc),
-        varchar("b", ["x", "y", "z"], &alloc),
+        borrowed_bigint("a", [1, 2, 3], &alloc),
+        borrowed_varchar("b", ["x", "y", "z"], &alloc),
     ]);
     accessor.add_table(table_ref_1, data1, 0_usize);
 
@@ -264,8 +264,8 @@ fn we_can_correctly_update_offsets() {
     let table_ref = "sxt.test".parse().unwrap();
 
     let data = table([
-        bigint("a", [1, 2, 3], &alloc),
-        bigint("b", [123, 5, 123], &alloc),
+        borrowed_bigint("a", [1, 2, 3], &alloc),
+        borrowed_bigint("b", [123, 5, 123], &alloc),
     ]);
     accessor1.add_table(table_ref, data.clone(), 0_usize);
 

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -1,0 +1,305 @@
+use super::{
+    Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor,
+    SchemaAccessor, TableTestAccessor, TestAccessor,
+};
+use crate::base::{
+    commitment::{
+        naive_commitment::NaiveCommitment, test_evaluation_proof::TestEvaluationProof, Commitment,
+        CommittableColumn,
+    },
+    database::table_utility::*,
+    scalar::test_scalar::TestScalar,
+};
+use bumpalo::Bump;
+use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+
+#[test]
+fn we_can_query_the_length_of_a_table() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
+    let table_ref_1 = "sxt.test".parse().unwrap();
+    let table_ref_2 = "sxt.test2".parse().unwrap();
+
+    let data1 = table([
+        bigint("a", [1, 2, 3], &alloc),
+        bigint("b", [4, 5, 6], &alloc),
+    ]);
+    accessor.add_table(table_ref_1, data1, 0_usize);
+
+    assert_eq!(accessor.get_length(table_ref_1), 3);
+
+    let data2 = table([
+        bigint("a", [1, 2, 3, 4], &alloc),
+        bigint("b", [4, 5, 6, 5], &alloc),
+    ]);
+    accessor.add_table(table_ref_2, data2, 0_usize);
+
+    assert_eq!(accessor.get_length(table_ref_1), 3);
+    assert_eq!(accessor.get_length(table_ref_2), 4);
+}
+
+#[test]
+fn we_can_access_the_columns_of_a_table() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
+    let table_ref_1 = "sxt.test".parse().unwrap();
+    let table_ref_2 = "sxt.test2".parse().unwrap();
+
+    let data1 = table([
+        bigint("a", [1, 2, 3], &alloc),
+        bigint("b", [4, 5, 6], &alloc),
+    ]);
+    accessor.add_table(table_ref_1, data1, 0_usize);
+
+    let column = ColumnRef::new(table_ref_1, "b".parse().unwrap(), ColumnType::BigInt);
+    match accessor.get_column(column) {
+        Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6]),
+        _ => panic!("Invalid column type"),
+    };
+
+    let data2 = table([
+        bigint("a", [1, 2, 3, 4], &alloc),
+        bigint("b", [4, 5, 6, 5], &alloc),
+        int128("c128", [1, 2, 3, 4], &alloc),
+        varchar("varchar", ["a", "bc", "d", "e"], &alloc),
+        scalar("scalar", [1, 2, 3, 4], &alloc),
+        boolean("boolean", [true, false, true, false], &alloc),
+        timestamptz(
+            "time",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::Utc,
+            [4, 5, 6, 5],
+            &alloc,
+        ),
+    ]);
+    accessor.add_table(table_ref_2, data2, 0_usize);
+
+    let column = ColumnRef::new(table_ref_1, "a".parse().unwrap(), ColumnType::BigInt);
+    match accessor.get_column(column) {
+        Column::BigInt(col) => assert_eq!(col.to_vec(), vec![1, 2, 3]),
+        _ => panic!("Invalid column type"),
+    };
+
+    let column = ColumnRef::new(table_ref_2, "b".parse().unwrap(), ColumnType::BigInt);
+    match accessor.get_column(column) {
+        Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
+        _ => panic!("Invalid column type"),
+    };
+
+    let column = ColumnRef::new(table_ref_2, "c128".parse().unwrap(), ColumnType::Int128);
+    match accessor.get_column(column) {
+        Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
+        _ => panic!("Invalid column type"),
+    };
+
+    let col_slice: Vec<_> = vec!["a", "bc", "d", "e"];
+    let col_scalars: Vec<_> = ["a", "bc", "d", "e"]
+        .iter()
+        .map(core::convert::Into::into)
+        .collect();
+    let column = ColumnRef::new(table_ref_2, "varchar".parse().unwrap(), ColumnType::VarChar);
+    match accessor.get_column(column) {
+        Column::VarChar((col, scals)) => {
+            assert_eq!(col.to_vec(), col_slice);
+            assert_eq!(scals.to_vec(), col_scalars);
+        }
+        _ => panic!("Invalid column type"),
+    };
+
+    let column = ColumnRef::new(table_ref_2, "scalar".parse().unwrap(), ColumnType::Scalar);
+    match accessor.get_column(column) {
+        Column::Scalar(col) => assert_eq!(
+            col.to_vec(),
+            vec![
+                TestScalar::from(1),
+                TestScalar::from(2),
+                TestScalar::from(3),
+                TestScalar::from(4)
+            ]
+        ),
+        _ => panic!("Invalid column type"),
+    };
+
+    let column = ColumnRef::new(table_ref_2, "boolean".parse().unwrap(), ColumnType::Boolean);
+    match accessor.get_column(column) {
+        Column::Boolean(col) => assert_eq!(col.to_vec(), vec![true, false, true, false]),
+        _ => panic!("Invalid column type"),
+    };
+
+    let column = ColumnRef::new(
+        table_ref_2,
+        "time".parse().unwrap(),
+        ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::Utc),
+    );
+    match accessor.get_column(column) {
+        Column::TimestampTZ(_, _, col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
+        _ => panic!("Invalid column type"),
+    };
+}
+
+#[test]
+fn we_can_access_the_commitments_of_table_columns() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
+    let table_ref_1 = "sxt.test".parse().unwrap();
+    let table_ref_2 = "sxt.test2".parse().unwrap();
+
+    let data1 = table([
+        bigint("a", [1, 2, 3], &alloc),
+        bigint("b", [4, 5, 6], &alloc),
+    ]);
+    accessor.add_table(table_ref_1, data1, 0_usize);
+
+    let column = ColumnRef::new(table_ref_1, "b".parse().unwrap(), ColumnType::BigInt);
+    assert_eq!(
+        accessor.get_commitment(column),
+        NaiveCommitment::compute_commitments(
+            &[CommittableColumn::from(&[4i64, 5, 6][..])],
+            0_usize,
+            &()
+        )[0]
+    );
+
+    let data2 = table([
+        bigint("a", [1, 2, 3, 4], &alloc),
+        bigint("b", [4, 5, 6, 5], &alloc),
+    ]);
+    accessor.add_table(table_ref_2, data2, 0_usize);
+
+    let column = ColumnRef::new(table_ref_1, "a".parse().unwrap(), ColumnType::BigInt);
+    assert_eq!(
+        accessor.get_commitment(column),
+        NaiveCommitment::compute_commitments(
+            &[CommittableColumn::from(&[1i64, 2, 3][..])],
+            0_usize,
+            &()
+        )[0]
+    );
+
+    let column = ColumnRef::new(table_ref_2, "b".parse().unwrap(), ColumnType::BigInt);
+    assert_eq!(
+        accessor.get_commitment(column),
+        NaiveCommitment::compute_commitments(
+            &[CommittableColumn::from(&[4i64, 5, 6, 5][..])],
+            0_usize,
+            &()
+        )[0]
+    );
+}
+
+#[test]
+fn we_can_access_the_type_of_table_columns() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
+    let table_ref_1 = "sxt.test".parse().unwrap();
+    let table_ref_2 = "sxt.test2".parse().unwrap();
+
+    let data1 = table([
+        bigint("a", [1, 2, 3], &alloc),
+        bigint("b", [4, 5, 6], &alloc),
+    ]);
+    accessor.add_table(table_ref_1, data1, 0_usize);
+
+    let column = ColumnRef::new(table_ref_1, "b".parse().unwrap(), ColumnType::BigInt);
+    assert_eq!(
+        accessor.lookup_column(column.table_ref(), column.column_id()),
+        Some(ColumnType::BigInt)
+    );
+
+    let column = ColumnRef::new(table_ref_1, "c".parse().unwrap(), ColumnType::BigInt);
+    assert!(accessor
+        .lookup_column(column.table_ref(), column.column_id())
+        .is_none());
+
+    let data2 = table([
+        bigint("a", [1, 2, 3, 4], &alloc),
+        bigint("b", [4, 5, 6, 5], &alloc),
+    ]);
+    accessor.add_table(table_ref_2, data2, 0_usize);
+
+    let column = ColumnRef::new(table_ref_1, "a".parse().unwrap(), ColumnType::BigInt);
+    assert_eq!(
+        accessor.lookup_column(column.table_ref(), column.column_id()),
+        Some(ColumnType::BigInt)
+    );
+
+    let column = ColumnRef::new(table_ref_2, "b".parse().unwrap(), ColumnType::BigInt);
+    assert_eq!(
+        accessor.lookup_column(column.table_ref(), column.column_id()),
+        Some(ColumnType::BigInt)
+    );
+
+    let column = ColumnRef::new(table_ref_2, "c".parse().unwrap(), ColumnType::BigInt);
+    assert!(accessor
+        .lookup_column(column.table_ref(), column.column_id())
+        .is_none());
+}
+
+#[test]
+fn we_can_access_schema_and_column_names() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
+    let table_ref_1 = "sxt.test".parse().unwrap();
+
+    let data1 = table([
+        bigint("a", [1, 2, 3], &alloc),
+        varchar("b", ["x", "y", "z"], &alloc),
+    ]);
+    accessor.add_table(table_ref_1, data1, 0_usize);
+
+    assert_eq!(
+        accessor.lookup_schema(table_ref_1),
+        vec![
+            ("a".parse().unwrap(), ColumnType::BigInt),
+            ("b".parse().unwrap(), ColumnType::VarChar)
+        ]
+    );
+    assert_eq!(accessor.get_column_names(table_ref_1), vec!["a", "b"]);
+}
+
+#[test]
+fn we_can_correctly_update_offsets() {
+    let alloc = Bump::new();
+    let mut accessor1 = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
+    let table_ref = "sxt.test".parse().unwrap();
+
+    let data = table([
+        bigint("a", [1, 2, 3], &alloc),
+        bigint("b", [123, 5, 123], &alloc),
+    ]);
+    accessor1.add_table(table_ref, data.clone(), 0_usize);
+
+    let offset = 123;
+    let mut accessor2 = TableTestAccessor::<TestEvaluationProof>::new_empty_with_setup(());
+    accessor2.add_table(table_ref, data, offset);
+
+    let column = ColumnRef::new(table_ref, "a".parse().unwrap(), ColumnType::BigInt);
+    assert_ne!(
+        accessor1.get_commitment(column),
+        accessor2.get_commitment(column)
+    );
+    let column = ColumnRef::new(table_ref, "b".parse().unwrap(), ColumnType::BigInt);
+    assert_ne!(
+        accessor1.get_commitment(column),
+        accessor2.get_commitment(column)
+    );
+
+    assert_eq!(accessor1.get_offset(table_ref), 0);
+    assert_eq!(accessor2.get_offset(table_ref), offset);
+
+    accessor1.update_offset(table_ref, offset);
+
+    let column = ColumnRef::new(table_ref, "a".parse().unwrap(), ColumnType::BigInt);
+    assert_eq!(
+        accessor1.get_commitment(column),
+        accessor2.get_commitment(column)
+    );
+    let column = ColumnRef::new(table_ref, "b".parse().unwrap(), ColumnType::BigInt);
+    assert_eq!(
+        accessor1.get_commitment(column),
+        accessor2.get_commitment(column)
+    );
+
+    assert_eq!(accessor1.get_offset(table_ref), offset);
+    assert_eq!(accessor2.get_offset(table_ref), offset);
+}

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -1,0 +1,339 @@
+//! Utility functions for creating [`Table`]s and [`Column`]s.
+//! These functions are primarily intended for use in tests.
+//!
+//! # Example
+//! ```
+//! use bumpalo::Bump;
+//! use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+//! let alloc = Bump::new();
+//! let result = table::<Curve25519Scalar>([
+//!     bigint("a", [1, 2, 3], &alloc),
+//!     boolean("b", [true, false, true], &alloc),
+//!     int128("c", [1, 2, 3], &alloc),
+//!     scalar("d", [1, 2, 3], &alloc),
+//!     varchar("e", ["a", "b", "c"], &alloc),
+//!     decimal75("f", 12, 1, [1, 2, 3], &alloc),
+//! ]);
+//! ```
+use super::{Column, Table};
+use crate::base::scalar::Scalar;
+use alloc::{string::String, vec::Vec};
+use bumpalo::Bump;
+use core::ops::Deref;
+use proof_of_sql_parser::{
+    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    Identifier,
+};
+
+/// Creates an [`Table`] from a list of `(Identifier, Column)` pairs.
+/// This is a convenience wrapper around [`Table::try_from_iter`] primarily for use in tests and
+/// intended to be used along with the other methods in this module (e.g. [bigint], [boolean], etc).
+/// The function will panic under a variety of conditions. See [`Table::try_from_iter`] for more details.
+///
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     bigint("a", [1, 2, 3], &alloc),
+///     boolean("b", [true, false, true], &alloc),
+///     int128("c", [1, 2, 3], &alloc),
+///     scalar("d", [1, 2, 3], &alloc),
+///     varchar("e", ["a", "b", "c"], &alloc),
+///     decimal75("f", 12, 1, [1, 2, 3], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if converting the iterator into an `Table<'a, S>` fails.
+pub fn table<'a, S: Scalar>(
+    iter: impl IntoIterator<Item = (Identifier, Column<'a, S>)>,
+) -> Table<'a, S> {
+    Table::try_from_iter(iter).unwrap()
+}
+
+/// Creates a (Identifier, `Column`) pair for a tinyint column.
+/// This is primarily intended for use in conjunction with [`table`].
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     tinyint("a", [1_i8, 2, 3], &alloc),
+/// ]);
+///```
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn tinyint<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i8>>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let transformed_data: Vec<i8> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (name.parse().unwrap(), Column::TinyInt(alloc_data))
+}
+
+/// Creates a `(Identifier, Column)` pair for a smallint column.
+/// This is primarily intended for use in conjunction with [`table`].
+///
+/// # Example
+/// ```rust
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     smallint("a", [1_i16, 2, 3], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn smallint<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i16>>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let transformed_data: Vec<i16> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (name.parse().unwrap(), Column::SmallInt(alloc_data))
+}
+
+/// Creates a `(Identifier, Column)` pair for an int column.
+/// This is primarily intended for use in conjunction with [`table`].
+///
+/// # Example
+/// ```rust
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     int("a", [1, 2, 3], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn int<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i32>>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let transformed_data: Vec<i32> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (name.parse().unwrap(), Column::Int(alloc_data))
+}
+
+/// Creates a `(Identifier, Column)` pair for a bigint column.
+/// This is primarily intended for use in conjunction with [`table`].
+///
+/// # Example
+/// ```rust
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     bigint("a", [1, 2, 3], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+#[allow(clippy::missing_panics_doc)]
+pub fn bigint<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i64>>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let transformed_data: Vec<i64> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (name.parse().unwrap(), Column::BigInt(alloc_data))
+}
+
+/// Creates a `(Identifier, Column)` pair for a boolean column.
+/// This is primarily intended for use in conjunction with [`table`].
+///
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     boolean("a", [true, false, true], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn boolean<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<bool>>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let transformed_data: Vec<bool> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (name.parse().unwrap(), Column::Boolean(alloc_data))
+}
+
+/// Creates a `(Identifier, Column)` pair for an int128 column.
+/// This is primarily intended for use in conjunction with [`table`].
+///
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     int128("a", [1, 2, 3], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn int128<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<i128>>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let transformed_data: Vec<i128> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (name.parse().unwrap(), Column::Int128(alloc_data))
+}
+
+/// Creates a `(Identifier, Column)` pair for a scalar column.
+/// This is primarily intended for use in conjunction with [`table`].
+///
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     scalar("a", [1, 2, 3], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn scalar<S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<S>>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let transformed_data: Vec<S> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (name.parse().unwrap(), Column::Scalar(alloc_data))
+}
+
+/// Creates a `(Identifier, Column)` pair for a varchar column.
+/// This is primarily intended for use in conjunction with [`table`].
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     varchar("a", ["a", "b", "c"], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn varchar<'a, S: Scalar>(
+    name: impl Deref<Target = str>,
+    data: impl IntoIterator<Item = impl Into<String>>,
+    alloc: &'a Bump,
+) -> (Identifier, Column<'a, S>) {
+    let strings: Vec<&'a str> = data
+        .into_iter()
+        .map(|item| {
+            let string = item.into();
+            alloc.alloc_str(&string) as &'a str
+        })
+        .collect();
+    let alloc_strings = alloc.alloc_slice_clone(&strings);
+    let scalars: Vec<S> = strings.into_iter().map(Into::into).collect();
+    let alloc_scalars = alloc.alloc_slice_copy(&scalars);
+    (
+        name.parse().unwrap(),
+        Column::VarChar((alloc_strings, alloc_scalars)),
+    )
+}
+
+/// Creates a `(Identifier, Column)` pair for a decimal75 column.
+/// This is primarily intended for use in conjunction with [`table`].
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     decimal75("a", 12, 1, [1, 2, 3], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+/// - Panics if creating the `Precision` from the specified precision value fails.
+pub fn decimal75<S: Scalar>(
+    name: impl Deref<Target = str>,
+    precision: u8,
+    scale: i8,
+    data: impl IntoIterator<Item = impl Into<S>>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let transformed_data: Vec<S> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (
+        name.parse().unwrap(),
+        Column::Decimal75(
+            crate::base::math::decimal::Precision::new(precision).unwrap(),
+            scale,
+            alloc_data,
+        ),
+    )
+}
+
+/// Creates a `(Identifier, Column)` pair for a timestamp column.
+/// This is primarily intended for use in conjunction with [`table`].
+///
+/// # Parameters
+/// - `name`: The name of the column.
+/// - `time_unit`: The time unit of the timestamps.
+/// - `timezone`: The timezone for the timestamps.
+/// - `data`: The data for the column, provided as an iterator over `i64` values representing time since the unix epoch.
+/// - `alloc`: The bump allocator to use for allocating the column data.
+///
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*,
+///     scalar::Curve25519Scalar,
+/// };
+/// use proof_of_sql_parser::{
+///    posql_time::{PoSQLTimeZone, PoSQLTimeUnit}};
+///
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, vec![1625072400, 1625076000, 1625079600], &alloc),
+/// ]);
+/// ```
+///
+/// # Panics
+/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+pub fn timestamptz<S: Scalar>(
+    name: impl Deref<Target = str>,
+    time_unit: PoSQLTimeUnit,
+    timezone: PoSQLTimeZone,
+    data: impl IntoIterator<Item = i64>,
+    alloc: &Bump,
+) -> (Identifier, Column<'_, S>) {
+    let vec_data: Vec<i64> = data.into_iter().collect();
+    let alloc_data = alloc.alloc_slice_copy(&vec_data);
+    (
+        name.parse().unwrap(),
+        Column::TimestampTZ(time_unit, timezone, alloc_data),
+    )
+}

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -7,12 +7,12 @@
 //! use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 //! let alloc = Bump::new();
 //! let result = table::<Curve25519Scalar>([
-//!     bigint("a", [1, 2, 3], &alloc),
-//!     boolean("b", [true, false, true], &alloc),
-//!     int128("c", [1, 2, 3], &alloc),
-//!     scalar("d", [1, 2, 3], &alloc),
-//!     varchar("e", ["a", "b", "c"], &alloc),
-//!     decimal75("f", 12, 1, [1, 2, 3], &alloc),
+//!     borrowed_bigint("a", [1, 2, 3], &alloc),
+//!     borrowed_boolean("b", [true, false, true], &alloc),
+//!     borrowed_int128("c", [1, 2, 3], &alloc),
+//!     borrowed_scalar("d", [1, 2, 3], &alloc),
+//!     borrowed_varchar("e", ["a", "b", "c"], &alloc),
+//!     borrowed_decimal75("f", 12, 1, [1, 2, 3], &alloc),
 //! ]);
 //! ```
 use super::{Column, Table};
@@ -36,12 +36,12 @@ use proof_of_sql_parser::{
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     bigint("a", [1, 2, 3], &alloc),
-///     boolean("b", [true, false, true], &alloc),
-///     int128("c", [1, 2, 3], &alloc),
-///     scalar("d", [1, 2, 3], &alloc),
-///     varchar("e", ["a", "b", "c"], &alloc),
-///     decimal75("f", 12, 1, [1, 2, 3], &alloc),
+///     borrowed_bigint("a", [1, 2, 3], &alloc),
+///     borrowed_boolean("b", [true, false, true], &alloc),
+///     borrowed_int128("c", [1, 2, 3], &alloc),
+///     borrowed_scalar("d", [1, 2, 3], &alloc),
+///     borrowed_varchar("e", ["a", "b", "c"], &alloc),
+///     borrowed_decimal75("f", 12, 1, [1, 2, 3], &alloc),
 /// ]);
 /// ```
 ///
@@ -61,12 +61,12 @@ pub fn table<'a, S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     tinyint("a", [1_i8, 2, 3], &alloc),
+///     borrowed_tinyint("a", [1_i8, 2, 3], &alloc),
 /// ]);
 ///```
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-pub fn tinyint<S: Scalar>(
+pub fn borrowed_tinyint<S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<i8>>,
     alloc: &Bump,
@@ -85,13 +85,13 @@ pub fn tinyint<S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     smallint("a", [1_i16, 2, 3], &alloc),
+///     borrowed_smallint("a", [1_i16, 2, 3], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-pub fn smallint<S: Scalar>(
+pub fn borrowed_smallint<S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<i16>>,
     alloc: &Bump,
@@ -110,13 +110,13 @@ pub fn smallint<S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     int("a", [1, 2, 3], &alloc),
+///     borrowed_int("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-pub fn int<S: Scalar>(
+pub fn borrowed_int<S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<i32>>,
     alloc: &Bump,
@@ -135,14 +135,14 @@ pub fn int<S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     bigint("a", [1, 2, 3], &alloc),
+///     borrowed_bigint("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 #[allow(clippy::missing_panics_doc)]
-pub fn bigint<S: Scalar>(
+pub fn borrowed_bigint<S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<i64>>,
     alloc: &Bump,
@@ -161,13 +161,13 @@ pub fn bigint<S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     boolean("a", [true, false, true], &alloc),
+///     borrowed_boolean("a", [true, false, true], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-pub fn boolean<S: Scalar>(
+pub fn borrowed_boolean<S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<bool>>,
     alloc: &Bump,
@@ -186,13 +186,13 @@ pub fn boolean<S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     int128("a", [1, 2, 3], &alloc),
+///     borrowed_int128("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-pub fn int128<S: Scalar>(
+pub fn borrowed_int128<S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<i128>>,
     alloc: &Bump,
@@ -211,13 +211,13 @@ pub fn int128<S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     scalar("a", [1, 2, 3], &alloc),
+///     borrowed_scalar("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-pub fn scalar<S: Scalar>(
+pub fn borrowed_scalar<S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<S>>,
     alloc: &Bump,
@@ -235,13 +235,13 @@ pub fn scalar<S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     varchar("a", ["a", "b", "c"], &alloc),
+///     borrowed_varchar("a", ["a", "b", "c"], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-pub fn varchar<'a, S: Scalar>(
+pub fn borrowed_varchar<'a, S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<String>>,
     alloc: &'a Bump,
@@ -254,7 +254,7 @@ pub fn varchar<'a, S: Scalar>(
         })
         .collect();
     let alloc_strings = alloc.alloc_slice_clone(&strings);
-    let scalars: Vec<S> = strings.into_iter().map(Into::into).collect();
+    let scalars: Vec<S> = strings.iter().map(|s| (*s).into()).collect();
     let alloc_scalars = alloc.alloc_slice_copy(&scalars);
     (
         name.parse().unwrap(),
@@ -270,14 +270,14 @@ pub fn varchar<'a, S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     decimal75("a", 12, 1, [1, 2, 3], &alloc),
+///     borrowed_decimal75("a", 12, 1, [1, 2, 3], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 /// - Panics if creating the `Precision` from the specified precision value fails.
-pub fn decimal75<S: Scalar>(
+pub fn borrowed_decimal75<S: Scalar>(
     name: impl Deref<Target = str>,
     precision: u8,
     scale: i8,
@@ -317,13 +317,13 @@ pub fn decimal75<S: Scalar>(
 ///
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, vec![1625072400, 1625076000, 1625079600], &alloc),
+///     borrowed_timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::Utc, vec![1625072400, 1625076000, 1625079600], &alloc),
 /// ]);
 /// ```
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-pub fn timestamptz<S: Scalar>(
+pub fn borrowed_timestamptz<S: Scalar>(
     name: impl Deref<Target = str>,
     time_unit: PoSQLTimeUnit,
     timezone: PoSQLTimeZone,

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -141,7 +141,6 @@ pub fn borrowed_int<S: Scalar>(
 ///
 /// # Panics
 /// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
-#[allow(clippy::missing_panics_doc)]
 pub fn borrowed_bigint<S: Scalar>(
     name: impl Deref<Target = str>,
     data: impl IntoIterator<Item = impl Into<i64>>,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to make `ProofPlan`s composable it is helpful to add `Table` which will replace `DataAccessor` in `ProofExpr`. In order to add tests that aren't too tedious it is necessary to add table utilities analogous to owned table ones.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `Table`
- add table utilities in `table_utility.rs`
- add `TableTestAccessor
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.