### PR TITLE
fix: `MultilinearExtension::id` uniqueness

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension_test.rs
@@ -1,5 +1,17 @@
 use super::MultilinearExtension;
 use crate::base::{database::Column, scalar::test_scalar::TestScalar};
+use bumpalo::Bump;
+
+#[test]
+fn allocated_slices_must_have_different_ids_even_when_one_is_empty() {
+    let alloc = Bump::new();
+    let foo = alloc.alloc_slice_fill_default(5) as &[TestScalar];
+    let bar = alloc.alloc_slice_fill_default(0) as &[TestScalar];
+    assert_ne!(
+        MultilinearExtension::<TestScalar>::id(&foo),
+        MultilinearExtension::<TestScalar>::id(&bar)
+    );
+}
 
 #[test]
 fn we_can_use_multilinear_extension_methods_for_i64_slice() {

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_state.rs
@@ -7,6 +7,7 @@ use crate::base::polynomial::CompositePolynomial;
 use crate::base::scalar::Scalar;
 use alloc::vec::Vec;
 
+#[derive(Debug)]
 pub struct ProverState<S: Scalar> {
     /// Stores the list of products that is meant to be added together. Each multiplicand is represented by
     /// the index in `flattened_ml_extensions`

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -17,7 +17,7 @@ pub struct CompositePolynomialBuilder<S: Scalar> {
     fr_multiplicands_rest: Vec<(S, Vec<Rc<Vec<S>>>)>,
     zerosum_multiplicands: Vec<(S, Vec<Rc<Vec<S>>>)>,
     fr: Rc<Vec<S>>,
-    mles: IndexMap<*const c_void, Rc<Vec<S>>>,
+    mles: IndexMap<(*const c_void, usize), Rc<Vec<S>>>,
 }
 
 impl<S: Scalar> CompositePolynomialBuilder<S> {

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -23,6 +23,7 @@ pub type SumcheckSubpolynomialTerm<'a, S> = (S, Vec<Box<dyn MultilinearExtension
 ///
 /// The subpolynomial is represented as a sum of terms, where each term is a
 /// product of multilinear extensions and a constant.
+#[derive(Debug)]
 pub struct SumcheckSubpolynomial<'a, S: Scalar> {
     terms: Vec<SumcheckSubpolynomialTerm<'a, S>>,
     subpolynomial_type: SumcheckSubpolynomialType,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In `Bumpalo` if we allocate a non-empty slice and then an empty one they have the same positions hence it is necessary to differentiate between them by adding the slice length to the identifier.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.