### PR TITLE
refactor!: make `QueryProof` private in favor of `VerifiableQueryResult`

### DIFF
--- a/crates/proof-of-sql/examples/albums/main.rs
+++ b/crates/proof-of-sql/examples/albums/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/avocado-prices/main.rs
+++ b/crates/proof-of-sql/examples/avocado-prices/main.rs
@@ -10,7 +10,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -47,7 +49,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -57,13 +59,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/books/main.rs
+++ b/crates/proof-of-sql/examples/books/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/brands/main.rs
+++ b/crates/proof-of-sql/examples/brands/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/census/main.rs
+++ b/crates/proof-of-sql/examples/census/main.rs
@@ -13,7 +13,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -50,7 +52,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -60,13 +62,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/countries/main.rs
+++ b/crates/proof-of-sql/examples/countries/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/dinosaurs/main.rs
+++ b/crates/proof-of-sql/examples/dinosaurs/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql/examples/dog_breeds/main.rs
@@ -11,7 +11,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -44,7 +46,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -54,13 +56,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/hello_world/main.rs
+++ b/crates/proof-of-sql/examples/hello_world/main.rs
@@ -8,7 +8,7 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, proof::QueryProof},
+    sql::{parse::QueryExpr, proof::VerifiableQueryResult},
 };
 use std::{
     io::{stdout, Write},
@@ -70,19 +70,14 @@ fn main() {
     .unwrap();
     end_timer(timer);
     let timer = start_timer("Generating Proof");
-    let (proof, serialized_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query.proof_expr(),
         &accessor,
         &&prover_setup,
     );
     end_timer(timer);
     let timer = start_timer("Verifying Proof");
-    let result = proof.verify(
-        query.proof_expr(),
-        &accessor,
-        serialized_result,
-        &&verifier_setup,
-    );
+    let result = verifiable_result.verify(query.proof_expr(), &accessor, &&verifier_setup);
     end_timer(timer);
     match result {
         Ok(result) => {

--- a/crates/proof-of-sql/examples/plastics/main.rs
+++ b/crates/proof-of-sql/examples/plastics/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/programming_books/main.rs
+++ b/crates/proof-of-sql/examples/programming_books/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -44,7 +46,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -54,13 +56,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/rockets/main.rs
+++ b/crates/proof-of-sql/examples/rockets/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/space/main.rs
+++ b/crates/proof-of-sql/examples/space/main.rs
@@ -15,7 +15,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -52,7 +54,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -62,13 +64,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/stocks/main.rs
+++ b/crates/proof-of-sql/examples/stocks/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/sushi/main.rs
+++ b/crates/proof-of-sql/examples/sushi/main.rs
@@ -10,7 +10,7 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, proof::QueryProof},
+    sql::{parse::QueryExpr, proof::VerifiableQueryResult},
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -35,7 +35,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -44,13 +44,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);
     // Display the result

--- a/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
+++ b/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
@@ -11,7 +11,7 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, proof::QueryProof},
+    sql::{parse::QueryExpr, proof::VerifiableQueryResult},
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{error::Error, fs::File, time::Instant};
@@ -32,7 +32,7 @@ fn prove_and_verify_query(
 
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -41,12 +41,7 @@ fn prove_and_verify_query(
 
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof.verify(
-        query_plan.proof_expr(),
-        accessor,
-        provable_result,
-        &verifier_setup,
-    )?;
+    let result = verifiable_result.verify(query_plan.proof_expr(), accessor, &verifier_setup)?;
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     println!("Query Result:");

--- a/crates/proof-of-sql/examples/vehicles/main.rs
+++ b/crates/proof-of-sql/examples/vehicles/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -43,7 +45,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -53,13 +55,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/wood_types/main.rs
+++ b/crates/proof-of-sql/examples/wood_types/main.rs
@@ -14,7 +14,9 @@ use proof_of_sql::{
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
-    sql::{parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::QueryProof},
+    sql::{
+        parse::QueryExpr, postprocessing::apply_postprocessing_steps, proof::VerifiableQueryResult,
+    },
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
@@ -47,7 +49,7 @@ fn prove_and_verify_query(
     // Generate the proof and result:
     print!("Generating proof...");
     let now = Instant::now();
-    let (proof, provable_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
@@ -57,13 +59,8 @@ fn prove_and_verify_query(
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = proof
-        .verify(
-            query_plan.proof_expr(),
-            accessor,
-            provable_result,
-            &verifier_setup,
-        )
+    let result = verifiable_result
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -39,7 +39,7 @@ pub use proof_plan::ProofPlan;
 pub(crate) use proof_plan::{HonestProver, ProverEvaluate, ProverHonestyMarker};
 
 mod query_proof;
-pub use query_proof::QueryProof;
+use query_proof::QueryProof;
 #[cfg(all(test, feature = "blitzar"))]
 mod query_proof_test;
 

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -49,7 +49,7 @@ fn get_index_range<'a>(
 /// cannot maintain any invariant on its data members; hence, they are
 /// all public so as to allow for easy manipulation for testing.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct QueryProof<CP: CommitmentEvaluationProof> {
+pub(super) struct QueryProof<CP: CommitmentEvaluationProof> {
     /// Bit distributions
     pub bit_distributions: Vec<BitDistribution>,
     /// One evaluation lengths

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -69,9 +69,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct VerifiableQueryResult<CP: CommitmentEvaluationProof> {
     /// The result of the query in intermediate form.
-    pub provable_result: Option<ProvableQueryResult>,
+    pub(super) provable_result: Option<ProvableQueryResult>,
     /// The proof that the query result is valid.
-    pub proof: Option<QueryProof<CP>>,
+    pub(super) proof: Option<QueryProof<CP>>,
 }
 
 impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -15,7 +15,7 @@ use proof_of_sql::{
     sql::{
         parse::{ConversionError, QueryExpr},
         postprocessing::apply_postprocessing_steps,
-        proof::{QueryError, QueryProof},
+        proof::{QueryError, VerifiableQueryResult},
     },
 };
 
@@ -34,10 +34,10 @@ fn we_can_prove_a_minimal_filter_query_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let expected_result = owned_table([boolean("a", [true])]);
@@ -65,15 +65,13 @@ fn we_can_prove_a_minimal_filter_query_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([boolean("a", [false])]);
@@ -99,18 +97,13 @@ fn we_can_prove_a_minimal_filter_query_with_dynamic_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query.proof_expr(),
         &accessor,
         &&prover_setup,
     );
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &&verifier_setup,
-        )
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &&verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([boolean("a", [false])]);
@@ -132,10 +125,10 @@ fn we_can_prove_a_basic_equality_query_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 1])]);
@@ -163,15 +156,13 @@ fn we_can_prove_a_basic_equality_query_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 1])]);
@@ -193,10 +184,10 @@ fn we_can_prove_a_basic_inequality_query_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 2])]);
@@ -224,10 +215,10 @@ fn we_can_prove_a_basic_query_containing_extrema_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -267,15 +258,13 @@ fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -303,10 +292,10 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -335,15 +324,13 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [3]), bigint("b", [2])]);
@@ -370,10 +357,10 @@ fn we_can_prove_a_basic_equality_with_out_of_order_results_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -403,15 +390,13 @@ fn we_can_prove_a_basic_inequality_query_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [2]), bigint("b", [0])]);
@@ -465,10 +450,10 @@ fn we_can_prove_a_complex_query_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -512,15 +497,13 @@ fn we_can_prove_a_complex_query_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -550,10 +533,10 @@ fn we_can_prove_a_minimal_group_by_query_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result: OwnedTable<Curve25519Scalar> = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result: OwnedTable<Curve25519Scalar> = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -584,10 +567,10 @@ fn we_can_prove_a_basic_group_by_query_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -647,10 +630,10 @@ fn we_can_prove_a_cat_group_by_query_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -719,18 +702,13 @@ fn we_can_prove_a_cat_group_by_query_with_dynamic_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) = QueryProof::<DynamicDoryEvaluationProof>::new(
+    let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
         query.proof_expr(),
         &accessor,
         &&prover_setup,
     );
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &&verifier_setup,
-        )
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &&verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -767,15 +745,13 @@ fn we_can_prove_a_basic_group_by_query_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -802,10 +778,10 @@ fn we_can_prove_a_query_with_overflow_with_curve25519() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
     assert!(matches!(
-        proof.verify(query.proof_expr(), &accessor, serialized_result, &()),
+        verifiable_result.verify(query.proof_expr(), &accessor, &()),
         Err(QueryError::Overflow)
     ));
 }
@@ -831,15 +807,13 @@ fn we_can_prove_a_query_with_overflow_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
     assert!(matches!(
-        proof.verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup
-        ),
+        verifiable_result.verify(query.proof_expr(), &accessor, &dory_verifier_setup,),
         Err(QueryError::Overflow)
     ));
 }
@@ -865,10 +839,10 @@ fn we_can_perform_arithmetic_and_conditional_operations_on_tinyint() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
-    let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, serialized_result, &())
+    let verifiable_result =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &())
         .unwrap()
         .table;
     let expected_result = owned_table([tinyint("result", [9_i8, 10])]);

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -9,10 +9,7 @@ use proof_of_sql::{
         DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup,
         PublicParameters, VerifierSetup,
     },
-    sql::{
-        parse::QueryExpr,
-        proof::{QueryProof, VerifiableQueryResult},
-    },
+    sql::{parse::QueryExpr, proof::VerifiableQueryResult},
 };
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
@@ -51,15 +48,13 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([timestamptz(
@@ -444,15 +439,13 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         &accessor,
     )
     .unwrap();
-    let (proof, serialized_result) =
-        QueryProof::<DoryEvaluationProof>::new(query.proof_expr(), &accessor, &dory_prover_setup);
-    let owned_table_result = proof
-        .verify(
-            query.proof_expr(),
-            &accessor,
-            serialized_result,
-            &dory_verifier_setup,
-        )
+    let verifiable_result = VerifiableQueryResult::<DoryEvaluationProof>::new(
+        query.proof_expr(),
+        &accessor,
+        &dory_prover_setup,
+    );
+    let owned_table_result = verifiable_result
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
         .unwrap()
         .table;
     let expected_result = owned_table([


### PR DESCRIPTION
# Rationale for this change

`QueryProof` exposes uneeded internals and is wrapped by `VerifiableQueryResult`, which should be used instead

# What changes are included in this PR?

See individual commits

# Are these changes tested?

This PR is mostly updating tests/examples.