### PR TITLE
bench: initial add memory tracing to jaeger benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 tempfile = "3.13.0"
 tracing = { version = "0.1.36", default-features = false }
 tracing-opentelemetry = { version = "0.22.0" }
-tracing-subscriber = { version = "0.3.0" }
+tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 wasm-bindgen = { version = "0.2.92" }
 zerocopy = { version = "0.7.34" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ serde_json = { version = "1", default-features = false, features = ["alloc"] }
 sha2 = "0.10.8"
 snafu = { version = "0.8.4", default-features = false }
 sqlparser = { version = "0.45.0", default-features = false }
+sysinfo = { version = "0.24" }
 tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 tempfile = "3.13.0"
 tracing = { version = "0.1.36", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ serde_json = { version = "1", default-features = false, features = ["alloc"] }
 sha2 = "0.10.8"
 snafu = { version = "0.8.4", default-features = false }
 sqlparser = { version = "0.45.0", default-features = false }
-sysinfo = { version = "0.24" }
+sysinfo = { version = "0.33" }
 tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 tempfile = "3.13.0"
 tracing = { version = "0.1.36", default-features = false }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
-sysinfo = {workspace = true, optional = true }
+sysinfo = {workspace = true }
 tiny-keccak = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 zerocopy = { workspace = true }
@@ -84,7 +84,6 @@ perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
 rayon = ["dep:rayon", "std"]
 std = ["snafu/std", "ark-serialize/std"]
-log-memory-usage = ["sysinfo"]
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
-sysinfo = {workspace = true }
+sysinfo = {workspace = true, optional = true }
 tiny-keccak = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 zerocopy = { workspace = true }
@@ -84,6 +84,7 @@ perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
 rayon = ["dep:rayon", "std"]
 std = ["snafu/std", "ark-serialize/std"]
+log-memory-usage = ["sysinfo"]
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -51,6 +51,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
+sysinfo = {workspace = true }
 tiny-keccak = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 zerocopy = { workspace = true }

--- a/crates/proof-of-sql/benches/README.md
+++ b/crates/proof-of-sql/benches/README.md
@@ -20,6 +20,15 @@ To run benchmarks with Jaeger, you need to do the following
     docker kill jaeger
     ```
 
+### Optional
+
+To add memory logging to the Jaeger benchmark, use the `log-memory-usage` feature flag.
+
+Example
+```
+cargo bench -p proof-of-sql --bench jaeger_benches DynamicDory --features=log-memory-usage
+```
+
 ## Criterion benchmarking
 
 To run benchmarks with Criterion, you need to do the following

--- a/crates/proof-of-sql/benches/README.md
+++ b/crates/proof-of-sql/benches/README.md
@@ -20,13 +20,13 @@ To run benchmarks with Jaeger, you need to do the following
     docker kill jaeger
     ```
 
-### Optional
+### Memory logging (optional)
 
-To add memory logging to the Jaeger benchmark, use the `log-memory-usage` feature flag.
+Jaeger benchmarks default to logging any traces at `DEBUG` level and above. Memory consumption is logged at `TRACE` level. In order to capture memory consumption in the Jaeger benchmarks, add `RUST_LOG=trace` to the command.
 
 Example
 ```
-cargo bench -p proof-of-sql --bench jaeger_benches DynamicDory --features=log-memory-usage
+RUST_LOG=trace cargo bench -p proof-of-sql --bench jaeger_benches DynamicDory
 ```
 
 ## Criterion benchmarking

--- a/crates/proof-of-sql/benches/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger_benches.rs
@@ -24,14 +24,21 @@ const SIZE: usize = 1_000_000;
 #[allow(clippy::items_after_statements)]
 fn main() {
     init_backend();
-    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
     let tracer = opentelemetry_jaeger::new_agent_pipeline()
         .with_service_name("benches")
         .install_simple()
         .unwrap();
+
     let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("DEBUG"));
+
     tracing_subscriber::registry()
         .with(opentelemetry)
+        .with(filter)
         .try_init()
         .unwrap();
 

--- a/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
+++ b/crates/proof-of-sql/src/base/polynomial/evaluation_vector.rs
@@ -1,4 +1,4 @@
-use crate::base::if_rayon;
+use crate::{base::if_rayon, utils::log};
 use core::{
     cmp,
     ops::{Mul, MulAssign, Sub, SubAssign},
@@ -43,6 +43,8 @@ pub fn compute_evaluation_vector<F>(v: &mut [F], point: &[F])
 where
     F: One + Sub<Output = F> + MulAssign + SubAssign + Mul<Output = F> + Send + Sync + Copy,
 {
+    log::log_memory_usage("Start");
+
     assert!(v.len() <= (1 << point.len()));
     if point.is_empty() || v.is_empty() {
         // v is guaranteed to be at most length 1 by the assert!.
@@ -62,4 +64,6 @@ where
         };
         compute_evaluation_vector_impl(left, right, *p);
     }
+
+    log::log_memory_usage("End");
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -7,6 +7,7 @@ use crate::{
             full_width_of_row, index_from_row_and_column, matrix_size, row_and_column_from_index,
         },
     },
+    utils::log,
 };
 use alloc::{vec, vec::Vec};
 use ark_ec::CurveGroup;
@@ -61,7 +62,9 @@ pub fn signed_commits(
         return vec![];
     }
 
-    if_rayon!(
+    log::log_memory_usage("Start");
+
+    let res = if_rayon!(
         all_sub_commits.par_chunks_exact(committable_columns.len() * 2),
         all_sub_commits.chunks_exact(committable_columns.len() * 2)
     )
@@ -80,7 +83,11 @@ pub fn signed_commits(
         })
         .collect::<Vec<_>>()
     })
-    .collect()
+    .collect();
+
+    log::log_memory_usage("End");
+
+    res
 }
 
 /// Copies the column data to the scalar row slice.
@@ -150,6 +157,8 @@ pub fn create_blitzar_metadata_tables(
     if committable_columns.is_empty() {
         return (vec![], vec![], vec![]);
     }
+
+    log::log_memory_usage("Start");
 
     // Keep track of the lengths of the columns to handled signed data columns.
     let ones_columns_lengths = committable_columns
@@ -268,6 +277,8 @@ pub fn create_blitzar_metadata_tables(
         });
     }
     span.exit();
+
+    log::log_memory_usage("End");
 
     (
         blitzar_output_bit_table,

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -218,7 +218,7 @@ pub fn create_blitzar_metadata_tables(
     let mut blitzar_scalars = vec![0u8; num_scalar_rows * num_scalar_columns];
 
     // Populate the scalars array.
-    let span = span!(Level::INFO, "pack_blitzar_scalars").entered();
+    let span = span!(Level::DEBUG, "pack_blitzar_scalars").entered();
     if !blitzar_scalars.is_empty() {
         if_rayon!(
             blitzar_scalars.par_chunks_exact_mut(num_scalar_columns),

--- a/crates/proof-of-sql/src/proof_primitive/dory/deferred_msm.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/deferred_msm.rs
@@ -1,3 +1,4 @@
+use crate::utils::log;
 use alloc::{vec, vec::Vec};
 use ark_ec::VariableBaseMSM;
 use core::ops::{Add, AddAssign, Mul, MulAssign};
@@ -24,12 +25,18 @@ impl<G, F: One> DeferredMSM<G, F> {
     /// Collapse/compute the MSM into a single group element
     #[tracing::instrument(name = "DeferredMSM::compute", level = "debug", skip_all)]
     pub fn compute<V: VariableBaseMSM<MulBase = G, ScalarField = F>>(self) -> V {
+        log::log_memory_usage("Start");
+
         let (bases, scalars): (Vec<_>, Vec<_>) = self
             .pairs
             .into_iter()
             .map(|(gt, f)| (gt, f.unwrap_or(F::one())))
             .unzip();
-        V::msm_unchecked(&bases, &scalars)
+        let res = V::msm_unchecked(&bases, &scalars);
+
+        log::log_memory_usage("End");
+
+        res
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
@@ -5,7 +5,10 @@ use super::{
     extended_dory_reduce_helper::extended_dory_reduce_verify_fold_s_vecs, DeferredGT,
     DoryCommitment, DoryMessages, DoryProverPublicSetup, DoryScalar, DoryVerifierPublicSetup, F,
 };
-use crate::base::{commitment::CommitmentEvaluationProof, proof::Transcript};
+use crate::{
+    base::{commitment::CommitmentEvaluationProof, proof::Transcript},
+    utils::log,
+};
 use snafu::Snafu;
 
 /// The `CommitmentEvaluationProof` for the Dory PCS.
@@ -40,6 +43,8 @@ impl CommitmentEvaluationProof for DoryEvaluationProof {
         generators_offset: u64,
         setup: &Self::ProverPublicSetup<'_>,
     ) -> Self {
+        log::log_memory_usage("Start");
+
         // Dory PCS Logic
         if generators_offset != 0 {
             // TODO: support offsets other than 0.
@@ -59,6 +64,9 @@ impl CommitmentEvaluationProof for DoryEvaluationProof {
         let mut messages = DoryMessages::default();
         let extended_state = eval_vmv_re_prove(&mut messages, transcript, state, prover_setup);
         extended_dory_inner_product_prove(&mut messages, transcript, extended_state, prover_setup);
+
+        log::log_memory_usage("End");
+
         messages
     }
 
@@ -78,6 +86,8 @@ impl CommitmentEvaluationProof for DoryEvaluationProof {
         _table_length: usize,
         setup: &Self::VerifierPublicSetup<'_>,
     ) -> Result<(), Self::Error> {
+        log::log_memory_usage("Start");
+
         let a_commit = DeferredGT::new(
             commit_batch.iter().map(|c| c.0),
             batching_factors.iter().map(|f| f.0),
@@ -115,6 +125,9 @@ impl CommitmentEvaluationProof for DoryEvaluationProof {
         ) {
             Err(DoryError::VerificationError)?;
         }
+
+        log::log_memory_usage("End");
+
         Ok(())
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -84,7 +84,7 @@ fn compute_dory_commitments_packed_impl(
         .collect();
 
     // Compute the Dory commitments using multi pairing of sub-commits.
-    let span = span!(Level::INFO, "multi_pairing").entered();
+    let span = span!(Level::DEBUG, "multi_pairing").entered();
     let dc: Vec<DoryCommitment> = if_rayon!(
         cumulative_sub_commit_sums.par_iter(),
         cumulative_sub_commit_sums.iter()

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_gpu.rs
@@ -1,5 +1,8 @@
 use super::{pack_scalars, pairings, DoryCommitment, DoryProverPublicSetup, G1Affine};
-use crate::base::{commitment::CommittableColumn, if_rayon, slice_ops::slice_cast};
+use crate::{
+    base::{commitment::CommittableColumn, if_rayon, slice_ops::slice_cast},
+    utils::log,
+};
 use blitzar::compute::ElementP2;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -20,6 +23,8 @@ fn compute_dory_commitments_packed_impl(
     offset: usize,
     setup: &DoryProverPublicSetup,
 ) -> Vec<DoryCommitment> {
+    log::log_memory_usage("Start");
+
     // Make sure that the committable columns are not empty.
     if committable_columns.is_empty() {
         return vec![];
@@ -99,6 +104,8 @@ fn compute_dory_commitments_packed_impl(
     })
     .collect();
     span.exit();
+
+    log::log_memory_usage("End");
 
     dc
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
@@ -5,7 +5,10 @@ use super::{
     extended_dory_inner_product_verify, DeferredGT, DoryMessages, DoryScalar,
     DynamicDoryCommitment, ProverSetup, VerifierSetup, F,
 };
-use crate::base::{commitment::CommitmentEvaluationProof, proof::Transcript};
+use crate::{
+    base::{commitment::CommitmentEvaluationProof, proof::Transcript},
+    utils::log,
+};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
@@ -42,6 +45,8 @@ impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
         generators_offset: u64,
         setup: &Self::ProverPublicSetup<'_>,
     ) -> Self {
+        log::log_memory_usage("Start");
+
         // Dory PCS Logic
         if generators_offset != 0 {
             // TODO: support offsets other than 0.
@@ -60,6 +65,9 @@ impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
         let mut messages = DoryMessages::default();
         let extended_state = eval_vmv_re_prove(&mut messages, transcript, state, setup);
         extended_dory_inner_product_prove(&mut messages, transcript, extended_state, setup);
+
+        log::log_memory_usage("End");
+
         Self(messages)
     }
 
@@ -79,6 +87,8 @@ impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
         _table_length: usize,
         setup: &Self::VerifierPublicSetup<'_>,
     ) -> Result<(), Self::Error> {
+        log::log_memory_usage("Start");
+
         let a_commit = DeferredGT::new(
             commit_batch.iter().map(|c| c.0),
             batching_factors.iter().map(|f| f.0),
@@ -115,6 +125,9 @@ impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
         ) {
             Err(DoryError::VerificationError)?;
         }
+
+        log::log_memory_usage("End");
+
         Ok(())
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -9,17 +9,13 @@ use crate::{
 use blitzar::compute::ElementP2;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+#[cfg(feature = "log-memory-usage")]
 use sysinfo::{System, SystemExt};
-use tracing::{debug, span, Level};
+#[cfg(feature = "log-memory-usage")]
+use tracing::debug;
+use tracing::{span, Level};
 
-fn log_memory_start_usage() {
-    log_memory_usage("Start");
-}
-
-fn log_memory_end_usage() {
-    log_memory_usage("End");
-}
-
+#[cfg(feature = "log-memory-usage")]
 #[allow(clippy::cast_precision_loss)]
 fn log_memory_usage(name: &str) {
     if tracing::level_enabled!(Level::DEBUG) {
@@ -126,7 +122,8 @@ pub(super) fn compute_dynamic_dory_commitments(
         });
     span.exit();
 
-    log_memory_end_usage();
+    #[cfg(feature = "log-memory-usage")]
+    log_memory_usage("End");
 
     ddc
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -38,7 +38,7 @@ pub(super) fn compute_dynamic_dory_commitments(
     setup: &ProverSetup,
 ) -> Vec<DynamicDoryCommitment> {
     log::log_memory_usage("Start");
-    
+
     if committable_columns.is_empty() {
         return vec![];
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -12,21 +12,33 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sysinfo::{System, SystemExt};
 use tracing::{debug, span, Level};
 
+fn log_start_memory_usage() {
+    log_memory_usage("Start");
+}
+
+fn log_end_memory_usage() {
+    log_memory_usage("End");
+}
+
 #[allow(clippy::cast_precision_loss)]
-fn log_memory_usage() {
-    let mut system = System::new_all();
-    system.refresh_memory();
+fn log_memory_usage(name: &str) {
+    if tracing::level_enabled!(Level::DEBUG) {
+        let mut system = System::new_all();
+        system.refresh_memory();
 
-    let available_memory = system.available_memory() as f64 / 1024.0;
-    let used_memory = system.used_memory() as f64 / 1024.0;
+        let available_memory = system.available_memory() as f64 / 1024.0;
+        let used_memory = system.used_memory() as f64 / 1024.0;
+        let percentage_memory_used = (used_memory / (used_memory + available_memory)) * 100.0;
 
-    tracing::Span::current().record("available_memory", available_memory);
-    tracing::Span::current().record("used_memory", used_memory);
+        tracing::Span::current().record("available_memory", available_memory);
+        tracing::Span::current().record("used_memory", used_memory);
+        tracing::Span::current().record("percentage_memory_used", percentage_memory_used);
 
-    debug!(
-        "Available memory: {:.2} MB, Used memory: {:.2} MB",
-        available_memory, used_memory
-    );
+        debug!(
+            "{} Available memory: {:.2} MB, Used memory: {:.2} MB, Percentage memory used: {:.2}%",
+            name, available_memory, used_memory, percentage_memory_used
+        );
+    }
 }
 
 /// Computes the dynamic Dory commitment using the GPU implementation of the `vlen_msm` algorithm.
@@ -48,7 +60,7 @@ fn log_memory_usage() {
     name = "compute_dynamic_dory_commitments (gpu)",
     level = "debug",
     skip_all,
-    fields(total_memory, used_memory)
+    fields(available_memory, used_memory, percentage_memory_used)
 )]
 pub(super) fn compute_dynamic_dory_commitments(
     committable_columns: &[CommittableColumn],
@@ -113,6 +125,8 @@ pub(super) fn compute_dynamic_dory_commitments(
             .collect()
         });
     span.exit();
+
+    log_end_memory_usage();
 
     ddc
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     base::{commitment::CommittableColumn, if_rayon, slice_ops::slice_cast},
     proof_primitive::dynamic_matrix_utils::matrix_structure::row_and_column_from_index,
-    utils::log::log_memory_usage,
+    utils::log,
 };
 use blitzar::compute::ElementP2;
 #[cfg(feature = "rayon")]
@@ -37,7 +37,7 @@ pub(super) fn compute_dynamic_dory_commitments(
     offset: usize,
     setup: &ProverSetup,
 ) -> Vec<DynamicDoryCommitment> {
-    log_memory_usage("Start");
+    log::log_memory_usage("Start");
     
     if committable_columns.is_empty() {
         return vec![];
@@ -98,7 +98,7 @@ pub(super) fn compute_dynamic_dory_commitments(
         });
     span.exit();
 
-    log_memory_usage("End");
+    log::log_memory_usage("End");
 
     ddc
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -9,7 +9,7 @@ use crate::{
 use blitzar::compute::ElementP2;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use sysinfo::{System, SystemExt};
+use sysinfo::System;
 use tracing::{span, trace, Level};
 
 #[allow(clippy::cast_precision_loss)]
@@ -18,8 +18,8 @@ fn log_memory_usage(name: &str) {
         let mut system = System::new_all();
         system.refresh_memory();
 
-        let available_memory = system.available_memory() as f64 / 1024.0;
-        let used_memory = system.used_memory() as f64 / 1024.0;
+        let available_memory = system.available_memory() as f64 / (1024.0 * 1024.0);
+        let used_memory = system.used_memory() as f64 / (1024.0 * 1024.0);
         let percentage_memory_used = (used_memory / (used_memory + available_memory)) * 100.0;
 
         trace!(

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -12,11 +12,11 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sysinfo::{System, SystemExt};
 use tracing::{debug, span, Level};
 
-fn log_start_memory_usage() {
+fn log_memory_start_usage() {
     log_memory_usage("Start");
 }
 
-fn log_end_memory_usage() {
+fn log_memory_end_usage() {
     log_memory_usage("End");
 }
 
@@ -126,7 +126,7 @@ pub(super) fn compute_dynamic_dory_commitments(
         });
     span.exit();
 
-    log_end_memory_usage();
+    log_memory_end_usage();
 
     ddc
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -5,32 +5,12 @@ use super::{
 use crate::{
     base::{commitment::CommittableColumn, if_rayon, slice_ops::slice_cast},
     proof_primitive::dynamic_matrix_utils::matrix_structure::row_and_column_from_index,
+    utils::log::log_memory_usage,
 };
 use blitzar::compute::ElementP2;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use sysinfo::System;
-use tracing::{span, trace, Level};
-
-#[allow(clippy::cast_precision_loss)]
-fn log_memory_usage(name: &str) {
-    if tracing::level_enabled!(Level::TRACE) {
-        let mut system = System::new_all();
-        system.refresh_memory();
-
-        let available_memory = system.available_memory() as f64 / (1024.0 * 1024.0);
-        let used_memory = system.used_memory() as f64 / (1024.0 * 1024.0);
-        let percentage_memory_used = (used_memory / (used_memory + available_memory)) * 100.0;
-
-        trace!(
-            "{} Available memory: {:.2} MB, Used memory: {:.2} MB, Percentage memory used: {:.2}%",
-            name,
-            available_memory,
-            used_memory,
-            percentage_memory_used
-        );
-    }
-}
+use tracing::{span, Level};
 
 /// Computes the dynamic Dory commitment using the GPU implementation of the `vlen_msm` algorithm.
 ///

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -10,8 +10,7 @@ use blitzar::compute::ElementP2;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sysinfo::{System, SystemExt};
-use tracing::trace;
-use tracing::{span, Level};
+use tracing::{span, trace, Level};
 
 #[allow(clippy::cast_precision_loss)]
 fn log_memory_usage(name: &str) {
@@ -22,10 +21,6 @@ fn log_memory_usage(name: &str) {
         let available_memory = system.available_memory() as f64 / 1024.0;
         let used_memory = system.used_memory() as f64 / 1024.0;
         let percentage_memory_used = (used_memory / (used_memory + available_memory)) * 100.0;
-
-        tracing::Span::current().record("available_memory", available_memory);
-        tracing::Span::current().record("used_memory", used_memory);
-        tracing::Span::current().record("percentage_memory_used", percentage_memory_used);
 
         trace!(
             "{} Available memory: {:.2} MB, Used memory: {:.2} MB, Percentage memory used: {:.2}%",
@@ -55,8 +50,7 @@ fn log_memory_usage(name: &str) {
 #[tracing::instrument(
     name = "compute_dynamic_dory_commitments (gpu)",
     level = "debug",
-    skip_all,
-    fields(available_memory, used_memory, percentage_memory_used)
+    skip_all
 )]
 pub(super) fn compute_dynamic_dory_commitments(
     committable_columns: &[CommittableColumn],

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_inner_product.rs
@@ -8,6 +8,7 @@ use crate::{
         extended_dory_reduce_prove, extended_dory_reduce_verify, fold_scalars_0_prove,
         fold_scalars_0_verify,
     },
+    utils::log,
 };
 
 /// This is the prover side of the extended Dory-Innerproduct algorithm in section 4.3 of https://eprint.iacr.org/2020/1274.pdf.
@@ -19,6 +20,8 @@ pub fn extended_dory_inner_product_prove(
     mut state: ExtendedProverState,
     setup: &ProverSetup,
 ) {
+    log::log_memory_usage("Start");
+
     let nu = state.base_state.nu;
     assert!(setup.max_nu >= nu);
     for _ in 0..nu {
@@ -26,6 +29,8 @@ pub fn extended_dory_inner_product_prove(
     }
     let base_state = fold_scalars_0_prove(messages, transcript, state, setup);
     scalar_product_prove(messages, transcript, &base_state);
+
+    log::log_memory_usage("End");
 }
 
 /// This is the verifier side of the extended Dory-Innerproduct algorithm in section 4.3 of https://eprint.iacr.org/2020/1274.pdf.
@@ -38,6 +43,8 @@ pub fn extended_dory_inner_product_verify(
     setup: &VerifierSetup,
     fold_s_tensors_verify: impl Fn(&ExtendedVerifierState) -> (F, F),
 ) -> bool {
+    log::log_memory_usage("Start");
+
     let nu = state.base_state.nu;
     assert!(setup.max_nu >= nu);
     for _ in 0..nu {
@@ -47,5 +54,9 @@ pub fn extended_dory_inner_product_verify(
     }
     let base_state =
         fold_scalars_0_verify(messages, transcript, state, setup, fold_s_tensors_verify);
-    scalar_product_verify(messages, transcript, base_state, setup)
+    let res = scalar_product_verify(messages, transcript, base_state, setup);
+
+    log::log_memory_usage("End");
+
+    res
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
@@ -10,7 +10,7 @@ use super::{
     extended_state::{ExtendedProverState, ExtendedVerifierState},
     DoryMessages, ProverSetup, VerifierSetup,
 };
-use crate::base::proof::Transcript;
+use crate::{base::proof::Transcript, utils::log};
 
 /// This is the prover side of the extended Dory-Reduce algorithm in section 3.2 & 4.2 of https://eprint.iacr.org/2020/1274.pdf.
 #[tracing::instrument(level = "debug", skip_all)]
@@ -20,6 +20,8 @@ pub fn extended_dory_reduce_prove(
     state: &mut ExtendedProverState,
     setup: &ProverSetup,
 ) {
+    log::log_memory_usage("Start");
+
     assert!(state.base_state.nu > 0);
     let half_n = 1usize << (state.base_state.nu - 1);
     let (D_1L, D_1R, D_2L, D_2R) = dory_reduce_prove_compute_Ds(&state.base_state, setup, half_n);
@@ -45,6 +47,8 @@ pub fn extended_dory_reduce_prove(
     dory_reduce_prove_fold_v_vecs(&mut state.base_state, alphas, half_n);
     extended_dory_reduce_prove_fold_s_vecs(state, alphas, half_n);
     state.base_state.nu -= 1;
+
+    log::log_memory_usage("End");
 }
 
 /// This is the verifier side of the extended Dory-Reduce algorithm in section 3.2 & 4.2 of https://eprint.iacr.org/2020/1274.pdf.
@@ -55,6 +59,8 @@ pub fn extended_dory_reduce_verify(
     state: &mut ExtendedVerifierState,
     setup: &VerifierSetup,
 ) -> bool {
+    log::log_memory_usage("Start");
+
     assert!(state.base_state.nu > 0);
     if messages.GT_messages.len() < 6
         || messages.G1_messages.len() < 3
@@ -100,5 +106,8 @@ pub fn extended_dory_reduce_verify(
     state.alphas[state.base_state.nu - 1] = alphas.0;
     state.alpha_invs[state.base_state.nu - 1] = alphas.1;
     state.base_state.nu -= 1;
+
+    log::log_memory_usage("End");
+
     true
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce_helper.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce_helper.rs
@@ -2,6 +2,7 @@ use super::{
     extended_state::{ExtendedProverState, ExtendedVerifierState},
     DeferredG1, DeferredG2, G1Affine, G1Projective, G2Affine, G2Projective, ProverSetup, F,
 };
+use crate::utils::log;
 use ark_ec::VariableBaseMSM;
 use ark_ff::Field;
 
@@ -15,10 +16,15 @@ pub fn extended_dory_reduce_prove_compute_E_betas(
     state: &ExtendedProverState,
     setup: &ProverSetup,
 ) -> (G1Affine, G2Affine) {
+    log::log_memory_usage("Start");
+
     let E_1beta: G1Affine =
         G1Projective::msm_unchecked(setup.Gamma_1[state.base_state.nu], &state.s2).into();
     let E_2beta: G2Affine =
         G2Projective::msm_unchecked(setup.Gamma_2[state.base_state.nu], &state.s1).into();
+
+    log::log_memory_usage("End");
+
     (E_1beta, E_2beta)
 }
 /// From the extended Dory-Reduce algorithm in section 4.2 of https://eprint.iacr.org/2020/1274.pdf.
@@ -33,6 +39,8 @@ pub fn extended_dory_reduce_prove_compute_signed_Es(
     state: &ExtendedProverState,
     half_n: usize,
 ) -> (G1Affine, G1Affine, G2Affine, G2Affine) {
+    log::log_memory_usage("Start");
+
     let (v_1L, v_1R) = state.base_state.v1.split_at(half_n);
     let (v_2L, v_2R) = state.base_state.v2.split_at(half_n);
     let (s_1L, s_1R) = state.s1.split_at(half_n);
@@ -41,6 +49,9 @@ pub fn extended_dory_reduce_prove_compute_signed_Es(
     let E_1minus = G1Projective::msm_unchecked(v_1R, s_2L).into();
     let E_2plus = G2Projective::msm_unchecked(v_2R, s_1L).into();
     let E_2minus = G2Projective::msm_unchecked(v_2L, s_1R).into();
+
+    log::log_memory_usage("End");
+
     (E_1plus, E_1minus, E_2plus, E_2minus)
 }
 /// From the extended Dory-Reduce algorithm in section 4.2 of https://eprint.iacr.org/2020/1274.pdf.
@@ -54,6 +65,8 @@ pub fn extended_dory_reduce_prove_fold_s_vecs(
     (alpha, alpha_inv): (F, F),
     half_n: usize,
 ) {
+    log::log_memory_usage("Start");
+
     let (s_1L, s_1R) = state.s1.split_at_mut(half_n);
     let (s_2L, s_2R) = state.s2.split_at_mut(half_n);
     s_1L.iter_mut()
@@ -64,6 +77,8 @@ pub fn extended_dory_reduce_prove_fold_s_vecs(
         .for_each(|(s_L, s_R)| *s_L = *s_L * alpha_inv + s_R);
     state.s1.truncate(half_n);
     state.s2.truncate(half_n);
+
+    log::log_memory_usage("End");
 }
 /// From the extended Dory-Reduce algorithm in section 4.2 of <https://eprint.iacr.org/2020/1274.pdf>.
 ///

--- a/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars.rs
@@ -3,7 +3,7 @@ use super::{
     pairings, DeferredGT, DoryMessages, G1Projective, G2Projective, ProverSetup, ProverState,
     VerifierSetup, VerifierState, F,
 };
-use crate::base::proof::Transcript;
+use crate::{base::proof::Transcript, utils::log};
 
 /// This is the prover side of the Fold-Scalars algorithm in section 4.1 of <https://eprint.iacr.org/2020/1274.pdf>.
 ///
@@ -36,6 +36,8 @@ pub fn fold_scalars_0_verify(
     setup: &VerifierSetup,
     fold_s_tensors_verify: impl Fn(&ExtendedVerifierState) -> (F, F),
 ) -> VerifierState {
+    log::log_memory_usage("Start");
+
     assert_eq!(state.base_state.nu, 0);
     let (gamma, gamma_inv) = messages.verifier_F_message(transcript);
     let (s1_folded, s2_folded) = fold_s_tensors_verify(&state);
@@ -50,5 +52,8 @@ pub fn fold_scalars_0_verify(
         )) * gamma_inv;
     state.base_state.D_1 += pairings::pairing(setup.H_1, setup.Gamma_2_0 * s1_folded * gamma);
     state.base_state.D_2 += pairings::pairing(setup.Gamma_1_0 * s2_folded * gamma_inv, setup.H_2);
+
+    log::log_memory_usage("End");
+
     state.base_state
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -1,6 +1,7 @@
 use super::{blitzar_metadata_table::min_as_f, G1Affine, G1Projective};
 use crate::{
     base::commitment::CommittableColumn, proof_primitive::dory::offset_to_bytes::OffsetToBytes,
+    utils::log,
 };
 use alloc::{vec, vec::Vec};
 use ark_std::ops::Mul;
@@ -65,6 +66,8 @@ pub fn modify_commits(
     offset: usize,
     num_matrix_commitment_columns: usize,
 ) -> Vec<G1Affine> {
+    log::log_memory_usage("Start");
+
     // Set parameters
     let num_offset_commits = OFFSET_SIZE + committable_columns.len();
     let num_sub_commits_in_full_commit = bit_table.len() - num_offset_commits;
@@ -122,7 +125,11 @@ pub fn modify_commits(
         }
     }
 
-    modifed_commits.into_iter().map(Into::into).collect()
+    let res = modifed_commits.into_iter().map(Into::into).collect();
+
+    log::log_memory_usage("End");
+
+    res
 }
 
 /// Packs bits of a committable column into the packed scalars array.
@@ -314,6 +321,8 @@ pub fn bit_table_and_scalars_for_packed_msm(
     offset: usize,
     num_matrix_commitment_columns: usize,
 ) -> (Vec<u32>, Vec<u8>) {
+    log::log_memory_usage("Start");
+
     // Make sure that the committable columns are not empty.
     if committable_columns.is_empty() {
         return (vec![], vec![]);
@@ -449,6 +458,8 @@ pub fn bit_table_and_scalars_for_packed_msm(
                 );
             }
         });
+
+    log::log_memory_usage("End");
 
     (bit_table, packed_scalars)
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pairings.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pairings.rs
@@ -1,4 +1,4 @@
-use crate::base::if_rayon;
+use crate::{base::if_rayon, utils::log};
 #[cfg(feature = "rayon")]
 use ark_ec::pairing::MillerLoopOutput;
 use ark_ec::pairing::{Pairing, PairingOutput};
@@ -18,6 +18,8 @@ pub fn multi_pairing<P: Pairing>(
     a: impl IntoIterator<Item = impl Into<P::G1Prepared> + Send> + Send,
     b: impl IntoIterator<Item = impl Into<P::G2Prepared> + Send> + Send,
 ) -> PairingOutput<P> {
+    log::log_memory_usage("Start");
+
     multi_pairing_impl(a, b)
 }
 #[tracing::instrument(level = "debug", skip_all)]
@@ -32,6 +34,8 @@ pub fn multi_pairing_2<P: Pairing>(
         impl IntoIterator<Item = impl Into<P::G2Prepared> + Send> + Send,
     ),
 ) -> (PairingOutput<P>, PairingOutput<P>) {
+    log::log_memory_usage("Start");
+
     multi_pairing_2_impl((a0, b0), (a1, b1))
 }
 #[tracing::instrument(level = "debug", skip_all)]
@@ -59,6 +63,8 @@ pub fn multi_pairing_4<P: Pairing>(
     PairingOutput<P>,
     PairingOutput<P>,
 ) {
+    log::log_memory_usage("Start");
+
     multi_pairing_4_impl((a0, b0), (a1, b1), (a2, b2), (a3, b3))
 }
 /// # Panics

--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 use super::{pairings, DoryMessages, ProverState, VerifierSetup, VerifierState};
-use crate::base::proof::Transcript;
+use crate::{base::proof::Transcript, utils::log};
 
 /// This is the prover side of the Scalar-Product algorithm in section 3.1 of <https://eprint.iacr.org/2020/1274.pdf>.
 #[allow(clippy::missing_panics_doc)]
@@ -61,6 +61,8 @@ pub fn scalar_product_verify(
     // * `Gamma_1_0` is the Γ_1 used in Scalar-Product algorithm.
     // * `Gamma_2_0` is the Γ_2 used in Scalar-Product algorithm.
 
+    log::log_memory_usage("Start");
+
     assert_eq!(state.nu, 0);
     if messages.G1_messages.len() != 1
         || messages.G2_messages.len() != 1
@@ -71,6 +73,10 @@ pub fn scalar_product_verify(
     let E_1 = messages.prover_recieve_G1_message(transcript);
     let E_2 = messages.prover_recieve_G2_message(transcript);
     let (d, d_inv) = messages.verifier_F_message(transcript);
-    pairings::pairing(E_1 + setup.Gamma_1_0 * d, E_2 + setup.Gamma_2_0 * d_inv)
-        == (state.C + setup.chi[0] + state.D_2 * d + state.D_1 * d_inv).compute()
+    let res = pairings::pairing(E_1 + setup.Gamma_1_0 * d, E_2 + setup.Gamma_2_0 * d_inv)
+        == (state.C + setup.chi[0] + state.D_2 * d + state.D_1 * d_inv).compute();
+
+    log::log_memory_usage("End");
+
+    res
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/setup.rs
@@ -1,5 +1,5 @@
 use super::{G1Affine, G2Affine, PublicParameters, GT};
-use crate::base::impl_serde_for_ark_serde_unchecked;
+use crate::{base::impl_serde_for_ark_serde_unchecked, utils::log};
 use alloc::vec::Vec;
 use ark_ec::pairing::{Pairing, PairingOutput};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
@@ -124,6 +124,8 @@ impl<'a> ProverSetup<'a> {
         element_num_bytes: u32,
         scalars: &[u8],
     ) {
+        log::log_memory_usage("Start");
+
         self.blitzar_handle.msm(res, element_num_bytes, scalars);
     }
 
@@ -135,6 +137,8 @@ impl<'a> ProverSetup<'a> {
         output_bit_table: &[u32],
         scalars: &[u8],
     ) {
+        log::log_memory_usage("Start");
+
         self.blitzar_handle
             .packed_msm(res, output_bit_table, scalars);
     }
@@ -148,6 +152,8 @@ impl<'a> ProverSetup<'a> {
         output_lengths: &[u32],
         scalars: &[u8],
     ) {
+        log::log_memory_usage("Start");
+
         self.blitzar_handle
             .vlen_msm(res, output_bit_table, output_lengths, scalars);
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/transpose.rs
@@ -1,4 +1,4 @@
-use crate::proof_primitive::dory::offset_to_bytes::OffsetToBytes;
+use crate::{proof_primitive::dory::offset_to_bytes::OffsetToBytes, utils::log};
 use alloc::{vec, vec::Vec};
 
 #[tracing::instrument(name = "transpose_for_fixed_msm (gpu)", level = "debug", skip_all)]
@@ -9,6 +9,8 @@ pub fn transpose_for_fixed_msm<const LEN: usize, T: OffsetToBytes<LEN>>(
     cols: usize,
     data_size: usize,
 ) -> Vec<u8> {
+    log::log_memory_usage("Start");
+
     let total_length_bytes = data_size * rows * cols;
     let mut transpose = vec![0_u8; total_length_bytes];
     for n in offset..(column.len() + offset) {
@@ -20,6 +22,9 @@ pub fn transpose_for_fixed_msm<const LEN: usize, T: OffsetToBytes<LEN>>(
         transpose[t_idx..t_idx + data_size]
             .copy_from_slice(column[p_idx].offset_to_bytes().as_slice());
     }
+
+    log::log_memory_usage("End");
+
     transpose
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof.rs
@@ -5,6 +5,7 @@ use crate::{
         scalar::Scalar,
     },
     proof_primitive::sumcheck::{prove_round, ProverState},
+    utils::log,
 };
 /*
  * Adapted from arkworks
@@ -31,6 +32,8 @@ impl<S: Scalar> SumcheckProof<S> {
         evaluation_point: &mut [S],
         mut state: ProverState<S>,
     ) -> Self {
+        log::log_memory_usage("Start");
+
         assert_eq!(evaluation_point.len(), state.num_vars);
         transcript.extend_as_be([state.max_multiplicands as u64, state.num_vars as u64]);
         // This challenge is in order to keep transcript messages grouped. (This simplifies the Solidity implementation.)
@@ -47,6 +50,8 @@ impl<S: Scalar> SumcheckProof<S> {
             r = Some(*scalar);
         }
 
+        log::log_memory_usage("End");
+
         SumcheckProof { coefficients }
     }
 
@@ -61,6 +66,8 @@ impl<S: Scalar> SumcheckProof<S> {
         num_variables: usize,
         claimed_sum: &S,
     ) -> Result<Subclaim<S>, ProofError> {
+        log::log_memory_usage("Start");
+
         let coefficients_len = self.coefficients.len();
         if coefficients_len % num_variables != 0 {
             return Err(ProofError::VerificationError {
@@ -96,6 +103,9 @@ impl<S: Scalar> SumcheckProof<S> {
             }
             expected_evaluation = round_evaluation;
         }
+
+        log::log_memory_usage("End");
+
         Ok(Subclaim {
             evaluation_point,
             expected_evaluation,

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -4,7 +4,7 @@ use crate::base::polynomial::CompositePolynomial;
  *
  * See third_party/license/arkworks.LICENSE
  */
-use crate::base::scalar::Scalar;
+use crate::{base::scalar::Scalar, utils::log};
 use alloc::vec::Vec;
 
 #[derive(Debug)]
@@ -37,6 +37,8 @@ impl<S: Scalar> ProverState<S> {
 
     #[tracing::instrument(name = "ProverState::create", level = "debug", skip_all)]
     pub fn create(polynomial: &CompositePolynomial<S>) -> Self {
+        log::log_memory_usage("Start");
+
         assert!(
             polynomial.num_variables != 0,
             "Attempt to prove a constant."
@@ -48,6 +50,8 @@ impl<S: Scalar> ProverState<S> {
             .iter()
             .map(|x| x.as_ref().clone())
             .collect();
+
+        log::log_memory_usage("End");
 
         ProverState::new(
             polynomial.products.clone(),

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -1,9 +1,12 @@
 use super::{SumcheckSubpolynomial, SumcheckSubpolynomialTerm, SumcheckSubpolynomialType};
-use crate::base::{
-    bit::BitDistribution,
-    commitment::{Commitment, CommittableColumn, VecCommitmentExt},
-    polynomial::MultilinearExtension,
-    scalar::Scalar,
+use crate::{
+    base::{
+        bit::BitDistribution,
+        commitment::{Commitment, CommittableColumn, VecCommitmentExt},
+        polynomial::MultilinearExtension,
+        scalar::Scalar,
+    },
+    utils::log,
 };
 use alloc::{boxed::Box, vec::Vec};
 
@@ -95,11 +98,17 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
         offset_generators: usize,
         setup: &C::PublicSetup<'_>,
     ) -> Vec<C> {
-        Vec::from_commitable_columns_with_offset(
+        log::log_memory_usage("Start");
+
+        let res = Vec::from_commitable_columns_with_offset(
             &self.commitment_descriptor,
             offset_generators,
             setup,
-        )
+        );
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     /// Produce a subpolynomial to be aggegated into sumcheck where the sum across binary
@@ -116,10 +125,15 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
         skip_all
     )]
     pub fn evaluate_pcs_proof_mles(&self, evaluation_vec: &[S]) -> Vec<S> {
+        log::log_memory_usage("Start");
+
         let mut res = Vec::with_capacity(self.pcs_proof_mles.len());
         for evaluator in &self.pcs_proof_mles {
             res.push(evaluator.inner_product(evaluation_vec));
         }
+
+        log::log_memory_usage("End");
+
         res
     }
 

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -18,6 +18,7 @@ use crate::{
         scalar::Scalar,
     },
     proof_primitive::sumcheck::SumcheckProof,
+    utils::log,
 };
 use alloc::{string::String, vec, vec::Vec};
 use bumpalo::Bump;
@@ -78,6 +79,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         accessor: &impl DataAccessor<CP::Scalar>,
         setup: &CP::ProverPublicSetup<'_>,
     ) -> (Self, OwnedTable<CP::Scalar>) {
+        log::log_memory_usage("Start");
+
         let (min_row_num, max_row_num) = get_index_range(accessor, &expr.get_table_references());
         let initial_range_length = max_row_num - min_row_num;
         let alloc = Bump::new();
@@ -212,6 +215,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             subpolynomial_constraint_count,
             post_result_challenge_count,
         };
+
+        log::log_memory_usage("End");
+
         (proof, provable_result)
     }
 
@@ -224,6 +230,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         result: OwnedTable<CP::Scalar>,
         setup: &CP::VerifierPublicSetup<'_>,
     ) -> QueryResult<CP::Scalar> {
+        log::log_memory_usage("Start");
+
         let table_refs = expr.get_table_references();
         let (min_row_num, _) = get_index_range(accessor, &table_refs);
         let num_sumcheck_variables = cmp::max(log2_up(self.range_length), 1);
@@ -381,6 +389,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             })?;
 
         let verification_hash = transcript.challenge_as_le();
+
+        log::log_memory_usage("End");
+
         Ok(QueryData {
             table: result,
             verification_hash,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -1,11 +1,14 @@
 use super::{ProofPlan, QueryData, QueryProof, QueryResult};
-use crate::base::{
-    commitment::CommitmentEvaluationProof,
-    database::{
-        ColumnField, ColumnType, CommitmentAccessor, DataAccessor, OwnedColumn, OwnedTable,
+use crate::{
+    base::{
+        commitment::CommitmentEvaluationProof,
+        database::{
+            ColumnField, ColumnType, CommitmentAccessor, DataAccessor, OwnedColumn, OwnedTable,
+        },
+        proof::ProofError,
+        scalar::Scalar,
     },
-    proof::ProofError,
-    scalar::Scalar,
+    utils::log,
 };
 use alloc::vec;
 use serde::{Deserialize, Serialize};
@@ -85,6 +88,8 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         accessor: &impl DataAccessor<CP::Scalar>,
         setup: &CP::ProverPublicSetup<'_>,
     ) -> Self {
+        log::log_memory_usage("Start");
+
         // a query must have at least one result column; if not, it should
         // have been rejected at the parsing stage.
 
@@ -101,6 +106,9 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         }
 
         let (proof, res) = QueryProof::new(expr, accessor, setup);
+
+        log::log_memory_usage("End");
+
         Self {
             result: Some(res),
             proof: Some(proof),
@@ -121,6 +129,8 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         accessor: &impl CommitmentAccessor<CP::Commitment>,
         setup: &CP::VerifierPublicSetup<'_>,
     ) -> QueryResult<CP::Scalar> {
+        log::log_memory_usage("Start");
+
         match (self.result, self.proof) {
             (Some(result), Some(proof)) => {
                 let QueryData {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -79,6 +79,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
     ///
     /// This function both computes the result of a query and constructs a proof of the results
     /// validity.
+    #[tracing::instrument(name = "VerifiableQueryResult::new", level = "info", skip_all)]
     pub fn new(
         expr: &(impl ProofPlan + Serialize),
         accessor: &impl DataAccessor<CP::Scalar>,
@@ -113,6 +114,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
     /// error.
     ///
     /// Note: This does NOT transform the result!
+    #[tracing::instrument(name = "VerifiableQueryResult::verify", level = "info", skip_all)]
     pub fn verify(
         self,
         expr: &(impl ProofPlan + Serialize),

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -7,6 +7,7 @@ use crate::{
         scalar::Scalar,
     },
     sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    utils::log,
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -65,16 +66,22 @@ impl ProofExpr for AddSubtractExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
+        log::log_memory_usage("Start");
+
         let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table);
         let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table);
-        Column::Scalar(add_subtract_columns(
+        let res = Column::Scalar(add_subtract_columns(
             lhs_column,
             rhs_column,
             self.lhs.data_type().scale().unwrap_or(0),
             self.rhs.data_type().scale().unwrap_or(0),
             alloc,
             self.is_subtract,
-        ))
+        ));
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregate_expr.rs
@@ -7,6 +7,7 @@ use crate::{
         scalar::Scalar,
     },
     sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    utils::log,
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -45,7 +46,13 @@ impl ProofExpr for AggregateExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
-        self.expr.result_evaluate(alloc, table)
+        log::log_memory_usage("Start");
+
+        let res = self.expr.result_evaluate(alloc, table);
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     #[tracing::instrument(name = "AggregateExpr::prover_evaluate", level = "debug", skip_all)]
@@ -55,7 +62,13 @@ impl ProofExpr for AggregateExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
-        self.expr.prover_evaluate(builder, alloc, table)
+        log::log_memory_usage("Start");
+
+        let res = self.expr.prover_evaluate(builder, alloc, table);
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -7,6 +7,7 @@ use crate::{
         scalar::Scalar,
     },
     sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    utils::log,
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
@@ -45,7 +46,13 @@ impl ProofExpr for LiteralExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
-        Column::from_literal_with_length(&self.value, table.num_rows(), alloc)
+        log::log_memory_usage("Start");
+
+        let res = Column::from_literal_with_length(&self.value, table.num_rows(), alloc);
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]
@@ -55,8 +62,14 @@ impl ProofExpr for LiteralExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
+        log::log_memory_usage("Start");
+
         let table_length = table.num_rows();
-        Column::from_literal_with_length(&self.value, table_length, alloc)
+        let res = Column::from_literal_with_length(&self.value, table_length, alloc);
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -10,6 +10,7 @@ use crate::{
         proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
         proof_exprs::multiply_columns,
     },
+    utils::log,
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
@@ -57,6 +58,8 @@ impl ProofExpr for MultiplyExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
+        log::log_memory_usage("Start");
+
         let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table);
         let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table);
 
@@ -72,7 +75,11 @@ impl ProofExpr for MultiplyExpr {
                 (-S::one(), vec![Box::new(lhs_column), Box::new(rhs_column)]),
             ],
         );
-        Column::Scalar(lhs_times_rhs)
+        let res = Column::Scalar(lhs_times_rhs);
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -7,6 +7,7 @@ use crate::{
         scalar::Scalar,
     },
     sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    utils::log,
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -36,9 +37,15 @@ impl ProofExpr for NotExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
+        log::log_memory_usage("Start");
+
         let expr_column: Column<'a, S> = self.expr.result_evaluate(alloc, table);
         let expr = expr_column.as_boolean().expect("expr is not boolean");
-        Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]))
+        let res = Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]));
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     #[tracing::instrument(name = "NotExpr::prover_evaluate", level = "debug", skip_all)]
@@ -48,9 +55,15 @@ impl ProofExpr for NotExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
+        log::log_memory_usage("Start");
+
         let expr_column: Column<'a, S> = self.expr.prover_evaluate(builder, alloc, table);
         let expr = expr_column.as_boolean().expect("expr is not boolean");
-        Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]))
+        let res = Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]));
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -7,6 +7,7 @@ use crate::{
         scalar::Scalar,
     },
     sql::proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+    utils::log,
 };
 use alloc::{boxed::Box, vec};
 use bumpalo::Bump;
@@ -37,11 +38,17 @@ impl ProofExpr for OrExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
+        log::log_memory_usage("Start");
+
         let lhs_column: Column<'a, S> = self.lhs.result_evaluate(alloc, table);
         let rhs_column: Column<'a, S> = self.rhs.result_evaluate(alloc, table);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        Column::Boolean(result_evaluate_or(table.num_rows(), alloc, lhs, rhs))
+        let res = Column::Boolean(result_evaluate_or(table.num_rows(), alloc, lhs, rhs));
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     #[tracing::instrument(name = "OrExpr::prover_evaluate", level = "debug", skip_all)]
@@ -51,11 +58,17 @@ impl ProofExpr for OrExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
     ) -> Column<'a, S> {
+        log::log_memory_usage("Start");
+
         let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table);
         let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
-        Column::Boolean(prover_evaluate_or(builder, alloc, lhs, rhs))
+        let res = Column::Boolean(prover_evaluate_or(builder, alloc, lhs, rhs));
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -10,6 +10,7 @@ use crate::{
     sql::proof::{
         FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
+    utils::log,
 };
 use alloc::vec::Vec;
 use bumpalo::Bump;
@@ -70,9 +71,16 @@ impl ProverEvaluate for EmptyExec {
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
         // Create an empty table with one row
-        Table::<'a, S>::try_new_with_options(IndexMap::default(), TableOptions::new(Some(1)))
-            .unwrap()
+        let res =
+            Table::<'a, S>::try_new_with_options(IndexMap::default(), TableOptions::new(Some(1)))
+                .unwrap();
+
+        log::log_memory_usage("End");
+
+        res
     }
 
     #[tracing::instrument(name = "EmptyExec::final_round_evaluate", level = "debug", skip_all)]
@@ -83,8 +91,15 @@ impl ProverEvaluate for EmptyExec {
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
         // Create an empty table with one row
-        Table::<'a, S>::try_new_with_options(IndexMap::default(), TableOptions::new(Some(1)))
-            .unwrap()
+        let res =
+            Table::<'a, S>::try_new_with_options(IndexMap::default(), TableOptions::new(Some(1)))
+                .unwrap();
+
+        log::log_memory_usage("End");
+
+        res
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -17,6 +17,7 @@ use crate::{
         },
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
     },
+    utils::log,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
@@ -146,6 +147,8 @@ impl ProverEvaluate for FilterExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
         let table = table_map
             .get(&self.table.table_ref)
             .expect("Table not found");
@@ -175,6 +178,9 @@ impl ProverEvaluate for FilterExec {
         .expect("Failed to create table from iterator");
         builder.request_post_result_challenges(2);
         builder.produce_one_evaluation_length(output_length);
+
+        log::log_memory_usage("End");
+
         res
     }
 
@@ -186,6 +192,8 @@ impl ProverEvaluate for FilterExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
         let table = table_map
             .get(&self.table.table_ref)
             .expect("Table not found");
@@ -224,14 +232,18 @@ impl ProverEvaluate for FilterExec {
             table.num_rows(),
             result_len,
         );
-        Table::<'a, S>::try_from_iter_with_options(
+        let res = Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results
                 .iter()
                 .map(|expr| expr.alias)
                 .zip(filtered_columns),
             TableOptions::new(Some(output_length)),
         )
-        .expect("Failed to create table from iterator")
+        .expect("Failed to create table from iterator");
+
+        log::log_memory_usage("End");
+
+        res
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -19,6 +19,7 @@ use crate::{
             ProofExpr,
         },
     },
+    utils::log,
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
@@ -40,6 +41,8 @@ impl ProverEvaluate for DishonestFilterExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
         let table = table_map
             .get(&self.table.table_ref)
             .expect("Table not found");
@@ -68,6 +71,9 @@ impl ProverEvaluate for DishonestFilterExec {
         .expect("Failed to create table from iterator");
         builder.request_post_result_challenges(2);
         builder.produce_one_evaluation_length(output_length);
+
+        log::log_memory_usage("End");
+
         res
     }
 
@@ -83,6 +89,8 @@ impl ProverEvaluate for DishonestFilterExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
         let table = table_map
             .get(&self.table.table_ref)
             .expect("Table not found");
@@ -121,14 +129,18 @@ impl ProverEvaluate for DishonestFilterExec {
             table.num_rows(),
             result_len,
         );
-        Table::<'a, S>::try_from_iter_with_options(
+        let res = Table::<'a, S>::try_from_iter_with_options(
             self.aliased_results
                 .iter()
                 .map(|expr| expr.alias)
                 .zip(filtered_columns),
             TableOptions::new(Some(output_length)),
         )
-        .expect("Failed to create table from iterator")
+        .expect("Failed to create table from iterator");
+
+        log::log_memory_usage("End");
+
+        res
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -19,6 +19,7 @@ use crate::{
         },
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, ProofExpr, TableExpr},
     },
+    utils::log,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
@@ -196,6 +197,8 @@ impl ProverEvaluate for GroupByExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
         let table = table_map
             .get(&self.table.table_ref)
             .expect("Table not found");
@@ -240,6 +243,9 @@ impl ProverEvaluate for GroupByExec {
         .expect("Failed to create table from column references");
         builder.request_post_result_challenges(2);
         builder.produce_one_evaluation_length(count_column.len());
+
+        log::log_memory_usage("End");
+
         res
     }
 
@@ -251,6 +257,8 @@ impl ProverEvaluate for GroupByExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
+        log::log_memory_usage("Start");
+
         let table = table_map
             .get(&self.table.table_ref)
             .expect("Table not found");
@@ -312,6 +320,9 @@ impl ProverEvaluate for GroupByExec {
             (&group_by_result_columns, &sum_result_columns, count_column),
             table.num_rows(),
         );
+
+        log::log_memory_usage("End");
+
         res
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -8,6 +8,7 @@ use crate::{
     sql::proof::{
         FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
+    utils::log,
 };
 use alloc::vec::Vec;
 use bumpalo::Bump;
@@ -79,10 +80,16 @@ impl ProverEvaluate for TableExec {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
-        table_map
+        log::log_memory_usage("Start");
+
+        let first_round_table = table_map
             .get(&self.table_ref)
             .expect("Table not found")
-            .clone()
+            .clone();
+
+        log::log_memory_usage("End");
+
+        first_round_table
     }
 
     #[tracing::instrument(name = "TableExec::final_round_evaluate", level = "debug", skip_all)]
@@ -93,9 +100,15 @@ impl ProverEvaluate for TableExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
-        table_map
+        log::log_memory_usage("Start");
+
+        let final_round_table = table_map
             .get(&self.table_ref)
             .expect("Table not found")
-            .clone()
+            .clone();
+
+        log::log_memory_usage("End");
+
+        final_round_table
     }
 }

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -1,0 +1,30 @@
+use sysinfo::System;
+use tracing::{trace, Level};
+
+/// Logs the memory usage of the system at the TRACE level.
+///
+/// This function logs the available memory, used memory, and the percentage of memory used.
+/// It only logs this information if the TRACE level is enabled in the tracing configuration.
+///
+/// # Arguments
+///
+/// * `name` - A string slice that holds the name to be included in the log message.
+#[allow(clippy::cast_precision_loss)]
+pub fn log_memory_usage(name: &str) {
+    if tracing::level_enabled!(Level::TRACE) {
+        let mut system = System::new_all();
+        system.refresh_memory();
+
+        let available_memory = system.available_memory() as f64 / (1024.0 * 1024.0);
+        let used_memory = system.used_memory() as f64 / (1024.0 * 1024.0);
+        let percentage_memory_used = (used_memory / (used_memory + available_memory)) * 100.0;
+
+        trace!(
+            "{} Available memory: {:.2} MB, Used memory: {:.2} MB, Percentage memory used: {:.2}%",
+            name,
+            available_memory,
+            used_memory,
+            percentage_memory_used
+        );
+    }
+}

--- a/crates/proof-of-sql/src/utils/mod.rs
+++ b/crates/proof-of-sql/src/utils/mod.rs
@@ -1,3 +1,6 @@
 //! This module contains utilities for working with the library
 /// Parse DDLs and find bigdecimal columns
 pub mod parse;
+
+/// This module provides logging utilities for the library, including functions to log system memory usage.
+pub mod log;


### PR DESCRIPTION
# Rationale for this change
Initial memory logging has been added to Jaeger benchmark tracing. Memory logging does add execution time to the overall benchmark, so it is placed at `TRACE` level and requires benchmarks to be run with the environment variable `RUST_LOG=trace` to execute.

The logging function does not impact performance when code runs at `DEBUG` level or above.

This benchmark is prior to the change 
![image](https://github.com/user-attachments/assets/aa450197-51fb-4b38-9fd2-ef1ec554dffc)
vs with the memory logging
![image](https://github.com/user-attachments/assets/f9ec4236-7773-4240-8ab7-8ed51dfc1a53)

# What changes are included in this PR?
- A `log` module is added to the `utils` crate and the function `log_memory_usage` is implemented.
- Memory logging is added to instrumented sections of code.
- Memory logging is placed at the `TRACE` level, requiring benchmarks to be run as `RUST_LOG=trace` in order to be viewed in the Jaeger UI.

# Are these changes tested?
Yes