### PR TITLE
refactor: remove `CompositePolynomialInfo`

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -38,16 +38,6 @@ pub struct CompositePolynomial<S: Scalar> {
     raw_pointers_lookup_table: IndexMap<*const Vec<S>, usize>,
 }
 
-/// Stores the number of variables and max number of multiplicands of the added polynomial used by the prover.
-/// This data structures will is used as the verifier key.
-#[derive(Clone, Debug)]
-pub struct CompositePolynomialInfo {
-    /// max number of multiplicands in each product
-    pub max_multiplicands: usize,
-    /// number of variables of the polynomial
-    pub num_variables: usize,
-}
-
 impl<S: Scalar> CompositePolynomial<S> {
     /// Returns an empty polynomial
     pub fn new(num_variables: usize) -> Self {

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -60,14 +60,6 @@ impl<S: Scalar> CompositePolynomial<S> {
         }
     }
 
-    /// Extract the max number of multiplicands and number of variables of the list of products.
-    pub fn info(&self) -> CompositePolynomialInfo {
-        CompositePolynomialInfo {
-            max_multiplicands: self.max_multiplicands,
-            num_variables: self.num_variables,
-        }
-    }
-
     /// Add a list of multilinear extensions that is meant to be multiplied together.
     /// The resulting polynomial will be multiplied by the scalar `coefficient`.
     #[allow(clippy::missing_panics_doc)]

--- a/crates/proof-of-sql/src/base/polynomial/mod.rs
+++ b/crates/proof-of-sql/src/base/polynomial/mod.rs
@@ -1,5 +1,5 @@
 mod composite_polynomial;
-pub use composite_polynomial::{CompositePolynomial, CompositePolynomialInfo};
+pub use composite_polynomial::CompositePolynomial;
 #[cfg(test)]
 mod composite_polynomial_test;
 

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -36,7 +36,10 @@ fn test_create_verify_proof() {
     let subclaim = proof
         .verify_without_evaluation(
             &mut transcript,
-            poly.info(),
+            CompositePolynomialInfo {
+                max_multiplicands: poly.max_multiplicands,
+                num_variables: poly.num_variables,
+            },
             &Curve25519Scalar::from(579u64),
         )
         .expect("verify failed");
@@ -52,7 +55,10 @@ fn test_create_verify_proof() {
     let subclaim = proof
         .verify_without_evaluation(
             &mut transcript,
-            poly.info(),
+            CompositePolynomialInfo {
+                max_multiplicands: poly.max_multiplicands,
+                num_variables: poly.num_variables,
+            },
             &Curve25519Scalar::from(579u64),
         )
         .expect("verify failed");
@@ -62,7 +68,10 @@ fn test_create_verify_proof() {
     let mut transcript = Transcript::new(b"sumchecktest");
     let subclaim = proof.verify_without_evaluation(
         &mut transcript,
-        poly.info(),
+        CompositePolynomialInfo {
+            max_multiplicands: poly.max_multiplicands,
+            num_variables: poly.num_variables,
+        },
         &Curve25519Scalar::from(123u64),
     );
     assert!(subclaim.is_err());
@@ -71,7 +80,10 @@ fn test_create_verify_proof() {
     proof.coefficients[0] += Curve25519Scalar::from(3u64);
     let subclaim = proof.verify_without_evaluation(
         &mut transcript,
-        poly.info(),
+        CompositePolynomialInfo {
+            max_multiplicands: poly.max_multiplicands,
+            num_variables: poly.num_variables,
+        },
         &Curve25519Scalar::from(579u64),
     );
     assert!(subclaim.is_err());
@@ -125,7 +137,10 @@ fn test_polynomial(nv: usize, num_multiplicands_range: (usize, usize), num_produ
     let mut rng = <ark_std::rand::rngs::StdRng as ark_std::rand::SeedableRng>::from_seed([0u8; 32]);
     let (poly, asserted_sum) =
         random_polynomial(nv, num_multiplicands_range, num_products, &mut rng);
-    let poly_info = poly.info();
+    let poly_info = CompositePolynomialInfo {
+        max_multiplicands: poly.max_multiplicands,
+        num_variables: poly.num_variables,
+    };
 
     // create a proof
     let mut transcript = Transcript::new(b"sumchecktest");

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -1,6 +1,6 @@
 use super::test_cases::sumcheck_test_cases;
 use crate::base::{
-    polynomial::{CompositePolynomial, CompositePolynomialInfo},
+    polynomial::CompositePolynomial,
     proof::Transcript as _,
     scalar::{test_scalar::TestScalar, Curve25519Scalar, MontScalar, Scalar},
 };
@@ -36,10 +36,8 @@ fn test_create_verify_proof() {
     let subclaim = proof
         .verify_without_evaluation(
             &mut transcript,
-            CompositePolynomialInfo {
-                max_multiplicands: poly.max_multiplicands,
-                num_variables: poly.num_variables,
-            },
+            poly.max_multiplicands,
+            poly.num_variables,
             &Curve25519Scalar::from(579u64),
         )
         .expect("verify failed");
@@ -55,10 +53,8 @@ fn test_create_verify_proof() {
     let subclaim = proof
         .verify_without_evaluation(
             &mut transcript,
-            CompositePolynomialInfo {
-                max_multiplicands: poly.max_multiplicands,
-                num_variables: poly.num_variables,
-            },
+            poly.max_multiplicands,
+            poly.num_variables,
             &Curve25519Scalar::from(579u64),
         )
         .expect("verify failed");
@@ -68,10 +64,8 @@ fn test_create_verify_proof() {
     let mut transcript = Transcript::new(b"sumchecktest");
     let subclaim = proof.verify_without_evaluation(
         &mut transcript,
-        CompositePolynomialInfo {
-            max_multiplicands: poly.max_multiplicands,
-            num_variables: poly.num_variables,
-        },
+        poly.max_multiplicands,
+        poly.num_variables,
         &Curve25519Scalar::from(123u64),
     );
     assert!(subclaim.is_err());
@@ -80,10 +74,8 @@ fn test_create_verify_proof() {
     proof.coefficients[0] += Curve25519Scalar::from(3u64);
     let subclaim = proof.verify_without_evaluation(
         &mut transcript,
-        CompositePolynomialInfo {
-            max_multiplicands: poly.max_multiplicands,
-            num_variables: poly.num_variables,
-        },
+        poly.max_multiplicands,
+        poly.num_variables,
         &Curve25519Scalar::from(579u64),
     );
     assert!(subclaim.is_err());
@@ -137,20 +129,21 @@ fn test_polynomial(nv: usize, num_multiplicands_range: (usize, usize), num_produ
     let mut rng = <ark_std::rand::rngs::StdRng as ark_std::rand::SeedableRng>::from_seed([0u8; 32]);
     let (poly, asserted_sum) =
         random_polynomial(nv, num_multiplicands_range, num_products, &mut rng);
-    let poly_info = CompositePolynomialInfo {
-        max_multiplicands: poly.max_multiplicands,
-        num_variables: poly.num_variables,
-    };
 
     // create a proof
     let mut transcript = Transcript::new(b"sumchecktest");
-    let mut evaluation_point = vec![Curve25519Scalar::zero(); poly_info.num_variables];
+    let mut evaluation_point = vec![Curve25519Scalar::zero(); poly.num_variables];
     let proof = SumcheckProof::create(&mut transcript, &mut evaluation_point, &poly);
 
     // verify proof
     let mut transcript = Transcript::new(b"sumchecktest");
     let subclaim = proof
-        .verify_without_evaluation(&mut transcript, poly_info, &asserted_sum)
+        .verify_without_evaluation(
+            &mut transcript,
+            poly.max_multiplicands,
+            poly.num_variables,
+            &asserted_sum,
+        )
         .expect("verify failed");
     assert_eq!(subclaim.evaluation_point, evaluation_point);
     assert_eq!(
@@ -194,10 +187,8 @@ fn we_can_verify_many_random_test_cases() {
         let subclaim = proof
             .verify_without_evaluation(
                 &mut transcript,
-                CompositePolynomialInfo {
-                    max_multiplicands: test_case.max_multiplicands,
-                    num_variables: test_case.num_vars,
-                },
+                test_case.max_multiplicands,
+                test_case.num_vars,
                 &test_case.sum,
             )
             .expect("verification should succeed with the correct setup");
@@ -215,10 +206,8 @@ fn we_can_verify_many_random_test_cases() {
         transcript.extend_serialize_as_le(&123u64);
         let verify_result = proof.verify_without_evaluation(
             &mut transcript,
-            CompositePolynomialInfo {
-                max_multiplicands: test_case.max_multiplicands,
-                num_variables: test_case.num_vars,
-            },
+            test_case.max_multiplicands,
+            test_case.num_vars,
             &test_case.sum,
         );
         if let Ok(subclaim) = verify_result {
@@ -233,10 +222,8 @@ fn we_can_verify_many_random_test_cases() {
             proof
                 .verify_without_evaluation(
                     &mut transcript,
-                    CompositePolynomialInfo {
-                        max_multiplicands: test_case.max_multiplicands,
-                        num_variables: test_case.num_vars,
-                    },
+                    test_case.max_multiplicands,
+                    test_case.num_vars,
                     &(test_case.sum + TestScalar::ONE),
                 )
                 .is_err(),
@@ -250,10 +237,8 @@ fn we_can_verify_many_random_test_cases() {
             modified_proof
                 .verify_without_evaluation(
                     &mut transcript,
-                    CompositePolynomialInfo {
-                        max_multiplicands: test_case.max_multiplicands,
-                        num_variables: test_case.num_vars,
-                    },
+                    test_case.max_multiplicands,
+                    test_case.num_vars,
                     &test_case.sum,
                 )
                 .is_err(),

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         map::{IndexMap, IndexSet},
         math::log2_up,
-        polynomial::{compute_evaluation_vector, CompositePolynomialInfo},
+        polynomial::compute_evaluation_vector,
         proof::{Keccak256Transcript, ProofError, Transcript},
     },
     proof_primitive::sumcheck::SumcheckProof,
@@ -272,15 +272,12 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             SumcheckRandomScalars::new(&random_scalars, self.range_length, num_sumcheck_variables);
 
         // verify sumcheck up to the evaluation check
-        let poly_info = CompositePolynomialInfo {
-            // This needs to be at least 2 since `CompositePolynomialBuilder::make_composite_polynomial`
-            // always adds a degree 2 term.
-            max_multiplicands: core::cmp::max(counts.sumcheck_max_multiplicands, 2),
-            num_variables: num_sumcheck_variables,
-        };
         let subclaim = self.sumcheck_proof.verify_without_evaluation(
             &mut transcript,
-            poly_info,
+            // This needs to be at least 2 since `CompositePolynomialBuilder::make_composite_polynomial`
+            // always adds a degree 2 term.
+            core::cmp::max(counts.sumcheck_max_multiplicands, 2),
+            num_sumcheck_variables,
             &Zero::zero(),
         )?;
 


### PR DESCRIPTION
# Rationale for this change

`CompositePolynomialInfo` is used in 2 test and one other place. Removing it simplifies the verifier code. This is especially pertinent to the Solidity port.

# What changes are included in this PR?

See commits.

# Are these changes tested?
NA