### PR TITLE
refactor!: change the output to `ProofPlan::verifier_evaluate` to `Result<IndexMap<ColumnRef, S>, ProofError>`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -21,7 +21,7 @@ pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
         builder: &mut VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError>;
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError>;
 
     /// Return all the result column fields
     fn get_column_result_fields(&self) -> Vec<ColumnField>;

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -296,11 +296,15 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             .map(|col| (col, builder.consume_anchored_mle()))
             .collect();
 
-        let verifier_evaluations = expr.verifier_evaluate(
-            &mut builder,
-            &evaluation_accessor,
-            Some(&owned_table_result),
-        )?;
+        let verifier_evaluations = expr
+            .verifier_evaluate(
+                &mut builder,
+                &evaluation_accessor,
+                Some(&owned_table_result),
+            )?
+            .into_iter()
+            .map(|(_, v)| v)
+            .collect::<Vec<_>>();
         // compute the evaluation of the result MLEs
         let result_evaluations = owned_table_result.mle_evaluations(&subclaim.evaluation_point);
         // check the evaluation of the result MLEs

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -10,7 +10,7 @@ use crate::{
             ColumnField, ColumnRef, ColumnType, OwnedTable, OwnedTableTestAccessor, Table,
             TableRef,
         },
-        map::{indexset, IndexMap, IndexSet},
+        map::{indexmap, indexset, IndexMap, IndexSet},
         proof::ProofError,
         scalar::{Curve25519Scalar, Scalar},
     },
@@ -85,13 +85,19 @@ impl ProofPlan for TrivialTestProofPlan {
         builder: &mut VerificationBuilder<S>,
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
         assert_eq!(builder.consume_intermediate_mle(), S::ZERO);
         builder.produce_sumcheck_subpolynomial_evaluation(
             &SumcheckSubpolynomialType::ZeroSum,
             S::from(self.evaluation),
         );
-        Ok(vec![S::ZERO])
+        Ok(indexmap! {
+            ColumnRef::new(
+                "sxt.test".parse().unwrap(),
+                "a1".parse().unwrap(),
+                ColumnType::BigInt,
+            ) => S::ZERO
+        })
     }
     ///
     /// # Panics
@@ -261,7 +267,7 @@ impl ProofPlan for SquareTestProofPlan {
         builder: &mut VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
         let x_eval = S::from(self.anchored_commit_multiplier)
             * *accessor
                 .get(&ColumnRef::new(
@@ -275,7 +281,13 @@ impl ProofPlan for SquareTestProofPlan {
             &SumcheckSubpolynomialType::Identity,
             res_eval - x_eval * x_eval,
         );
-        Ok(vec![res_eval])
+        Ok(indexmap! {
+            ColumnRef::new(
+                "sxt.test".parse().unwrap(),
+                "a1".parse().unwrap(),
+                ColumnType::BigInt,
+            ) => res_eval
+        })
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
@@ -451,7 +463,7 @@ impl ProofPlan for DoubleSquareTestProofPlan {
         builder: &mut VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
         let x_eval = *accessor
             .get(&ColumnRef::new(
                 "sxt.test".parse().unwrap(),
@@ -473,7 +485,13 @@ impl ProofPlan for DoubleSquareTestProofPlan {
             &SumcheckSubpolynomialType::Identity,
             res_eval - z_eval * z_eval,
         );
-        Ok(vec![res_eval])
+        Ok(indexmap! {
+            ColumnRef::new(
+                "sxt.test".parse().unwrap(),
+                "a1".parse().unwrap(),
+                ColumnType::BigInt,
+            ) => res_eval
+        })
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]
@@ -650,7 +668,7 @@ impl ProofPlan for ChallengeTestProofPlan {
         builder: &mut VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
         let alpha = builder.consume_post_result_challenge();
         let _beta = builder.consume_post_result_challenge();
         let x_eval = *accessor
@@ -665,7 +683,13 @@ impl ProofPlan for ChallengeTestProofPlan {
             &SumcheckSubpolynomialType::Identity,
             alpha * res_eval - alpha * x_eval * x_eval,
         );
-        Ok(vec![res_eval])
+        Ok(indexmap! {
+            ColumnRef::new(
+                "sxt.test".parse().unwrap(),
+                "a1".parse().unwrap(),
+                ColumnType::BigInt,
+            ) => res_eval
+        })
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         vec![ColumnField::new("a1".parse().unwrap(), ColumnType::BigInt)]

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -66,13 +66,25 @@ impl ProofPlan for EmptyTestQueryExpr {
         builder: &mut VerificationBuilder<S>,
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
         let _ = std::iter::repeat_with(|| {
             assert_eq!(builder.consume_intermediate_mle(), S::ZERO);
         })
         .take(self.columns)
         .collect::<Vec<_>>();
-        Ok(vec![S::ZERO])
+        let res_map: IndexMap<ColumnRef, S> = (1..=self.columns)
+            .map(|i| {
+                (
+                    ColumnRef::new(
+                        "sxt.test".parse().unwrap(),
+                        format!("a{i}").parse().unwrap(),
+                        ColumnType::BigInt,
+                    ),
+                    S::ZERO,
+                )
+            })
+            .collect();
+        Ok(res_map)
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -44,8 +44,8 @@ impl ProofPlan for EmptyExec {
         _builder: &mut VerificationBuilder<S>,
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
-        Ok(Vec::new())
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
+        Ok(IndexMap::default())
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -78,7 +78,7 @@ where
         builder: &mut VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
         // 1. selection
         let selection_eval = self.where_clause.verifier_evaluate(builder, accessor)?;
         // 2. columns
@@ -105,7 +105,13 @@ where
             selection_eval,
             &filtered_columns_evals,
         )?;
-        Ok(filtered_columns_evals)
+        let filtered_evals_map: IndexMap<ColumnRef, S> = self
+            .get_column_result_fields()
+            .into_iter()
+            .map(|field| ColumnRef::new(self.table.table_ref, field.name(), field.data_type()))
+            .zip(filtered_columns_evals)
+            .collect();
+        Ok(filtered_evals_map)
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -53,14 +53,20 @@ impl ProofPlan for ProjectionExec {
         builder: &mut VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
         self.aliased_results
             .iter()
             .map(|aliased_expr| aliased_expr.expr.verifier_evaluate(builder, accessor))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(repeat_with(|| builder.consume_intermediate_mle())
-            .take(self.aliased_results.len())
-            .collect::<Vec<_>>())
+        let evals_map: IndexMap<ColumnRef, S> = self
+            .get_column_result_fields()
+            .into_iter()
+            .map(|field| ColumnRef::new(self.table.table_ref, field.name(), field.data_type()))
+            .zip(
+                repeat_with(|| builder.consume_intermediate_mle()).take(self.aliased_results.len()),
+            )
+            .collect();
+        Ok(evals_map)
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -45,10 +45,13 @@ impl ProofPlan for TableExec {
         builder: &mut VerificationBuilder<S>,
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
-    ) -> Result<Vec<S>, ProofError> {
-        Ok(repeat_with(|| builder.consume_intermediate_mle())
-            .take(self.schema.len())
-            .collect::<Vec<_>>())
+    ) -> Result<IndexMap<ColumnRef, S>, ProofError> {
+        Ok(self
+            .schema
+            .iter()
+            .map(|field| ColumnRef::new(self.table_ref, field.name(), field.data_type()))
+            .zip(repeat_with(|| builder.consume_intermediate_mle()).take(self.schema.len()))
+            .collect::<IndexMap<_, _>>())
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {


### PR DESCRIPTION

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to make `ProofPlan`s composable it is better if we can feed the result of `ProofPlan::verifier_evaluate` back into another call of the same method.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
Change the output to `ProofPlan::verifier_evaluate` to `Result<IndexMap<ColumnRef, S>, ProofError>`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests do pass.