### PR TITLE
docs: specify the jaeger all-in-one docker image version

### DIFF
--- a/crates/proof-of-sql/benches/README.md
+++ b/crates/proof-of-sql/benches/README.md
@@ -6,7 +6,7 @@ To run benchmarks with Jaeger, you need to do the following
 
 1. Spin up Jaeger service on port 6831 to receive the benchmarks trace data, and provides Jaeger UI on port 16686.
     ```bash
-    docker run --rm -d --name jaeger -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:latest
+    docker run --rm -d --name jaeger -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:1.62.0
     ```
 2. Run a benchmark.
     ```bash

--- a/crates/proof-of-sql/benches/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger_benches.rs
@@ -1,7 +1,7 @@
 //! Benchmarking/Tracing using Jaeger.
 //! To run, execute the following commands:
 //! ```bash
-//! docker run --rm -d --name jaeger -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:latest
+//! docker run --rm -d --name jaeger -p 6831:6831/udp -p 16686:16686 jaegertracing/all-in-one:1.62.0
 //! cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof
 //! cargo bench -p proof-of-sql --bench jaeger_benches Dory
 //! cargo bench -p proof-of-sql --bench jaeger_benches DynamicDory


### PR DESCRIPTION
# Rationale for this change
The latest Jaeger all-in-one Docker image, version `1.63.0`, has a bug. After running benchmarks you cannot view the output from the UI - https://github.com/jaegertracing/jaeger/issues/6200. This PR updates the documents referencing the Jaeger all-in-one image version to point to the latest working version - `1.62.0`.

# What changes are included in this PR?
- Docs are updated to specify the latest working Jaeger all-in-one Docker image version - `1.62.0`.

# Are these changes tested?
Yes
