### PR TITLE
refactor!: move `table_length` to `FirstRoundBuilder`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -15,7 +15,7 @@ pub struct FinalRoundBuilder<'a, S: Scalar> {
     num_sumcheck_variables: usize,
     bit_distributions: Vec<BitDistribution>,
     commitment_descriptor: Vec<CommittableColumn<'a>>,
-    pub(crate) pcs_proof_mles: Vec<Box<dyn MultilinearExtension<S> + 'a>>,
+    pcs_proof_mles: Vec<Box<dyn MultilinearExtension<S> + 'a>>,
     sumcheck_subpolynomials: Vec<SumcheckSubpolynomial<'a, S>>,
     /// The challenges used in creation of the constraints in the proof.
     /// Specifically, these are the challenges that the verifier sends to
@@ -45,6 +45,10 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
 
     pub fn num_sumcheck_subpolynomials(&self) -> usize {
         self.sumcheck_subpolynomials.len()
+    }
+
+    pub fn pcs_proof_mles(&self) -> &[Box<dyn MultilinearExtension<S> + 'a>] {
+        &self.pcs_proof_mles
     }
 
     /// Produce a bit distribution that describes which bits are constant

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -8,16 +8,14 @@ use crate::base::{
     polynomial::{CompositePolynomial, MultilinearExtension},
     scalar::Scalar,
 };
-use alloc::{boxed::Box, vec, vec::Vec};
-use num_traits::Zero;
+use alloc::{boxed::Box, vec::Vec};
 
 /// Track components used to form a query's proof
 pub struct FinalRoundBuilder<'a, S: Scalar> {
-    table_length: usize,
     num_sumcheck_variables: usize,
     bit_distributions: Vec<BitDistribution>,
     commitment_descriptor: Vec<CommittableColumn<'a>>,
-    pcs_proof_mles: Vec<Box<dyn MultilinearExtension<S> + 'a>>,
+    pub(crate) pcs_proof_mles: Vec<Box<dyn MultilinearExtension<S> + 'a>>,
     sumcheck_subpolynomials: Vec<SumcheckSubpolynomial<'a, S>>,
     /// The challenges used in creation of the constraints in the proof.
     /// Specifically, these are the challenges that the verifier sends to
@@ -30,13 +28,8 @@ pub struct FinalRoundBuilder<'a, S: Scalar> {
 }
 
 impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
-    pub fn new(
-        table_length: usize,
-        num_sumcheck_variables: usize,
-        post_result_challenges: Vec<S>,
-    ) -> Self {
+    pub fn new(num_sumcheck_variables: usize, post_result_challenges: Vec<S>) -> Self {
         Self {
-            table_length,
             num_sumcheck_variables,
             bit_distributions: Vec::new(),
             commitment_descriptor: Vec::new(),
@@ -44,10 +37,6 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
             sumcheck_subpolynomials: Vec::new(),
             post_result_challenges,
         }
-    }
-
-    pub fn table_length(&self) -> usize {
-        self.table_length
     }
 
     pub fn num_sumcheck_variables(&self) -> usize {
@@ -148,22 +137,6 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
         let mut res = Vec::with_capacity(self.pcs_proof_mles.len());
         for evaluator in &self.pcs_proof_mles {
             res.push(evaluator.inner_product(evaluation_vec));
-        }
-        res
-    }
-
-    /// Given random multipliers, multiply and add together all of the MLEs used in sumcheck except
-    /// for those that correspond to result columns sent to the verifier.
-    #[tracing::instrument(
-        name = "FinalRoundBuilder::fold_pcs_proof_mles",
-        level = "debug",
-        skip_all
-    )]
-    pub fn fold_pcs_proof_mles(&self, multipliers: &[S]) -> Vec<S> {
-        assert_eq!(multipliers.len(), self.pcs_proof_mles.len());
-        let mut res = vec![Zero::zero(); self.table_length];
-        for (multiplier, evaluator) in multipliers.iter().zip(self.pcs_proof_mles.iter()) {
-            evaluator.mul_add(&mut res, multiplier);
         }
         res
     }

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -22,7 +22,7 @@ use num_traits::{One, Zero};
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(2, 1, Vec::new());
+    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(1, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 0_usize;
@@ -41,7 +41,7 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
 fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(2, 1, Vec::new());
+    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(1, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 123_usize;
@@ -60,7 +60,7 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
 fn we_can_evaluate_pcs_proof_mles() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::new(2, 1, Vec::new());
+    let mut builder = FinalRoundBuilder::new(1, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let evaluation_vec = [
@@ -80,7 +80,7 @@ fn we_can_form_an_aggregated_sumcheck_polynomial() {
     let mle1 = [1, 2, -1];
     let mle2 = [10i64, 20, 100, 30];
     let mle3 = [2000i64, 3000, 5000, 7000];
-    let mut builder = FinalRoundBuilder::new(4, 2, Vec::new());
+    let mut builder = FinalRoundBuilder::new(2, Vec::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     builder.produce_intermediate_mle(&mle3[..]);
@@ -167,25 +167,8 @@ fn we_can_form_the_provable_query_result() {
 }
 
 #[test]
-fn we_can_fold_pcs_proof_mles() {
-    let mle1 = [1, 2];
-    let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::new(2, 1, Vec::new());
-    builder.produce_anchored_mle(&mle1);
-    builder.produce_intermediate_mle(&mle2[..]);
-    let multipliers = [Curve25519Scalar::from(100u64), Curve25519Scalar::from(2u64)];
-    let z = builder.fold_pcs_proof_mles(&multipliers);
-    let expected_z = [
-        Curve25519Scalar::from(120u64),
-        Curve25519Scalar::from(240u64),
-    ];
-    assert_eq!(z, expected_z);
-}
-
-#[test]
 fn we_can_consume_post_result_challenges_in_proof_builder() {
     let mut builder = FinalRoundBuilder::new(
-        0,
         0,
         vec![
             Curve25519Scalar::from(123),

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
@@ -5,19 +5,29 @@ pub struct FirstRoundBuilder {
     /// the prover after the prover sends the result, but before the prover
     /// send commitments to the intermediate witness columns.
     num_post_result_challenges: usize,
-}
 
-impl Default for FirstRoundBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// Used to determine the indices of generators we use
+    range_length: usize,
 }
 
 impl FirstRoundBuilder {
-    /// Create a new result builder for a table with the given length. For multi table queries, this will likely need to change.
-    pub fn new() -> Self {
+    pub fn new(range_length: usize) -> Self {
         Self {
             num_post_result_challenges: 0,
+            range_length,
+        }
+    }
+
+    pub fn range_length(&self) -> usize {
+        self.range_length
+    }
+
+    /// Used if a `ProofPlan` can cause output `table_length` to be larger
+    /// than the largest of the input ones e.g. unions and joins since it will
+    /// force us to update `range_length`.
+    pub fn update_range_length(&mut self, table_length: usize) {
+        if table_length > self.range_length {
+            self.range_length = table_length;
         }
     }
 

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -161,9 +161,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 .take(pcs_proof_evaluations.len())
                 .collect();
 
-        assert_eq!(random_scalars.len(), builder.pcs_proof_mles.len());
+        assert_eq!(random_scalars.len(), builder.pcs_proof_mles().len());
         let mut folded_mle = vec![Zero::zero(); range_length];
-        for (multiplier, evaluator) in random_scalars.iter().zip(builder.pcs_proof_mles.iter()) {
+        for (multiplier, evaluator) in random_scalars.iter().zip(builder.pcs_proof_mles().iter()) {
             evaluator.mul_add(&mut folded_mle, multiplier);
         }
 

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -60,6 +60,10 @@ pub struct QueryProof<CP: CommitmentEvaluationProof> {
     pub pcs_proof_evaluations: Vec<CP::Scalar>,
     /// Inner product proof of the MLEs' evaluations
     pub evaluation_proof: CP,
+    /// Minimum index
+    pub min_row_num: usize,
+    /// Maximum index
+    pub max_row_num: usize,
 }
 
 impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
@@ -71,10 +75,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         setup: &CP::ProverPublicSetup<'_>,
     ) -> (Self, ProvableQueryResult) {
         let (min_row_num, max_row_num) = get_index_range(accessor, expr.get_table_references());
-        let range_length = max_row_num - min_row_num;
-        let num_sumcheck_variables = cmp::max(log2_up(range_length), 1);
-        assert!(num_sumcheck_variables > 0);
-
+        let initial_range_length = max_row_num - min_row_num;
         let alloc = Bump::new();
 
         let total_col_refs = expr.get_column_references();
@@ -95,8 +96,11 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let provable_result = expr.result_evaluate(&alloc, &table_map).into();
 
         // Prover First Round
-        let mut first_round_builder = FirstRoundBuilder::new();
+        let mut first_round_builder = FirstRoundBuilder::new(initial_range_length);
         expr.first_round_evaluate(&mut first_round_builder);
+        let range_length = first_round_builder.range_length();
+        let num_sumcheck_variables = cmp::max(log2_up(range_length), 1);
+        assert!(num_sumcheck_variables > 0);
 
         // construct a transcript for the proof
         let mut transcript: Keccak256Transcript =
@@ -112,8 +116,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 .take(first_round_builder.num_post_result_challenges())
                 .collect();
 
-        let mut builder =
-            FinalRoundBuilder::new(range_length, num_sumcheck_variables, post_result_challenges);
+        let mut builder = FinalRoundBuilder::new(num_sumcheck_variables, post_result_challenges);
 
         for col_ref in total_col_refs {
             builder.produce_anchored_mle(accessor.get_column(col_ref));
@@ -159,7 +162,12 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             core::iter::repeat_with(|| transcript.scalar_challenge_as_be())
                 .take(pcs_proof_evaluations.len())
                 .collect();
-        let folded_mle = builder.fold_pcs_proof_mles(&random_scalars);
+
+        assert_eq!(random_scalars.len(), builder.pcs_proof_mles.len());
+        let mut folded_mle = vec![Zero::zero(); range_length];
+        for (multiplier, evaluator) in random_scalars.iter().zip(builder.pcs_proof_mles.iter()) {
+            evaluator.mul_add(&mut folded_mle, multiplier);
+        }
 
         // finally, form the inner product proof of the MLEs' evaluations
         let evaluation_proof = CP::new(
@@ -176,6 +184,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             sumcheck_proof,
             pcs_proof_evaluations,
             evaluation_proof,
+            min_row_num,
+            max_row_num: min_row_num + range_length,
         };
         (proof, provable_result)
     }
@@ -191,8 +201,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     ) -> QueryResult<CP::Scalar> {
         let owned_table_result = result.to_owned_table(&expr.get_column_result_fields())?;
 
-        let (min_row_num, max_row_num) = get_index_range(accessor, expr.get_table_references());
-        let range_length = max_row_num - min_row_num;
+        let range_length = self.max_row_num - self.min_row_num;
         let num_sumcheck_variables = cmp::max(log2_up(range_length), 1);
         assert!(num_sumcheck_variables > 0);
 
@@ -222,7 +231,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         // construct a transcript for the proof
         let mut transcript: Keccak256Transcript =
-            make_transcript(expr, result, range_length, min_row_num);
+            make_transcript(expr, result, range_length, self.min_row_num);
 
         // These are the challenges that will be consumed by the proof
         // Specifically, these are the challenges that the verifier sends to
@@ -278,7 +287,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             &self.pcs_proof_evaluations,
         );
         let mut builder = VerificationBuilder::new(
-            min_row_num,
+            self.min_row_num,
             sumcheck_evaluations,
             &self.bit_distributions,
             sumcheck_random_scalars.subpolynomial_multipliers,
@@ -326,7 +335,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 builder.inner_product_multipliers(),
                 &product,
                 &subclaim.evaluation_point,
-                min_row_num as u64,
+                self.min_row_num as u64,
                 range_length,
                 setup,
             )

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -67,7 +67,12 @@ impl ProofExpr for EqualsExpr {
         let rhs_scale = self.rhs.data_type().scale().unwrap_or(0);
         let res = scale_and_subtract(alloc, lhs_column, rhs_column, lhs_scale, rhs_scale, true)
             .expect("Failed to scale and subtract");
-        Column::Boolean(prover_evaluate_equals_zero(builder, alloc, res))
+        Column::Boolean(prover_evaluate_equals_zero(
+            table.num_rows(),
+            builder,
+            alloc,
+            res,
+        ))
     }
 
     fn verifier_evaluate<S: Scalar>(
@@ -103,12 +108,11 @@ pub fn result_evaluate_equals_zero<'a, S: Scalar>(
 }
 
 pub fn prover_evaluate_equals_zero<'a, S: Scalar>(
+    table_length: usize,
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     lhs: &'a [S],
 ) -> &'a [bool] {
-    let table_length = builder.table_length();
-
     // lhs_pseudo_inv
     let lhs_pseudo_inv = alloc.alloc_slice_copy(lhs);
     slice_ops::batch_inversion(lhs_pseudo_inv);

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -103,7 +103,7 @@ impl ProofExpr for InequalityExpr {
         };
 
         // diff == 0
-        let equals_zero = prover_evaluate_equals_zero(builder, alloc, diff);
+        let equals_zero = prover_evaluate_equals_zero(table.num_rows(), builder, alloc, diff);
 
         // sign(diff) == -1
         let sign = prover_evaluate_sign(

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
@@ -15,7 +15,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_constant_column() {
     let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
     let alloc = Bump::new();
     let data: Vec<Curve25519Scalar> = data.into_iter().map(Curve25519Scalar::from).collect();
-    let mut builder = FinalRoundBuilder::new(3, 2, Vec::new());
+    let mut builder = FinalRoundBuilder::new(2, Vec::new());
     let sign = prover_evaluate_sign(&mut builder, &alloc, &data, false);
     assert_eq!(sign, [false; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
@@ -27,7 +27,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_negative_constant_colum
     let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
     let alloc = Bump::new();
     let data: Vec<Curve25519Scalar> = data.into_iter().map(Curve25519Scalar::from).collect();
-    let mut builder = FinalRoundBuilder::new(3, 2, Vec::new());
+    let mut builder = FinalRoundBuilder::new(2, Vec::new());
     let sign = prover_evaluate_sign(&mut builder, &alloc, &data, false);
     assert_eq!(sign, [true; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -218,6 +218,7 @@ impl ProverEvaluate for FilterExec {
             &columns,
             selection,
             &filtered_columns,
+            table.num_rows(),
             result_len,
         );
         Table::<'a, S>::try_from_iter_with_options(
@@ -278,9 +279,9 @@ pub(super) fn prove_filter<'a, S: Scalar + 'a>(
     c: &[Column<S>],
     s: &'a [bool],
     d: &[Column<S>],
+    n: usize,
     m: usize,
 ) {
-    let n = builder.table_length();
     let chi = alloc.alloc_slice_fill_copy(n, false);
     chi[..m].fill(true);
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -12,8 +12,8 @@ use crate::{
     },
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
-            ProverEvaluate, VerifiableQueryResult,
+            exercise_verification, ProofPlan, ProvableQueryResult, ProverEvaluate,
+            VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, LiteralExpr, TableExpr},
     },
@@ -198,9 +198,6 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_result
         tab(t),
         where_clause,
     );
-
-    let mut builder = FirstRoundBuilder::new();
-    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -246,8 +243,6 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_result_evaluate() {
         tab(t),
         where_clause,
     );
-    let mut builder = FirstRoundBuilder::new();
-    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -289,8 +284,6 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_resu
     accessor.add_table(t, data, 0);
     let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(5));
     let expr = filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause);
-    let mut builder = FirstRoundBuilder::new();
-    expr.first_round_evaluate(&mut builder);
     let fields = &[];
     let res: OwnedTable<Curve25519Scalar> =
         ProvableQueryResult::from(expr.result_evaluate(&alloc, &table_map))
@@ -322,8 +315,6 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_result_evaluate() {
         tab(t),
         where_clause,
     );
-    let mut builder = FirstRoundBuilder::new();
-    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -118,6 +118,7 @@ impl ProverEvaluate for DishonestFilterExec {
             &columns,
             selection,
             &filtered_columns,
+            table.num_rows(),
             result_len,
         );
         Table::<'a, S>::try_from_iter_with_options(

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -316,6 +316,7 @@ impl ProverEvaluate for GroupByExec {
             beta,
             (&group_by_columns, &sum_columns, selection),
             (&group_by_result_columns, &sum_result_columns, count_column),
+            table.num_rows(),
         );
         res
     }
@@ -375,8 +376,8 @@ pub fn prove_group_by<'a, S: Scalar>(
     beta: S,
     (g_in, sum_in, sel_in): (&[Column<S>], &[Column<S>], &'a [bool]),
     (g_out, sum_out, count_out): (&[Column<S>], &[&'a [S]], &'a [i64]),
+    n: usize,
 ) {
-    let n = builder.table_length();
     let m_out = count_out.len();
 
     // g_in_fold = alpha + sum beta^j * g_in[j]

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     sql::{
         proof::{
-            exercise_verification, FirstRoundBuilder, ProofPlan, ProvableQueryResult,
-            ProverEvaluate, VerifiableQueryResult,
+            exercise_verification, ProofPlan, ProvableQueryResult, ProverEvaluate,
+            VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, ColumnExpr, DynProofExpr, TableExpr},
     },
@@ -171,9 +171,6 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
     accessor.add_table(t, data, 0);
     let expr: DynProofPlan =
         projection(cols_expr_plan(t, &["b", "c", "d", "e"], &accessor), tab(t));
-
-    let mut builder = FirstRoundBuilder::new();
-    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("c".parse().unwrap(), ColumnType::Int128),
@@ -214,8 +211,6 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(t, data, 0);
     let expr: DynProofPlan = projection(cols_expr_plan(t, &[], &accessor), tab(t));
-    let mut builder = FirstRoundBuilder::new();
-    expr.first_round_evaluate(&mut builder);
     let fields = &[];
     let res: OwnedTable<Curve25519Scalar> =
         ProvableQueryResult::from(expr.result_evaluate(&alloc, &table_map))
@@ -253,8 +248,6 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_result_evaluate()
         ],
         tab(t),
     );
-    let mut builder = FirstRoundBuilder::new();
-    expr.first_round_evaluate(&mut builder);
     let fields = &[
         ColumnField::new("b".parse().unwrap(), ColumnType::BigInt),
         ColumnField::new("prod".parse().unwrap(), ColumnType::Int128),


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
Currently there are still places where `FinalRoundBuilder::table_length` is used in `ProofExpr` which is wrong when we start composing `ProofPlan`s. Moreover in cases where a `ProofPlan` causes its output table to be longer than any of the input tables (e.g. joins and unions) we need to bump the `max_row_num`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- remove `table_length` from `FinalRoundBuilder`
- add `range_length` to `FirstRoundBuilder` to track the max table length in a query (updates are NOT to be applied to any `ProofPlan` that can not cause its output table to have more rows than any of its inputs such as filter and projection)
- update `range_length` after `FirstRoundBuilder` goes through the AST
- store `min_row_num` and `max_row_num` in `QueryProof` for the verifier
- remove `FirstRoundBuilder` from exclusively `result_evaluate` tests
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests should pass.