### PR TITLE
feat: add `UnionExec`

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -117,7 +117,6 @@ pub(crate) mod group_by_util;
 #[cfg(test)]
 mod group_by_util_test;
 
-#[allow(dead_code)]
 pub(crate) mod union_util;
 
 pub(crate) mod order_by_util;

--- a/crates/proof-of-sql/src/base/database/table_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/table_evaluation.rs
@@ -28,7 +28,7 @@ impl<S: Scalar> TableEvaluation<S> {
 
     /// Returns the evaluation of an all-one column with the same length as the table.
     #[must_use]
-    pub fn one_eval(&self) -> &S {
-        &self.one_eval
+    pub fn one_eval(&self) -> S {
+        self.one_eval
     }
 }

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -172,7 +172,7 @@ pub fn column_union<'a, S: Scalar>(
 /// # Panics
 /// This function should never panic as long as it is written correctly
 pub fn table_union<'a, S: Scalar>(
-    tables: &[&Table<'a, S>],
+    tables: &[Table<'a, S>],
     alloc: &'a Bump,
     schema: Vec<ColumnField>,
 ) -> TableOperationResult<Table<'a, S>> {
@@ -190,7 +190,7 @@ pub fn table_union<'a, S: Scalar>(
     }
     // Union the columns
     // Make sure to consider the case where the tables have no columns
-    let num_rows = tables.iter().map(|table| table.num_rows()).sum();
+    let num_rows = tables.iter().map(Table::num_rows).sum();
     let result = Table::<'a, S>::try_from_iter_with_options(
         schema.iter().enumerate().map(|(i, field)| {
             let columns: Vec<_> = tables
@@ -290,7 +290,7 @@ mod tests {
             TableOptions::new(Some(0)),
         )
         .unwrap();
-        let result = table_union(&[&table0, &table1, &table2], &alloc, vec![]).unwrap();
+        let result = table_union(&[table0, table1, table2], &alloc, vec![]).unwrap();
         assert_eq!(
             result,
             Table::<'_, TestScalar>::try_new_with_options(
@@ -322,7 +322,7 @@ mod tests {
         )
         .unwrap();
         let result = table_union(
-            &[&table0, &table1],
+            &[table0, table1],
             &alloc,
             vec![
                 ColumnField::new("e".parse().unwrap(), ColumnType::BigInt),
@@ -365,7 +365,7 @@ mod tests {
         )
         .unwrap();
         let result = table_union(
-            &[&table0, &table1],
+            &[table0, table1],
             &alloc,
             vec![
                 ColumnField::new("e".parse().unwrap(), ColumnType::BigInt),

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,4 +1,4 @@
-use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, TableExec};
+use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, TableExec, UnionExec};
 use crate::{
     base::{
         database::{ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableRef},
@@ -48,4 +48,14 @@ pub enum DynProofPlan {
     ///     <ProofPlan> LIMIT <fetch> [OFFSET <skip>]
     /// ```
     Slice(SliceExec),
+    /// `ProofPlan` for queries of the form
+    /// ```ignore
+    ///     <ProofPlan>
+    ///     UNION ALL
+    ///     <ProofPlan>
+    ///     ...
+    ///     UNION ALL
+    ///     <ProofPlan>
+    /// ```
+    Union(UnionExec),
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -36,10 +36,14 @@ pub(crate) use group_by_exec::GroupByExec;
 mod group_by_exec_test;
 
 mod slice_exec;
-#[allow(unused_imports)]
 pub(crate) use slice_exec::SliceExec;
 #[cfg(all(test, feature = "blitzar"))]
 mod slice_exec_test;
+
+mod union_exec;
+pub(crate) use union_exec::UnionExec;
+#[cfg(all(test, feature = "blitzar"))]
+mod union_exec_test;
 
 mod dyn_proof_plan;
 pub use dyn_proof_plan::DynProofPlan;

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -95,7 +95,7 @@ where
             builder,
             alpha,
             beta,
-            *input_table_eval.one_eval(),
+            input_table_eval.one_eval(),
             output_one_eval,
             columns_evals,
             selection_eval,

--- a/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
@@ -1,10 +1,15 @@
 use super::{
     DynProofPlan, EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, TableExec,
+    UnionExec,
 };
 use crate::{
-    base::database::{ColumnField, TableRef},
+    base::database::{ColumnField, ColumnType, TableRef},
     sql::proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
 };
+
+pub fn column_field(name: &str, column_type: ColumnType) -> ColumnField {
+    ColumnField::new(name.parse().unwrap(), column_type)
+}
 
 pub fn empty_exec() -> DynProofPlan {
     DynProofPlan::Empty(EmptyExec::new())
@@ -47,4 +52,8 @@ pub fn group_by(
 
 pub fn slice_exec(input: DynProofPlan, skip: usize, fetch: Option<usize>) -> DynProofPlan {
     DynProofPlan::Slice(SliceExec::new(Box::new(input), skip, fetch))
+}
+
+pub fn union_exec(inputs: Vec<DynProofPlan>, schema: Vec<ColumnField>) -> DynProofPlan {
+    DynProofPlan::Union(UnionExec::new(inputs, schema))
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -1,0 +1,321 @@
+use super::{fold_columns, fold_vals, DynProofPlan};
+use crate::{
+    base::{
+        database::{
+            union_util::table_union, Column, ColumnField, ColumnRef, OwnedTable, Table,
+            TableEvaluation, TableRef,
+        },
+        map::{IndexMap, IndexSet},
+        polynomial::MultilinearExtension,
+        proof::ProofError,
+        scalar::Scalar,
+        slice_ops,
+    },
+    sql::proof::{
+        CountBuilder, FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
+        SumcheckSubpolynomialType, VerificationBuilder,
+    },
+};
+use alloc::{boxed::Box, vec, vec::Vec};
+use bumpalo::Bump;
+use core::iter::repeat_with;
+use num_traits::{One, Zero};
+use serde::{Deserialize, Serialize};
+
+/// `ProofPlan` for queries of the form
+/// ```ignore
+///     <ProofPlan>
+///     UNION ALL
+///     <ProofPlan>
+///     ...
+///     UNION ALL
+///     <ProofPlan>
+/// ```
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct UnionExec {
+    pub(super) inputs: Vec<DynProofPlan>,
+    pub(super) schema: Vec<ColumnField>,
+}
+
+impl UnionExec {
+    /// Creates a new union execution plan.
+    ///
+    /// # Panics
+    /// Panics if the number of inputs is less than 2 which in practice should never happen.
+    pub fn new(inputs: Vec<DynProofPlan>, schema: Vec<ColumnField>) -> Self {
+        // There should be at least two inputs
+        assert!(inputs.len() > 1);
+        Self { inputs, schema }
+    }
+}
+
+impl ProofPlan for UnionExec
+where
+    UnionExec: ProverEvaluate,
+{
+    fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
+        let num_parts = self.inputs.len();
+        self.inputs
+            .iter()
+            .try_for_each(|input| input.count(builder))?;
+        builder.count_intermediate_mles(num_parts + self.schema.len() + 1);
+        builder.count_subpolynomials(num_parts + 2);
+        builder.count_degree(3);
+        builder.count_post_result_challenges(2);
+        Ok(())
+    }
+
+    #[allow(unused_variables)]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        let input_table_evals = self
+            .inputs
+            .iter()
+            .map(|input| input.verifier_evaluate(builder, accessor, None, one_eval_map))
+            .collect::<Result<Vec<_>, _>>()?;
+        let num_parts = self.inputs.len();
+        let input_column_evals = input_table_evals
+            .iter()
+            .map(TableEvaluation::column_evals)
+            .collect::<Vec<_>>();
+        let output_column_evals: Vec<_> = repeat_with(|| builder.consume_intermediate_mle())
+            .take(self.schema.len())
+            .collect();
+        let input_one_evals = input_table_evals
+            .iter()
+            .map(TableEvaluation::one_eval)
+            .collect::<Vec<_>>();
+        let output_one_eval = builder.consume_one_evaluation();
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+        verify_union(
+            builder,
+            alpha,
+            beta,
+            &input_column_evals,
+            &output_column_evals,
+            &input_one_evals,
+            output_one_eval,
+        );
+        Ok(TableEvaluation::new(output_column_evals, output_one_eval))
+    }
+
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        self.schema.clone()
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        self.inputs
+            .iter()
+            .flat_map(ProofPlan::get_column_references)
+            .collect()
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        self.inputs
+            .iter()
+            .flat_map(ProofPlan::get_table_references)
+            .collect()
+    }
+}
+
+impl ProverEvaluate for UnionExec {
+    #[tracing::instrument(name = "UnionExec::first_round_evaluate", level = "debug", skip_all)]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        let inputs = self
+            .inputs
+            .iter()
+            .map(|input| input.first_round_evaluate(builder, alloc, table_map))
+            .collect::<Vec<_>>();
+        let res = table_union(&inputs, alloc, self.schema.clone()).expect("Failed to union tables");
+        builder.request_post_result_challenges(2);
+        builder.produce_one_evaluation_length(res.num_rows());
+        res
+    }
+
+    #[tracing::instrument(name = "UnionExec::prover_evaluate", level = "debug", skip_all)]
+    #[allow(unused_variables)]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        let inputs = self
+            .inputs
+            .iter()
+            .map(|input| input.final_round_evaluate(builder, alloc, table_map))
+            .collect::<Vec<_>>();
+        let input_lengths = inputs.iter().map(Table::num_rows).collect::<Vec<_>>();
+        let res = table_union(&inputs, alloc, self.schema.clone()).expect("Failed to union tables");
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+        let input_columns: Vec<Vec<Column<'a, S>>> = inputs
+            .iter()
+            .map(|table| table.columns().copied().collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+        let output_columns: Vec<Column<'a, S>> = res.columns().copied().collect::<Vec<_>>();
+        // Produce intermediate MLEs for the union
+        output_columns.iter().copied().for_each(|column| {
+            builder.produce_intermediate_mle(column);
+        });
+        // Produce the proof for the union
+        prove_union(
+            builder,
+            alloc,
+            alpha,
+            beta,
+            &input_columns,
+            &output_columns,
+            &input_lengths,
+            res.num_rows(),
+        );
+        res
+    }
+}
+
+/// Verifies the union of tables.
+///
+/// # Panics
+/// Should never panic if the code is correct.
+#[allow(clippy::too_many_arguments)]
+fn verify_union<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    input_evals: &[&[S]],
+    output_eval: &[S],
+    input_one_evals: &[S],
+    output_one_eval: S,
+) {
+    assert_eq!(input_evals.len(), input_one_evals.len());
+    let c_star_evals = input_evals
+        .iter()
+        .zip(input_one_evals)
+        .map(|(&input_eval, &input_one_eval)| {
+            let c_fold_eval = alpha * output_one_eval + fold_vals(beta, input_eval);
+            let c_star_eval = builder.consume_intermediate_mle();
+            // c_fold * c_star - input_ones = 0
+            builder.produce_sumcheck_subpolynomial_evaluation(
+                &SumcheckSubpolynomialType::Identity,
+                c_fold_eval * c_star_eval - input_one_eval,
+            );
+            c_star_eval
+        })
+        .collect::<Vec<_>>();
+
+    let d_bar_fold_eval = alpha * output_one_eval + fold_vals(beta, output_eval);
+    let d_star_eval = builder.consume_intermediate_mle();
+
+    // d_bar_fold * d_star - output_ones = 0
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        &SumcheckSubpolynomialType::Identity,
+        d_bar_fold_eval * d_star_eval - output_one_eval,
+    );
+
+    // sum (sum c_star) - d_star = 0
+    let zero_sum_terms_eval = c_star_evals
+        .into_iter()
+        .chain(core::iter::once(-d_star_eval))
+        .sum::<S>();
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        &SumcheckSubpolynomialType::ZeroSum,
+        zero_sum_terms_eval,
+    );
+}
+
+/// Proves the union of tables.
+///
+/// # Panics
+/// Should never panic if the code is correct.
+#[allow(clippy::too_many_arguments)]
+fn prove_union<'a, S: Scalar + 'a>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    input_tables: &[Vec<Column<'a, S>>],
+    output_table: &[Column<'a, S>],
+    input_lengths: &[usize],
+    output_length: usize,
+) {
+    // Number of `ProofPlan`s should be a constant
+    assert_eq!(input_tables.len(), input_lengths.len());
+    let c_stars = input_lengths
+        .iter()
+        .zip(input_tables.iter())
+        .map(|(&input_length, input_table)| {
+            // Indicator vector for the input table
+            let input_ones = alloc.alloc_slice_fill_copy(output_length, false);
+            input_ones[..input_length].fill(true);
+
+            let c_fold = alloc.alloc_slice_fill_copy(output_length, alpha);
+            fold_columns(c_fold, One::one(), beta, input_table);
+
+            let c_star = alloc.alloc_slice_copy(c_fold);
+            c_star[input_length..].fill(Zero::zero());
+            slice_ops::batch_inversion(&mut c_star[..input_length]);
+            let c_star_copy = alloc.alloc_slice_copy(c_star);
+            builder.produce_intermediate_mle(c_star as &[_]);
+
+            // c_fold * c_star - input_ones = 0
+            builder.produce_sumcheck_subpolynomial(
+                SumcheckSubpolynomialType::Identity,
+                vec![
+                    (
+                        S::one(),
+                        vec![Box::new(c_star as &[_]), Box::new(c_fold as &[_])],
+                    ),
+                    (-S::one(), vec![Box::new(input_ones as &[_])]),
+                ],
+            );
+            c_star_copy
+        })
+        .collect::<Vec<_>>();
+    // No need to produce intermediate MLEs for `d_bar_fold` because it is
+    // the sum of `c_fold`
+    let d_bar_fold = alloc.alloc_slice_fill_copy(output_length, alpha);
+    fold_columns(d_bar_fold, One::one(), beta, output_table);
+
+    let d_star = alloc.alloc_slice_copy(d_bar_fold);
+    slice_ops::batch_inversion(d_star);
+    builder.produce_intermediate_mle(d_star as &[_]);
+    // d_bar_fold * d_star - output_ones = 0
+    let output_ones = alloc.alloc_slice_fill_copy(output_length, true);
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (
+                S::one(),
+                vec![Box::new(d_star as &[_]), Box::new(d_bar_fold as &[_])],
+            ),
+            (-S::one(), vec![Box::new(output_ones as &[_])]),
+        ],
+    );
+
+    // sum (sum c_star) - d_star = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::ZeroSum,
+        c_stars
+            .into_iter()
+            .map(|c_star| {
+                let boxed_c_star: Box<dyn MultilinearExtension<S>> = Box::new(c_star as &[_]);
+                (S::one(), vec![boxed_c_star])
+            })
+            .chain(core::iter::once({
+                let boxed_d_star: Box<dyn MultilinearExtension<S>> = Box::new(d_star as &[_]);
+                (-S::one(), vec![boxed_d_star])
+            }))
+            .collect(),
+    );
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -39,12 +39,7 @@ pub struct UnionExec {
 
 impl UnionExec {
     /// Creates a new union execution plan.
-    ///
-    /// # Panics
-    /// Panics if the number of inputs is less than 2 which in practice should never happen.
     pub fn new(inputs: Vec<DynProofPlan>, schema: Vec<ColumnField>) -> Self {
-        // There should be at least two inputs
-        assert!(inputs.len() > 1);
         Self { inputs, schema }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -1,0 +1,221 @@
+use super::test_utility::*;
+use crate::{
+    base::{
+        database::{
+            owned_table_utility::*, table_utility::*, ColumnType, OwnedTable,
+            OwnedTableTestAccessor, TableTestAccessor, TestAccessor,
+        },
+        map::indexmap,
+        scalar::Curve25519Scalar,
+    },
+    sql::{
+        proof::{
+            exercise_verification, FirstRoundBuilder, ProvableQueryResult, ProverEvaluate,
+            VerifiableQueryResult,
+        },
+        proof_exprs::test_utility::*,
+    },
+};
+use blitzar::proof::InnerProductProof;
+use bumpalo::Bump;
+
+#[test]
+fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
+    let data0 = owned_table([bigint("a0", [0_i64; 0])]);
+    let t0 = "sxt.t0".parse().unwrap();
+    let data1 = owned_table([bigint("a1", [0_i64; 0])]);
+    let t1 = "sxt.t1".parse().unwrap();
+    let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t0, data0, 0);
+    accessor.add_table(t1, data1, 0);
+    let ast = union_exec(
+        vec![
+            projection(cols_expr_plan(t1, &["a1"], &accessor), tab(t1)),
+            projection(cols_expr_plan(t0, &["a0"], &accessor), tab(t0)),
+        ],
+        vec![column_field("a", ColumnType::BigInt)],
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, t0);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([bigint("a", [0_i64; 0])]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
+    let alloc = Bump::new();
+    let data0 = table([
+        borrowed_bigint("a0", [1_i64, 2, 3, 4, 5], &alloc),
+        borrowed_varchar("b0", ["1", "2", "3", "4", "5"], &alloc),
+    ]);
+    let t0 = "sxt.t0".parse().unwrap();
+    let data1 = table([
+        borrowed_bigint("a1", [2_i64, 3, 4, 5, 6], &alloc),
+        borrowed_varchar("b1", ["2", "3", "4", "5", "6"], &alloc),
+    ]);
+    let t1 = "sxt.t1".parse().unwrap();
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t0, data0, 0);
+    accessor.add_table(t1, data1, 0);
+    let ast = union_exec(
+        vec![
+            projection(cols_expr_plan(t0, &["a0", "b0"], &accessor), tab(t0)),
+            table_exec(
+                t1,
+                vec![
+                    column_field("a1", ColumnType::BigInt),
+                    column_field("b1", ColumnType::VarChar),
+                ],
+            ),
+        ],
+        vec![
+            column_field("a", ColumnType::BigInt),
+            column_field("b", ColumnType::VarChar),
+        ],
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, t0);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("a", [1_i64, 2, 3, 4, 5, 2, 3, 4, 5, 6]),
+        varchar("b", ["1", "2", "3", "4", "5", "2", "3", "4", "5", "6"]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
+    let alloc = Bump::new();
+    let data0 = table([
+        borrowed_bigint("a0", [1_i64, 2, 3, 4, 5], &alloc),
+        borrowed_varchar("b0", ["1", "2", "3", "4", "5"], &alloc),
+    ]);
+    let t0 = "sxt.t0".parse().unwrap();
+    let data1 = table([
+        borrowed_bigint("a1", [2_i64, 3, 4, 5, 6], &alloc),
+        borrowed_varchar("b1", ["2", "3", "4", "5", "6"], &alloc),
+    ]);
+    let t1 = "sxt.t1".parse().unwrap();
+    let data2 = table([
+        borrowed_bigint("a2", [3_i64, 4, 5, 6, 7], &alloc),
+        borrowed_varchar("b2", ["3", "4", "5", "6", "7"], &alloc),
+    ]);
+    let t2 = "sxt.t2".parse().unwrap();
+    let data3 = table([
+        borrowed_bigint("a3", [4_i64, 5, 6, 7, 8], &alloc),
+        borrowed_varchar("b3", ["4", "5", "6", "7", "8"], &alloc),
+    ]);
+    let t3 = "sxt.t3".parse().unwrap();
+    let data4 = table([
+        borrowed_bigint("a4", [0_i64; 0], &alloc),
+        borrowed_varchar("b4", [""; 0], &alloc),
+    ]);
+    let t4 = "sxt.t4".parse().unwrap();
+    let data5 = table([
+        borrowed_bigint("a5", [5_i64, 6, 7, 8], &alloc),
+        borrowed_varchar("b5", ["5", "6", "7", "8"], &alloc),
+    ]);
+    let t5 = "sxt.t5".parse().unwrap();
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t0, data0, 0);
+    accessor.add_table(t1, data1, 0);
+    accessor.add_table(t2, data2, 0);
+    accessor.add_table(t3, data3, 0);
+    accessor.add_table(t4, data4, 0);
+    accessor.add_table(t5, data5, 0);
+    let ast = slice_exec(
+        union_exec(
+            vec![
+                projection(cols_expr_plan(t0, &["a0", "b0"], &accessor), tab(t0)),
+                projection(cols_expr_plan(t1, &["a1", "b1"], &accessor), tab(t1)),
+                slice_exec(
+                    filter(
+                        cols_expr_plan(t2, &["a2", "b2"], &accessor),
+                        tab(t2),
+                        gte(column(t2, "a2", &accessor), const_smallint(5_i16)),
+                    ),
+                    2,
+                    None,
+                ),
+                filter(
+                    vec![
+                        aliased_plan(const_bigint(105_i64), "const"),
+                        col_expr_plan(t3, "b3", &accessor),
+                    ],
+                    tab(t3),
+                    equal(column(t3, "a3", &accessor), const_int128(6_i128)),
+                ),
+                projection(cols_expr_plan(t4, &["a4", "b4"], &accessor), tab(t4)),
+                table_exec(
+                    t5,
+                    vec![
+                        column_field("a5", ColumnType::BigInt),
+                        column_field("b5", ColumnType::VarChar),
+                    ],
+                ),
+            ],
+            vec![
+                column_field("a", ColumnType::BigInt),
+                column_field("b", ColumnType::VarChar),
+            ],
+        ),
+        4,
+        Some(11),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, t0);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("a", [5_i64, 2, 3, 4, 5, 6, 7, 105, 5, 6, 7]),
+        varchar("b", ["5", "2", "3", "4", "5", "6", "7", "6", "5", "6", "7"]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_get_result_from_union_using_first_round_evaluate() {
+    let alloc = Bump::new();
+    let data0 = table([
+        borrowed_bigint("a0", [1_i64, 2, 3, 4, 5], &alloc),
+        borrowed_varchar("b0", ["1", "2", "3", "4", "5"], &alloc),
+    ]);
+    let t0 = "sxt.t0".parse().unwrap();
+    let data1 = table([
+        borrowed_bigint("a1", [2_i64, 3, 4, 5, 6], &alloc),
+        borrowed_varchar("b1", ["2", "3", "4", "5", "6"], &alloc),
+    ]);
+    let t1 = "sxt.t1".parse().unwrap();
+    let table_map = indexmap! {
+        t0 => data0.clone(),
+        t1 => data1.clone()
+    };
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    accessor.add_table(t0, data0, 0);
+    accessor.add_table(t1, data1, 0);
+    let fields = vec![
+        column_field("a", ColumnType::BigInt),
+        column_field("b", ColumnType::VarChar),
+    ];
+    let ast = union_exec(
+        vec![
+            projection(cols_expr_plan(t0, &["a0", "b0"], &accessor), tab(t0)),
+            projection(cols_expr_plan(t1, &["a1", "b1"], &accessor), tab(t1)),
+        ],
+        fields.clone(),
+    );
+    let first_round_builder = &mut FirstRoundBuilder::new();
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(ast.first_round_evaluate(
+        first_round_builder,
+        &alloc,
+        &table_map,
+    ))
+    .to_owned_table(&fields)
+    .unwrap();
+    let expected: OwnedTable<Curve25519Scalar> = owned_table([
+        bigint("a", [1_i64, 2, 3, 4, 5, 2, 3, 4, 5, 6]),
+        varchar("b", ["1", "2", "3", "4", "5", "2", "3", "4", "5", "6"]),
+    ]);
+
+    assert_eq!(res, expected);
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -125,6 +125,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
     assert_eq!(res, expected_res);
 }
 
+#[allow(clippy::too_many_lines)]
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
     let alloc = Bump::new();


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- The following upstream PRs have been approved and merged:
  - [x] #405
  - [x] #423

# Rationale for this change
We need to add support for `UNION ALL`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `UnionExec`
- add some code to simplify debugging of sumchecks

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.