### PR TITLE
chore: add conversion from `Table` to `OwnedTable`.

### DIFF
--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -12,6 +12,7 @@ macro_rules! indexmap_macro {
             // Note: `stringify!($key)` is just here to consume the repetition,
             // but we throw away that string literal during constant evaluation.
             const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
+            #[allow(unused_mut)]
             let mut map = $crate::base::map::IndexMap::with_capacity_and_hasher(CAP, <_>::default());
             $(
                 map.insert($key, $value);


### PR DESCRIPTION
# Rationale for this change

Conversions from `Table` to `OwnedTable` will be useful in future PRs.

# What changes are included in this PR?

`From<&Table>` and `From<Table>` are implemented for `OwnedTable`.

# Are these changes tested?
Yes
