### PR TITLE
feat!: allow `ProjectionExec` to take general inputs

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -1,7 +1,9 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, OwnedTableTestAccessor, TableRef},
+        database::{
+            owned_table_utility::*, ColumnField, ColumnType, OwnedTableTestAccessor, TableRef,
+        },
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -16,7 +18,13 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
     let t = TableRef::new("sxt", "t");
     let accessor =
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
-    let ast = projection(cols_expr_plan(&t, &["a"], &accessor), tab(&t));
+    let ast = projection(
+        cols_expr_plan(&t, &["a"], &accessor),
+        table_exec(
+            t.clone(),
+            vec![ColumnField::new("a".into(), ColumnType::Boolean)],
+        ),
+    );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -65,7 +65,7 @@ impl ProofPlan for ProjectionExec {
             });
         }
         // Covers the case of tablelessness
-        let input_table_ref = if let Some(table_ref) = input_table_refs.iter().next() {
+        let input_table_ref = if let Some(table_ref) = input_table_refs.first() {
             table_ref.clone()
         } else {
             TableRef::from_names(None, "empty")

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -1,3 +1,4 @@
+use super::DynProofPlan;
 use crate::{
     base::{
         database::{
@@ -11,30 +12,30 @@ use crate::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
-        proof_exprs::{AliasedDynProofExpr, ProofExpr, TableExpr},
+        proof_exprs::{AliasedDynProofExpr, ProofExpr},
     },
     utils::log,
 };
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 
 /// Provable expressions for queries of the form
 /// ```ignore
-///     SELECT <result_expr1>, ..., <result_exprN> FROM <table>
+///     SELECT <result_expr1>, ..., <result_exprN> FROM <input>
 /// ```
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct ProjectionExec {
     pub(super) aliased_results: Vec<AliasedDynProofExpr>,
-    pub(super) table: TableExpr,
+    pub(super) input: Box<DynProofPlan>,
 }
 
 impl ProjectionExec {
     /// Creates a new projection expression.
-    pub fn new(aliased_results: Vec<AliasedDynProofExpr>, table: TableExpr) -> Self {
+    pub fn new(aliased_results: Vec<AliasedDynProofExpr>, input: Box<DynProofPlan>) -> Self {
         Self {
             aliased_results,
-            table,
+            input,
         }
     }
 }
@@ -49,20 +50,51 @@ impl ProofPlan for ProjectionExec {
         chi_eval_map: &IndexMap<TableRef, S>,
     ) -> Result<TableEvaluation<S>, ProofError> {
         // For projections input and output have the same length and hence the same chi eval
-        let chi_eval = *chi_eval_map
-            .get(&self.table.table_ref)
-            .expect("Chi eval not found");
-        self.aliased_results
+        let input_eval = self
+            .input
+            .verifier_evaluate(builder, accessor, None, chi_eval_map)?;
+        let chi_eval = input_eval.chi_eval();
+        // Build new accessors
+        // TODO: Make this work with inputs with multiple tables such as join
+        // and union results
+        let input_schema = self.input.get_column_result_fields();
+        let input_table_refs = self.input.get_table_references();
+        if input_table_refs.len() > 1 {
+            return Err(ProofError::UnsupportedQueryPlan {
+                error: "Projections with multiple tables are not supported yet",
+            });
+        }
+        // Covers the case of tablelessness
+        let input_table_ref = if let Some(table_ref) = input_table_refs.iter().next() {
+            table_ref.clone()
+        } else {
+            TableRef::from_names(None, "empty")
+        };
+        let current_accessor = input_schema
+            .iter()
+            .zip(input_eval.column_evals())
+            .map(|(field, eval)| {
+                (
+                    ColumnRef::new(
+                        input_table_ref.clone(),
+                        field.name().clone(),
+                        field.data_type(),
+                    ),
+                    *eval,
+                )
+            })
+            .collect::<IndexMap<_, _>>();
+
+        let output_column_evals = self
+            .aliased_results
             .iter()
             .map(|aliased_expr| {
                 aliased_expr
                     .expr
-                    .verifier_evaluate(builder, accessor, chi_eval)
+                    .verifier_evaluate(builder, &current_accessor, chi_eval)
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let column_evals =
-            builder.try_consume_final_round_mle_evaluations(self.aliased_results.len())?;
-        Ok(TableEvaluation::new(column_evals, chi_eval))
+        Ok(TableEvaluation::new(output_column_evals, chi_eval))
     }
 
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
@@ -75,15 +107,12 @@ impl ProofPlan for ProjectionExec {
     }
 
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
-        let mut columns = IndexSet::default();
-        self.aliased_results.iter().for_each(|aliased_expr| {
-            aliased_expr.expr.get_column_references(&mut columns);
-        });
-        columns
+        // For projections any output column reference is a reference to an input column
+        self.input.get_column_references()
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        IndexSet::from_iter([self.table.table_ref.clone()])
+        self.input.get_table_references()
     }
 }
 
@@ -95,23 +124,22 @@ impl ProverEvaluate for ProjectionExec {
     )]
     fn first_round_evaluate<'a, S: Scalar>(
         &self,
-        _builder: &mut FirstRoundBuilder<'a, S>,
+        builder: &mut FirstRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         log::log_memory_usage("Start");
 
-        let table = table_map
-            .get(&self.table.table_ref)
-            .expect("Table not found");
+        let input = self.input.first_round_evaluate(builder, alloc, table_map);
+
         let res = Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results.iter().map(|aliased_expr| {
                 (
                     aliased_expr.alias.clone(),
-                    aliased_expr.expr.result_evaluate(alloc, table),
+                    aliased_expr.expr.result_evaluate(alloc, &input),
                 )
             }),
-            TableOptions::new(Some(table.num_rows())),
+            TableOptions::new(Some(input.num_rows())),
         )
         .expect("Failed to create table from iterator");
 
@@ -134,24 +162,18 @@ impl ProverEvaluate for ProjectionExec {
     ) -> Table<'a, S> {
         log::log_memory_usage("Start");
 
-        let table = table_map
-            .get(&self.table.table_ref)
-            .expect("Table not found");
-        // 1. Evaluate result expressions
+        let input = self.input.final_round_evaluate(builder, alloc, table_map);
+        // Evaluate result expressions
         let res = Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results.iter().map(|aliased_expr| {
                 (
                     aliased_expr.alias.clone(),
-                    aliased_expr.expr.prover_evaluate(builder, alloc, table),
+                    aliased_expr.expr.prover_evaluate(builder, alloc, &input),
                 )
             }),
-            TableOptions::new(Some(table.num_rows())),
+            TableOptions::new(Some(input.num_rows())),
         )
         .expect("Failed to create table from iterator");
-        // 2. Produce MLEs
-        for column in res.columns().copied() {
-            builder.produce_intermediate_mle(column);
-        }
 
         log::log_memory_usage("End");
 

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -31,7 +31,16 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
     let accessor =
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = slice_exec(
-        projection(cols_expr_plan(&t, &["a", "b"], &accessor), tab(&t)),
+        projection(
+            cols_expr_plan(&t, &["a", "b"], &accessor),
+            table_exec(
+                t.clone(),
+                vec![
+                    ColumnField::new("a".into(), ColumnType::BigInt),
+                    ColumnField::new("b".into(), ColumnType::VarChar),
+                ],
+            ),
+        ),
         1,
         Some(2),
     );
@@ -48,7 +57,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
         bigint("a", [1_i64, 2, 3, 4, 5]),
         varchar("b", ["1", "2", "3", "4", "5"]),
     ]);
-    let t: TableRef = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let accessor =
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(2));

--- a/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
@@ -20,8 +20,8 @@ pub fn table_exec(table_ref: TableRef, schema: Vec<ColumnField>) -> DynProofPlan
     DynProofPlan::Table(TableExec::new(table_ref, schema))
 }
 
-pub fn projection(results: Vec<AliasedDynProofExpr>, table: TableExpr) -> DynProofPlan {
-    DynProofPlan::Projection(ProjectionExec::new(results, table))
+pub fn projection(results: Vec<AliasedDynProofExpr>, input: DynProofPlan) -> DynProofPlan {
+    DynProofPlan::Projection(ProjectionExec::new(results, Box::new(input)))
 }
 
 pub fn filter(

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -71,8 +71,14 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
     accessor.add_table(t1.clone(), data1, 0);
     let ast = union_exec(
         vec![
-            projection(cols_expr_plan(&t1, &["a1"], &accessor), tab(&t1)),
-            projection(cols_expr_plan(&t0, &["a0"], &accessor), tab(&t0)),
+            projection(
+                cols_expr_plan(&t1, &["a1"], &accessor),
+                table_exec(t1, vec![column_field("a1", ColumnType::BigInt)]),
+            ),
+            projection(
+                cols_expr_plan(&t0, &["a0"], &accessor),
+                table_exec(t0.clone(), vec![column_field("a0", ColumnType::BigInt)]),
+            ),
         ],
         vec![column_field("a", ColumnType::BigInt)],
     );
@@ -101,7 +107,16 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
     accessor.add_table(t1.clone(), data1, 0);
     let ast = union_exec(
         vec![
-            projection(cols_expr_plan(&t0, &["a0", "b0"], &accessor), tab(&t0)),
+            projection(
+                cols_expr_plan(&t0, &["a0", "b0"], &accessor),
+                table_exec(
+                    t0.clone(),
+                    vec![
+                        column_field("a0", ColumnType::BigInt),
+                        column_field("b0", ColumnType::VarChar),
+                    ],
+                ),
+            ),
             table_exec(
                 t1,
                 vec![
@@ -177,8 +192,26 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
             slice_exec(
                 union_exec(
                     vec![
-                        projection(cols_expr_plan(&t0, &["a0", "b0"], &accessor), tab(&t0)),
-                        projection(cols_expr_plan(&t1, &["a1", "b1"], &accessor), tab(&t1)),
+                        projection(
+                            cols_expr_plan(&t0, &["a0", "b0"], &accessor),
+                            table_exec(
+                                t0.clone(),
+                                vec![
+                                    column_field("a0", ColumnType::BigInt),
+                                    column_field("b0", ColumnType::VarChar),
+                                ],
+                            ),
+                        ),
+                        projection(
+                            cols_expr_plan(&t1, &["a1", "b1"], &accessor),
+                            table_exec(
+                                t1.clone(),
+                                vec![
+                                    column_field("a1", ColumnType::BigInt),
+                                    column_field("b1", ColumnType::VarChar),
+                                ],
+                            ),
+                        ),
                         slice_exec(
                             filter(
                                 cols_expr_plan(&t2, &["a2", "b2"], &accessor),
@@ -196,7 +229,16 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
                             tab(&t3),
                             equal(column(&t3, "a3", &accessor), const_int128(6_i128)),
                         ),
-                        projection(cols_expr_plan(&t4, &["a4", "b4"], &accessor), tab(&t4)),
+                        projection(
+                            cols_expr_plan(&t4, &["a4", "b4"], &accessor),
+                            table_exec(
+                                t4.clone(),
+                                vec![
+                                    column_field("a4", ColumnType::BigInt),
+                                    column_field("b4", ColumnType::VarChar),
+                                ],
+                            ),
+                        ),
                         table_exec(
                             t5,
                             vec![
@@ -274,8 +316,26 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
     ];
     let ast = union_exec(
         vec![
-            projection(cols_expr_plan(&t0, &["a0", "b0"], &accessor), tab(&t0)),
-            projection(cols_expr_plan(&t1, &["a1", "b1"], &accessor), tab(&t1)),
+            projection(
+                cols_expr_plan(&t0, &["a0", "b0"], &accessor),
+                table_exec(
+                    t0.clone(),
+                    vec![
+                        column_field("a0", ColumnType::BigInt),
+                        column_field("b0", ColumnType::VarChar),
+                    ],
+                ),
+            ),
+            projection(
+                cols_expr_plan(&t1, &["a1", "b1"], &accessor),
+                table_exec(
+                    t1.clone(),
+                    vec![
+                        column_field("a1", ColumnType::BigInt),
+                        column_field("b1", ColumnType::VarChar),
+                    ],
+                ),
+            ),
         ],
         fields.clone(),
     );


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
We need to make it possible to compose `ProjectionExec` with `ProofPlan`s. After this generalization it should work at least in situations where there is one input table.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- replace `TableExpr` in `ProjectionExec` with `Box<DynProofPlan>`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.