### PR TITLE
fix: dynamic dory commitment GPU computation should handle empty committable columns

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -57,6 +57,10 @@ pub fn signed_commits(
     all_sub_commits: &Vec<G1Affine>,
     committable_columns: &[CommittableColumn],
 ) -> Vec<G1Affine> {
+    if committable_columns.is_empty() {
+        return vec![];
+    }
+
     if_rayon!(
         all_sub_commits.par_chunks_exact(committable_columns.len() * 2),
         all_sub_commits.chunks_exact(committable_columns.len() * 2)
@@ -143,6 +147,10 @@ pub fn create_blitzar_metadata_tables(
     committable_columns: &[CommittableColumn],
     offset: usize,
 ) -> (Vec<u32>, Vec<u32>, Vec<u8>) {
+    if committable_columns.is_empty() {
+        return (vec![], vec![], vec![]);
+    }
+
     // Keep track of the lengths of the columns to handled signed data columns.
     let ones_columns_lengths = committable_columns
         .iter()
@@ -296,6 +304,11 @@ mod tests {
             scalars, expected_scalars,
             "Scalars mismatch for offset {offset}"
         );
+    }
+
+    #[test]
+    fn we_can_handle_empty_committable_columns_in_blitzar_metadata_tables() {
+        assert_blitzar_metadata(&[], 0, &[], &[], &[]);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_gpu.rs
@@ -34,6 +34,10 @@ pub(super) fn compute_dynamic_dory_commitments(
     offset: usize,
     setup: &ProverSetup,
 ) -> Vec<DynamicDoryCommitment> {
+    if committable_columns.is_empty() {
+        return vec![];
+    }
+
     let Gamma_2 = setup.Gamma_2.last().unwrap();
     let (gamma_2_offset, _) = row_and_column_from_index(offset);
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
@@ -9,6 +9,15 @@ use num_traits::Zero;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
 #[test]
+fn we_can_handle_calling_with_an_empty_committable_column() {
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let setup = ProverSetup::from(&public_parameters);
+    let res = compute_dynamic_dory_commitments(&[], 0, &setup);
+
+    assert!(res.is_empty());
+}
+
+#[test]
 fn we_can_compute_a_dynamic_dory_commitment_with_unsigned_bigint_values() {
     let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
     let setup = ProverSetup::from(&public_parameters);


### PR DESCRIPTION
# Rationale for this change
The dynamic Dory commitment computation on the GPU will try to divide by zero if it is provided an empty commitable column vector. This PR fixes the empty committable column vector case.

# What changes are included in this PR?
- The `dynamic_dory_commitment_helper_gpu` and `blitzar_metadata_tables` modules handle empty committable column vectors.
- Tests are added for empty committable column cases.

# Are these changes tested?
Yes