### PR TITLE
feat: unsound efficient range check

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -88,5 +88,6 @@ pub(crate) use column_expr::ColumnExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod column_expr_test;
 
-#[allow(dead_code, unused_variables)]
-mod range_check;
+pub mod range_check;
+#[cfg(all(test, feature = "blitzar"))]
+pub mod range_check_test_expr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check.rs
@@ -1,13 +1,106 @@
-use crate::base::{scalar::Scalar, slice_ops};
-use alloc::vec::Vec;
+//! Implements a cryptographic range check using logarithmic derivatives to decompose a column of scalars
+//! into a matrix of words. This method leverages the properties of logarithmic derivatives to efficiently
+//! verify range proofs in a zero-knowledge setting by performing word-wise decompositions, intermediate MLEs,
+//! and modular inversions.
+//!
+//! The approach builds on the techniques outlined in the paper "Multivariate Lookups Based on Logarithmic
+//! Derivatives" [ePrint 2022/1530](https://eprint.iacr.org/2022/1530.pdf), which characterizes the use of
+//! logarithmic derivatives to perform multivariate lookups in cryptographic protocols.
+//!
+//! ## Key Steps:
+//! * Word-Sized Decomposition: Each scalar is decomposed into its byte-level representation, forming a matrix where
+//!   each row corresponds to the decomposition of a scalar and each column corresponds to the bytes from the same position
+//!   across all scalars.
+//! * Intermediate MLE Computation: Multi-linear extensions are computed for each word column and for the count of how
+//!   often each word appears.
+//! * Logarithmic Derivative Calculation: After decomposing the scalars, the verifier's challenge is added to each word,
+//!   and the modular multiplicative inverse of this sum is computed, forming a new matrix of logarithmic derivatives.
+//!   This matrix is key to constructing range constraints.
+//!
+//! ## Optimization Opportunities:
+//! * Batch Inversion: Inversions of large vectors are computationally expensive
+//! * Parallelization: Single-threaded execution of these operations is a performance bottleneck
+use crate::{
+    base::{
+        database::TableRef, map::IndexMap, polynomial::MultilinearExtension, scalar::Scalar,
+        slice_ops,
+    },
+    sql::proof::{CountBuilder, FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+};
+use alloc::{boxed::Box, vec::Vec};
+use bumpalo::Bump;
 use bytemuck::cast_slice;
+use core::cmp::max;
 
-// Decomposes a scalar to requisite words, additionally tracks the total
-// number of occurences of each word for later use in the argument.
+/// Prove that a word-wise decomposition of a collection of scalars
+/// are all within the range 0 to 2^248. (want this power to be flexible, want to pick word size and range)
+#[allow(clippy::missing_panics_doc)]
+pub fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    scalars: &[S],
+    table_length: usize,
+    alloc: &'a Bump,
+) {
+    // Create 31 columns, each will collect the corresponding word from all scalars.
+    // 31 because a scalar will only ever have 248 bits of data set.
+    let mut word_columns: Vec<&mut [u8]> = (0..31)
+        .map(|_| alloc.alloc_slice_fill_with(scalars.len(), |_| 0))
+        .collect();
+
+    // Allocate space for the eventual inverted word columns.
+    let mut inverted_word_columns: Vec<&mut [S]> = (0..31)
+        .map(|_| alloc.alloc_slice_fill_with(scalars.len(), |_| S::ZERO))
+        .collect();
+
+    // Initialize a vector to count occurrences of each byte (0-255).
+    // The vector has 256 elements padded with zeros to match the length of the word columns
+    // The size is the larger of 256 or the number of scalars.
+    let word_counts: &mut [i64] = alloc.alloc_slice_fill_with(max(256, scalars.len()), |_| 0);
+
+    decompose_scalar_to_words(scalars, &mut word_columns, word_counts);
+
+    // Retrieve verifier challenge here, *after* Phase 1
+    let alpha = builder.consume_post_result_challenge();
+
+    get_logarithmic_derivative(
+        builder,
+        alloc,
+        &mut word_columns,
+        alpha,
+        table_length,
+        &mut inverted_word_columns,
+    );
+
+    // Produce an MLE over the word values
+    prove_word_values(alloc, scalars, alpha, table_length, builder);
+
+    // Argue that the sum of all words in each row, minus the count of each
+    // word multiplied by the inverted word value, is zero.
+    prove_row_zero_sum(
+        builder,
+        word_counts,
+        alloc,
+        scalars,
+        &inverted_word_columns,
+        alpha,
+    );
+}
+
+/// Decomposes a scalar to requisite words, additionally tracks the total
+/// number of occurrences of each word for later use in the argument.
+///
+/// ```text
+/// | Column 0   | Column 1   | Column 2   | ... | Column 31   |
+/// |------------|------------|------------|-----|-------------|
+/// |  w₀,₀      |  w₀,₁      |  w₀,₂      | ... |  w₀,₃₁      |
+/// |  w₁,₀      |  w₁,₁      |  w₁,₂      | ... |  w₁,₃₁      |
+/// |  w₂,₀      |  w₂,₁      |  w₂,₂      | ... |  w₂,₃₁      |
+/// ------------------------------------------------------------
+/// ```
 fn decompose_scalar_to_words<'a, S: Scalar + 'a>(
-    scalars: &mut [S],
+    scalars: &[S],
     word_columns: &mut [&mut [u8]],
-    byte_counts: &mut [u64],
+    byte_counts: &mut [i64],
 ) {
     for (i, scalar) in scalars.iter().enumerate() {
         let scalar_array: [u64; 4] = (*scalar).into(); // Convert scalar to u64 array
@@ -23,44 +116,313 @@ fn decompose_scalar_to_words<'a, S: Scalar + 'a>(
     }
 }
 
-// For a word w and a verifier challenge alpha, compute
-// 1 / (word + alpha), which is the modular multiplicative
-// inverse of (word + alpha) in the scalar field.
+/// For a word w and a verifier challenge α, compute
+/// wᵢⱼ + α, and produce an Int. MLE over this column:
+///
+/// ```text
+/// | Column 0     | Column 1     | Column 2     | ... | Column 31    |
+/// |--------------|--------------|--------------|-----|--------------|
+/// | w₀,₀ + α     | w₀,₁ + α     | w₀,₂ + α     | ... | w₀,₃₁ + α    |
+/// | w₁,₀ + α     | w₁,₁ + α     | w₁,₂ + α     | ... | w₁,₃₁ + α    |
+/// | w₂,₀ + α     | w₂,₁ + α     | w₂,₂ + α     | ... | w₂,₃₁ + α    |
+/// -------------------------------------------------------------------
+///       |               |              |                   |            
+///       v               v              v                   v          
+///    Int. MLE        Int. MLE       Int. MLE            Int. MLE     
+/// ```
+///
+/// Then, invert each column, producing the modular multiplicative
+/// inverse of (wᵢⱼ + α), which is the logarithmic derivative
+/// of wᵢⱼ + α:
+///
+/// ```text
+/// | Column 0     | Column 1     | Column 2     | ... | Column 31     |
+/// |--------------|--------------|--------------|-----|---------------|
+/// | (w₀,₀ + α)⁻¹ | (w₀,₁ + α)⁻¹ | (w₀,₂ + α)⁻¹ | ... | (w₀,₃₁ + α)⁻¹ |
+/// | (w₁,₀ + α)⁻¹ | (w₁,₁ + α)⁻¹ | (w₁,₂ + α)⁻¹ | ... | (w₁,₃₁ + α)⁻¹ |
+/// | (w₂,₀ + α)⁻¹ | (w₂,₁ + α)⁻¹ | (w₂,₂ + α)⁻¹ | ... | (w₂,₃₁ + α)⁻¹ |
+/// --------------------------------------------------------------------
+///       |              |              |                    |            
+///       v              v              v                    v          
+///    Int. MLE      Int. MLE      Int. MLE             Int. MLE     
+/// ```
+#[allow(clippy::missing_panics_doc)]
 fn get_logarithmic_derivative<'a, S: Scalar + 'a>(
-    byte_columns: &[&mut [u8]],
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    word_columns: &mut [&mut [u8]],
     alpha: S,
+    table_length: usize,
     inverted_word_columns: &mut [&mut [S]],
 ) {
-    // Iterate over each column
-    for (i, byte_column) in byte_columns.iter().enumerate() {
-        // Convert bytes to field elements and add alpha
-        let mut terms_to_invert: Vec<S> = byte_column.iter().map(|w| S::from(w) + alpha).collect();
+    for i in 0..31 {
+        let byte_column = &mut word_columns[i];
 
-        // Invert all the terms in the column at once
-        slice_ops::batch_inversion(&mut terms_to_invert);
+        // Allocate words_plus_alpha
+        let words_plus_alpha: &mut [S] =
+            alloc.alloc_slice_fill_with(byte_column.len(), |j| S::from(&byte_column[j]) + alpha);
 
-        // Assign the inverted values back to the inverted_word_columns
-        inverted_word_columns[i].copy_from_slice(&terms_to_invert);
+        // Allocate words_plus_alpha_inv
+        let words_plus_alpha_inv: &mut [S] =
+            alloc.alloc_slice_fill_with(byte_column.len(), |j| S::from(&byte_column[j]) + alpha);
+        slice_ops::batch_inversion(&mut words_plus_alpha_inv[..]);
+
+        // Produce an MLE over words_plus_alpha
+        builder.produce_intermediate_mle(words_plus_alpha as &[_]);
+
+        // Copy words_plus_alpha_inv to the corresponding inverted_word_columns[i]
+        builder.produce_intermediate_mle(words_plus_alpha_inv as &[_]);
+
+        inverted_word_columns[i].copy_from_slice(words_plus_alpha_inv);
+        assert_eq!(words_plus_alpha_inv, inverted_word_columns[i]);
+
+        let input_ones = alloc.alloc_slice_fill_copy(table_length, true);
+
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::Identity,
+            vec![
+                (
+                    S::one(),
+                    vec![
+                        Box::new(words_plus_alpha as &[_]),
+                        Box::new(words_plus_alpha_inv as &[_]),
+                    ],
+                ),
+                (-S::one(), vec![Box::new(input_ones as &[_])]),
+            ],
+        );
     }
+}
+
+/// Produce the range of possible values that a word can take on,
+/// based on the word's bit size, along with an intermediate MLE:
+///
+/// ```text
+/// | Column 0           |
+/// |--------------------|
+/// |  0                 |
+/// |  1                 |
+/// |  ...               |
+/// |  2ⁿ - 1            |
+/// ----------------------
+///       |       
+///       v  
+///    Int. MLE
+/// ```
+/// Here, `n` represents the bit size of the word (e.g., for an 8-bit word, `2⁸ - 1 = 255`).
+///
+/// Then, add the verifier challenge α, invert, and produce an
+/// intermediate MLE:
+///
+/// ```text
+/// | Column 0
+/// |--------------------|
+/// | (0 + α)⁻¹          |
+/// | (1 + α)⁻¹          |
+/// | ...                |
+/// | (2ⁿ - 1 + α)⁻¹     |
+/// ----------------------
+///       |      
+///       v        
+///    Int. MLE  
+/// ```
+/// Finally, argue that (`word_values` + α)⁻¹ * (`word_values` + α) - 1 = 0
+///
+use alloc::vec;
+#[allow(clippy::missing_panics_doc)]
+#[allow(clippy::cast_possible_truncation)]
+fn prove_word_values<'a, S: Scalar + 'a>(
+    alloc: &'a Bump,
+    scalars: &[S],
+    alpha: S,
+    table_length: usize,
+    builder: &mut FinalRoundBuilder<'a, S>,
+) {
+    // Allocate from 0 to 255 and pertrub with verifier challenge
+    let word_values_plus_alpha: &mut [S] =
+        alloc.alloc_slice_fill_with(max(256, scalars.len()), |i| S::from(&(i as u8)) + alpha);
+    builder.produce_intermediate_mle(word_values_plus_alpha as &[_]);
+
+    // Now produce an intermediate MLE over the inverted word values + verifier challenge alpha
+    let inverted_word_values_plus_alpha: &mut [S] = alloc.alloc_slice_fill_with(256, |i| {
+        S::try_from(i.into()).expect("word value will always fit into S") + alpha
+    });
+    slice_ops::batch_inversion(&mut inverted_word_values_plus_alpha[..]);
+    builder.produce_intermediate_mle(inverted_word_values_plus_alpha as &[_]);
+
+    let input_ones = alloc.alloc_slice_fill_copy(table_length, true);
+
+    // Argument:
+    // (word_values + α)⁻¹ * (word_values + α) - 1 = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (
+                S::one(),
+                vec![
+                    Box::new(inverted_word_values_plus_alpha as &[_]),
+                    Box::new(word_values_plus_alpha as &[_]),
+                ],
+            ),
+            (-S::one(), vec![Box::new(input_ones as &[_])]),
+        ],
+    );
+}
+
+/// Argue that the sum of all words in each row, minus the count of each word
+/// multiplied by the inverted word value, is zero.
+///
+/// ```text
+/// ∑ (I₀ + I₁ + I₂ + I₃ - (C * IN)) = 0
+/// ```
+///
+/// Where:
+/// - `I₀, I₁, I₂, I₃` are the inverted word columns.
+/// - `C` is the count of each word.
+/// - `IN` is the inverted word values column.
+#[allow(clippy::missing_panics_doc)]
+fn prove_row_zero_sum<'a, S: Scalar + 'a>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    word_counts: &'a mut [i64],
+    alloc: &'a Bump,
+    scalars: &[S],
+    inverted_word_columns: &[&mut [S]],
+    alpha: S,
+) {
+    // Produce an MLE over the counts of each word value
+    builder.produce_intermediate_mle(word_counts as &[_]);
+
+    // Allocate row_sums from the bump allocator, ensuring it lives as long as 'a
+    let row_sums = alloc.alloc_slice_fill_with(scalars.len(), |_| S::ZERO);
+
+    // Iterate over each column and sum up the corresponding row values
+    for column in inverted_word_columns {
+        // Iterate over each scalar in the column
+        for (i, inv_word) in column.iter().enumerate() {
+            row_sums[i] += *inv_word;
+        }
+    }
+
+    // Pass the row_sums reference with the correct lifetime to the builder
+    builder.produce_intermediate_mle(row_sums as &[_]);
+
+    // Allocate and store the row sums in a Box using the bump allocator
+    let row_sums_box: Box<_> =
+        Box::new(alloc.alloc_slice_copy(row_sums) as &[_]) as Box<dyn MultilinearExtension<S>>;
+
+    let inverted_word_values_plus_alpha: &mut [S] = alloc.alloc_slice_fill_with(256, |i| {
+        S::try_from(i.into()).expect("word value will always fit into S") + alpha
+    });
+
+    slice_ops::batch_inversion(&mut inverted_word_values_plus_alpha[..]);
+
+    // Now pass the vector to the builder
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::ZeroSum,
+        vec![
+            (S::one(), vec![row_sums_box]),
+            (
+                -S::one(),
+                vec![
+                    Box::new(word_counts as &[_]),
+                    Box::new(inverted_word_values_plus_alpha as &[_]),
+                ],
+            ),
+        ],
+    );
+}
+
+/// Verify that the prover claim is correct.
+#[allow(clippy::missing_panics_doc)]
+pub fn verifier_evaluate_range_check<C>(
+    builder: &mut VerificationBuilder<'_, C>,
+    one_eval_map: &IndexMap<TableRef, C>,
+) where
+    C: Scalar,
+{
+    let _alpha = builder.consume_post_result_challenge();
+    let mut w_plus_alpha_inv_evals: Vec<_> = Vec::with_capacity(31);
+
+    // Consume the (wᵢⱼ + α)  and (wᵢⱼ + α)⁻¹ MLEs
+    for _ in 0..31 {
+        let w_plus_alpha_eval = builder.consume_intermediate_mle();
+        let w_plus_alpha_inv_eval = builder.consume_intermediate_mle();
+
+        // Store the evaluations of (wᵢⱼ + α)⁻¹
+        w_plus_alpha_inv_evals.push(w_plus_alpha_inv_eval);
+
+        // Verify that:
+        // (wᵢⱼ + α)⁻¹ * (wᵢⱼ + α) - 1 = 0
+        let one_eval = one_eval_map
+            .values()
+            .next()
+            .expect("one_eval_map should have at least one value");
+        let word_eval = (w_plus_alpha_inv_eval * w_plus_alpha_eval) - *one_eval;
+        builder.produce_sumcheck_subpolynomial_evaluation(
+            &SumcheckSubpolynomialType::Identity,
+            word_eval,
+        );
+    }
+
+    // // Consume the (word_values + α)⁻¹ * (word_values + α) MLEs:
+    let word_plus_alpha_evals = builder.consume_intermediate_mle();
+    let inverted_word_values_eval = builder.consume_intermediate_mle();
+
+    let one_eval = one_eval_map
+        .values()
+        .next()
+        .expect("one_eval_map should have at least one value");
+
+    // // Verify that:
+    // (word_values + α)⁻¹ * (word_values + α) - 1 = 0
+    let word_value_eval = (inverted_word_values_eval * word_plus_alpha_evals) - *one_eval;
+
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        &SumcheckSubpolynomialType::Identity,
+        word_value_eval,
+    );
+
+    // Consume the word count mle:
+    let count_eval = builder.consume_intermediate_mle();
+
+    let row_sum_eval = builder.consume_intermediate_mle();
+    let count_value_product_eval = count_eval * inverted_word_values_eval;
+
+    builder.produce_sumcheck_subpolynomial_evaluation(
+        &SumcheckSubpolynomialType::ZeroSum,
+        row_sum_eval - count_value_product_eval,
+    );
+}
+
+/// Get a count of the intermediate MLEs, post-result challenges, and subpolynomials
+pub fn count_range_check(builder: &mut CountBuilder<'_>) {
+    builder.count_intermediate_mles(66);
+    builder.count_post_result_challenges(1);
+    builder.count_degree(3);
+    builder.count_subpolynomials(33);
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
         base::scalar::{Curve25519Scalar as S, Scalar},
-        sql::proof_exprs::range_check::{decompose_scalar_to_words, get_logarithmic_derivative},
+        sql::{
+            proof::FinalRoundBuilder,
+            proof_exprs::range_check::{decompose_scalar_to_words, get_logarithmic_derivative},
+        },
     };
+    use bumpalo::Bump;
     use num_traits::Inv;
 
     #[test]
     fn we_can_decompose_small_scalars_to_words() {
-        let mut scalars: Vec<S> = [1, 2, 3, 255, 256, 257].iter().map(S::from).collect();
+        let scalars: Vec<S> = [1, 2, 3, 255, 256, 257].iter().map(S::from).collect();
 
         let mut word_columns = vec![vec![0; scalars.len()]; 31];
         let mut word_slices: Vec<&mut [u8]> = word_columns.iter_mut().map(|c| &mut c[..]).collect();
         let mut byte_counts = vec![0; 256];
 
-        decompose_scalar_to_words(&mut scalars, &mut word_slices, &mut byte_counts);
+        decompose_scalar_to_words(&scalars, &mut word_slices, &mut byte_counts);
 
         let mut expected_word_columns = vec![vec![0; scalars.len()]; 31];
         expected_word_columns[0] = vec![1, 2, 3, 255, 0, 1];
@@ -80,7 +442,7 @@ mod tests {
 
     #[test]
     fn we_can_decompose_large_scalars_to_words() {
-        let mut scalars: Vec<S> = [S::MAX_SIGNED, S::from(u64::MAX), S::from(-1)]
+        let scalars: Vec<S> = [S::MAX_SIGNED, S::from(u64::MAX), S::from(-1)]
             .iter()
             .map(S::from)
             .collect();
@@ -89,7 +451,7 @@ mod tests {
         let mut word_slices: Vec<&mut [u8]> = word_columns.iter_mut().map(|c| &mut c[..]).collect();
         let mut byte_counts = vec![0; 256];
 
-        decompose_scalar_to_words(&mut scalars, &mut word_slices, &mut byte_counts);
+        decompose_scalar_to_words(&scalars, &mut word_slices, &mut byte_counts);
 
         let expected_word_columns = [
             [246, 255, 236],
@@ -159,7 +521,7 @@ mod tests {
         word_columns[0] = [1, 2, 3, 255, 0, 1].to_vec();
         word_columns[1] = [0, 0, 0, 0, 1, 1].to_vec();
 
-        let word_slices: Vec<&mut [u8]> = word_columns.iter_mut().map(|c| &mut c[..]).collect();
+        let mut word_slices: Vec<&mut [u8]> = word_columns.iter_mut().map(|c| &mut c[..]).collect();
 
         let alpha = S::from(5);
 
@@ -173,7 +535,17 @@ mod tests {
             .map(Vec::as_mut_slice)
             .collect();
 
-        get_logarithmic_derivative(&word_slices, alpha, &mut word_columns_from_log_deriv);
+        let alloc = Bump::new();
+        let mut builder = FinalRoundBuilder::new(2, Vec::new());
+
+        get_logarithmic_derivative(
+            &mut builder,
+            &alloc,
+            &mut word_slices,
+            alpha,
+            256,
+            &mut word_columns_from_log_deriv,
+        );
 
         let expected_data: [[u8; 6]; 31] = [
             [1, 2, 3, 255, 0, 1],
@@ -253,7 +625,7 @@ mod tests {
         // Simulate a verifier challenge, then prepare storage for
         // 1 / (word + alpha)
         let alpha = S::from(5);
-        let word_slices: Vec<&mut [u8]> = word_columns.iter_mut().map(|c| &mut c[..]).collect();
+        let mut word_slices: Vec<&mut [u8]> = word_columns.iter_mut().map(|c| &mut c[..]).collect();
         let mut inverted_word_columns_plus_alpha: Vec<Vec<S>> =
             vec![vec![S::ZERO; scalars.len()]; 31];
         // Convert Vec<Vec<S>> into Vec<&mut [S]> for use in get_logarithmic_derivative
@@ -262,7 +634,16 @@ mod tests {
             .map(Vec::as_mut_slice)
             .collect();
 
-        get_logarithmic_derivative(&word_slices, alpha, &mut word_columns_from_log_deriv);
+        let alloc = Bump::new();
+        let mut builder = FinalRoundBuilder::new(2, Vec::new());
+        get_logarithmic_derivative(
+            &mut builder,
+            &alloc,
+            &mut word_slices,
+            alpha,
+            256,
+            &mut word_columns_from_log_deriv,
+        );
 
         let expected_data: [[u8; 2]; 31] = [
             [0xFF, 0xFF],

--- a/crates/proof-of-sql/src/sql/proof_exprs/range_check_test_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/range_check_test_expr.rs
@@ -1,0 +1,126 @@
+use super::range_check::{
+    count_range_check, final_round_evaluate_range_check, verifier_evaluate_range_check,
+};
+use crate::{
+    base::{
+        database::{ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableRef},
+        map::{indexset, IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        CountBuilder, FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
+        VerificationBuilder,
+    },
+};
+use bumpalo::Bump;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct RangeCheckTestExpr {
+    pub column: ColumnRef,
+}
+
+impl ProverEvaluate for RangeCheckTestExpr {
+    #[doc = " Evaluate the query, modify `FirstRoundBuilder` and return the result."]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder,
+        _alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        builder.request_post_result_challenges(1);
+        table_map[&self.column.table_ref()].clone()
+    }
+
+    // extract data to test on from here, feed it into range check
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the table from the map using the table reference
+        let table: &Table<'a, S> = table_map
+            .get(&self.column.table_ref())
+            .expect("Table not found");
+
+        let scalars = table
+            .inner_table()
+            .get(&self.column.column_id())
+            .expect("Column not found in table")
+            .as_scalar()
+            .expect("Failed to convert column to scalar");
+        final_round_evaluate_range_check(builder, scalars, 256, alloc);
+        table.clone()
+    }
+}
+
+impl ProofPlan for RangeCheckTestExpr {
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        vec![ColumnField::new(
+            self.column.column_id(),
+            *self.column.column_type(),
+        )]
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        indexset! {self.column}
+    }
+
+    #[doc = " Return all the tables referenced in the Query"]
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        indexset! {self.column.table_ref()}
+    }
+
+    #[doc = " Count terms used within the Query\'s proof"]
+    fn count(&self, builder: &mut CountBuilder) -> Result<(), ProofError> {
+        count_range_check(builder);
+        Ok(())
+    }
+
+    #[doc = " Form components needed to verify and proof store into `VerificationBuilder`"]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        verifier_evaluate_range_check(builder, one_eval_map);
+
+        Ok(TableEvaluation::new(
+            vec![accessor[&self.column]],
+            one_eval_map[&self.column.table_ref()],
+        ))
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod tests {
+
+    use crate::{
+        base::database::{
+            owned_table_utility::{owned_table, scalar},
+            ColumnRef, ColumnType, OwnedTableTestAccessor,
+        },
+        sql::{
+            proof::VerifiableQueryResult, proof_exprs::range_check_test_expr::RangeCheckTestExpr,
+        },
+    };
+    use blitzar::proof::InnerProductProof;
+
+    #[test]
+    fn we_can_prove_a_range_check() {
+        let data = owned_table([scalar("a", 0..256)]);
+        // let data = owned_table([bigint("a", vec![0; 256])]);
+        let t = "sxt.t".parse().unwrap();
+        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let ast = RangeCheckTestExpr {
+            column: ColumnRef::new(t, "a".parse().unwrap(), ColumnType::Scalar),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
+        let res = verifiable_res.verify(&ast, &accessor, &());
+        assert!(res.is_ok());
+    }
+}


### PR DESCRIPTION
# Rationale for this change

Currently, ranges on scalar values are verified in a bitwise decomposition for each bit. This requires a proportionally large amount of work to verify, since each bit must be checked. A more efficient range check can leverage a lookup table and protocol with a verifying party to efficiently argue range and uniqueness against columns of scalar values.

# What changes are included in this PR?

Adds an unsound, efficient, byte-oriented range check protocol via lookup table with logarithmic derivative arguments

# Are these changes tested?
- [x] Thorough unit tests for individual range check components
- [x] A demo RangeCheckExpr based off of a ProofPlan trait implementation so that the prover and verifier builder structs can be accessed

# TODO

- [ ] Introduce threading to heavy matrix operations
- [ ] Maybe dont use ProofPlan as the test expression, ProofExpr might be better
- [ ] Handle panics? or introduce error handling
- [ ] Make the protocol sound
- [ ] configurable, generic word sizes