### PR TITLE
feat!: upgrade Arkworks and Blitzar crates to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,20 @@ license-file = "LICENSE"
 [workspace.dependencies]
 ahash = { version = "0.8.11", default-features = false }
 alloy-sol-types = { version = "0.8.5" }
-ark-bls12-381 = { version = "0.4.0" }
-ark-curve25519 = { version = "0.4.0" }
-ark-ec = { version = "0.4.0" }
-ark-ff = { version = "0.4.0" }
-ark-poly = { version = "0.4.0" }
-ark-serialize = { version = "0.4.0" }
-ark-std = { version = "0.4.0", default-features = false }
+ark-bls12-381 = { version = "0.5.0" }
+ark-curve25519 = { version = "0.5.0" }
+ark-ec = { version = "0.5.0" }
+ark-ff = { version = "0.5.0" }
+ark-poly = { version = "0.5.0" }
+ark-serialize = { version = "0.5.0" }
+ark-std = { version = "0.5.0", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
 arrow = { version = "51.0.0" }
 arrow-csv = { version = "51.0.0" }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3", default-features = false }
-blitzar = { version = "3.4.0" }
+blitzar = { version = "4.0.0" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
 byte-slice-cast = { version = "1.2.1", default-features = false }

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector_test.rs
@@ -1,6 +1,6 @@
 use super::compute_evaluation_vector;
 use crate::base::{scalar::test_scalar::TestScalar, slice_ops};
-use ark_poly::MultilinearExtension;
+use ark_poly::Polynomial;
 use num_traits::{One, Zero};
 
 #[test]
@@ -90,6 +90,6 @@ fn we_get_the_same_result_using_evaluation_vector_as_direct_evaluation() {
         3,
         &TestScalar::unwrap_slice(&xs),
     );
-    let expected_eval = TestScalar::new(poly.evaluate(&TestScalar::unwrap_slice(&point)).unwrap());
+    let expected_eval = TestScalar::new(poly.evaluate(&TestScalar::unwrap_slice(&point)));
     assert_eq!(eval, expected_eval);
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_helper.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use alloc::{vec, vec::Vec};
-use ark_ff::Field;
+use ark_ff::{AdditiveGroup, Field};
 #[cfg(feature = "blitzar")]
 use blitzar::compute::ElementP2;
 #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_standard_basis_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_standard_basis_helper.rs
@@ -2,7 +2,7 @@
 //! vector used in a Vector-Matrix-Vector product in the dynamic dory scheme.
 
 use super::F;
-use ark_ff::Field;
+use ark_ff::{AdditiveGroup, Field};
 
 #[allow(dead_code)]
 /// This method produces evaluation vectors from a point. This is a helper method for generating a Vector-Matrix-Vector product in the dynamic dory scheme.


### PR DESCRIPTION
# Rationale for this change
The Arkworks project have released a new version of their crates - `0.5.0`. This PR updates the Arkworks crates. Additionally it upgrades the `blitzar` crate to a version that supports the updated Arkworks crate.

Benchmarks indicate no impact to performance is expected with the upgrade.

# What changes are included in this PR?
- Arkworks crates are updated to version `0.5.0`
- The `blitzar` crate is updated to version `4.0.0`
- All build errors related to the update are addressed

# Are these changes tested?
Yes by running tests and benchmarks.