### PR TITLE
feat: add `CrossJoinExec`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/cross_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/cross_join_exec.rs
@@ -1,0 +1,125 @@
+use super::DynProofPlan;
+use crate::{
+    base::{
+        database::{
+            join_util::cross_join, ColumnField, ColumnRef, OwnedTable, Table,
+            TableEvaluation, TableOptions, TableRef,
+        },
+        map::{IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        CountBuilder, FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
+        VerificationBuilder,
+    },
+};
+use alloc::{boxed::Box, vec, vec::Vec};
+use bumpalo::Bump;
+use core::iter::repeat_with;
+use serde::{Deserialize, Serialize};
+
+/// `ProofPlan` for queries of the form
+/// ```ignore
+///     <ProofPlan> JOIN <ProofPlan>
+/// ```
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct CrossJoinExec {
+    pub(super) left: Box<DynProofPlan>,
+    pub(super) right: Box<DynProofPlan>,
+}
+
+impl CrossJoinExec {
+    /// Create a new `CrossJoinExec` with the given left and right plans
+    pub fn new(left: Box<DynProofPlan>, right: Box<DynProofPlan>) -> Self {
+        Self { left, right }
+    }
+}
+
+impl ProofPlan for CrossJoinExec
+where
+    CrossJoinExec: ProverEvaluate,
+{
+    fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
+        self.left.count(builder)?;
+        self.right.count(builder)?;
+        Ok(())
+    }
+
+    #[allow(unused_variables)]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        // 1. columns
+        // TODO: Make sure `GroupByExec` as self.input is supported
+        let left_eval = self
+            .left
+            .verifier_evaluate(builder, accessor, None, one_eval_map)?;
+        let right_eval = self
+            .right
+            .verifier_evaluate(builder, accessor, None, one_eval_map)?;
+        let output_one_eval = builder.consume_one_eval();
+        todo!()
+    }
+
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        self.left
+            .get_column_result_fields()
+            .into_iter()
+            .chain(self.right.get_column_result_fields())
+            .collect()
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        self.left
+            .get_column_references()
+            .into_iter()
+            .chain(self.right.get_column_references())
+            .collect()
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        self.left
+            .get_table_references()
+            .into_iter()
+            .chain(self.right.get_table_references())
+            .collect()
+    }
+}
+
+impl ProverEvaluate for CrossJoinExec {
+    #[tracing::instrument(name = "CrossJoinExec::result_evaluate", level = "debug", skip_all)]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        let left = self.left.first_round_evaluate(builder, alloc, table_map);
+        let right = self.right.first_round_evaluate(builder, alloc, table_map);
+        let res = cross_join(left, right, alloc);
+        let output_length = left.num_rows() * right.num_rows();
+        builder.request_post_result_challenges(2);
+        builder.produce_one_evaluation_length(output_length);
+        res
+    }
+
+    #[tracing::instrument(name = "CrossJoinExec::prover_evaluate", level = "debug", skip_all)]
+    #[allow(unused_variables)]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        let left = self.left.prover_evaluate(builder, alloc, table_map);
+        let right = self.right.prover_evaluate(builder, alloc, table_map);
+        let res = cross_join(left, right, alloc);
+        
+        
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,4 +1,4 @@
-use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, TableExec, UnionExec};
+use super::{CrossJoinExec, EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, TableExec, UnionExec};
 use crate::{
     base::{
         database::{ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableRef},
@@ -58,4 +58,9 @@ pub enum DynProofPlan {
     ///     <ProofPlan>
     /// ```
     Union(UnionExec),
+    /// [`ProofPlan`] for queries of the form
+    /// ```ignore
+    ///     <ProofPlan> JOIN <ProofPlan>
+    /// ```
+    CrossJoin(CrossJoinExec),
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -45,6 +45,9 @@ pub(crate) use union_exec::UnionExec;
 #[cfg(all(test, feature = "blitzar"))]
 mod union_exec_test;
 
+mod cross_join_exec;
+pub(crate) use cross_join_exec::CrossJoinExec;
+
 mod dyn_proof_plan;
 pub use dyn_proof_plan::DynProofPlan;
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
