### PR TITLE
refactor: simplify into `consume_mle_evaluations`

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof.rs
@@ -56,7 +56,7 @@ pub trait CommitmentEvaluationProof {
             transcript,
             core::slice::from_ref(a_commit),
             &[Self::Scalar::ONE],
-            product,
+            core::slice::from_ref(product),
             b_point,
             generators_offset,
             table_length,
@@ -70,7 +70,7 @@ pub trait CommitmentEvaluationProof {
         transcript: &mut impl Transcript,
         commit_batch: &[Self::Commitment],
         batching_factors: &[Self::Scalar],
-        product: &Self::Scalar,
+        evaluations: &[Self::Scalar],
         b_point: &[Self::Scalar],
         generators_offset: u64,
         table_length: usize,
@@ -117,7 +117,7 @@ impl CommitmentEvaluationProof for InnerProductProof {
         transcript: &mut impl Transcript,
         commit_batch: &[Self::Commitment],
         batching_factors: &[Self::Scalar],
-        product: &Self::Scalar,
+        evaluations: &[Self::Scalar],
         b_point: &[Self::Scalar],
         generators_offset: u64,
         table_length: usize,
@@ -131,6 +131,11 @@ impl CommitmentEvaluationProof for InnerProductProof {
         } else {
             crate::base::polynomial::compute_evaluation_vector(b, b_point);
         }
+        let product: Self::Scalar = evaluations
+            .iter()
+            .zip(batching_factors)
+            .map(|(&e, &f)| e * f)
+            .sum();
         // The InnerProductProof from blitzar only works with the merlin Transcript.
         // So, we wrap the call to it.
         transcript.wrap_transcript(|transcript| {

--- a/crates/proof-of-sql/src/base/commitment/naive_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_evaluation_proof.rs
@@ -56,7 +56,7 @@ impl CommitmentEvaluationProof for NaiveEvaluationProof {
         transcript: &mut impl Transcript,
         commit_batch: &[Self::Commitment],
         batching_factors: &[Self::Scalar],
-        product: &Self::Scalar,
+        evaluations: &[Self::Scalar],
         b_point: &[Self::Scalar],
         generators_offset: u64,
         _table_length: usize,
@@ -74,6 +74,11 @@ impl CommitmentEvaluationProof for NaiveEvaluationProof {
             .zip(batching_factors)
             .map(|(c, m)| *m * c)
             .fold(NaiveCommitment(vec![]), Add::add);
+        let product = evaluations
+            .iter()
+            .zip(batching_factors)
+            .map(|(&e, &f)| e * f)
+            .sum();
         if folded_commits != self.a {
             return Err(NaiveEvaluationProofError);
         }
@@ -87,7 +92,7 @@ impl CommitmentEvaluationProof for NaiveEvaluationProof {
             .zip(b_vec)
             .map(|(&a, b)| a * b)
             .sum::<TestScalar>();
-        if expected_product != *product {
+        if expected_product != product {
             return Err(NaiveEvaluationProofError);
         }
         transcript.extend_scalars_as_be(&self.a.0);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_evaluation_proof.rs
@@ -72,7 +72,7 @@ impl CommitmentEvaluationProof for DoryEvaluationProof {
         transcript: &mut impl Transcript,
         commit_batch: &[Self::Commitment],
         batching_factors: &[Self::Scalar],
-        product: &Self::Scalar,
+        evaluations: &[Self::Scalar],
         b_point: &[Self::Scalar],
         generators_offset: u64,
         _table_length: usize,
@@ -82,6 +82,11 @@ impl CommitmentEvaluationProof for DoryEvaluationProof {
             commit_batch.iter().map(|c| c.0),
             batching_factors.iter().map(|f| f.0),
         );
+        let product: Self::Scalar = evaluations
+            .iter()
+            .zip(batching_factors)
+            .map(|(&e, &f)| e * f)
+            .sum();
         // Dory PCS Logic
         if generators_offset != 0 {
             return Err(DoryError::InvalidGeneratorsOffset {

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_evaluation_proof.rs
@@ -73,7 +73,7 @@ impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
         transcript: &mut impl Transcript,
         commit_batch: &[Self::Commitment],
         batching_factors: &[Self::Scalar],
-        product: &Self::Scalar,
+        evaluations: &[Self::Scalar],
         b_point: &[Self::Scalar],
         generators_offset: u64,
         _table_length: usize,
@@ -83,6 +83,11 @@ impl CommitmentEvaluationProof for DynamicDoryEvaluationProof {
             commit_batch.iter().map(|c| c.0),
             batching_factors.iter().map(|f| f.0),
         );
+        let product: Self::Scalar = evaluations
+            .iter()
+            .zip(batching_factors)
+            .map(|(&e, &f)| e * f)
+            .sum();
         // Dory PCS Logic
         if generators_offset != 0 {
             return Err(DoryError::InvalidGeneratorsOffset {

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -340,7 +340,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             .collect();
         let evaluation_accessor: IndexMap<_, _> = column_references
             .into_iter()
-            .map(|col| (col, builder.consume_anchored_mle()))
+            .map(|col| (col, builder.consume_mle_evaluation()))
             .collect();
 
         let verifier_evaluations = expr.verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -367,13 +367,12 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         }
 
         // finally, check the MLE evaluations with the inner product proof
-        let product = builder.folded_pcs_proof_evaluation();
         self.evaluation_proof
             .verify_batched_proof(
                 &mut transcript,
                 &pcs_proof_commitments,
-                builder.inner_product_multipliers(),
-                &product,
+                &evaluation_random_scalars,
+                &self.pcs_proof_evaluations,
                 &subclaim.evaluation_point,
                 min_row_num as u64,
                 self.range_length,

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -329,7 +329,6 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             sumcheck_evaluations,
             &self.bit_distributions,
             sumcheck_random_scalars.subpolynomial_multipliers,
-            &evaluation_random_scalars,
             post_result_challenges,
             self.one_evaluation_lengths.clone(),
         );

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -87,7 +87,7 @@ impl ProofPlan for TrivialTestProofPlan {
         _result: Option<&OwnedTable<S>>,
         _one_eval_map: &IndexMap<TableRef, S>,
     ) -> Result<TableEvaluation<S>, ProofError> {
-        assert_eq!(builder.consume_intermediate_mle(), S::ZERO);
+        assert_eq!(builder.consume_mle_evaluation(), S::ZERO);
         builder.produce_sumcheck_subpolynomial_evaluation(
             SumcheckSubpolynomialType::ZeroSum,
             S::from(self.evaluation),
@@ -278,7 +278,7 @@ impl ProofPlan for SquareTestProofPlan {
                     ColumnType::BigInt,
                 ))
                 .unwrap();
-        let res_eval = builder.consume_intermediate_mle();
+        let res_eval = builder.consume_mle_evaluation();
         builder.produce_sumcheck_subpolynomial_evaluation(
             SumcheckSubpolynomialType::Identity,
             res_eval - x_eval * x_eval,
@@ -474,8 +474,8 @@ impl ProofPlan for DoubleSquareTestProofPlan {
                 ColumnType::BigInt,
             ))
             .unwrap();
-        let z_eval = builder.consume_intermediate_mle();
-        let res_eval = builder.consume_intermediate_mle();
+        let z_eval = builder.consume_mle_evaluation();
+        let res_eval = builder.consume_mle_evaluation();
 
         // poly1
         builder.produce_sumcheck_subpolynomial_evaluation(
@@ -681,7 +681,7 @@ impl ProofPlan for ChallengeTestProofPlan {
                 ColumnType::BigInt,
             ))
             .unwrap();
-        let res_eval = builder.consume_intermediate_mle();
+        let res_eval = builder.consume_mle_evaluation();
         builder.produce_sumcheck_subpolynomial_evaluation(
             SumcheckSubpolynomialType::Identity,
             alpha * res_eval - alpha * x_eval * x_eval,

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -70,11 +70,10 @@ impl ProofPlan for EmptyTestQueryExpr {
         _result: Option<&OwnedTable<S>>,
         _one_eval_map: &IndexMap<TableRef, S>,
     ) -> Result<TableEvaluation<S>, ProofError> {
-        let _ = std::iter::repeat_with(|| {
-            assert_eq!(builder.consume_intermediate_mle(), S::ZERO);
-        })
-        .take(self.columns)
-        .collect::<Vec<_>>();
+        assert_eq!(
+            builder.consume_mle_evaluations(self.columns),
+            vec![S::ZERO; self.columns]
+        );
         Ok(TableEvaluation::new(
             vec![S::ZERO; self.columns],
             builder.consume_one_evaluation(),

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -1,6 +1,7 @@
 use super::{SumcheckMleEvaluations, SumcheckSubpolynomialType};
 use crate::base::{bit::BitDistribution, scalar::Scalar};
 use alloc::vec::Vec;
+use core::iter;
 
 /// Track components used to verify a query's proof
 pub struct VerificationBuilder<'a, S: Scalar> {
@@ -72,10 +73,17 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
     /// Consume the evaluation of an anchored MLE used in sumcheck and provide the commitment of the MLE
     ///
     /// An anchored MLE is an MLE where the verifier has access to the commitment
-    pub fn consume_anchored_mle(&mut self) -> S {
+    pub fn consume_mle_evaluation(&mut self) -> S {
         let index = self.consumed_pcs_proof_mles;
         self.consumed_pcs_proof_mles += 1;
         self.mle_evaluations.pcs_proof_evaluations[index]
+    }
+
+    /// Consume multiple MLE evaluations
+    pub fn consume_mle_evaluations(&mut self, count: usize) -> Vec<S> {
+        iter::repeat_with(|| self.consume_mle_evaluation())
+            .take(count)
+            .collect()
     }
 
     /// Consume a bit distribution that describes which bits are constant
@@ -84,13 +92,6 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
         let res = self.bit_distributions[0].clone();
         self.bit_distributions = &self.bit_distributions[1..];
         res
-    }
-
-    /// Consume the evaluation of an intermediate MLE used in sumcheck
-    ///
-    /// An interemdiate MLE is one where the verifier doesn't have access to its commitment
-    pub fn consume_intermediate_mle(&mut self) -> S {
-        self.consume_anchored_mle()
     }
 
     /// Produce the evaluation of a subpolynomial used in sumcheck

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -7,13 +7,10 @@ pub struct VerificationBuilder<'a, S: Scalar> {
     pub mle_evaluations: SumcheckMleEvaluations<'a, S>,
     generator_offset: usize,
     subpolynomial_multipliers: &'a [S],
-    inner_product_multipliers: &'a [S],
     sumcheck_evaluation: S,
     bit_distributions: &'a [BitDistribution],
-    folded_pcs_proof_evaluation: S,
     consumed_one_evaluations: usize,
     consumed_pcs_proof_mles: usize,
-    consumed_intermediate_mles: usize,
     produced_subpolynomials: usize,
     /// The challenges used in creation of the constraints in the proof.
     /// Specifically, these are the challenges that the verifier sends to
@@ -36,25 +33,17 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
         mle_evaluations: SumcheckMleEvaluations<'a, S>,
         bit_distributions: &'a [BitDistribution],
         subpolynomial_multipliers: &'a [S],
-        inner_product_multipliers: &'a [S],
         post_result_challenges: Vec<S>,
         one_evaluation_length_queue: Vec<usize>,
     ) -> Self {
-        assert_eq!(
-            inner_product_multipliers.len(),
-            mle_evaluations.pcs_proof_evaluations.len()
-        );
         Self {
             mle_evaluations,
             generator_offset,
             bit_distributions,
             subpolynomial_multipliers,
-            inner_product_multipliers,
             sumcheck_evaluation: S::zero(),
-            folded_pcs_proof_evaluation: S::zero(),
             consumed_one_evaluations: 0,
             consumed_pcs_proof_mles: 0,
-            consumed_intermediate_mles: 0,
             produced_subpolynomials: 0,
             post_result_challenges,
             one_evaluation_length_queue,
@@ -85,11 +74,8 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
     /// An anchored MLE is an MLE where the verifier has access to the commitment
     pub fn consume_anchored_mle(&mut self) -> S {
         let index = self.consumed_pcs_proof_mles;
-        let multiplier = self.inner_product_multipliers[index];
         self.consumed_pcs_proof_mles += 1;
-        let res = self.mle_evaluations.pcs_proof_evaluations[index];
-        self.folded_pcs_proof_evaluation += multiplier * res;
-        res
+        self.mle_evaluations.pcs_proof_evaluations[index]
     }
 
     /// Consume a bit distribution that describes which bits are constant
@@ -104,7 +90,6 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
     ///
     /// An interemdiate MLE is one where the verifier doesn't have access to its commitment
     pub fn consume_intermediate_mle(&mut self) -> S {
-        self.consumed_intermediate_mles += 1;
         self.consume_anchored_mle()
     }
 
@@ -132,27 +117,6 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
     pub fn sumcheck_evaluation(&self) -> S {
         assert!(self.completed());
         self.sumcheck_evaluation
-    }
-
-    #[allow(
-        clippy::missing_panics_doc,
-        reason = "Panic conditions are self-evident from the completed assertion."
-    )]
-    /// Get folding factors for the pre-result commitments
-    pub fn inner_product_multipliers(&self) -> &[S] {
-        assert!(self.completed());
-        self.inner_product_multipliers
-    }
-
-    #[allow(
-        clippy::missing_panics_doc,
-        reason = "The panic condition is evident due to the assertion ensuring completion."
-    )]
-    /// Get the evaluation of the folded pre-result MLE vectors used in a verifiable query's
-    /// bulletproof
-    pub fn folded_pcs_proof_evaluation(&self) -> S {
-        assert!(self.completed());
-        self.folded_pcs_proof_evaluation
     }
 
     /// Check that the verification builder is completely built up

--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -13,12 +13,10 @@ fn an_empty_sumcheck_polynomial_evaluates_to_zero() {
         mle_evaluations,
         &[][..],
         &[][..],
-        &[][..],
         Vec::new(),
         Vec::new(),
     );
     assert_eq!(builder.sumcheck_evaluation(), Curve25519Scalar::zero());
-    assert_eq!(builder.inner_product_multipliers(), &[]);
 }
 
 #[test]
@@ -36,7 +34,6 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
         mle_evaluations,
         &[][..],
         &subpolynomial_multipliers,
-        &[][..],
         Vec::new(),
         Vec::new(),
     );
@@ -54,52 +51,10 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
 }
 
 #[test]
-fn we_build_up_the_folded_pcs_proof_commitment() {
-    let pcs_proof_evaluations = [
-        Curve25519Scalar::from(123u64),
-        Curve25519Scalar::from(456u64),
-    ];
-    let mle_evaluations = SumcheckMleEvaluations {
-        num_sumcheck_variables: 1,
-        pcs_proof_evaluations: &pcs_proof_evaluations,
-        ..Default::default()
-    };
-    let inner_product_multipliers = [
-        Curve25519Scalar::from(10u64),
-        Curve25519Scalar::from(100u64),
-    ];
-    let mut builder = VerificationBuilder::new(
-        0,
-        mle_evaluations,
-        &[][..],
-        &[][..],
-        &inner_product_multipliers,
-        Vec::new(),
-        Vec::new(),
-    );
-    let eval = builder.consume_anchored_mle();
-    assert_eq!(eval, Curve25519Scalar::from(123u64));
-    let eval = builder.consume_intermediate_mle();
-    assert_eq!(eval, Curve25519Scalar::from(456u64));
-    assert_eq!(
-        builder.inner_product_multipliers(),
-        &[inner_product_multipliers[0], inner_product_multipliers[1]]
-    );
-    let expected_folded_pcs_proof_evaluation = inner_product_multipliers[0]
-        * Curve25519Scalar::from(123u64)
-        + inner_product_multipliers[1] * Curve25519Scalar::from(456u64);
-    assert_eq!(
-        builder.folded_pcs_proof_evaluation(),
-        expected_folded_pcs_proof_evaluation
-    );
-}
-
-#[test]
 fn we_can_consume_post_result_challenges_in_proof_builder() {
     let mut builder = VerificationBuilder::new(
         0,
         SumcheckMleEvaluations::default(),
-        &[][..],
         &[][..],
         &[][..],
         vec![

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -92,7 +92,7 @@ impl ProofExpr for AndExpr {
         let rhs = self.rhs.verifier_evaluate(builder, accessor, one_eval)?;
 
         // lhs_and_rhs
-        let lhs_and_rhs = builder.consume_intermediate_mle();
+        let lhs_and_rhs = builder.consume_mle_evaluation();
 
         // subpolynomial: lhs_and_rhs - lhs * rhs
         builder.produce_sumcheck_subpolynomial_evaluation(

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -154,8 +154,8 @@ pub fn verifier_evaluate_equals_zero<S: Scalar>(
     one_eval: S,
 ) -> S {
     // consume mle evaluations
-    let lhs_pseudo_inv_eval = builder.consume_intermediate_mle();
-    let selection_not_eval = builder.consume_intermediate_mle();
+    let lhs_pseudo_inv_eval = builder.consume_mle_evaluation();
+    let selection_not_eval = builder.consume_mle_evaluation();
     let selection_eval = one_eval - selection_not_eval;
 
     // subpolynomial: selection * lhs

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -94,7 +94,7 @@ impl ProofExpr for MultiplyExpr {
         let rhs = self.rhs.verifier_evaluate(builder, accessor, one_eval)?;
 
         // lhs_times_rhs
-        let lhs_times_rhs = builder.consume_intermediate_mle();
+        let lhs_times_rhs = builder.consume_mle_evaluation();
 
         // subpolynomial: lhs_times_rhs - lhs * rhs
         builder.produce_sumcheck_subpolynomial_evaluation(

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -134,7 +134,7 @@ pub fn verifier_evaluate_or<S: Scalar>(
     rhs: &S,
 ) -> S {
     // lhs_and_rhs
-    let lhs_and_rhs = builder.consume_intermediate_mle();
+    let lhs_and_rhs = builder.consume_mle_evaluation();
 
     // subpolynomial: lhs_and_rhs - lhs * rhs
     builder.produce_sumcheck_subpolynomial_evaluation(

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr.rs
@@ -136,7 +136,7 @@ pub fn verifier_evaluate_sign<S: Scalar>(
     // bits of the expression
     let mut bit_evals = Vec::with_capacity(num_varying_bits);
     for _ in 0..num_varying_bits {
-        let eval = builder.consume_intermediate_mle();
+        let eval = builder.consume_mle_evaluation();
         bit_evals.push(eval);
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/sign_expr_test.rs
@@ -66,15 +66,8 @@ fn we_can_verify_a_constant_decomposition() {
     let one_evals = sumcheck_evaluations.one_evaluations.clone();
     let one_eval = one_evals.values().next().unwrap();
 
-    let mut builder = VerificationBuilder::new(
-        0,
-        sumcheck_evaluations,
-        &dists,
-        &[],
-        &[],
-        Vec::new(),
-        Vec::new(),
-    );
+    let mut builder =
+        VerificationBuilder::new(0, sumcheck_evaluations, &dists, &[], Vec::new(), Vec::new());
     let data_eval = (&data).evaluate_at_point(&evaluation_point);
     let eval = verifier_evaluate_sign(&mut builder, data_eval, *one_eval).unwrap();
     assert_eq!(eval, Curve25519Scalar::zero());
@@ -98,15 +91,8 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
     let one_evals = sumcheck_evaluations.one_evaluations.clone();
     let one_eval = one_evals.values().next().unwrap();
 
-    let mut builder = VerificationBuilder::new(
-        0,
-        sumcheck_evaluations,
-        &dists,
-        &[],
-        &[],
-        Vec::new(),
-        Vec::new(),
-    );
+    let mut builder =
+        VerificationBuilder::new(0, sumcheck_evaluations, &dists, &[], Vec::new(), Vec::new());
     let data_eval = Curve25519Scalar::from(2) * (&data).evaluate_at_point(&evaluation_point);
     assert!(verifier_evaluate_sign(&mut builder, data_eval, *one_eval).is_err());
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
-use core::{iter::repeat_with, marker::PhantomData};
+use core::marker::PhantomData;
 use num_traits::{One, Zero};
 use serde::{Deserialize, Serialize};
 
@@ -99,9 +99,7 @@ where
                 .collect::<Result<Vec<_>, _>>()?,
         );
         // 3. filtered_columns
-        let filtered_columns_evals: Vec<_> = repeat_with(|| builder.consume_intermediate_mle())
-            .take(self.aliased_results.len())
-            .collect();
+        let filtered_columns_evals = builder.consume_mle_evaluations(self.aliased_results.len());
         assert!(filtered_columns_evals.len() == self.aliased_results.len());
 
         let alpha = builder.consume_post_result_challenge();
@@ -262,8 +260,8 @@ pub(super) fn verify_filter<S: Scalar>(
 ) -> Result<(), ProofError> {
     let c_fold_eval = alpha * fold_vals(beta, c_evals);
     let d_fold_eval = alpha * fold_vals(beta, d_evals);
-    let c_star_eval = builder.consume_intermediate_mle();
-    let d_star_eval = builder.consume_intermediate_mle();
+    let c_star_eval = builder.consume_mle_evaluation();
+    let d_star_eval = builder.consume_mle_evaluation();
 
     // sum c_star * s - d_star = 0
     builder.produce_sumcheck_subpolynomial_evaluation(

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use alloc::vec::Vec;
 use bumpalo::Bump;
-use core::iter::repeat_with;
 use serde::{Deserialize, Serialize};
 
 /// Provable expressions for queries of the form
@@ -69,9 +68,7 @@ impl ProofPlan for ProjectionExec {
                     .verifier_evaluate(builder, accessor, one_eval)
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let column_evals = repeat_with(|| builder.consume_intermediate_mle())
-            .take(self.aliased_results.len())
-            .collect::<Vec<_>>();
+        let column_evals = builder.consume_mle_evaluations(self.aliased_results.len());
         Ok(TableEvaluation::new(column_evals, one_eval))
     }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec::Vec};
 use bumpalo::Bump;
-use core::iter::{repeat, repeat_with};
+use core::iter::repeat;
 use itertools::repeat_n;
 use serde::{Deserialize, Serialize};
 
@@ -85,9 +85,7 @@ where
         let max_one_eval = builder.consume_one_evaluation();
         let selection_eval = max_one_eval - offset_one_eval;
         // 3. filtered_columns
-        let filtered_columns_evals: Vec<_> = repeat_with(|| builder.consume_intermediate_mle())
-            .take(columns_evals.len())
-            .collect();
+        let filtered_columns_evals = builder.consume_mle_evaluations(columns_evals.len());
         let alpha = builder.consume_post_result_challenge();
         let beta = builder.consume_post_result_challenge();
 


### PR DESCRIPTION
# Rationale for this change

The `VerificationBuilder` should be simplified for easier porting to Solidity.

# What changes are included in this PR?

See individual commits.

# Are these changes tested?
Yes, by existing code.