### PR TITLE
feat: add `column_index_operation`

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -1,0 +1,150 @@
+use super::{slice_operation::apply_slice_to_indexes, Column, ColumnOperationResult, ColumnType};
+use crate::base::scalar::Scalar;
+use bumpalo::Bump;
+
+/// Apply a `Column` to a vector of indexes, returning a new `Column` with the
+/// values at the given indexes. Repetitions are allowed.
+///
+/// # Panics
+/// Panics if any of the indexes are out of bounds.
+#[allow(dead_code)]
+pub(crate) fn apply_column_to_indexes<'a, S>(
+    column: &Column<'a, S>,
+    alloc: &'a Bump,
+    indexes: &[usize],
+) -> ColumnOperationResult<Column<'a, S>>
+where
+    S: Scalar,
+{
+    match column.column_type() {
+        ColumnType::Boolean => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_boolean().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::Boolean(alloc.alloc_slice_copy(&raw_values) as &[_]))
+        }
+        ColumnType::TinyInt => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_tinyint().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::TinyInt(alloc.alloc_slice_copy(&raw_values) as &[_]))
+        }
+        ColumnType::SmallInt => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_smallint().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::SmallInt(alloc.alloc_slice_copy(&raw_values) as &[_]))
+        }
+        ColumnType::Int => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_int().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::Int(alloc.alloc_slice_copy(&raw_values) as &[_]))
+        }
+        ColumnType::BigInt => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_bigint().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::BigInt(alloc.alloc_slice_copy(&raw_values) as &[_]))
+        }
+        ColumnType::Int128 => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_int128().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::Int128(alloc.alloc_slice_copy(&raw_values) as &[_]))
+        }
+        ColumnType::Scalar => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_scalar().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::Scalar(alloc.alloc_slice_copy(&raw_values) as &[_]))
+        }
+        ColumnType::Decimal75(precision, scale) => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_decimal75().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::Decimal75(
+                precision,
+                scale,
+                alloc.alloc_slice_copy(&raw_values) as &[_],
+            ))
+        }
+        ColumnType::VarChar => {
+            let (raw_values, raw_scalars) = column.as_varchar().expect("Column types should match");
+            let raw_values = apply_slice_to_indexes(raw_values, indexes)?;
+            let scalars = apply_slice_to_indexes(raw_scalars, indexes)?;
+            Ok(Column::VarChar((
+                alloc.alloc_slice_clone(&raw_values) as &[_],
+                alloc.alloc_slice_copy(&scalars) as &[_],
+            )))
+        }
+        ColumnType::TimestampTZ(tu, tz) => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_timestamptz().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::TimestampTZ(
+                tu,
+                tz,
+                alloc.alloc_slice_copy(&raw_values) as &[_],
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::{database::ColumnOperationError, scalar::test_scalar::TestScalar};
+
+    #[test]
+    fn test_apply_index_op() {
+        let bump = Bump::new();
+        let column: Column<TestScalar> = Column::Int(&[1, 2, 3, 4, 5]);
+        let indexes = [1, 3, 1, 2];
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        assert_eq!(result, Column::Int(&[2, 4, 2, 3]));
+
+        let scalars = [1, 2, 3].iter().map(TestScalar::from).collect::<Vec<_>>();
+        let column: Column<TestScalar> = Column::Scalar(&scalars);
+        let indexes = [1, 1, 1];
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        let expected_scalars = [2, 2, 2].iter().map(TestScalar::from).collect::<Vec<_>>();
+        assert_eq!(result, Column::Scalar(&expected_scalars));
+
+        let strings = vec!["a", "b", "c"];
+        let scalars = strings.iter().map(TestScalar::from).collect::<Vec<_>>();
+        let column: Column<TestScalar> = Column::VarChar((&strings, &scalars));
+        let indexes = [2, 1, 1];
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        let expected_strings = vec!["c", "b", "b"];
+        let expected_scalars = expected_strings
+            .iter()
+            .map(TestScalar::from)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            result,
+            Column::VarChar((&expected_strings, &expected_scalars))
+        );
+    }
+
+    #[test]
+    fn test_apply_index_op_out_of_bound() {
+        let bump = Bump::new();
+        let column: Column<TestScalar> = Column::Int(&[1, 2, 3, 4, 5]);
+        let indexes = [1, 3, 1, 2, 5];
+        let result = apply_column_to_indexes(&column, &bump, &indexes);
+        assert!(matches!(
+            result,
+            Err(ColumnOperationError::IndexOutOfBounds { .. })
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -63,6 +63,15 @@ pub enum ColumnOperationError {
         /// The type of the column that caused the error
         actual_type: ColumnType,
     },
+
+    /// Errors related to index out of bounds
+    #[snafu(display("Index out of bounds: {index} >= {len}"))]
+    IndexOutOfBounds {
+        /// The index that caused the error
+        index: usize,
+        /// The length of the column
+        len: usize,
+    },
 }
 
 /// Result type for column operations

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -25,6 +25,8 @@ pub(super) use column_comparison_operation::{
     ComparisonOp, EqualOp, GreaterThanOrEqualOp, LessThanOrEqualOp,
 };
 
+mod column_index_operation;
+
 mod column_repetition_operation;
 pub(super) use column_repetition_operation::{ColumnRepeatOp, ElementwiseRepeatOp, RepetitionOp};
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In sort-merge joins we need to be able to apply columns to possibly repetitive indexes. Hence let's add this before actually adding `sort_merge_join`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `ColumnOperationError::IndexOutOfBounds`.
- add `apply_slice_to_indexes` in `slice_operation.rs`.
- add `IndexOp` and `ApplyIndexOp` to apply the new op to `Column`s.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.