### PR TITLE
fix: remove blitzar as a dev-dependency

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -45,19 +45,33 @@ jobs:
       - name: Run cargo check (proof-of-sql) (no features)
         run: cargo check -p proof-of-sql --no-default-features
       - name: Run cargo check (proof-of-sql) (all features)
-        run: cargo check -p proof-of-sql --all-features
+        run: |
+          cargo check -p proof-of-sql --all-features
+          cargo check -p proof-of-sql --all-targets --all-features
       - name: Run cargo check (proof-of-sql) (just "test" feature)
-        run: cargo check -p proof-of-sql --no-default-features --features="test"
+        run: |
+          cargo check -p proof-of-sql --no-default-features --features="test"
+          cargo check -p proof-of-sql --all-targets --no-default-features --features="test"
       - name: Run cargo check (proof-of-sql) (just "blitzar" feature)
-        run: cargo check -p proof-of-sql --no-default-features --features="blitzar"
+        run: |
+          cargo check -p proof-of-sql --no-default-features --features="blitzar"
+          cargo check -p proof-of-sql --all-targets --no-default-features --features="blitzar"
       - name: Run cargo check (proof-of-sql) (just "arrow" feature)
-        run: cargo check -p proof-of-sql --no-default-features --features="arrow"
+        run: |
+          cargo check -p proof-of-sql --no-default-features --features="arrow"
+          cargo check -p proof-of-sql --all-targets --no-default-features --features="arrow"
       - name: Run cargo check (proof-of-sql) (just "rayon" feature)
-        run: cargo check -p proof-of-sql --no-default-features --features="rayon"
+        run: |
+          cargo check -p proof-of-sql --no-default-features --features="rayon"
+          cargo check -p proof-of-sql --all-targets --no-default-features --features="rayon"
       - name: Run cargo check (proof-of-sql) (just "perf" feature)
-        run: cargo check -p proof-of-sql --no-default-features --features="perf"
+        run: |
+          cargo check -p proof-of-sql --no-default-features --features="perf"
+          cargo check -p proof-of-sql --all-targets --no-default-features --features="perf"
       - name: Run cargo check (proof-of-sql) (just "std" feature)
-        run: cargo check -p proof-of-sql --no-default-features --features="std"
+        run: |
+          cargo check -p proof-of-sql --no-default-features --features="std"
+          cargo check -p proof-of-sql --all-targets --no-default-features --features="std"
       - name: Run cargo check (proof-of-sql-parser) with no_std target.
         run: |
           rustup target add thumbv7em-none-eabi

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -58,7 +58,6 @@ zerocopy = { workspace = true }
 [dev-dependencies]
 alloy-sol-types = { workspace = true }
 arrow-csv = { workspace = true }
-blitzar = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
 merlin = { workspace = true }
 opentelemetry = { workspace = true }
@@ -83,7 +82,7 @@ test = ["dep:rand", "std"]
 perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
 rayon = ["dep:rayon", "std"]
-std = ["snafu/std"]
+std = ["snafu/std", "ark-serialize/std"]
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql/README.md
+++ b/crates/proof-of-sql/README.md
@@ -49,7 +49,7 @@ Workaround for non-Linux and/or non-GPU machines.
     ```
 * Workaround #2: disable the `blitzar` feature in the repo. Example
     ```bash
-    cargo test --no-default-features --features="arrow rayon ark-ec/parallel ark-poly/parallel ark-ff/asm"
+    cargo test --no-default-features --features="arrow cpu-perf"
     ```
 
 </details>

--- a/crates/proof-of-sql/examples/hello_world/README.md
+++ b/crates/proof-of-sql/examples/hello_world/README.md
@@ -18,7 +18,7 @@ cargo run --example hello_world
 > [!NOTE]
 > To run this example without the `blitzar` (i.e CPU only) feature:
 > ```bash
-> cargo run --example hello_world --no-default-features --features="test rayon"
+> cargo run --example hello_world --no-default-features --features="test cpu-perf"
 > ```
 
 #### Output

--- a/crates/proof-of-sql/examples/hello_world/main.rs
+++ b/crates/proof-of-sql/examples/hello_world/main.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("README.md")]
 use ark_std::test_rng;
-use blitzar::compute::init_backend;
 use proof_of_sql::{
     base::database::{
         owned_table_utility::{bigint, owned_table, varchar},
@@ -41,9 +40,12 @@ fn end_timer(instant: Instant) {
 /// - Will panic if the query expression creation fails.
 /// - Will panic if printing fails during error handling.
 fn main() {
-    let timer = start_timer("Warming up GPU");
-    init_backend();
-    end_timer(timer);
+    #[cfg(feature = "blitzar")]
+    {
+        let timer = start_timer("Warming up GPU");
+        proof_of_sql::base::commitment::init_backend();
+        end_timer(timer);
+    }
     let timer = start_timer("Loading data");
     let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);

--- a/crates/proof-of-sql/examples/posql_db/README.md
+++ b/crates/proof-of-sql/examples/posql_db/README.md
@@ -8,7 +8,7 @@ Run `cargo install --example posql_db --path crates/proof-of-sql` to install the
 > [!NOTE]
 > To run this example without the `blitzar` (i.e CPU only )feature 
 > ```bash
-> cargo install --example posql_db --path crates/proof-of-sql --no-default-features --features="rayon"
+> cargo install --example posql_db --path crates/proof-of-sql --no-default-features --features="cpu-perf"
 > ```
 
 ## Quick Start Exmaple

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -150,9 +150,13 @@ fn end_timer(instant: Instant) {
 #[allow(clippy::too_many_lines)]
 fn main() {
     let args = CliArgs::parse();
-    println!("Warming up GPU...");
-    blitzar::compute::init_backend();
-    println!("Done.");
+
+    #[cfg(feature = "blitzar")]
+    {
+        println!("Warming up GPU...");
+        proof_of_sql::base::commitment::init_backend();
+        println!("Done.");
+    }
 
     let mut rng = <ark_std::rand::rngs::StdRng as ark_std::rand::SeedableRng>::from_seed([0u8; 32]);
     let public_parameters = PublicParameters::rand(5, &mut rng);


### PR DESCRIPTION
Closes #383 

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->
Tests cannot currently be run on alternative architectures because they
enable the blitzar dependency.
However, this is not strictly necessary, because all tests using blitzar
are behind the blitzar feature flag.
So, this removes blitzar as a dev dependency, as well as making a couple related changes to the README and CI.
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->
- fix: remove blitzar as a dev-dependency
- docs: simplify README cargo test command excluding blitzar feature
- ci: check all targets in feature-specific checks of Check package job

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
These changes do not change existing functionality, which is verified by existing tests.