### PR TITLE
feat: add union utils

### DIFF
--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -247,23 +247,6 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
 
-    /// Returns the column as a slice of scalars
-    pub(crate) fn to_scalar(self, alloc: &'a Bump) -> &'a [S] {
-        match self {
-            Self::Boolean(col) => alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i])),
-            Self::TinyInt(col) => alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i])),
-            Self::SmallInt(col) => alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i])),
-            Self::Int(col) => alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i])),
-            Self::BigInt(col) => alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i])),
-            Self::Int128(col) => alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i])),
-            Self::Scalar(col) | Self::Decimal75(_, _, col) => col,
-            Self::VarChar((_, scals)) => scals,
-            Self::TimestampTZ(_, _, col) => {
-                alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i]))
-            }
-        }
-    }
-
     /// Returns element at index as scalar
     ///
     /// Note that if index is out of bounds, this function will return None

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -175,8 +175,80 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
 
+    /// Returns the column as a slice of i8 if it is a tinyint column. Otherwise, returns None.
+    pub(crate) fn as_tinyint(&self) -> Option<&'a [i8]> {
+        match self {
+            Self::TinyInt(col) => Some(col),
+            _ => None,
+        }
+    }
+
+    /// Returns the column as a slice of i16 if it is a smallint column. Otherwise, returns None.
+    pub(crate) fn as_smallint(&self) -> Option<&'a [i16]> {
+        match self {
+            Self::SmallInt(col) => Some(col),
+            _ => None,
+        }
+    }
+
+    /// Returns the column as a slice of i32 if it is an int column. Otherwise, returns None.
+    pub(crate) fn as_int(&self) -> Option<&'a [i32]> {
+        match self {
+            Self::Int(col) => Some(col),
+            _ => None,
+        }
+    }
+
+    /// Returns the column as a slice of i64 if it is a bigint column. Otherwise, returns None.
+    pub(crate) fn as_bigint(&self) -> Option<&'a [i64]> {
+        match self {
+            Self::BigInt(col) => Some(col),
+            _ => None,
+        }
+    }
+
+    /// Returns the column as a slice of i128 if it is an int128 column. Otherwise, returns None.
+    pub(crate) fn as_int128(&self) -> Option<&'a [i128]> {
+        match self {
+            Self::Int128(col) => Some(col),
+            _ => None,
+        }
+    }
+
+    /// Returns the column as a slice of scalars if it is a scalar column. Otherwise, returns None.
+    pub(crate) fn as_scalar(&self) -> Option<&'a [S]> {
+        match self {
+            Self::Scalar(col) => Some(col),
+            _ => None,
+        }
+    }
+
+    /// Returns the column as a slice of scalars if it is a decimal75 column. Otherwise, returns None.
+    pub(crate) fn as_decimal75(&self) -> Option<&'a [S]> {
+        match self {
+            Self::Decimal75(_, _, col) => Some(col),
+            _ => None,
+        }
+    }
+
+    /// Returns the column as a slice of strings and a slice of scalars if it is a varchar column. Otherwise, returns None.
+    pub(crate) fn as_varchar(&self) -> Option<(&'a [&'a str], &'a [S])> {
+        match self {
+            Self::VarChar((col, scals)) => Some((col, scals)),
+            _ => None,
+        }
+    }
+
+    /// Returns the column as a slice of i64 if it is a timestamp column. Otherwise, returns None.
+    pub(crate) fn as_timestamptz(&self) -> Option<&'a [i64]> {
+        match self {
+            Self::TimestampTZ(_, _, col) => Some(col),
+            _ => None,
+        }
+    }
+
     /// Returns the column as a slice of scalars
-    pub(crate) fn as_scalar(&self, alloc: &'a Bump) -> &'a [S] {
+    pub(crate) fn to_scalar(self, alloc: &'a Bump) -> &'a [S] {
         match self {
             Self::Boolean(col) => alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i])),
             Self::TinyInt(col) => alloc.alloc_slice_fill_with(col.len(), |i| S::from(col[i])),

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -52,6 +52,17 @@ pub enum ColumnOperationError {
         /// The underlying source error
         source: DecimalError,
     },
+
+    /// Errors related to unioning columns of different types
+    #[snafu(display(
+        "Cannot union columns of different types: {correct_type:?} and {actual_type:?}"
+    ))]
+    UnionDifferentTypes {
+        /// The correct data type
+        correct_type: ColumnType,
+        /// The type of the column that caused the error
+        actual_type: ColumnType,
+    },
 }
 
 /// Result type for column operations

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -28,6 +28,9 @@ pub(super) use column_comparison_operation::{
 mod column_operation_error;
 pub use column_operation_error::{ColumnOperationError, ColumnOperationResult};
 
+mod table_operation_error;
+pub use table_operation_error::{TableOperationError, TableOperationResult};
+
 mod columnar_value;
 pub use columnar_value::ColumnarValue;
 
@@ -105,3 +108,6 @@ mod filter_util_test;
 pub(crate) mod group_by_util;
 #[cfg(test)]
 mod group_by_util_test;
+
+#[allow(dead_code)]
+pub(crate) mod union_util;

--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -1,5 +1,6 @@
-use super::Column;
+use super::{Column, ColumnField};
 use crate::base::{map::IndexMap, scalar::Scalar};
+use alloc::vec::Vec;
 use proof_of_sql_parser::Identifier;
 use snafu::Snafu;
 
@@ -116,6 +117,14 @@ impl<'a, S: Scalar> Table<'a, S> {
     pub fn inner_table(&self) -> &IndexMap<Identifier, Column<'a, S>> {
         &self.table
     }
+    /// Return the schema of this table as a `Vec` of `ColumnField`s
+    #[must_use]
+    pub fn schema(&self) -> Vec<ColumnField> {
+        self.table
+            .iter()
+            .map(|(name, column)| ColumnField::new(*name, column.column_type()))
+            .collect()
+    }
     /// Returns the columns of this table as an Iterator
     pub fn column_names(&self) -> impl Iterator<Item = &Identifier> {
         self.table.keys()
@@ -123,6 +132,11 @@ impl<'a, S: Scalar> Table<'a, S> {
     /// Returns the columns of this table as an Iterator
     pub fn columns(&self) -> impl Iterator<Item = &Column<'a, S>> {
         self.table.values()
+    }
+    /// Returns the column with the given position.
+    #[must_use]
+    pub fn column(&self, index: usize) -> Option<&Column<'a, S>> {
+        self.table.values().nth(index)
     }
 }
 

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -1,0 +1,22 @@
+use crate::base::database::ColumnField;
+use alloc::vec::Vec;
+use core::result::Result;
+use snafu::Snafu;
+
+/// Errors from operations on tables.
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum TableOperationError {
+    /// Errors related to unioning tables with incompatible schemas.
+    #[snafu(display(
+        "Cannot union tables with incompatible schemas: {correct_schema:?} and {actual_schema:?}"
+    ))]
+    UnionIncompatibleSchemas {
+        /// The correct data type
+        correct_schema: Vec<ColumnField>,
+        /// The schema of the table that caused the error
+        actual_schema: Vec<ColumnField>,
+    },
+}
+
+/// Result type for table operations
+pub type TableOperationResult<T> = Result<T, TableOperationError>;

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -1,0 +1,337 @@
+use super::{
+    Column, ColumnField, ColumnOperationError, ColumnOperationResult, ColumnType, Table,
+    TableOperationError, TableOperationResult, TableOptions,
+};
+use crate::base::scalar::Scalar;
+use alloc::vec::Vec;
+use bumpalo::Bump;
+
+/// Check if two schemas are compatible
+/// Note that we can tolerate differences in column names but not in column types
+fn are_schemas_compatible(left: &[ColumnField], right: &[ColumnField]) -> bool {
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right)
+            .all(|(field1, field2)| field1.data_type() == field2.data_type())
+}
+
+/// Union multiple columns of the same type into a single column
+///
+/// # Panics
+/// This function should never panic as long as it is written correctly
+pub fn column_union<'a, S: Scalar>(
+    columns: &[&Column<'a, S>],
+    alloc: &'a Bump,
+    column_type: ColumnType,
+) -> ColumnOperationResult<Column<'a, S>> {
+    // Check for type mismatch
+    let possible_bad_column_type = columns.iter().find_map(|col| {
+        let found_column_type = col.column_type();
+        (found_column_type != column_type).then_some(found_column_type)
+    });
+    if let Some(bad_column_type) = possible_bad_column_type {
+        return Err(ColumnOperationError::UnionDifferentTypes {
+            actual_type: bad_column_type,
+            correct_type: column_type,
+        });
+    }
+    Ok(match column_type {
+        ColumnType::Boolean => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_boolean().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::Boolean(alloc.alloc_slice_copy(&result) as &[_])
+        }
+        ColumnType::TinyInt => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_tinyint().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::TinyInt(alloc.alloc_slice_copy(&result) as &[_])
+        }
+        ColumnType::SmallInt => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_smallint().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::SmallInt(alloc.alloc_slice_copy(&result) as &[_])
+        }
+        ColumnType::Int => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_int().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::Int(alloc.alloc_slice_copy(&result) as &[_])
+        }
+        ColumnType::BigInt => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_bigint().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::BigInt(alloc.alloc_slice_copy(&result) as &[_])
+        }
+        ColumnType::Int128 => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_int128().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::Int128(alloc.alloc_slice_copy(&result) as &[_])
+        }
+        ColumnType::Scalar => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_scalar().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::Scalar(alloc.alloc_slice_copy(&result) as &[_])
+        }
+        ColumnType::Decimal75(precision, scale) => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_decimal75().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::Decimal75(precision, scale, alloc.alloc_slice_copy(&result) as &[_])
+        }
+        ColumnType::VarChar => {
+            let (nested_result, nested_scalars): (Vec<_>, Vec<_>) = columns
+                .iter()
+                .map(|col| col.as_varchar().expect("Column types should match"))
+                .unzip();
+            let result: Vec<_> = nested_result.into_iter().flatten().copied().collect();
+            let scalars: Vec<_> = nested_scalars.into_iter().flatten().copied().collect();
+            Column::VarChar((
+                alloc.alloc_slice_copy(&result) as &[_],
+                alloc.alloc_slice_copy(&scalars) as &[_],
+            ))
+        }
+        ColumnType::TimestampTZ(tu, tz) => {
+            let result: Vec<_> = columns
+                .iter()
+                .flat_map(|col| col.as_timestamptz().expect("Column types should match"))
+                .copied()
+                .collect();
+            Column::TimestampTZ(tu, tz, alloc.alloc_slice_copy(&result) as &[_])
+        }
+    })
+}
+
+/// Union multiple tables with compatible schemas into a single table
+///
+/// # Panics
+/// This function should never panic as long as it is written correctly
+pub fn table_union<'a, S: Scalar>(
+    tables: &[&Table<'a, S>],
+    alloc: &'a Bump,
+    schema: Vec<ColumnField>,
+) -> TableOperationResult<Table<'a, S>> {
+    // Check schema equality
+    let possible_bad_schema = tables
+        .iter()
+        .filter(|&table| (!are_schemas_compatible(&schema, &table.schema())))
+        .map(|table| table.schema().clone())
+        .next();
+    if let Some(bad_schema) = possible_bad_schema {
+        return Err(TableOperationError::UnionIncompatibleSchemas {
+            actual_schema: bad_schema.clone(),
+            correct_schema: schema,
+        });
+    }
+    // Union the columns
+    // Make sure to consider the case where the tables have no columns
+    let num_rows = tables.iter().map(|table| table.num_rows()).sum();
+    let result = Table::<'a, S>::try_from_iter_with_options(
+        schema.iter().enumerate().map(|(i, field)| {
+            let columns: Vec<_> = tables
+                .iter()
+                .map(|table| table.column(i).expect("Schemas should be compatible"))
+                .collect();
+            (
+                field.name(),
+                column_union(&columns, alloc, field.data_type()).expect("Failed to union columns"),
+            )
+        }),
+        TableOptions::new(Some(num_rows)),
+    )
+    .expect("Failed to create table from iterator");
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{map::IndexMap, scalar::test_scalar::TestScalar};
+
+    #[test]
+    fn we_can_union_no_columns() {
+        let alloc = Bump::new();
+        let result = column_union::<TestScalar>(&[], &alloc, ColumnType::BigInt).unwrap();
+        assert_eq!(result, Column::BigInt(&[]));
+    }
+
+    #[test]
+    fn we_can_union_columns_of_the_same_type() {
+        let alloc = Bump::new();
+        let col0: Column<TestScalar> = Column::BigInt(&[]);
+        let col1: Column<TestScalar> = Column::BigInt(&[1, 2, 3]);
+        let col2: Column<TestScalar> = Column::BigInt(&[4, 5, 6]);
+        let col3: Column<TestScalar> = Column::BigInt(&[7, 8, 9]);
+        let result =
+            column_union(&[&col0, &col1, &col2, &col3], &alloc, ColumnType::BigInt).unwrap();
+        assert_eq!(result, Column::BigInt(&[1, 2, 3, 4, 5, 6, 7, 8, 9]));
+
+        let strings = vec!["a", "b", "c"];
+        let scalars = strings
+            .iter()
+            .map(|s| TestScalar::from(*s))
+            .collect::<Vec<_>>();
+        let col0: Column<TestScalar> = Column::VarChar((&strings, &scalars));
+        let col1: Column<TestScalar> = Column::VarChar((&strings, &scalars));
+        let result = column_union(&[&col0, &col1], &alloc, ColumnType::VarChar).unwrap();
+        let doubled_strings: Vec<_> = strings.iter().chain(strings.iter()).copied().collect();
+        let doubled_scalars: Vec<_> = scalars.iter().chain(scalars.iter()).copied().collect();
+        assert_eq!(
+            result,
+            Column::VarChar((&doubled_strings, &doubled_scalars))
+        );
+    }
+
+    #[test]
+    fn we_cannot_union_columns_with_wrong_types() {
+        let alloc = Bump::new();
+        let col0: Column<TestScalar> = Column::BigInt(&[]);
+        let result = column_union(&[&col0], &alloc, ColumnType::Int);
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::UnionDifferentTypes { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_union_no_tables() {
+        let alloc = Bump::new();
+        let result = table_union::<TestScalar>(&[], &alloc, vec![]).unwrap();
+        assert_eq!(
+            result,
+            Table::<'_, TestScalar>::try_new_with_options(
+                IndexMap::default(),
+                TableOptions::new(Some(0))
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_union_tables_without_columns() {
+        let alloc = Bump::new();
+        let table0 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions::new(Some(2)),
+        )
+        .unwrap();
+        let table1 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions::new(Some(5)),
+        )
+        .unwrap();
+        let table2 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions::new(Some(0)),
+        )
+        .unwrap();
+        let result = table_union(&[&table0, &table1, &table2], &alloc, vec![]).unwrap();
+        assert_eq!(
+            result,
+            Table::<'_, TestScalar>::try_new_with_options(
+                IndexMap::default(),
+                TableOptions::new(Some(7))
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_union_tables() {
+        let alloc = Bump::new();
+        // Column names don't matter
+        let table0 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::from_iter(vec![
+                ("a".parse().unwrap(), Column::BigInt(&[1, 2, 3])),
+                ("b".parse().unwrap(), Column::BigInt(&[4, 5, 6])),
+            ]),
+            TableOptions::new(Some(3)),
+        )
+        .unwrap();
+        let table1 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::from_iter(vec![
+                ("c".parse().unwrap(), Column::BigInt(&[7, 8, 9])),
+                ("d".parse().unwrap(), Column::BigInt(&[10, 11, 12])),
+            ]),
+            TableOptions::new(Some(3)),
+        )
+        .unwrap();
+        let result = table_union(
+            &[&table0, &table1],
+            &alloc,
+            vec![
+                ColumnField::new("e".parse().unwrap(), ColumnType::BigInt),
+                ColumnField::new("f".parse().unwrap(), ColumnType::BigInt),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            Table::<'_, TestScalar>::try_new_with_options(
+                IndexMap::from_iter(vec![
+                    ("e".parse().unwrap(), Column::BigInt(&[1, 2, 3, 7, 8, 9])),
+                    ("f".parse().unwrap(), Column::BigInt(&[4, 5, 6, 10, 11, 12])),
+                ]),
+                TableOptions::new(Some(6)),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_cannot_union_tables_with_incompatible_schema() {
+        let alloc = Bump::new();
+        // Any difference in column types between a table and the result schema will do
+        // regardless of whether the tables have the same schema
+        let table0 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::from_iter(vec![
+                ("a".parse().unwrap(), Column::BigInt(&[1, 2, 3])),
+                ("b".parse().unwrap(), Column::BigInt(&[4, 5, 6])),
+            ]),
+            TableOptions::new(Some(3)),
+        )
+        .unwrap();
+        let table1 = Table::<'_, TestScalar>::try_new_with_options(
+            IndexMap::from_iter(vec![
+                ("c".parse().unwrap(), Column::BigInt(&[7, 8, 9])),
+                ("d".parse().unwrap(), Column::BigInt(&[10, 11, 12])),
+            ]),
+            TableOptions::new(Some(3)),
+        )
+        .unwrap();
+        let result = table_union(
+            &[&table0, &table1],
+            &alloc,
+            vec![
+                ColumnField::new("e".parse().unwrap(), ColumnType::BigInt),
+                ColumnField::new("f".parse().unwrap(), ColumnType::Int),
+            ],
+        );
+        assert!(matches!(
+            result,
+            Err(TableOperationError::UnionIncompatibleSchemas { .. })
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -134,9 +134,9 @@ impl ProverEvaluate for ProjectionExec {
         )
         .expect("Failed to create table from iterator");
         // 2. Produce MLEs
-        res.inner_table().values().for_each(|column| {
-            builder.produce_intermediate_mle(column.to_scalar(alloc));
-        });
+        for column in res.columns().copied() {
+            builder.produce_intermediate_mle(column);
+        }
         res
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -135,7 +135,7 @@ impl ProverEvaluate for ProjectionExec {
         .expect("Failed to create table from iterator");
         // 2. Produce MLEs
         res.inner_table().values().for_each(|column| {
-            builder.produce_intermediate_mle(column.as_scalar(alloc));
+            builder.produce_intermediate_mle(column.to_scalar(alloc));
         });
         res
     }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to support `UnionExec` we need to add union utils and have them tested.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- rename `Column::as_scalar` to `Column::into_scalar` since `as_` methods such as `as_boolean` serve different purposes
- add `as_` method for every enum variant in `Column`
- add `union_util.rs` which contains column and table unioning.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Will be.