### PR TITLE
refactor!: simplify VerifiableQueryResult::verify

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/mod.rs
+++ b/crates/proof-of-sql/benches/scaffold/mod.rs
@@ -74,7 +74,7 @@ pub fn jaeger_scaffold<CP: CommitmentEvaluationProof>(
 }
 
 #[allow(dead_code, clippy::module_name_repetitions)]
-pub fn criterion_scaffold<CP: CommitmentEvaluationProof>(
+pub fn criterion_scaffold<CP: CommitmentEvaluationProof + Clone>(
     c: &mut Criterion,
     title: &str,
     query: &str,
@@ -107,7 +107,11 @@ pub fn criterion_scaffold<CP: CommitmentEvaluationProof>(
             });
         });
         group.bench_function("Verify Proof", |b| {
-            b.iter(|| result.verify(query.proof_expr(), &accessor, verifier_setup));
+            b.iter(|| {
+                result
+                    .clone()
+                    .verify(query.proof_expr(), &accessor, verifier_setup)
+            });
         });
     }
 }

--- a/crates/proof-of-sql/examples/albums/main.rs
+++ b/crates/proof-of-sql/examples/albums/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/avocado-prices/main.rs
+++ b/crates/proof-of-sql/examples/avocado-prices/main.rs
@@ -61,7 +61,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/books/main.rs
+++ b/crates/proof-of-sql/examples/books/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/brands/main.rs
+++ b/crates/proof-of-sql/examples/brands/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/census/main.rs
+++ b/crates/proof-of-sql/examples/census/main.rs
@@ -64,7 +64,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/countries/main.rs
+++ b/crates/proof-of-sql/examples/countries/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/dinosaurs/main.rs
+++ b/crates/proof-of-sql/examples/dinosaurs/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql/examples/dog_breeds/main.rs
@@ -58,7 +58,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/hello_world/main.rs
+++ b/crates/proof-of-sql/examples/hello_world/main.rs
@@ -80,7 +80,7 @@ fn main() {
     let result = proof.verify(
         query.proof_expr(),
         &accessor,
-        &serialized_result,
+        serialized_result,
         &&verifier_setup,
     );
     end_timer(timer);

--- a/crates/proof-of-sql/examples/plastics/main.rs
+++ b/crates/proof-of-sql/examples/plastics/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/programming_books/main.rs
+++ b/crates/proof-of-sql/examples/programming_books/main.rs
@@ -58,7 +58,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/rockets/main.rs
+++ b/crates/proof-of-sql/examples/rockets/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/space/main.rs
+++ b/crates/proof-of-sql/examples/space/main.rs
@@ -66,7 +66,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/stocks/main.rs
+++ b/crates/proof-of-sql/examples/stocks/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/sushi/main.rs
+++ b/crates/proof-of-sql/examples/sushi/main.rs
@@ -48,7 +48,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
+++ b/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
@@ -44,7 +44,7 @@ fn prove_and_verify_query(
     let result = proof.verify(
         query_plan.proof_expr(),
         accessor,
-        &provable_result,
+        provable_result,
         &verifier_setup,
     )?;
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/vehicles/main.rs
+++ b/crates/proof-of-sql/examples/vehicles/main.rs
@@ -57,7 +57,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/examples/wood_types/main.rs
+++ b/crates/proof-of-sql/examples/wood_types/main.rs
@@ -61,7 +61,7 @@ fn prove_and_verify_query(
         .verify(
             query_plan.proof_expr(),
             accessor,
-            &provable_result,
+            provable_result,
             &verifier_setup,
         )
         .unwrap();

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -205,10 +205,10 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
     #[tracing::instrument(name = "QueryProof::verify", level = "debug", skip_all, err)]
     /// Verify a `QueryProof`. Note: This does NOT transform the result!
     pub fn verify(
-        &self,
+        self,
         expr: &(impl ProofPlan + Serialize),
         accessor: &impl CommitmentAccessor<CP::Commitment>,
-        result: &ProvableQueryResult,
+        result: ProvableQueryResult,
         setup: &CP::VerifierPublicSetup<'_>,
     ) -> QueryResult<CP::Scalar> {
         let owned_table_result = result.to_owned_table(&expr.get_column_result_fields())?;
@@ -244,7 +244,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         // construct a transcript for the proof
         let mut transcript: Keccak256Transcript = make_transcript(
             expr,
-            result,
+            &result,
             self.range_length,
             min_row_num,
             &self.one_evaluation_lengths,

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -132,7 +132,10 @@ fn verify_a_trivial_query_proof_with_given_offset(n: usize, offset_generators: u
     let QueryData {
         verification_hash,
         table,
-    } = proof.verify(&expr, &accessor, &result, &()).unwrap();
+    } = proof
+        .clone()
+        .verify(&expr, &accessor, result.clone(), &())
+        .unwrap();
     assert_ne!(verification_hash, [0; 32]);
     let expected_result = owned_table([bigint("a1", column)]);
     assert_eq!(table, expected_result);
@@ -166,7 +169,7 @@ fn verify_fails_if_the_summation_in_sumcheck_isnt_zero() {
         (),
     );
     let (proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[test]
@@ -184,7 +187,7 @@ fn verify_fails_if_the_sumcheck_evaluation_isnt_correct() {
         (),
     );
     let (proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[test]
@@ -202,7 +205,7 @@ fn verify_fails_if_counts_dont_match() {
         (),
     );
     let (proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 /// prove and verify an artificial query where
@@ -320,7 +323,10 @@ fn verify_a_proof_with_an_anchored_commitment_and_given_offset(offset_generators
     let QueryData {
         verification_hash,
         table,
-    } = proof.verify(&expr, &accessor, &result, &()).unwrap();
+    } = proof
+        .clone()
+        .verify(&expr, &accessor, result.clone(), &())
+        .unwrap();
     assert_ne!(verification_hash, [0; 32]);
     let expected_result = owned_table([bigint("a1", [9, 25])]);
     assert_eq!(table, expected_result);
@@ -332,7 +338,7 @@ fn verify_a_proof_with_an_anchored_commitment_and_given_offset(offset_generators
         offset_generators + 1,
         (),
     );
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[test]
@@ -363,7 +369,7 @@ fn verify_fails_if_the_result_doesnt_satisfy_an_anchored_equation() {
         (),
     );
     let (proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[test]
@@ -382,7 +388,7 @@ fn verify_fails_if_the_anchored_commitment_doesnt_match() {
         (),
     );
     let (proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 // prove and verify an artificial query where
@@ -523,7 +529,10 @@ fn verify_a_proof_with_an_intermediate_commitment_and_given_offset(offset_genera
     let QueryData {
         verification_hash,
         table,
-    } = proof.verify(&expr, &accessor, &result, &()).unwrap();
+    } = proof
+        .clone()
+        .verify(&expr, &accessor, result.clone(), &())
+        .unwrap();
     assert_ne!(verification_hash, [0; 32]);
     let expected_result = owned_table([bigint("a1", [81, 625])]);
     assert_eq!(table, expected_result);
@@ -535,7 +544,7 @@ fn verify_a_proof_with_an_intermediate_commitment_and_given_offset(offset_genera
         offset_generators + 1,
         (),
     );
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[test]
@@ -565,7 +574,7 @@ fn verify_fails_if_an_intermediate_commitment_doesnt_match() {
     );
     let (mut proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
     proof.commitments[0] = proof.commitments[0] * Curve25519Scalar::from(2u64);
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[test]
@@ -586,7 +595,7 @@ fn verify_fails_if_an_intermediate_equation_isnt_satified() {
         (),
     );
     let (proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[test]
@@ -608,7 +617,7 @@ fn verify_fails_the_result_doesnt_satisfy_an_intermediate_equation() {
         (),
     );
     let (proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[derive(Debug, Serialize)]
@@ -717,7 +726,10 @@ fn verify_a_proof_with_a_post_result_challenge_and_given_offset(offset_generator
     let QueryData {
         verification_hash,
         table,
-    } = proof.verify(&expr, &accessor, &result, &()).unwrap();
+    } = proof
+        .clone()
+        .verify(&expr, &accessor, result.clone(), &())
+        .unwrap();
     assert_ne!(verification_hash, [0; 32]);
     let expected_result = owned_table([bigint("a1", [9, 25])]);
     assert_eq!(table, expected_result);
@@ -729,7 +741,7 @@ fn verify_a_proof_with_a_post_result_challenge_and_given_offset(offset_generator
         offset_generators + 1,
         (),
     );
-    assert!(proof.verify(&expr, &accessor, &result, &()).is_err());
+    assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -149,12 +149,9 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
                 error: "non-zero sumcheck variables but empty result",
             })?;
         }
-        self.proof.as_ref().unwrap().verify(
-            expr,
-            accessor,
-            self.provable_result.as_ref().unwrap(),
-            setup,
-        )
+        self.proof
+            .unwrap()
+            .verify(expr, accessor, self.provable_result.unwrap(), setup)
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -119,7 +119,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
     ///   - `self.proof.as_ref().unwrap()` is called but `self.proof` is `None`.
     ///   - `self.provable_result.as_ref().unwrap()` is called but `self.provable_result` is `None`.
     pub fn verify(
-        &self,
+        self,
         expr: &(impl ProofPlan + Serialize),
         accessor: &impl CommitmentAccessor<CP::Commitment>,
         setup: &CP::VerifierPublicSetup<'_>,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -33,7 +33,7 @@ pub fn exercise_verification(
     accessor: &impl TestAccessor<RistrettoPoint>,
     table_ref: TableRef,
 ) {
-    let verification_result = res.verify(expr, accessor, &());
+    let verification_result = res.clone().verify(expr, accessor, &());
     assert!(
         verification_result.is_ok(),
         "Verification failed: {:?}",
@@ -82,9 +82,9 @@ pub fn exercise_verification(
         let offset_generators = accessor.get_offset(table_ref);
         let mut fake_accessor = accessor.clone();
         fake_accessor.update_offset(table_ref, offset_generators);
-        res.verify(expr, &fake_accessor, &()).unwrap();
+        res.clone().verify(expr, &fake_accessor, &()).unwrap();
         fake_accessor.update_offset(table_ref, offset_generators + 1);
-        assert!(res.verify(expr, &fake_accessor, &()).is_err());
+        assert!(res.clone().verify(expr, &fake_accessor, &()).is_err());
     }
 }
 

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -37,7 +37,7 @@ fn we_can_prove_a_minimal_filter_query_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let expected_result = owned_table([boolean("a", [true])]);
@@ -71,7 +71,7 @@ fn we_can_prove_a_minimal_filter_query_with_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()
@@ -108,7 +108,7 @@ fn we_can_prove_a_minimal_filter_query_with_dynamic_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &&verifier_setup,
         )
         .unwrap()
@@ -135,7 +135,7 @@ fn we_can_prove_a_basic_equality_query_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 1])]);
@@ -169,7 +169,7 @@ fn we_can_prove_a_basic_equality_query_with_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()
@@ -196,7 +196,7 @@ fn we_can_prove_a_basic_inequality_query_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 2])]);
@@ -227,7 +227,7 @@ fn we_can_prove_a_basic_query_containing_extrema_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -273,7 +273,7 @@ fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()
@@ -306,7 +306,7 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -341,7 +341,7 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()
@@ -373,7 +373,7 @@ fn we_can_prove_a_basic_equality_with_out_of_order_results_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -409,7 +409,7 @@ fn we_can_prove_a_basic_inequality_query_with_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()
@@ -468,7 +468,7 @@ fn we_can_prove_a_complex_query_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -518,7 +518,7 @@ fn we_can_prove_a_complex_query_with_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()
@@ -553,7 +553,7 @@ fn we_can_prove_a_minimal_group_by_query_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result: OwnedTable<Curve25519Scalar> = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -587,7 +587,7 @@ fn we_can_prove_a_basic_group_by_query_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -650,7 +650,7 @@ fn we_can_prove_a_cat_group_by_query_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -728,7 +728,7 @@ fn we_can_prove_a_cat_group_by_query_with_dynamic_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &&verifier_setup,
         )
         .unwrap()
@@ -773,7 +773,7 @@ fn we_can_prove_a_basic_group_by_query_with_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()
@@ -805,7 +805,7 @@ fn we_can_prove_a_query_with_overflow_with_curve25519() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     assert!(matches!(
-        proof.verify(query.proof_expr(), &accessor, &serialized_result, &()),
+        proof.verify(query.proof_expr(), &accessor, serialized_result, &()),
         Err(QueryError::Overflow)
     ));
 }
@@ -837,7 +837,7 @@ fn we_can_prove_a_query_with_overflow_with_dory() {
         proof.verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup
         ),
         Err(QueryError::Overflow)
@@ -868,7 +868,7 @@ fn we_can_perform_arithmetic_and_conditional_operations_on_tinyint() {
     let (proof, serialized_result) =
         QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &serialized_result, &())
+        .verify(query.proof_expr(), &accessor, serialized_result, &())
         .unwrap()
         .table;
     let expected_result = owned_table([tinyint("result", [9_i8, 10])]);

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -57,7 +57,7 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()
@@ -450,7 +450,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         .verify(
             query.proof_expr(),
             &accessor,
-            &serialized_result,
+            serialized_result,
             &dory_verifier_setup,
         )
         .unwrap()


### PR DESCRIPTION
# Rationale for this change

`VerifiableQueryResult::verify` is more complex than it needs to be

# What changes are included in this PR?

See individual commit messages.

# Are these changes tested?

Yes, by existing tests.