### PR TITLE
refactor!: replace `DataAccessor` in `ProofPlan` with `IndexMap`

### DIFF
--- a/crates/proof-of-sql/src/base/database/accessor.rs
+++ b/crates/proof-of-sql/src/base/database/accessor.rs
@@ -90,7 +90,7 @@ pub trait DataAccessor<S: Scalar>: MetadataAccessor {
     /// Creates a new [`Table`] from a [`TableRef`] and [`ColumnRef`]s.
     ///
     /// Columns are retrieved from the [`DataAccessor`] using the provided [`TableRef`] and [`ColumnRef`]s.
-    /// The only reason why [`table_ref` is needed is because `column_refs` can be empty.
+    /// The only reason why [`table_ref`] is needed is because [`column_refs`] can be empty.
     /// # Panics
     /// Column length mismatches can occur in theory. In practice, this should not happen.
     fn get_table(&self, table_ref: TableRef, column_refs: &IndexSet<ColumnRef>) -> Table<S> {

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,6 +1,6 @@
 use super::{CountBuilder, FinalRoundBuilder, FirstRoundBuilder, VerificationBuilder};
 use crate::base::{
-    database::{ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableRef},
+    database::{ColumnField, ColumnRef, OwnedTable, Table, TableRef},
     map::{IndexMap, IndexSet},
     proof::ProofError,
     scalar::Scalar,
@@ -39,7 +39,7 @@ pub trait ProverEvaluate {
     fn result_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<S>,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S>;
 
     /// Evaluate the query and modify `FirstRoundBuilder` to form the query's proof.
@@ -55,7 +55,7 @@ pub trait ProverEvaluate {
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<S>,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S>;
 }
 

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -8,8 +8,8 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             table_utility::*,
-            ColumnField, ColumnRef, ColumnType, DataAccessor, OwnedTable, OwnedTableTestAccessor,
-            Table, TableRef,
+            ColumnField, ColumnRef, ColumnType, OwnedTable, OwnedTableTestAccessor, Table,
+            TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
@@ -29,7 +29,7 @@ impl ProverEvaluate for EmptyTestQueryExpr {
     fn result_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
-        _accessor: &'a dyn DataAccessor<S>,
+        _table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         let zeros = vec![0_i64; self.length];
         table_with_row_count(
@@ -42,7 +42,7 @@ impl ProverEvaluate for EmptyTestQueryExpr {
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        _accessor: &'a dyn DataAccessor<S>,
+        _table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         let zeros = vec![0_i64; self.length];
         let res: &[_] = alloc.alloc_slice_copy(&zeros);

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,7 +1,7 @@
 use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec, TableExec};
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableRef},
+        database::{ColumnField, ColumnRef, OwnedTable, Table, TableRef},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,8 +1,6 @@
 use crate::{
     base::{
-        database::{
-            ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableOptions, TableRef,
-        },
+        database::{ColumnField, ColumnRef, OwnedTable, Table, TableOptions, TableRef},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -68,7 +66,7 @@ impl ProverEvaluate for EmptyExec {
     fn result_evaluate<'a, S: Scalar>(
         &self,
         _alloc: &'a Bump,
-        _accessor: &'a dyn DataAccessor<S>,
+        _table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         // Create an empty table with one row
         Table::<'a, S>::try_new_with_options(IndexMap::default(), TableOptions::new(Some(1)))
@@ -83,7 +81,7 @@ impl ProverEvaluate for EmptyExec {
         &self,
         _builder: &mut FinalRoundBuilder<'a, S>,
         _alloc: &'a Bump,
-        _accessor: &'a dyn DataAccessor<S>,
+        _table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         // Create an empty table with one row
         Table::<'a, S>::try_new_with_options(IndexMap::default(), TableOptions::new(Some(1)))

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -2,8 +2,8 @@ use super::{fold_columns, fold_vals};
 use crate::{
     base::{
         database::{
-            filter_util::filter_columns, Column, ColumnField, ColumnRef, DataAccessor, OwnedTable,
-            Table, TableOptions, TableRef,
+            filter_util::filter_columns, Column, ColumnField, ColumnRef, OwnedTable, Table,
+            TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -140,12 +140,13 @@ impl ProverEvaluate for FilterExec {
     fn result_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<S>,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
-        let column_refs = self.get_column_references();
-        let used_table = accessor.get_table(self.table.table_ref, &column_refs);
+        let table = table_map
+            .get(&self.table.table_ref)
+            .expect("Table not found");
         // 1. selection
-        let selection_column: Column<'a, S> = self.where_clause.result_evaluate(alloc, &used_table);
+        let selection_column: Column<'a, S> = self.where_clause.result_evaluate(alloc, table);
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
@@ -155,7 +156,7 @@ impl ProverEvaluate for FilterExec {
         let columns: Vec<_> = self
             .aliased_results
             .iter()
-            .map(|aliased_expr| aliased_expr.expr.result_evaluate(alloc, &used_table))
+            .map(|aliased_expr| aliased_expr.expr.result_evaluate(alloc, table))
             .collect();
 
         // Compute filtered_columns and indexes
@@ -180,14 +181,14 @@ impl ProverEvaluate for FilterExec {
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<S>,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
-        let column_refs = self.get_column_references();
-        let used_table = accessor.get_table(self.table.table_ref, &column_refs);
+        let table = table_map
+            .get(&self.table.table_ref)
+            .expect("Table not found");
         // 1. selection
         let selection_column: Column<'a, S> =
-            self.where_clause
-                .prover_evaluate(builder, alloc, &used_table);
+            self.where_clause.prover_evaluate(builder, alloc, table);
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
@@ -197,11 +198,7 @@ impl ProverEvaluate for FilterExec {
         let columns: Vec<_> = self
             .aliased_results
             .iter()
-            .map(|aliased_expr| {
-                aliased_expr
-                    .expr
-                    .prover_evaluate(builder, alloc, &used_table)
-            })
+            .map(|aliased_expr| aliased_expr.expr.prover_evaluate(builder, alloc, table))
             .collect();
         // Compute filtered_columns
         let (filtered_columns, result_len) = filter_columns(alloc, &columns, selection);

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, DataAccessor, OwnedTable, Table, TableRef},
+        database::{ColumnField, ColumnRef, OwnedTable, Table, TableRef},
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -72,9 +72,12 @@ impl ProverEvaluate for TableExec {
     fn result_evaluate<'a, S: Scalar>(
         &self,
         _alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<S>,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
-        accessor.get_table(self.table_ref, &self.get_column_references())
+        table_map
+            .get(&self.table_ref)
+            .expect("Table not found")
+            .clone()
     }
 
     fn first_round_evaluate(&self, _builder: &mut FirstRoundBuilder) {}
@@ -85,9 +88,12 @@ impl ProverEvaluate for TableExec {
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
-        accessor: &'a dyn DataAccessor<S>,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
-        let table = accessor.get_table(self.table_ref, &self.get_column_references());
+        let table = table_map
+            .get(&self.table_ref)
+            .expect("Table not found")
+            .clone();
         for column in table.columns() {
             builder.produce_intermediate_mle(column.as_scalar(alloc));
         }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This is the next step in making `ProofPlan` composable. Let's centralize fetching of table maps using `DataAccessor` to `query_proof.rs`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests do pass.