### PR TITLE
bench: add more queries to jaeger benches

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -169,5 +169,5 @@ pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &
         COMPLEX_CONDITION_TITLE,
         COMPLEX_CONDITION_SQL,
         COMPLEX_CONDITION_COLUMNS,
-    ),    
+    ),
 ];

--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -86,6 +86,38 @@ const BOOLEAN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ("b", ColumnType::VarChar, None),
     ("c", ColumnType::Boolean, None),
 ];
+const LARGE_COLUMN_SET_TITLE: &str = "Large Column Set";
+const LARGE_COLUMN_SET_SQL: &str = "SELECT * FROM table WHERE b = d";
+const LARGE_COLUMN_SET_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
+    ("a", ColumnType::Boolean, None),
+    (
+        "b",
+        ColumnType::TinyInt,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    (
+        "c",
+        ColumnType::SmallInt,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    (
+        "d",
+        ColumnType::Int,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    (
+        "e",
+        ColumnType::BigInt,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    (
+        "f",
+        ColumnType::Int128,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    ("g", ColumnType::VarChar, None),
+    ("h", ColumnType::Scalar, None),
+];
 
 #[allow(clippy::type_complexity)]
 pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &[
@@ -106,5 +138,10 @@ pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &
         BOOLEAN_FILTER_TITLE,
         BOOLEAN_FILTER_SQL,
         BOOLEAN_FILTER_COLUMNS,
+    ),
+    (
+        LARGE_COLUMN_SET_TITLE,
+        LARGE_COLUMN_SET_SQL,
+        LARGE_COLUMN_SET_COLUMNS,
     ),
 ];

--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -29,7 +29,8 @@ const MULTI_COLUMN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ("c", ColumnType::VarChar, None),
 ];
 const ARITHMETIC_TITLE: &str = "Arithmetic";
-const ARITHMETIC_SQL: &str = "SELECT a + b as r0, a * b - 2 as r1, c FROM table WHERE a >= b";
+const ARITHMETIC_SQL: &str =
+    "SELECT a + b as r0, a * b - 2 as r1, c FROM table WHERE a <= b AND a >= 0";
 const ARITHMETIC_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
@@ -38,7 +39,7 @@ const ARITHMETIC_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ),
     (
         "b",
-        ColumnType::BigInt,
+        ColumnType::TinyInt,
         Some(|size| (size / 10).max(10) as i64),
     ),
     ("c", ColumnType::VarChar, None),

--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -60,6 +60,21 @@ const GROUPBY_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ),
     ("c", ColumnType::Boolean, None),
 ];
+const AGGREGATE_TITLE: &str = "Aggregate";
+const AGGREGATE_SQL: &str = "SELECT SUM(a) FROM table WHERE b = a OR c = 'ab'";
+const AGGREGATE_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
+    (
+        "a",
+        ColumnType::BigInt,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    (
+        "b",
+        ColumnType::Int,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    ("c", ColumnType::VarChar, None),
+];
 
 #[allow(clippy::type_complexity)]
 pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &[
@@ -75,4 +90,5 @@ pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &
     ),
     (ARITHMETIC_TITLE, ARITHMETIC_SQL, ARITHMETIC_COLUMNS),
     (GROUPBY_TITLE, GROUPBY_SQL, GROUPBY_COLUMNS),
+    (AGGREGATE_TITLE, AGGREGATE_SQL, AGGREGATE_COLUMNS),
 ];

--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -75,6 +75,17 @@ const AGGREGATE_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ),
     ("c", ColumnType::VarChar, None),
 ];
+const BOOLEAN_FILTER_TITLE: &str = "Boolean Filter";
+const BOOLEAN_FILTER_SQL: &str = "SELECT * FROM table WHERE c = TRUE and b = 'aaa' or a = 0";
+const BOOLEAN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
+    (
+        "a",
+        ColumnType::BigInt,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    ("b", ColumnType::VarChar, None),
+    ("c", ColumnType::Boolean, None),
+];
 
 #[allow(clippy::type_complexity)]
 pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &[
@@ -91,4 +102,9 @@ pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &
     (ARITHMETIC_TITLE, ARITHMETIC_SQL, ARITHMETIC_COLUMNS),
     (GROUPBY_TITLE, GROUPBY_SQL, GROUPBY_COLUMNS),
     (AGGREGATE_TITLE, AGGREGATE_SQL, AGGREGATE_COLUMNS),
+    (
+        BOOLEAN_FILTER_TITLE,
+        BOOLEAN_FILTER_SQL,
+        BOOLEAN_FILTER_COLUMNS,
+    ),
 ];

--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -44,6 +44,22 @@ const ARITHMETIC_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ),
     ("c", ColumnType::VarChar, None),
 ];
+const GROUPBY_TITLE: &str = "Group By";
+const GROUPBY_SQL: &str =
+    "SELECT a, COUNT(*) FROM table WHERE (c = TRUE) and (a <= b) and (a > 0) GROUP BY a";
+const GROUPBY_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
+    (
+        "a",
+        ColumnType::Int128,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    (
+        "b",
+        ColumnType::TinyInt,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    ("c", ColumnType::Boolean, None),
+];
 
 #[allow(clippy::type_complexity)]
 pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &[
@@ -58,4 +74,5 @@ pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &
         MULTI_COLUMN_FILTER_COLUMNS,
     ),
     (ARITHMETIC_TITLE, ARITHMETIC_SQL, ARITHMETIC_COLUMNS),
+    (GROUPBY_TITLE, GROUPBY_SQL, GROUPBY_COLUMNS),
 ];

--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -61,7 +61,7 @@ const GROUPBY_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ("c", ColumnType::Boolean, None),
 ];
 const AGGREGATE_TITLE: &str = "Aggregate";
-const AGGREGATE_SQL: &str = "SELECT SUM(a) FROM table WHERE b = a OR c = 'ab'";
+const AGGREGATE_SQL: &str = "SELECT SUM(a) FROM table WHERE b = a OR c = 'yz'";
 const AGGREGATE_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
@@ -76,7 +76,7 @@ const AGGREGATE_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ("c", ColumnType::VarChar, None),
 ];
 const BOOLEAN_FILTER_TITLE: &str = "Boolean Filter";
-const BOOLEAN_FILTER_SQL: &str = "SELECT * FROM table WHERE c = TRUE and b = 'aaa' or a = 0";
+const BOOLEAN_FILTER_SQL: &str = "SELECT * FROM table WHERE c = TRUE and b = 'xyz' or a = 0";
 const BOOLEAN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",
@@ -120,7 +120,7 @@ const LARGE_COLUMN_SET_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
 ];
 const COMPLEX_CONDITION_TITLE: &str = "Complex Condition";
 const COMPLEX_CONDITION_SQL: &str =
-    "SELECT * FROM table WHERE (a > c * c AND b < c + 10) OR (d = 'abc')";
+    "SELECT * FROM table WHERE (a > c * c AND b < c + 10) OR (d = 'xyz')";
 const COMPLEX_CONDITION_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     (
         "a",

--- a/crates/proof-of-sql/benches/scaffold/querys.rs
+++ b/crates/proof-of-sql/benches/scaffold/querys.rs
@@ -118,6 +118,27 @@ const LARGE_COLUMN_SET_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ("g", ColumnType::VarChar, None),
     ("h", ColumnType::Scalar, None),
 ];
+const COMPLEX_CONDITION_TITLE: &str = "Complex Condition";
+const COMPLEX_CONDITION_SQL: &str =
+    "SELECT * FROM table WHERE (a > c * c AND b < c + 10) OR (d = 'abc')";
+const COMPLEX_CONDITION_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
+    (
+        "a",
+        ColumnType::BigInt,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    (
+        "b",
+        ColumnType::BigInt,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    (
+        "c",
+        ColumnType::Int128,
+        Some(|size| (size / 10).max(10) as i64),
+    ),
+    ("d", ColumnType::VarChar, None),
+];
 
 #[allow(clippy::type_complexity)]
 pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &[
@@ -144,4 +165,9 @@ pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &
         LARGE_COLUMN_SET_SQL,
         LARGE_COLUMN_SET_COLUMNS,
     ),
+    (
+        COMPLEX_CONDITION_TITLE,
+        COMPLEX_CONDITION_SQL,
+        COMPLEX_CONDITION_COLUMNS,
+    ),    
 ];

--- a/crates/proof-of-sql/benches/scaffold/random_util.rs
+++ b/crates/proof-of-sql/benches/scaffold/random_util.rs
@@ -25,6 +25,9 @@ pub fn generate_random_columns<'a, S: Scalar>(
             (
                 id.parse().unwrap(),
                 match (ty, bound) {
+                    (ColumnType::Boolean, _) => {
+                        Column::Boolean(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
+                    }
                     (ColumnType::BigInt, None) => {
                         Column::BigInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }
@@ -32,9 +35,6 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::BigInt(alloc.alloc_slice_fill_with(num_rows, |_| {
                             rng.gen_range(-b(num_rows)..=b(num_rows))
                         }))
-                    }
-                    (ColumnType::Boolean, _) => {
-                        Column::Boolean(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }
                     (ColumnType::Int128, None) => {
                         Column::Int128(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))

--- a/crates/proof-of-sql/benches/scaffold/random_util.rs
+++ b/crates/proof-of-sql/benches/scaffold/random_util.rs
@@ -38,7 +38,18 @@ pub fn generate_random_columns<'a, S: Scalar>(
                                 b_value.clamp(i8::MIN as i64, i8::MAX as i64) as i8;
                             rng.gen_range(-clamped_b_value..=clamped_b_value)
                         }))
-                    }                    
+                    }
+                    (ColumnType::SmallInt, None) => {
+                        Column::SmallInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
+                    }
+                    (ColumnType::SmallInt, Some(b)) => {
+                        Column::SmallInt(alloc.alloc_slice_fill_with(num_rows, |_| {
+                            let b_value = b(num_rows);
+                            let clamped_b_value =
+                                b_value.clamp(i16::MIN as i64, i16::MAX as i64) as i16;
+                            rng.gen_range(-clamped_b_value..=clamped_b_value)
+                        }))
+                    }
                     (ColumnType::BigInt, None) => {
                         Column::BigInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }

--- a/crates/proof-of-sql/benches/scaffold/random_util.rs
+++ b/crates/proof-of-sql/benches/scaffold/random_util.rs
@@ -93,6 +93,21 @@ pub fn generate_random_columns<'a, S: Scalar>(
                             alloc.alloc_slice_fill_iter(strs.iter().map(|&s| Into::into(s))),
                         ))
                     }
+                    (ColumnType::Scalar, _) => {
+                        let strs = alloc.alloc_slice_fill_with(num_rows, |_| {
+                            let len = rng
+                                .gen_range(0..=bound.map(|b| b(num_rows) as usize).unwrap_or(10));
+                            alloc.alloc_str(
+                                &rng.sample_iter(&rand::distributions::Alphanumeric)
+                                    .take(len)
+                                    .map(char::from)
+                                    .collect::<String>(),
+                            ) as &str
+                        });
+                        Column::Scalar(
+                            alloc.alloc_slice_fill_iter(strs.iter().map(|&s| Into::into(s))),
+                        )
+                    }
                     _ => todo!(),
                 },
             )

--- a/crates/proof-of-sql/benches/scaffold/random_util.rs
+++ b/crates/proof-of-sql/benches/scaffold/random_util.rs
@@ -50,6 +50,17 @@ pub fn generate_random_columns<'a, S: Scalar>(
                             rng.gen_range(-clamped_b_value..=clamped_b_value)
                         }))
                     }
+                    (ColumnType::Int, None) => {
+                        Column::Int(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
+                    }
+                    (ColumnType::Int, Some(b)) => {
+                        Column::Int(alloc.alloc_slice_fill_with(num_rows, |_| {
+                            let b_value = b(num_rows);
+                            let clamped_b_value =
+                                b_value.clamp(i32::MIN as i64, i32::MAX as i64) as i32;
+                            rng.gen_range(-clamped_b_value..=clamped_b_value)
+                        }))
+                    }
                     (ColumnType::BigInt, None) => {
                         Column::BigInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }

--- a/crates/proof-of-sql/benches/scaffold/random_util.rs
+++ b/crates/proof-of-sql/benches/scaffold/random_util.rs
@@ -35,7 +35,7 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::TinyInt(alloc.alloc_slice_fill_with(num_rows, |_| {
                             let b_value = b(num_rows);
                             let clamped_b_value =
-                                b_value.clamp(i8::MIN as i64, i8::MAX as i64) as i8;
+                                b_value.clamp(i64::from(i8::MIN), i64::from(i8::MAX)) as i8;
                             rng.gen_range(-clamped_b_value..=clamped_b_value)
                         }))
                     }
@@ -46,7 +46,7 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::SmallInt(alloc.alloc_slice_fill_with(num_rows, |_| {
                             let b_value = b(num_rows);
                             let clamped_b_value =
-                                b_value.clamp(i16::MIN as i64, i16::MAX as i64) as i16;
+                                b_value.clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16;
                             rng.gen_range(-clamped_b_value..=clamped_b_value)
                         }))
                     }
@@ -57,7 +57,7 @@ pub fn generate_random_columns<'a, S: Scalar>(
                         Column::Int(alloc.alloc_slice_fill_with(num_rows, |_| {
                             let b_value = b(num_rows);
                             let clamped_b_value =
-                                b_value.clamp(i32::MIN as i64, i32::MAX as i64) as i32;
+                                b_value.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32;
                             rng.gen_range(-clamped_b_value..=clamped_b_value)
                         }))
                     }

--- a/crates/proof-of-sql/benches/scaffold/random_util.rs
+++ b/crates/proof-of-sql/benches/scaffold/random_util.rs
@@ -28,6 +28,17 @@ pub fn generate_random_columns<'a, S: Scalar>(
                     (ColumnType::Boolean, _) => {
                         Column::Boolean(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }
+                    (ColumnType::TinyInt, None) => {
+                        Column::TinyInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
+                    }
+                    (ColumnType::TinyInt, Some(b)) => {
+                        Column::TinyInt(alloc.alloc_slice_fill_with(num_rows, |_| {
+                            let b_value = b(num_rows);
+                            let clamped_b_value =
+                                b_value.clamp(i8::MIN as i64, i8::MAX as i64) as i8;
+                            rng.gen_range(-clamped_b_value..=clamped_b_value)
+                        }))
+                    }                    
                     (ColumnType::BigInt, None) => {
                         Column::BigInt(alloc.alloc_slice_fill_with(num_rows, |_| rng.gen()))
                     }


### PR DESCRIPTION
# Rationale for this change
The Jaeger benchmarks only measure a small number of queries with a limited amount of column types.. This PR expands the benchmarks to include more queries over most column types.

The `Decimal75` and `TimestampTZ` column types are still not supported in the benchmarks `random_util` module. They are not used in the new queries.

# What changes are included in this PR?
- The `random_util` module is expanded to support most column types.
- Additional queries are added which measure supported SQL functions inside the Jaeger benchmarks.
- The arithmetic query is updated to produce a smaller output table.

# Are these changes tested?
Yes.