### PR TITLE
refactor!: remove commitment serialization from proof creation

### DIFF
--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -14,6 +14,8 @@ pub trait Transcript {
     /// Appends the provided messages by appending the reversed raw bytes (i.e. assuming the message is bigendian)
     fn extend_as_be<M: FromBytes + AsBytes>(&mut self, messages: impl IntoIterator<Item = M>);
     /// Appends the provided messages by appending the raw bytes (i.e. assuming the message is littleendian)
+    fn extend_as_le<M: AsBytes>(&mut self, messages: impl IntoIterator<Item = M>);
+    /// Appends the provided messages by appending the raw bytes (i.e. assuming the message is littleendian)
     fn extend_as_le_from_refs<'a, M: AsBytes + 'a + ?Sized>(
         &mut self,
         messages: impl IntoIterator<Item = &'a M>,
@@ -51,9 +53,9 @@ pub trait Transcript {
     /// This allows for interopability between transcript types.
     fn wrap_transcript<T: Transcript, R>(&mut self, op: impl FnOnce(&mut T) -> R) -> R {
         let mut transcript = T::new();
-        transcript.extend_as_le_from_refs([&self.challenge_as_le()]);
+        transcript.extend_as_le([self.challenge_as_le()]);
         let result = op(&mut transcript);
-        self.extend_as_le_from_refs([&transcript.challenge_as_le()]);
+        self.extend_as_le([transcript.challenge_as_le()]);
         result
     }
 }

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -36,6 +36,11 @@ impl<T: TranscriptCore> Transcript for T {
             self.raw_append(bytes);
         });
     }
+    fn extend_as_le<M: AsBytes>(&mut self, messages: impl IntoIterator<Item = M>) {
+        messages
+            .into_iter()
+            .for_each(|message| self.raw_append(message.as_bytes()));
+    }
     fn extend_as_le_from_refs<'a, M: AsBytes + 'a + ?Sized>(
         &mut self,
         messages: impl IntoIterator<Item = &'a M>,

--- a/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
@@ -17,6 +17,19 @@ fn we_can_add_values_to_the_transcript_in_big_endian_form() {
 #[test]
 fn we_can_add_values_to_the_transcript_in_little_endian_form() {
     let mut transcript1: T = TranscriptCore::new();
+    transcript1.extend_as_le([1u16, 1000, 2]);
+
+    let mut transcript2: T = TranscriptCore::new();
+    transcript2.raw_append(&[1, 0]);
+    transcript2.raw_append(&[232, 3]);
+    transcript2.raw_append(&[2, 0]);
+
+    assert_eq!(transcript1.raw_challenge(), transcript2.raw_challenge());
+}
+
+#[test]
+fn we_can_add_values_to_the_transcript_in_little_endian_form_from_refs() {
+    let mut transcript1: T = TranscriptCore::new();
     transcript1.extend_as_le_from_refs(&[1u16, 1000, 2]);
 
     let mut transcript2: T = TranscriptCore::new();

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment.rs
@@ -82,4 +82,34 @@ impl Commitment for DynamicDoryCommitment {
     ) -> Vec<Self> {
         super::compute_dynamic_dory_commitments(committable_columns, offset, setup)
     }
+
+    fn append_to_transcript(&self, transcript: &mut impl crate::base::proof::Transcript) {
+        transcript.extend_canonical_serialize_as_le(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DynamicDoryCommitment, GT};
+    use crate::base::{
+        commitment::Commitment,
+        proof::{Keccak256Transcript, Transcript},
+    };
+    use ark_ff::UniformRand;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn we_can_append_different_dynamic_dory_commitments_and_get_different_transcripts() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let commitment1 = DynamicDoryCommitment(GT::rand(&mut rng));
+        let commitment2 = DynamicDoryCommitment(GT::rand(&mut rng));
+
+        let mut transcript1 = Keccak256Transcript::new();
+        let mut transcript2 = Keccak256Transcript::new();
+
+        commitment1.append_to_transcript(&mut transcript1);
+        commitment2.append_to_transcript(&mut transcript2);
+
+        assert_ne!(transcript1.challenge_as_le(), transcript2.challenge_as_le());
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     base::{
         bit::BitDistribution,
-        commitment::CommitmentEvaluationProof,
+        commitment::{Commitment, CommitmentEvaluationProof},
         database::{
             ColumnRef, CommitmentAccessor, DataAccessor, MetadataAccessor, Table, TableRef,
         },
@@ -430,11 +430,13 @@ fn make_transcript<T: Transcript>(
     transcript
 }
 
-fn extend_transcript<C: serde::Serialize>(
+fn extend_transcript<C: Commitment>(
     transcript: &mut impl Transcript,
-    commitments: &C,
+    commitments: &[C],
     bit_distributions: &[BitDistribution],
 ) {
-    transcript.extend_serialize_as_le(commitments);
+    for commitment in commitments {
+        commitment.append_to_transcript(transcript);
+    }
     transcript.extend_serialize_as_le(bit_distributions);
 }


### PR DESCRIPTION
# Rationale for this change

Serde is not easily portable to other languages, Solidity in particular. This is part of an effort to remove the dependency on serde _within_ proof verification.

# What changes are included in this PR?

* `Commitment::append_to_transcript` is added and implemented. This is leveraged to append the commitments to the transcript instead of always using postcard/serde.
* `Transcript::extend_as_le` is added and implemented to facilitate this.

# Are these changes tested?
Yes