### PR TITLE
fix!: fix `GroupByExec` input length in proof && move `GroupByExec` top level restriction to `GroupByExec` itself

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -74,12 +74,6 @@ where
         one_eval_map: &IndexMap<TableRef, S>,
     ) -> Result<TableEvaluation<S>, ProofError> {
         // 1. columns
-        // We do not support `GroupByExec` as input for now
-        if matches!(*self.input, DynProofPlan::GroupBy(_)) {
-            return Err(ProofError::UnsupportedQueryPlan {
-                error: "GroupByExec as input for another plan is not supported",
-            });
-        }
         let input_table_eval =
             self.input
                 .verifier_evaluate(builder, accessor, None, one_eval_map)?;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This PR is partly the equivalent of #401 for `GroupbyExec`. Moreover we should move the temporary `GroupByExec` top level restriction to `GroupByExec` itself so that we don't have to keep it everywhere.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- Replace blanket 1 columns with columns with 1 up to input length in `GroupByExec`.
- Move `GroupByExec` composition restriction to `GroupByExec` itself.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests should pass.