### PR TITLE
feat!: allow `ProjectionExec` to take general inputs

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, OwnedTableTestAccessor},
+        database::{owned_table_utility::*, ColumnField, ColumnType, OwnedTableTestAccessor},
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -15,7 +15,13 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
     let data = owned_table([boolean("a", [true, false])]);
     let t = "sxt.t".parse().unwrap();
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
-    let ast = projection(cols_expr_plan(t, &["a"], &accessor), tab(t));
+    let ast = projection(
+        cols_expr_plan(t, &["a"], &accessor),
+        table_exec(
+            t,
+            vec![ColumnField::new("a".parse().unwrap(), ColumnType::Boolean)],
+        ),
+    );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
     exercise_verification(&verifiable_res, &ast, &accessor, t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -31,10 +31,10 @@ pub struct ProjectionExec {
 
 impl ProjectionExec {
     /// Creates a new projection expression.
-    pub fn new(aliased_results: Vec<AliasedDynProofExpr>, input: DynProofPlan) -> Self {
+    pub fn new(aliased_results: Vec<AliasedDynProofExpr>, input: Box<DynProofPlan>) -> Self {
         Self {
             aliased_results,
-            input: Box::new(input),
+            input,
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -56,8 +56,8 @@ impl ProofPlan for ProjectionExec {
         accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
     ) -> Result<Vec<S>, ProofError> {
-        //TODO: Switch to ref to the input itself
-        let table_ref = *self.input.get_table_references().iter().next().unwrap();
+        //TODO: Make `TableRef` optional in `ColumnRef` and None here by default
+        let table_ref = "PLACEHOLDER_SCHEMA.PLACEHOLDER_TABLE".parse().unwrap();
         let input_commitment_map: IndexMap<ColumnRef, S> = self
             .input
             .get_column_result_fields()

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -46,13 +46,13 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 "b",
             ),
         ],
-        DynProofPlan::Table(TableExec::new(
+        Box::new(DynProofPlan::Table(TableExec::new(
             table_ref,
             vec![
                 ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
                 ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
             ],
-        )),
+        ))),
     );
     let column_fields: Vec<ColumnField> = provable_ast.get_column_result_fields();
     assert_eq!(
@@ -88,13 +88,13 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                 "f",
             ),
         ],
-        DynProofPlan::Table(TableExec::new(
+        Box::new(DynProofPlan::Table(TableExec::new(
             table_ref,
             vec![
                 ColumnField::new("a".parse().unwrap(), ColumnType::BigInt),
                 ColumnField::new("f".parse().unwrap(), ColumnType::BigInt),
             ],
-        )),
+        ))),
     );
 
     let ref_columns = provable_ast.get_column_references();

--- a/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
@@ -3,13 +3,14 @@ use crate::{
     base::database::{ColumnField, TableRef},
     sql::proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
 };
+use alloc::boxed::Box;
 
 pub fn table_exec(table_ref: TableRef, schema: Vec<ColumnField>) -> DynProofPlan {
     DynProofPlan::Table(TableExec::new(table_ref, schema))
 }
 
 pub fn projection(results: Vec<AliasedDynProofExpr>, input: DynProofPlan) -> DynProofPlan {
-    DynProofPlan::Projection(ProjectionExec::new(results, input))
+    DynProofPlan::Projection(ProjectionExec::new(results, Box::new(input)))
 }
 
 pub fn filter(

--- a/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
@@ -8,8 +8,8 @@ pub fn table_exec(table_ref: TableRef, schema: Vec<ColumnField>) -> DynProofPlan
     DynProofPlan::Table(TableExec::new(table_ref, schema))
 }
 
-pub fn projection(results: Vec<AliasedDynProofExpr>, table: TableExpr) -> DynProofPlan {
-    DynProofPlan::Projection(ProjectionExec::new(results, table))
+pub fn projection(results: Vec<AliasedDynProofExpr>, input: DynProofPlan) -> DynProofPlan {
+    DynProofPlan::Projection(ProjectionExec::new(results, input))
 }
 
 pub fn filter(


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
We need to make it possible to compose `ProjectionExec` with `ProofPlan`s.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- replace `TableExpr` in `ProjectionExec` with `Box<DynProofPlan>`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.