### PR TITLE
perf: reduce sumcheck memory usage

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -1,5 +1,5 @@
 use crate::base::{database::Column, if_rayon, scalar::Scalar, slice_ops};
-use alloc::{rc::Rc, vec::Vec};
+use alloc::vec::Vec;
 use core::{ffi::c_void, fmt::Debug};
 use num_traits::Zero;
 #[cfg(feature = "rayon")]
@@ -15,7 +15,7 @@ pub trait MultilinearExtension<S: Scalar>: Debug {
     fn mul_add(&self, res: &mut [S], multiplier: &S);
 
     /// convert the MLE to a form that can be used in sumcheck
-    fn to_sumcheck_term(&self, num_vars: usize) -> Rc<Vec<S>>;
+    fn to_sumcheck_term(&self, num_vars: usize) -> Vec<S>;
 
     /// pointer to identify the slice forming the MLE
     fn id(&self) -> (*const c_void, usize);
@@ -42,18 +42,17 @@ where
         slice_ops::mul_add_assign(res, *multiplier, &slice_ops::slice_cast(self));
     }
 
-    fn to_sumcheck_term(&self, num_vars: usize) -> Rc<Vec<S>> {
+    fn to_sumcheck_term(&self, num_vars: usize) -> Vec<S> {
         let values = self;
         let n = 1 << num_vars;
         assert!(n >= values.len());
-        let scalars = if_rayon!(values.par_iter(), values.iter())
+        if_rayon!(values.par_iter(), values.iter())
             .map(Into::into)
             .chain(if_rayon!(
                 rayon::iter::repeatn(Zero::zero(), n - values.len()),
                 itertools::repeat_n(Zero::zero(), n - values.len())
             ))
-            .collect();
-        Rc::new(scalars)
+            .collect()
     }
 
     fn id(&self) -> (*const c_void, usize) {
@@ -72,7 +71,7 @@ macro_rules! slice_like_mle_impl {
             (&self[..]).mul_add(res, multiplier)
         }
 
-        fn to_sumcheck_term(&self, num_vars: usize) -> Rc<Vec<S>> {
+        fn to_sumcheck_term(&self, num_vars: usize) -> Vec<S> {
             (&self[..]).to_sumcheck_term(num_vars)
         }
 
@@ -127,7 +126,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
         }
     }
 
-    fn to_sumcheck_term(&self, num_vars: usize) -> Rc<Vec<S>> {
+    fn to_sumcheck_term(&self, num_vars: usize) -> Vec<S> {
         match self {
             Column::Boolean(c) => c.to_sumcheck_term(num_vars),
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
@@ -167,7 +166,7 @@ impl<S: Scalar> MultilinearExtension<S> for Column<'_, S> {
         (&self).mul_add(res, multiplier);
     }
 
-    fn to_sumcheck_term(&self, num_vars: usize) -> Rc<Vec<S>> {
+    fn to_sumcheck_term(&self, num_vars: usize) -> Vec<S> {
         (&self).to_sumcheck_term(num_vars)
     }
 

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -32,7 +32,7 @@ impl<S: Scalar> CompositePolynomialBuilder<S> {
             fr_multiplicands_degree1: vec![Zero::zero(); fr.len()],
             fr_multiplicands_rest: vec![],
             zerosum_multiplicands: vec![],
-            fr: fr.to_sumcheck_term(num_sumcheck_variables),
+            fr: fr.to_sumcheck_term(num_sumcheck_variables).into(),
             mles: IndexMap::default(),
         }
     }
@@ -89,8 +89,8 @@ impl<S: Scalar> CompositePolynomialBuilder<S> {
                 deduplicated_terms.push(cached_term.clone());
             } else {
                 let new_term = term.to_sumcheck_term(self.num_sumcheck_variables);
-                self.mles.insert(id, new_term.clone());
-                deduplicated_terms.push(new_term);
+                self.mles.insert(id, new_term.clone().into());
+                deduplicated_terms.push(new_term.into());
             }
         }
         deduplicated_terms
@@ -103,7 +103,9 @@ impl<S: Scalar> CompositePolynomialBuilder<S> {
         res.add_product(
             [
                 self.fr.clone(),
-                (&self.fr_multiplicands_degree1).to_sumcheck_term(self.num_sumcheck_variables),
+                (&self.fr_multiplicands_degree1)
+                    .to_sumcheck_term(self.num_sumcheck_variables)
+                    .into(),
             ],
             One::one(),
         );

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder_test.rs
@@ -33,7 +33,7 @@ fn we_dont_duplicate_repeated_mles() {
     builder.produce_fr_multiplicand(&One::one(), &[Box::new(&mle1), Box::new(&mle2)]);
     let p = builder.make_composite_polynomial();
     assert_eq!(p.products.len(), 3);
-    assert_eq!(p.flattened_ml_extensions.len(), 4);
+    assert_eq!(p.flattened_ml_extensions.len(), 5);
     let pt = [Curve25519Scalar::from(9_268_764_u64)];
     let m0 = Curve25519Scalar::one() - pt[0];
     let m1 = pt[0];

--- a/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
+++ b/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
@@ -97,11 +97,11 @@ impl<'a, S: Scalar> FlattenedMLEBuilder<'a, S> {
     fn flattened_ml_extensions(self) -> Vec<Vec<S>> {
         self.entrywise_multipliers
             .into_iter()
-            .map(|mle| (&mle).to_sumcheck_term(self.num_vars).as_ref().clone())
+            .map(|mle| (&mle).to_sumcheck_term(self.num_vars))
             .chain(
                 self.all_ml_extensions
                     .iter()
-                    .map(|mle| mle.to_sumcheck_term(self.num_vars).as_ref().clone()),
+                    .map(|mle| mle.to_sumcheck_term(self.num_vars)),
             )
             .collect()
     }

--- a/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
+++ b/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
@@ -1,107 +1,269 @@
-use super::{CompositePolynomialBuilder, SumcheckRandomScalars, SumcheckSubpolynomial};
+use super::{SumcheckRandomScalars, SumcheckSubpolynomial, SumcheckSubpolynomialType};
 use crate::{
-    base::{polynomial::CompositePolynomial, scalar::Scalar},
+    base::{polynomial::MultilinearExtension, scalar::Scalar},
     proof_primitive::sumcheck::ProverState,
 };
+use alloc::vec::Vec;
+use itertools::Itertools;
 
+#[tracing::instrument(
+    name = "query_proof::make_sumcheck_prover_state",
+    level = "debug",
+    skip_all
+)]
 pub fn make_sumcheck_prover_state<S: Scalar>(
     subpolynomials: &[SumcheckSubpolynomial<'_, S>],
     num_vars: usize,
     scalars: &SumcheckRandomScalars<S>,
 ) -> ProverState<S> {
-    ProverState::create(&make_sumcheck_polynomial(subpolynomials, num_vars, scalars))
-}
-
-/// Given random multipliers, construct an aggregatated sumcheck polynomial from all
-/// the individual subpolynomials.
-#[tracing::instrument(name = "proof::make_sumcheck_polynomial", level = "debug", skip_all)]
-fn make_sumcheck_polynomial<S: Scalar>(
-    subpolynomials: &[SumcheckSubpolynomial<'_, S>],
-    num_vars: usize,
-    scalars: &SumcheckRandomScalars<S>,
-) -> CompositePolynomial<S> {
-    let mut builder =
-        CompositePolynomialBuilder::new(num_vars, &scalars.compute_entrywise_multipliers());
-    for (multiplier, subpoly) in scalars
+    let needs_entrywise_multipliers = subpolynomials
+        .iter()
+        .any(|s| matches!(s.subpolynomial_type(), SumcheckSubpolynomialType::Identity));
+    let all_terms = scalars
         .subpolynomial_multipliers
         .iter()
-        .zip(subpolynomials.iter())
-    {
-        subpoly.compose(&mut builder, *multiplier);
+        .zip(subpolynomials)
+        .flat_map(|(multiplier, terms)| terms.iter_mul_by(*multiplier));
+    let mut builder = FlattenedMLEBuilder::new(
+        needs_entrywise_multipliers.then(|| scalars.compute_entrywise_multipliers()),
+        num_vars,
+    );
+    let list_of_products = all_terms
+        .map(|(ty, coeff, term)| {
+            (
+                coeff,
+                term.iter()
+                    .map(|multiplicand| builder.position_or_insert(multiplicand.as_ref()))
+                    .chain(matches!(ty, SumcheckSubpolynomialType::Identity).then_some(0))
+                    .collect_vec(),
+            )
+        })
+        .collect_vec();
+    let max_multiplicands = list_of_products
+        .iter()
+        .map(|(_, p)| p.len())
+        .max()
+        .unwrap_or(0);
+    ProverState::new(
+        list_of_products,
+        builder.flattened_ml_extensions(),
+        num_vars,
+        max_multiplicands,
+    )
+}
+
+struct FlattenedMLEBuilder<'a, S: Scalar> {
+    multiplicand_count: usize,
+    all_ml_extensions: Vec<&'a dyn MultilinearExtension<S>>,
+    entrywise_multipliers: Option<Vec<S>>,
+    num_vars: usize,
+}
+impl<'a, S: Scalar> FlattenedMLEBuilder<'a, S> {
+    fn new(entrywise_multipliers: Option<Vec<S>>, num_vars: usize) -> Self {
+        Self {
+            multiplicand_count: entrywise_multipliers.is_some().into(),
+            all_ml_extensions: Vec::new(),
+            entrywise_multipliers,
+            num_vars,
+        }
     }
-    builder.make_composite_polynomial()
+    fn position_or_insert(&mut self, multiplicand: &'a dyn MultilinearExtension<S>) -> usize {
+        self.all_ml_extensions.push(multiplicand);
+        self.multiplicand_count += 1;
+        self.multiplicand_count - 1
+    }
+    #[tracing::instrument(
+        name = "FlattenedMLEBuilder::flattened_ml_extensions",
+        level = "debug",
+        skip_all
+    )]
+    fn flattened_ml_extensions(self) -> Vec<Vec<S>> {
+        self.entrywise_multipliers
+            .into_iter()
+            .map(|mle| (&mle).to_sumcheck_term(self.num_vars).as_ref().clone())
+            .chain(
+                self.all_ml_extensions
+                    .iter()
+                    .map(|mle| mle.to_sumcheck_term(self.num_vars).as_ref().clone()),
+            )
+            .collect()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        base::{
-            polynomial::{compute_evaluation_vector, CompositePolynomial, MultilinearExtension},
-            scalar::Curve25519Scalar,
-        },
-        sql::proof::SumcheckSubpolynomialType,
-    };
+    use crate::base::scalar::test_scalar::TestScalar;
     use alloc::boxed::Box;
-    use num_traits::{One, Zero};
 
     #[test]
-    fn we_can_form_an_aggregated_sumcheck_polynomial() {
-        let mle1 = [1, 2, -1];
-        let mle2 = [10i64, 20, 100, 30];
-        let mle3 = [2000i64, 3000, 5000, 7000];
+    fn we_can_make_sumcheck_prover_state() {
+        let mle1 = &[1, 2];
+        let mle2 = &[3, 4];
 
-        let subpolynomials = &[
+        let subpolynomials = vec![
             SumcheckSubpolynomial::new(
                 SumcheckSubpolynomialType::Identity,
-                vec![(-Curve25519Scalar::one(), vec![Box::new(&mle1)])],
-            ),
-            SumcheckSubpolynomial::new(
-                SumcheckSubpolynomialType::Identity,
-                vec![(-Curve25519Scalar::from(10u64), vec![Box::new(&mle2)])],
+                vec![
+                    (TestScalar::from(101), vec![Box::new(mle1)]),
+                    (TestScalar::from(102), vec![Box::new(mle2), Box::new(mle1)]),
+                ],
             ),
             SumcheckSubpolynomial::new(
                 SumcheckSubpolynomialType::ZeroSum,
-                vec![(Curve25519Scalar::from(9876u64), vec![Box::new(&mle3)])],
+                vec![
+                    (TestScalar::from(103), vec![Box::new(mle1)]),
+                    (TestScalar::from(104), vec![Box::new(mle2), Box::new(mle1)]),
+                ],
             ),
         ];
 
-        let multipliers = [
-            Curve25519Scalar::from(5u64),
-            Curve25519Scalar::from(2u64),
-            Curve25519Scalar::from(50u64),
-            Curve25519Scalar::from(25u64),
-            Curve25519Scalar::from(11u64),
+        let scalars = vec![
+            TestScalar::from(201),
+            TestScalar::from(202),
+            TestScalar::from(203),
+        ];
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 2, 1);
+
+        let prover_state = make_sumcheck_prover_state(&subpolynomials, 1, &random_scalars);
+
+        assert_eq!(
+            prover_state.list_of_products,
+            vec![
+                (TestScalar::from(101 * 202), vec![1, 0]),
+                (TestScalar::from(102 * 202), vec![2, 3, 0]),
+                (TestScalar::from(103 * 203), vec![4]),
+                (TestScalar::from(104 * 203), vec![5, 6])
+            ]
+        );
+        assert_eq!(
+            prover_state.flattened_ml_extensions,
+            vec![
+                vec![TestScalar::from(1 - 201), TestScalar::from(201)],
+                vec![TestScalar::from(1), TestScalar::from(2)],
+                vec![TestScalar::from(3), TestScalar::from(4)],
+                vec![TestScalar::from(1), TestScalar::from(2)],
+                vec![TestScalar::from(1), TestScalar::from(2)],
+                vec![TestScalar::from(3), TestScalar::from(4)],
+                vec![TestScalar::from(1), TestScalar::from(2)],
+            ]
+        );
+        assert_eq!(prover_state.num_vars, 1);
+        assert_eq!(prover_state.max_multiplicands, 3);
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn we_can_make_complex_sumcheck_prover_state() {
+        let mle1 = &[0; 0];
+        let mle2 = &[1];
+        let mle3 = &[2, 3];
+        let mle4 = &[4, 5, 6, 7, 8];
+
+        let subpolynomials = vec![
+            SumcheckSubpolynomial::new(
+                SumcheckSubpolynomialType::Identity,
+                vec![
+                    (TestScalar::from(101), vec![]),
+                    (TestScalar::from(102), vec![]),
+                    (TestScalar::from(103), vec![Box::new(mle1)]),
+                    (TestScalar::from(104), vec![Box::new(mle2)]),
+                ],
+            ),
+            SumcheckSubpolynomial::new(
+                SumcheckSubpolynomialType::Identity,
+                vec![
+                    (TestScalar::from(105), vec![Box::new(mle2), Box::new(mle3)]),
+                    (
+                        TestScalar::from(106),
+                        vec![Box::new(mle1), Box::new(mle2), Box::new(mle4)],
+                    ),
+                ],
+            ),
+            SumcheckSubpolynomial::new(
+                SumcheckSubpolynomialType::ZeroSum,
+                vec![
+                    (TestScalar::from(107), vec![]),
+                    (TestScalar::from(108), vec![]),
+                    (TestScalar::from(109), vec![Box::new(mle3)]),
+                    (TestScalar::from(110), vec![Box::new(mle4)]),
+                ],
+            ),
+            SumcheckSubpolynomial::new(
+                SumcheckSubpolynomialType::ZeroSum,
+                vec![
+                    (TestScalar::from(111), vec![Box::new(mle1), Box::new(mle2)]),
+                    (
+                        TestScalar::from(112),
+                        vec![Box::new(mle3), Box::new(mle2), Box::new(mle4)],
+                    ),
+                ],
+            ),
         ];
 
-        let mut evaluation_vector = vec![Zero::zero(); 4];
-        compute_evaluation_vector(&mut evaluation_vector, &multipliers[..2]);
-
-        let poly = make_sumcheck_polynomial(
-            subpolynomials,
-            2,
-            &SumcheckRandomScalars::new(&multipliers, 4, 2),
-        );
-        let mut expected_poly = CompositePolynomial::new(2);
-        let fr = (&evaluation_vector).to_sumcheck_term(2);
-        expected_poly.add_product(
-            [fr.clone(), (&mle1).to_sumcheck_term(2)],
-            -Curve25519Scalar::from(1u64) * multipliers[2],
-        );
-        expected_poly.add_product(
-            [fr, (&mle2).to_sumcheck_term(2)],
-            -Curve25519Scalar::from(10u64) * multipliers[3],
-        );
-        expected_poly.add_product(
-            [(&mle3).to_sumcheck_term(2)],
-            Curve25519Scalar::from(9876u64) * multipliers[4],
-        );
-        let random_point = [
-            Curve25519Scalar::from(123u64),
-            Curve25519Scalar::from(101_112_u64),
+        let scalars = vec![
+            TestScalar::from(201),
+            TestScalar::from(202),
+            TestScalar::from(203),
+            TestScalar::from(204),
+            TestScalar::from(205),
+            TestScalar::from(206),
+            TestScalar::from(207),
         ];
-        let eval = poly.evaluate(&random_point);
-        let expected_eval = expected_poly.evaluate(&random_point);
-        assert_eq!(eval, expected_eval);
+        let random_scalars = SumcheckRandomScalars::new(&scalars, 6, 3);
+
+        let prover_state = make_sumcheck_prover_state(&subpolynomials, 3, &random_scalars);
+
+        assert_eq!(
+            prover_state.list_of_products,
+            vec![
+                (TestScalar::from(101 * 204), vec![0]),
+                (TestScalar::from(102 * 204), vec![0]),
+                (TestScalar::from(103 * 204), vec![1, 0]),
+                (TestScalar::from(104 * 204), vec![2, 0]),
+                (TestScalar::from(105 * 205), vec![3, 4, 0]),
+                (TestScalar::from(106 * 205), vec![5, 6, 7, 0]),
+                (TestScalar::from(107 * 206), vec![]),
+                (TestScalar::from(108 * 206), vec![]),
+                (TestScalar::from(109 * 206), vec![8]),
+                (TestScalar::from(110 * 206), vec![9]),
+                (TestScalar::from(111 * 207), vec![10, 11]),
+                (TestScalar::from(112 * 207), vec![12, 13, 14])
+            ]
+        );
+        assert_eq!(
+            prover_state.flattened_ml_extensions,
+            vec![
+                vec![
+                    (1 - 201) * (1 - 202) * (1 - 203),
+                    201 * (1 - 202) * (1 - 203),
+                    (1 - 201) * 202 * (1 - 203),
+                    201 * 202 * (1 - 203),
+                    (1 - 201) * (1 - 202) * 203,
+                    201 * (1 - 202) * 203,
+                    0,
+                    0
+                ],
+                vec![0, 0, 0, 0, 0, 0, 0, 0],
+                vec![1, 0, 0, 0, 0, 0, 0, 0],
+                vec![1, 0, 0, 0, 0, 0, 0, 0],
+                vec![2, 3, 0, 0, 0, 0, 0, 0],
+                vec![0, 0, 0, 0, 0, 0, 0, 0],
+                vec![1, 0, 0, 0, 0, 0, 0, 0],
+                vec![4, 5, 6, 7, 8, 0, 0, 0],
+                vec![2, 3, 0, 0, 0, 0, 0, 0],
+                vec![4, 5, 6, 7, 8, 0, 0, 0],
+                vec![0, 0, 0, 0, 0, 0, 0, 0],
+                vec![1, 0, 0, 0, 0, 0, 0, 0],
+                vec![2, 3, 0, 0, 0, 0, 0, 0],
+                vec![1, 0, 0, 0, 0, 0, 0, 0],
+                vec![4, 5, 6, 7, 8, 0, 0, 0],
+            ]
+            .into_iter()
+            .map(|v| v.into_iter().map(TestScalar::from).collect_vec())
+            .collect_vec()
+        );
+        assert_eq!(prover_state.num_vars, 3);
+        assert_eq!(prover_state.max_multiplicands, 4);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -70,3 +70,5 @@ mod first_round_builder_test;
 mod provable_query_result_test;
 
 mod make_sumcheck_state;
+
+mod sumcheck_term_optimizer;

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -346,8 +346,6 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         // verify sumcheck up to the evaluation check
         let subclaim = self.sumcheck_proof.verify_without_evaluation(
             &mut transcript,
-            // This needs to be at least 2 since `CompositePolynomialBuilder::make_composite_polynomial`
-            // always adds a degree 2 term.
             num_sumcheck_variables,
             &Zero::zero(),
         )?;

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -3,7 +3,7 @@ use crate::base::{polynomial::MultilinearExtension, scalar::Scalar};
 use alloc::{boxed::Box, vec::Vec};
 
 /// The type of a sumcheck subpolynomial
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum SumcheckSubpolynomialType {
     /// The subpolynomial should be zero at every entry/row
     Identity,
@@ -82,15 +82,11 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
         Item = (
             SumcheckSubpolynomialType,
             S,
-            &[Box<dyn MultilinearExtension<S> + 'a>],
+            &Vec<Box<dyn MultilinearExtension<S> + 'a>>,
         ),
     > {
         self.terms.iter().map(move |(coeff, multiplicands)| {
-            (
-                self.subpolynomial_type,
-                multiplier * *coeff,
-                multiplicands.as_slice(),
-            )
+            (self.subpolynomial_type, multiplier * *coeff, multiplicands)
         })
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_term_optimizer.rs
@@ -1,0 +1,143 @@
+use super::SumcheckSubpolynomialType;
+use crate::base::{map::IndexMap, polynomial::MultilinearExtension, scalar::Scalar};
+use alloc::{boxed::Box, vec, vec::Vec};
+use core::{
+    iter::{Chain, Copied, Flatten, Map},
+    slice,
+};
+
+type SumcheckTerm<'a, S> = Vec<Box<dyn MultilinearExtension<S> + 'a>>;
+
+pub struct SumcheckTermOptimizer<'a, S: Scalar> {
+    merged_terms: Vec<(SumcheckSubpolynomialType, S, Vec<Vec<S>>)>,
+    old_grouped_terms: Vec<Vec<(SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>)>>,
+}
+pub struct OptimizedSumcheckTerms<'a, S: Scalar> {
+    old_grouped_terms: &'a Vec<Vec<(SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>)>>,
+    new_mle_terms: Vec<(SumcheckSubpolynomialType, S, SumcheckTerm<'a, S>)>,
+}
+
+fn merge_subquadratic_terms<'a, S: Scalar + 'a>(
+    maybe_constant_terms: Option<Vec<(SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>)>>,
+    maybe_linear_terms: Option<Vec<(SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>)>>,
+    merged_terms: &mut Vec<(SumcheckSubpolynomialType, S, Vec<Vec<S>>)>,
+    term_length: usize,
+    ty: SumcheckSubpolynomialType,
+) -> Option<Vec<(SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>)>> {
+    let maybe_constant_sum =
+        maybe_constant_terms.map(|terms| terms.into_iter().map(|(_, coeff, _)| coeff).sum());
+
+    match (maybe_constant_sum, maybe_linear_terms) {
+        (Some(constant_sum), None) => {
+            merged_terms.push((ty, constant_sum, vec![]));
+            None
+        }
+        (maybe_constant_sum, Some(linear_terms))
+            if maybe_constant_sum.is_some() || linear_terms.len() >= 2 =>
+        {
+            let mut combined_term = vec![maybe_constant_sum.unwrap_or(S::ZERO); term_length];
+            for (_, coeff, linear_term) in linear_terms {
+                linear_term[0].mul_add(&mut combined_term, &coeff);
+            }
+            merged_terms.push((ty, S::ONE, vec![combined_term]));
+            None
+        }
+        (_, maybe_linear_terms) => maybe_linear_terms,
+    }
+}
+
+impl<'a, S: Scalar + 'a> SumcheckTermOptimizer<'a, S> {
+    pub fn new(
+        all_terms: impl Iterator<Item = (SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>)>,
+        term_length: usize,
+    ) -> Self {
+        let mut groups = all_terms.fold(
+            IndexMap::<_, Vec<_>>::default(),
+            |mut lookup, (ty, coeff, multiplicands)| {
+                lookup
+                    .entry((ty, multiplicands.len().min(2)))
+                    .or_default()
+                    .push((ty, coeff, multiplicands));
+                lookup
+            },
+        );
+        let mut merged_terms = Vec::with_capacity(2);
+        let old_grouped_terms = [
+            SumcheckSubpolynomialType::ZeroSum,
+            SumcheckSubpolynomialType::Identity,
+        ]
+        .into_iter()
+        .flat_map(|ty| {
+            let maybe_constant_terms = groups.swap_remove(&(ty, 0));
+            let maybe_linear_terms = groups.swap_remove(&(ty, 1));
+            let maybe_superlinear_terms = groups.swap_remove(&(ty, 2));
+
+            let maybe_combined_terms = merge_subquadratic_terms(
+                maybe_constant_terms,
+                maybe_linear_terms,
+                &mut merged_terms,
+                term_length,
+                ty,
+            );
+
+            [maybe_combined_terms, maybe_superlinear_terms]
+                .into_iter()
+                .flatten()
+        })
+        .collect();
+
+        Self {
+            merged_terms,
+            old_grouped_terms,
+        }
+    }
+}
+
+impl<'a, S: Scalar + 'a> SumcheckTermOptimizer<'a, S> {
+    pub fn terms(&'a self) -> OptimizedSumcheckTerms<'a, S> {
+        OptimizedSumcheckTerms {
+            old_grouped_terms: &self.old_grouped_terms,
+            new_mle_terms: self
+                .merged_terms
+                .iter()
+                .map(|(ty, coeff, terms)| {
+                    (
+                        *ty,
+                        *coeff,
+                        terms
+                            .iter()
+                            .map(|mle| -> Box<dyn MultilinearExtension<S>> { Box::new(mle) })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl<'a, S: Scalar + 'a> IntoIterator for &'a OptimizedSumcheckTerms<'a, S> {
+    type Item = (SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>);
+
+    // Currently, `impl Trait` in associated types is unstable. We can change this to the following when it stabilizes:
+    // type IntoIter = impl Iterator<Item = (SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>)>;
+    type IntoIter = Chain<
+        Copied<
+            Flatten<slice::Iter<'a, Vec<(SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>)>>>,
+        >,
+        Map<
+            slice::Iter<'a, (SumcheckSubpolynomialType, S, SumcheckTerm<'a, S>)>,
+            fn(
+                &'a (SumcheckSubpolynomialType, S, SumcheckTerm<'a, S>),
+            ) -> (SumcheckSubpolynomialType, S, &'a SumcheckTerm<'a, S>),
+        >,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let result = self.old_grouped_terms.iter().flatten().copied().chain(
+            self.new_mle_terms
+                .iter()
+                .map((|(ty, coeff, terms)| (*ty, *coeff, terms)) as fn(&'a _) -> _),
+        );
+        result
+    }
+}


### PR DESCRIPTION
# Rationale for this change

The sumcheck prover currently consumes a lot of memory.

# What changes are included in this PR?

See individual commits. Broadly speaking, this is just a refactor of `make_sumcheck_prover_state`, so it is fairly isolated.

# Are these changes tested?
Yes