### PR TITLE
feat: derive serde for `OwnedTable`/`OwnedColumn`

### DIFF
--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -19,8 +19,9 @@ use proof_of_sql_parser::{
     intermediate_ast::OrderByDirection,
     posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
 };
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Clone, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 /// Supported types for [`OwnedColumn`]
 pub enum OwnedColumn<S: Scalar> {

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -1,6 +1,7 @@
 use super::OwnedColumn;
 use crate::base::{map::IndexMap, scalar::Scalar};
 use proof_of_sql_parser::Identifier;
+use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 /// An error that occurs when working with tables.
@@ -15,7 +16,7 @@ pub enum OwnedTableError {
 /// This is primarily used as an internal result that is used before
 /// converting to the final result in either Arrow format or JSON.
 /// This is the analog of an arrow [`RecordBatch`](arrow::record_batch::RecordBatch).
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
 pub struct OwnedTable<S: Scalar> {
     table: IndexMap<Identifier, OwnedColumn<S>>,
 }


### PR DESCRIPTION
# Rationale for this change

`OwnedTable` Serialization is needed upstream.

# What changes are included in this PR?

`serde` is derived for both `OwnedTable` and `OwnedColumn`.

# Are these changes tested?
NA