### PR TITLE
refactor!: replace output of `result_evaluate` and `final_round_evaluate` of `ProofPlan` with `Table`

### DIFF
--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -120,6 +120,10 @@ impl<'a, S: Scalar> Table<'a, S> {
     pub fn column_names(&self) -> impl Iterator<Item = &Identifier> {
         self.table.keys()
     }
+    /// Returns the columns of this table as an Iterator
+    pub fn columns(&self) -> impl Iterator<Item = &Column<'a, S>> {
+        self.table.values()
+    }
 }
 
 // Note: we modify the default PartialEq for IndexMap to also check for column ordering.

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -15,7 +15,7 @@
 //!     borrowed_decimal75("f", 12, 1, [1, 2, 3], &alloc),
 //! ]);
 //! ```
-use super::{Column, Table};
+use super::{Column, Table, TableOptions};
 use crate::base::scalar::Scalar;
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -27,7 +27,8 @@ use proof_of_sql_parser::{
 
 /// Creates an [`Table`] from a list of `(Identifier, Column)` pairs.
 /// This is a convenience wrapper around [`Table::try_from_iter`] primarily for use in tests and
-/// intended to be used along with the other methods in this module (e.g. [bigint], [boolean], etc).
+/// intended to be used along with the other methods in this module (e.g. [`borrowed_bigint`],
+/// [`borrowed_boolean`], etc).
 /// The function will panic under a variety of conditions. See [`Table::try_from_iter`] for more details.
 ///
 /// # Example
@@ -51,6 +52,19 @@ pub fn table<'a, S: Scalar>(
     iter: impl IntoIterator<Item = (Identifier, Column<'a, S>)>,
 ) -> Table<'a, S> {
     Table::try_from_iter(iter).unwrap()
+}
+
+/// Creates an [`Table`] from a list of `(Identifier, Column)` pairs with a specified row count.
+/// The main reason for this function is to allow for creating tables that may potentially have
+/// no columns, but still have a specified row count.
+///
+/// # Panics
+/// - Panics if the given row count doesn't match the number of rows in any of the columns.
+pub fn table_with_row_count<'a, S: Scalar>(
+    iter: impl IntoIterator<Item = (Identifier, Column<'a, S>)>,
+    row_count: usize,
+) -> Table<'a, S> {
+    Table::try_from_iter_with_options(iter, TableOptions::new(Some(row_count))).unwrap()
 }
 
 /// Creates a (Identifier, `Column`) pair for a tinyint column.

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,6 +1,6 @@
 use super::{CountBuilder, FinalRoundBuilder, FirstRoundBuilder, VerificationBuilder};
 use crate::base::{
-    database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
+    database::{ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableRef},
     map::{IndexMap, IndexSet},
     proof::ProofError,
     scalar::Scalar,
@@ -40,7 +40,7 @@ pub trait ProverEvaluate {
         &self,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>>;
+    ) -> Table<'a, S>;
 
     /// Evaluate the query and modify `FirstRoundBuilder` to form the query's proof.
     fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder);
@@ -56,7 +56,7 @@ pub trait ProverEvaluate {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>>;
+    ) -> Table<'a, S>;
 }
 
 /// Marker used as a trait bound for generic [`ProofPlan`] types to indicate the honesty of their implementation.

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -1,6 +1,6 @@
 use super::{decode_and_convert, decode_multiple_elements, ProvableResultColumn, QueryError};
 use crate::base::{
-    database::{Column, ColumnField, ColumnType, OwnedColumn, OwnedTable},
+    database::{Column, ColumnField, ColumnType, OwnedColumn, OwnedTable, Table},
     polynomial::compute_evaluation_vector,
     scalar::Scalar,
 };
@@ -53,6 +53,13 @@ impl ProvableQueryResult {
             table_length,
             data,
         }
+    }
+
+    /// Form intermediate query result from a table
+    #[must_use]
+    pub fn new_from_table<S: Scalar>(table: &Table<S>) -> Self {
+        let columns = table.columns().copied().collect::<Vec<_>>();
+        Self::new(table.num_rows() as u64, &columns)
     }
 
     /// Form intermediate query result from index rows and result columns

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -55,13 +55,6 @@ impl ProvableQueryResult {
         }
     }
 
-    /// Form intermediate query result from a table
-    #[must_use]
-    pub fn new_from_table<S: Scalar>(table: &Table<S>) -> Self {
-        let columns = table.columns().copied().collect::<Vec<_>>();
-        Self::new(table.num_rows() as u64, &columns)
-    }
-
     /// Form intermediate query result from index rows and result columns
     /// # Panics
     ///
@@ -224,5 +217,17 @@ impl ProvableQueryResult {
         assert_eq!(owned_table.num_columns(), self.num_columns());
 
         Ok(owned_table)
+    }
+}
+
+impl<S: Scalar> From<Table<'_, S>> for ProvableQueryResult {
+    fn from(table: Table<S>) -> Self {
+        let num_rows = table.num_rows();
+        let columns = table
+            .into_inner()
+            .into_iter()
+            .map(|(_, col)| col)
+            .collect::<Vec<_>>();
+        Self::new(num_rows as u64, &columns)
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -6,7 +6,7 @@ use crate::{
     base::{
         bit::BitDistribution,
         commitment::CommitmentEvaluationProof,
-        database::{Column, CommitmentAccessor, DataAccessor, MetadataAccessor, TableRef},
+        database::{CommitmentAccessor, DataAccessor, MetadataAccessor, TableRef},
         map::IndexMap,
         math::log2_up,
         polynomial::{compute_evaluation_vector, CompositePolynomialInfo},
@@ -76,9 +76,14 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let alloc = Bump::new();
 
         // Evaluate query result
-        let result_cols = expr.result_evaluate(&alloc, accessor);
-        let output_length = result_cols.first().map_or(0, Column::len);
-        let provable_result = ProvableQueryResult::new(output_length as u64, &result_cols);
+        let result_table = expr.result_evaluate(&alloc, accessor);
+        let result_cols = result_table
+            .inner_table()
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let provable_result =
+            ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols);
 
         // Prover First Round
         let mut first_round_builder = FirstRoundBuilder::new();

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -76,8 +76,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let alloc = Bump::new();
 
         // Evaluate query result
-        let result_table = expr.result_evaluate(&alloc, accessor);
-        let provable_result = ProvableQueryResult::new_from_table(&result_table);
+        let provable_result = expr.result_evaluate(&alloc, accessor).into();
 
         // Prover First Round
         let mut first_round_builder = FirstRoundBuilder::new();

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -77,13 +77,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         // Evaluate query result
         let result_table = expr.result_evaluate(&alloc, accessor);
-        let result_cols = result_table
-            .inner_table()
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        let provable_result =
-            ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols);
+        let provable_result = ProvableQueryResult::new_from_table(&result_table);
 
         // Prover First Round
         let mut first_round_builder = FirstRoundBuilder::new();

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -7,9 +7,9 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable,
-            OwnedTableTestAccessor, TableRef,
+            OwnedTableTestAccessor, Table, TableRef,
         },
-        map::{indexset, IndexMap, IndexSet},
+        map::{indexmap, indexset, IndexMap, IndexSet},
         proof::ProofError,
         scalar::{Curve25519Scalar, Scalar},
     },
@@ -44,9 +44,12 @@ impl ProverEvaluate for TrivialTestProofPlan {
         &self,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let col = alloc.alloc_slice_fill_copy(self.length, self.column_fill_value);
-        vec![Column::BigInt(col)]
+        Table::<'a, S>::try_new(indexmap! {
+            "a1".parse().unwrap() => Column::BigInt(col),
+        })
+        .unwrap()
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -56,14 +59,17 @@ impl ProverEvaluate for TrivialTestProofPlan {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let col = alloc.alloc_slice_fill_copy(self.length, self.column_fill_value);
         builder.produce_intermediate_mle(col as &[_]);
         builder.produce_sumcheck_subpolynomial(
             SumcheckSubpolynomialType::Identity,
             vec![(S::ONE, vec![Box::new(col as &[_])])],
         );
-        vec![Column::BigInt(col)]
+        Table::<'a, S>::try_new(indexmap! {
+            "a1".parse().unwrap() => Column::BigInt(col),
+        })
+        .unwrap()
     }
 }
 impl ProofPlan for TrivialTestProofPlan {
@@ -213,9 +219,12 @@ impl ProverEvaluate for SquareTestProofPlan {
         &self,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        vec![Column::BigInt(res)]
+        Table::<'a, S>::try_new(indexmap! {
+            "a1".parse().unwrap() => Column::BigInt(res),
+        })
+        .unwrap()
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -225,7 +234,7 @@ impl ProverEvaluate for SquareTestProofPlan {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
@@ -240,7 +249,10 @@ impl ProverEvaluate for SquareTestProofPlan {
                 (-S::ONE, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        vec![Column::BigInt(res)]
+        Table::<'a, S>::try_new(indexmap! {
+            "a1".parse().unwrap() => Column::BigInt(&[9, 25]),
+        })
+        .unwrap()
     }
 }
 impl ProofPlan for SquareTestProofPlan {
@@ -390,9 +402,12 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
         &self,
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        vec![Column::BigInt(res)]
+        Table::<'a, S>::try_new(indexmap! {
+            "a1".parse().unwrap() => Column::BigInt(res),
+        })
+        .unwrap()
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -402,7 +417,7 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
@@ -430,7 +445,10 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
             ],
         );
         builder.produce_intermediate_mle(res);
-        vec![Column::BigInt(res)]
+        Table::<'a, S>::try_new(indexmap! {
+            "a1".parse().unwrap() => Column::BigInt(res),
+        })
+        .unwrap()
     }
 }
 impl ProofPlan for DoubleSquareTestProofPlan {
@@ -597,8 +615,11 @@ impl ProverEvaluate for ChallengeTestProofPlan {
         &self,
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
-        vec![Column::BigInt(&[9, 25])]
+    ) -> Table<'a, S> {
+        Table::<'a, S>::try_new(indexmap! {
+            "a1".parse().unwrap() => Column::BigInt(&[9, 25]),
+        })
+        .unwrap()
     }
 
     fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder) {
@@ -610,7 +631,7 @@ impl ProverEvaluate for ChallengeTestProofPlan {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let x = accessor.get_column(ColumnRef::new(
             "sxt.test".parse().unwrap(),
             "x".parse().unwrap(),
@@ -627,7 +648,10 @@ impl ProverEvaluate for ChallengeTestProofPlan {
                 (-alpha, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        vec![Column::BigInt(&[9, 25])]
+        Table::<'a, S>::try_new(indexmap! {
+            "a1".parse().unwrap() => Column::BigInt(&[9, 25]),
+        })
+        .unwrap()
     }
 }
 impl ProofPlan for ChallengeTestProofPlan {

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -6,10 +6,11 @@ use crate::{
         commitment::InnerProductProof,
         database::{
             owned_table_utility::{bigint, owned_table},
-            Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable,
-            OwnedTableTestAccessor, Table, TableRef,
+            table_utility::*,
+            ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable, OwnedTableTestAccessor,
+            Table, TableRef,
         },
-        map::{indexmap, indexset, IndexMap, IndexSet},
+        map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
         scalar::{Curve25519Scalar, Scalar},
     },
@@ -45,11 +46,8 @@ impl ProverEvaluate for TrivialTestProofPlan {
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Table<'a, S> {
-        let col = alloc.alloc_slice_fill_copy(self.length, self.column_fill_value);
-        Table::<'a, S>::try_new(indexmap! {
-            "a1".parse().unwrap() => Column::BigInt(col),
-        })
-        .unwrap()
+        let col = vec![self.column_fill_value; self.length];
+        table([borrowed_bigint("a1", col, alloc)])
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -66,10 +64,11 @@ impl ProverEvaluate for TrivialTestProofPlan {
             SumcheckSubpolynomialType::Identity,
             vec![(S::ONE, vec![Box::new(col as &[_])])],
         );
-        Table::<'a, S>::try_new(indexmap! {
-            "a1".parse().unwrap() => Column::BigInt(col),
-        })
-        .unwrap()
+        table([borrowed_bigint(
+            "a1",
+            vec![self.column_fill_value; self.length],
+            alloc,
+        )])
     }
 }
 impl ProofPlan for TrivialTestProofPlan {
@@ -220,11 +219,7 @@ impl ProverEvaluate for SquareTestProofPlan {
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Table<'a, S> {
-        let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        Table::<'a, S>::try_new(indexmap! {
-            "a1".parse().unwrap() => Column::BigInt(res),
-        })
-        .unwrap()
+        table([borrowed_bigint("a1", self.res, alloc)])
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -249,10 +244,7 @@ impl ProverEvaluate for SquareTestProofPlan {
                 (-S::ONE, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        Table::<'a, S>::try_new(indexmap! {
-            "a1".parse().unwrap() => Column::BigInt(&[9, 25]),
-        })
-        .unwrap()
+        table([borrowed_bigint("a1", self.res, alloc)])
     }
 }
 impl ProofPlan for SquareTestProofPlan {
@@ -403,11 +395,7 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
         alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Table<'a, S> {
-        let res: &[_] = alloc.alloc_slice_copy(&self.res);
-        Table::<'a, S>::try_new(indexmap! {
-            "a1".parse().unwrap() => Column::BigInt(res),
-        })
-        .unwrap()
+        table([borrowed_bigint("a1", self.res, alloc)])
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -445,10 +433,7 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
             ],
         );
         builder.produce_intermediate_mle(res);
-        Table::<'a, S>::try_new(indexmap! {
-            "a1".parse().unwrap() => Column::BigInt(res),
-        })
-        .unwrap()
+        table([borrowed_bigint("a1", self.res, alloc)])
     }
 }
 impl ProofPlan for DoubleSquareTestProofPlan {
@@ -613,13 +598,10 @@ struct ChallengeTestProofPlan {}
 impl ProverEvaluate for ChallengeTestProofPlan {
     fn result_evaluate<'a, S: Scalar>(
         &self,
-        _alloc: &'a Bump,
+        alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Table<'a, S> {
-        Table::<'a, S>::try_new(indexmap! {
-            "a1".parse().unwrap() => Column::BigInt(&[9, 25]),
-        })
-        .unwrap()
+        table([borrowed_bigint("a1", [9, 25], alloc)])
     }
 
     fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder) {
@@ -648,10 +630,7 @@ impl ProverEvaluate for ChallengeTestProofPlan {
                 (-alpha, vec![Box::new(x), Box::new(x)]),
             ],
         );
-        Table::<'a, S>::try_new(indexmap! {
-            "a1".parse().unwrap() => Column::BigInt(&[9, 25]),
-        })
-        .unwrap()
+        table([borrowed_bigint("a1", [9, 25], alloc)])
     }
 }
 impl ProofPlan for ChallengeTestProofPlan {

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,7 +1,7 @@
 use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec, TableExec};
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
+        database::{ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableRef},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnRef, DataAccessor, OwnedTable, TableRef},
+        database::{ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableRef},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -67,8 +67,8 @@ impl ProverEvaluate for EmptyExec {
         &self,
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
-        Vec::new()
+    ) -> Table<'a, S> {
+        Table::<'a, S>::try_new(IndexMap::default()).unwrap()
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -80,7 +80,7 @@ impl ProverEvaluate for EmptyExec {
         _builder: &mut FinalRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
-        Vec::new()
+    ) -> Table<'a, S> {
+        Table::<'a, S>::try_new(IndexMap::default()).unwrap()
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableRef},
+        database::{
+            ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableOptions, TableRef,
+        },
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -68,7 +70,9 @@ impl ProverEvaluate for EmptyExec {
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Table<'a, S> {
-        Table::<'a, S>::try_new(IndexMap::default()).unwrap()
+        // Create an empty table with one row
+        Table::<'a, S>::try_new_with_options(IndexMap::default(), TableOptions::new(Some(1)))
+            .unwrap()
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -81,6 +85,8 @@ impl ProverEvaluate for EmptyExec {
         _alloc: &'a Bump,
         _accessor: &'a dyn DataAccessor<S>,
     ) -> Table<'a, S> {
-        Table::<'a, S>::try_new(IndexMap::default()).unwrap()
+        // Create an empty table with one row
+        Table::<'a, S>::try_new_with_options(IndexMap::default(), TableOptions::new(Some(1)))
+            .unwrap()
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         database::{
             filter_util::filter_columns, Column, ColumnField, ColumnRef, DataAccessor, OwnedTable,
-            TableRef,
+            Table, TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -149,6 +149,7 @@ impl ProverEvaluate for FilterExec {
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
+        let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
         let columns: Vec<_> = self
@@ -159,11 +160,12 @@ impl ProverEvaluate for FilterExec {
 
         // Compute filtered_columns and indexes
         let (filtered_columns, _) = filter_columns(alloc, &columns, selection);
-        Table::<'a, S>::try_from_iter(
+        Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results
                 .iter()
                 .map(|expr| expr.alias)
                 .zip(filtered_columns),
+            TableOptions::new(Some(output_length)),
         )
         .expect("Failed to create table from iterator")
     }
@@ -189,6 +191,7 @@ impl ProverEvaluate for FilterExec {
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
+        let output_length = selection.iter().filter(|b| **b).count();
 
         // 2. columns
         let columns: Vec<_> = self
@@ -220,11 +223,12 @@ impl ProverEvaluate for FilterExec {
             &filtered_columns,
             result_len,
         );
-        Table::<'a, S>::try_from_iter(
+        Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results
                 .iter()
                 .map(|expr| expr.alias)
                 .zip(filtered_columns),
+            TableOptions::new(Some(output_length)),
         )
         .expect("Failed to create table from iterator")
     }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -194,7 +194,6 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         where_clause,
     );
     let alloc = Bump::new();
-    let result_table = expr.result_evaluate(&alloc, &accessor);
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -206,9 +205,10 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
             ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::from(expr.result_evaluate(&alloc, &accessor))
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -238,7 +238,6 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let result_table = expr.result_evaluate(&alloc, &accessor);
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -250,9 +249,10 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::from(expr.result_evaluate(&alloc, &accessor))
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -278,13 +278,13 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
     let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
-    let result_table = expr.result_evaluate(&alloc, &accessor);
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[];
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::from(expr.result_evaluate(&alloc, &accessor))
+            .to_owned_table(fields)
+            .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
     assert_eq!(res, expected);
 }
@@ -308,7 +308,6 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let result_table = expr.result_evaluate(&alloc, &accessor);
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -320,9 +319,10 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::from(expr.result_evaluate(&alloc, &accessor))
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [3, 5]),
         int128("c", [3, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -2,8 +2,8 @@ use super::{test_utility::*, FilterExec};
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType, LiteralValue,
-            OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
+            owned_table_utility::*, ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTable,
+            OwnedTableTestAccessor, TableRef, TestAccessor,
         },
         map::{IndexMap, IndexSet},
         math::decimal::Precision,
@@ -194,8 +194,12 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(&alloc, &accessor);
-    let output_length = result_cols.first().map_or(0, Column::len) as u64;
+    let result_table = expr.result_evaluate(&alloc, &accessor);
+    let result_cols = result_table
+        .inner_table()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -208,7 +212,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(output_length as u64, &result_cols)
+        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -240,8 +244,12 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(&alloc, &accessor);
-    let output_length = result_cols.first().map_or(0, Column::len) as u64;
+    let result_table = expr.result_evaluate(&alloc, &accessor);
+    let result_cols = result_table
+        .inner_table()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -254,7 +262,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(output_length as u64, &result_cols)
+        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -282,13 +290,17 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
     let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(&alloc, &accessor);
-    let output_length = result_cols.first().map_or(0, Column::len) as u64;
+    let result_table = expr.result_evaluate(&alloc, &accessor);
+    let result_cols = result_table
+        .inner_table()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(output_length as u64, &result_cols)
+        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
@@ -314,8 +326,12 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         where_clause,
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(&alloc, &accessor);
-    let output_length = result_cols.first().map_or(0, Column::len) as u64;
+    let result_table = expr.result_evaluate(&alloc, &accessor);
+    let result_cols = result_table
+        .inner_table()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -328,7 +344,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(output_length as u64, &result_cols)
+        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -195,11 +195,6 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
     );
     let alloc = Bump::new();
     let result_table = expr.result_evaluate(&alloc, &accessor);
-    let result_cols = result_table
-        .inner_table()
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -211,10 +206,9 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
             ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
-            .to_owned_table(fields)
-            .unwrap();
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
+        .to_owned_table(fields)
+        .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -245,11 +239,6 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let result_table = expr.result_evaluate(&alloc, &accessor);
-    let result_cols = result_table
-        .inner_table()
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -261,10 +250,9 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
-            .to_owned_table(fields)
-            .unwrap();
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
+        .to_owned_table(fields)
+        .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -291,18 +279,12 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
     let alloc = Bump::new();
     let result_table = expr.result_evaluate(&alloc, &accessor);
-    let result_cols = result_table
-        .inner_table()
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[];
-    let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
-            .to_owned_table(fields)
-            .unwrap();
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
+        .to_owned_table(fields)
+        .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
     assert_eq!(res, expected);
 }
@@ -327,11 +309,6 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
     );
     let alloc = Bump::new();
     let result_table = expr.result_evaluate(&alloc, &accessor);
-    let result_cols = result_table
-        .inner_table()
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -343,10 +320,9 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
-            .to_owned_table(fields)
-            .unwrap();
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
+        .to_owned_table(fields)
+        .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [3, 5]),
         int128("c", [3, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         database::{
             filter_util::*, owned_table_utility::*, Column, DataAccessor, OwnedTableTestAccessor,
-            TestAccessor,
+            Table, TableOptions, TestAccessor,
         },
         proof::ProofError,
         scalar::Scalar,
@@ -45,6 +45,7 @@ impl ProverEvaluate for DishonestFilterExec {
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
+        let output_length = selection.iter().filter(|b| **b).count();
         // 2. columns
         let columns: Vec<_> = self
             .aliased_results
@@ -54,11 +55,12 @@ impl ProverEvaluate for DishonestFilterExec {
         // Compute filtered_columns
         let (filtered_columns, _) = filter_columns(alloc, &columns, selection);
         let filtered_columns = tamper_column(alloc, filtered_columns);
-        Table::<'a, S>::try_from_iter(
+        Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results
                 .iter()
                 .map(|expr| expr.alias)
                 .zip(filtered_columns),
+            TableOptions::new(Some(output_length)),
         )
         .expect("Failed to create table from iterator")
     }
@@ -88,6 +90,7 @@ impl ProverEvaluate for DishonestFilterExec {
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
+        let output_length = selection.iter().filter(|b| **b).count();
         // 2. columns
         let columns: Vec<_> = self
             .aliased_results
@@ -119,11 +122,12 @@ impl ProverEvaluate for DishonestFilterExec {
             &filtered_columns,
             result_len,
         );
-        Table::<'a, S>::try_from_iter(
+        Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results
                 .iter()
                 .map(|expr| expr.alias)
                 .zip(filtered_columns),
+            TableOptions::new(Some(output_length)),
         )
         .expect("Failed to create table from iterator")
     }

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -299,13 +299,12 @@ impl ProverEvaluate for GroupByExec {
             .clone()
             .into_iter()
             .chain(sum_result_columns_iter)
-            .chain(iter::once(Column::BigInt(count_column)))
-            .collect::<Vec<_>>();
+            .chain(iter::once(Column::BigInt(count_column)));
         let res = Table::<'a, S>::try_from_iter(
             self.get_column_result_fields()
                 .into_iter()
                 .map(|field| field.name())
-                .zip(columns.clone().into_iter()),
+                .zip(columns.clone()),
         )
         .expect("Failed to create table from column references");
         // 5. Produce MLEs

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -5,7 +5,7 @@ use crate::{
             group_by_util::{
                 aggregate_columns, compare_indexes_by_owned_columns, AggregatedColumns,
             },
-            Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable, TableRef,
+            Column, ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable, Table, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -309,7 +309,7 @@ impl ProverEvaluate for GroupByExec {
         )
         .expect("Failed to create table from column references");
         // 5. Produce MLEs
-        for column in columns.into_iter() {
+        for column in columns {
             builder.produce_intermediate_mle(column);
         }
         // 6. Prove group by

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -200,7 +200,7 @@ impl ProverEvaluate for GroupByExec {
         &self,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let column_refs = self.get_column_references();
         let used_table = accessor.get_table(self.table.table_ref, &column_refs);
         // 1. selection
@@ -230,11 +230,18 @@ impl ProverEvaluate for GroupByExec {
         } = aggregate_columns(alloc, &group_by_columns, &sum_columns, &[], &[], selection)
             .expect("columns should be aggregatable");
         let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(col));
-        group_by_result_columns
-            .into_iter()
-            .chain(sum_result_columns_iter)
-            .chain(iter::once(Column::BigInt(count_column)))
-            .collect::<Vec<_>>()
+        Table::<'a, S>::try_from_iter(
+            self.get_column_result_fields()
+                .into_iter()
+                .map(|field| field.name())
+                .zip(
+                    group_by_result_columns
+                        .into_iter()
+                        .chain(sum_result_columns_iter)
+                        .chain(iter::once(Column::BigInt(count_column))),
+                ),
+        )
+        .expect("Failed to create table from column references")
     }
 
     fn first_round_evaluate(&self, builder: &mut FirstRoundBuilder) {
@@ -248,7 +255,7 @@ impl ProverEvaluate for GroupByExec {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         accessor: &'a dyn DataAccessor<S>,
-    ) -> Vec<Column<'a, S>> {
+    ) -> Table<'a, S> {
         let column_refs = self.get_column_references();
         let used_table = accessor.get_table(self.table.table_ref, &column_refs);
         // 1. selection
@@ -288,16 +295,23 @@ impl ProverEvaluate for GroupByExec {
 
         // 4. Tally results
         let sum_result_columns_iter = sum_result_columns.iter().map(|col| Column::Scalar(col));
-        let res = group_by_result_columns
+        let columns = group_by_result_columns
             .clone()
             .into_iter()
             .chain(sum_result_columns_iter)
-            .chain(core::iter::once(Column::BigInt(count_column)))
+            .chain(iter::once(Column::BigInt(count_column)))
             .collect::<Vec<_>>();
+        let res = Table::<'a, S>::try_from_iter(
+            self.get_column_result_fields()
+                .into_iter()
+                .map(|field| field.name())
+                .zip(columns.clone().into_iter()),
+        )
+        .expect("Failed to create table from column references");
         // 5. Produce MLEs
-        res.iter().copied().for_each(|column| {
+        for column in columns.into_iter() {
             builder.produce_intermediate_mle(column);
-        });
+        }
         // 6. Prove group by
         prove_group_by(
             builder,

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -169,11 +169,6 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
     let result_table = expr.result_evaluate(&alloc, &accessor);
-    let result_cols = result_table
-        .inner_table()
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -185,10 +180,9 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
             ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
-            .to_owned_table(fields)
-            .unwrap();
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
+        .to_owned_table(fields)
+        .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -214,18 +208,12 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     let expr: DynProofPlan = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
     let result_table = expr.result_evaluate(&alloc, &accessor);
-    let result_cols = result_table
-        .inner_table()
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[];
-    let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
-            .to_owned_table(fields)
-            .unwrap();
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
+        .to_owned_table(fields)
+        .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
     assert_eq!(res, expected);
 }
@@ -256,11 +244,6 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
     );
     let alloc = Bump::new();
     let result_table = expr.result_evaluate(&alloc, &accessor);
-    let result_cols = result_table
-        .inner_table()
-        .values()
-        .cloned()
-        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -272,10 +255,9 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
-            .to_owned_table(fields)
-            .unwrap();
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
+        .to_owned_table(fields)
+        .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [2, 3, 4, 5, 6]),
         int128("prod", [1, 4, 9, 16, 25]),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -2,7 +2,7 @@ use super::{test_utility::*, DynProofPlan, ProjectionExec};
 use crate::{
     base::{
         database::{
-            owned_table_utility::*, Column, ColumnField, ColumnRef, ColumnType, OwnedTable,
+            owned_table_utility::*, ColumnField, ColumnRef, ColumnType, OwnedTable,
             OwnedTableTestAccessor, TableRef, TestAccessor,
         },
         map::{IndexMap, IndexSet},
@@ -168,8 +168,12 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     let expr: DynProofPlan =
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(&alloc, &accessor);
-    let output_length = result_cols.first().map_or(0, Column::len) as u64;
+    let result_table = expr.result_evaluate(&alloc, &accessor);
+    let result_cols = result_table
+        .inner_table()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -182,7 +186,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(output_length as u64, &result_cols)
+        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -209,13 +213,17 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     accessor.add_table(t, data, 0);
     let expr: DynProofPlan = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(&alloc, &accessor);
-    let output_length = result_cols.first().map_or(0, Column::len) as u64;
+    let result_table = expr.result_evaluate(&alloc, &accessor);
+    let result_cols = result_table
+        .inner_table()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(output_length as u64, &result_cols)
+        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
@@ -247,8 +255,12 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         tab(t),
     );
     let alloc = Bump::new();
-    let result_cols = expr.result_evaluate(&alloc, &accessor);
-    let output_length = result_cols.first().map_or(0, Column::len) as u64;
+    let result_table = expr.result_evaluate(&alloc, &accessor);
+    let result_cols = result_table
+        .inner_table()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -261,7 +273,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         ),
     ];
     let res: OwnedTable<Curve25519Scalar> =
-        ProvableQueryResult::new(output_length as u64, &result_cols)
+        ProvableQueryResult::new(result_table.num_rows() as u64, &result_cols)
             .to_owned_table(fields)
             .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -168,7 +168,6 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     let expr: DynProofPlan =
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
     let alloc = Bump::new();
-    let result_table = expr.result_evaluate(&alloc, &accessor);
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -180,9 +179,10 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
             ColumnType::Decimal75(Precision::new(75).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::from(expr.result_evaluate(&alloc, &accessor))
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -207,13 +207,13 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     accessor.add_table(t, data, 0);
     let expr: DynProofPlan = projection(cols_expr_plan(t, &[], &accessor), tab(t));
     let alloc = Bump::new();
-    let result_table = expr.result_evaluate(&alloc, &accessor);
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[];
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::from(expr.result_evaluate(&alloc, &accessor))
+            .to_owned_table(fields)
+            .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
     assert_eq!(res, expected);
 }
@@ -243,7 +243,6 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         tab(t),
     );
     let alloc = Bump::new();
-    let result_table = expr.result_evaluate(&alloc, &accessor);
     let mut builder = FirstRoundBuilder::new();
     expr.first_round_evaluate(&mut builder);
     let fields = &[
@@ -255,9 +254,10 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
             ColumnType::Decimal75(Precision::new(1).unwrap(), 0),
         ),
     ];
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::new_from_table(&result_table)
-        .to_owned_table(fields)
-        .unwrap();
+    let res: OwnedTable<Curve25519Scalar> =
+        ProvableQueryResult::from(expr.result_evaluate(&alloc, &accessor))
+            .to_owned_table(fields)
+            .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("b", [2, 3, 4, 5, 6]),
         int128("prod", [1, 4, 9, 16, 25]),

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -33,6 +33,10 @@ impl TableExec {
     }
 
     /// Returns the entire table.
+    ///
+    /// # Panics
+    /// Panics if columns from the accessor have different lengths.
+    /// In practice, this should never happen.
     fn get_table<'a, S: Scalar>(&self, accessor: &'a dyn DataAccessor<S>) -> Table<'a, S> {
         Table::<'a, S>::try_from_iter(self.schema.iter().map(|field| {
             (


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
To make `ProofPlan`s composable it is more natural for us to return `Table`s in `result_evaluate` and `final_round_evaluate` in `ProofPlan`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- replace output of `result_evaluate` and `final_round_evaluate` of `ProofPlan` with `Table`
- add `Table::columns`, `ProvableQueryResult::new_from_table` to simplify the code
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.