### PR TITLE
refactor!: identifier to ident and update docs

### DIFF
--- a/crates/proof-of-sql/README.md
+++ b/crates/proof-of-sql/README.md
@@ -90,7 +90,7 @@ Parsing Query... 1.870256ms
 Generating Proof... 467.45371ms
 Verifying Proof... 7.106864ms
 Valid proof!
-Query result: OwnedTable { table: {Identifier { name: "b" }: VarChar(["hello", "world"])} }
+Query result: OwnedTable { table: {Ident { value: "b", quote_style: None }: VarChar(["hello", "world"])} }
 ```
 
 For a detailed explanation of the example and its implementation, refer to the [README](https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/crates/proof-of-sql/examples/hello_world/README.md) and source code in [hello_world/main.rs](https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/crates/proof-of-sql/examples/hello_world/main.rs).

--- a/crates/proof-of-sql/benches/scaffold/random_util.rs
+++ b/crates/proof-of-sql/benches/scaffold/random_util.rs
@@ -10,7 +10,6 @@ pub type OptionalRandBound = Option<fn(usize) -> i64>;
 /// # Panics
 ///
 /// Will panic if:
-/// - The provided identifier cannot be parsed into an `Identifier` type.
 /// - An unsupported `ColumnType` is encountered, triggering a panic in the `todo!()` macro.
 #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 pub fn generate_random_columns<'a, S: Scalar>(

--- a/crates/proof-of-sql/examples/hello_world/README.md
+++ b/crates/proof-of-sql/examples/hello_world/README.md
@@ -30,5 +30,5 @@ Parsing Query... 1.870256ms
 Generating Proof... 467.45371ms
 Verifying Proof... 7.106864ms
 Valid proof!
-Query result: OwnedTable { table: {Identifier { name: "b" }: VarChar(["hello", "world"])} }
+Query result: OwnedTable { table: {Ident { value: "b", quote_style: None }: VarChar(["hello", "world"])} }
 ```

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -25,7 +25,8 @@ use proof_of_sql::{
     },
     sql::{parse::QueryExpr, proof::VerifiableQueryResult},
 };
-use proof_of_sql_parser::{Identifier, SelectStatement};
+use proof_of_sql_parser::SelectStatement;
+use sqlparser::ast::Ident;
 use std::{
     fs,
     io::{prelude::Write, stdout},
@@ -78,7 +79,7 @@ enum Commands {
         table: TableRef,
         /// The comma delimited column names of the table.
         #[arg(short, long, value_parser, num_args = 0.., value_delimiter = ',')]
-        columns: Vec<Identifier>,
+        columns: Vec<Ident>,
         /// The comma delimited data types of the columns.
         #[arg(short, long, value_parser, num_args = 0.., value_delimiter = ',')]
         data_types: Vec<CsvDataType>,
@@ -175,7 +176,9 @@ fn main() {
                 columns
                     .iter()
                     .zip_eq(data_types.iter())
-                    .map(|(name, data_type)| Field::new(name.as_str(), data_type.into(), false))
+                    .map(|(name, data_type)| {
+                        Field::new(name.value.as_str(), data_type.into(), false)
+                    })
                     .collect::<Vec<_>>(),
             );
             let batch = RecordBatch::new_empty(Arc::new(schema));

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -49,10 +49,10 @@ pub enum OwnedArrowConversionError {
         /// The unsupported datatype
         datatype: DataType,
     },
-    /// This error occurs when trying to convert from a record batch with duplicate identifiers (e.g. `"a"` and `"A"`).
-    #[snafu(display("conversion resulted in duplicate identifiers"))]
-    DuplicateIdentifiers,
-    /// This error occurs when convering from a record batch name to an identifier fails. (Which may my impossible.)
+    /// This error occurs when trying to convert from a record batch with duplicate idents(e.g. `"a"` and `"A"`).
+    #[snafu(display("conversion resulted in duplicate idents"))]
+    DuplicateIdents,
+    /// This error occurs when convering from a record batch name to an idents fails. (Which may my impossible.)
     #[snafu(transparent)]
     FieldParseFail {
         /// The underlying source error
@@ -311,7 +311,7 @@ impl<S: Scalar> TryFrom<RecordBatch> for OwnedTable<S> {
         if num_columns == owned_table.num_columns() {
             Ok(owned_table)
         } else {
-            Err(OwnedArrowConversionError::DuplicateIdentifiers)
+            Err(OwnedArrowConversionError::DuplicateIdents)
         }
     }
 }

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -57,7 +57,7 @@ impl<C: Commitment> TableCommitment<C> {
                 panic!("RecordBatches cannot have columns of mixed length")
             }
             Err(AppendTableCommitmentError::AppendColumnCommitments {
-                source: AppendColumnCommitmentsError::DuplicateIdentifiers { .. },
+                source: AppendColumnCommitmentsError::DuplicateIdents { .. },
             }) => {
                 panic!("RecordBatches cannot have duplicate identifiers")
             }
@@ -92,7 +92,7 @@ impl<C: Commitment> TableCommitment<C> {
             Err(TableCommitmentFromColumnsError::MixedLengthColumns { .. }) => {
                 panic!("RecordBatches cannot have columns of mixed length")
             }
-            Err(TableCommitmentFromColumnsError::DuplicateIdentifiers { .. }) => {
+            Err(TableCommitmentFromColumnsError::DuplicateIdents { .. }) => {
                 panic!("RecordBatches cannot have duplicate identifiers")
             }
         }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -7,7 +7,7 @@ use alloc::string::{String, ToString};
 use snafu::Snafu;
 use sqlparser::ast::Ident;
 
-/// Mapping of column identifiers to column metadata used to associate metadata with commitments.
+/// Mapping of column idents to column metadata used to associate metadata with commitments.
 pub type ColumnCommitmentMetadataMap = IndexMap<Ident, ColumnCommitmentMetadata>;
 
 /// During commitment operation, metadata indicates that operand tables cannot be the same.
@@ -22,16 +22,14 @@ pub enum ColumnCommitmentsMismatch {
     /// Commitments with different column counts cannot operate with each other.
     #[snafu(display("commitments with different column counts cannot operate with each other"))]
     NumColumns,
-    /// Columns with mismatched identifiers cannot operate with each other.
+    /// Columns with mismatched idents cannot operate with each other.
     ///
-    /// Strings are used here instead of Identifiers to decrease the size of this variant
-    #[snafu(display(
-        "column with identifier {id_a} cannot operate with column with identifier {id_b}"
-    ))]
+    /// Strings are used here instead of Idents to decrease the size of this variant
+    #[snafu(display("column with ident {id_a} cannot operate with column with ident {id_b}"))]
     Ident {
-        /// The first column identifier
+        /// The first column ident
         id_a: String,
-        /// The second column identifier
+        /// The second column ident
         id_b: String,
     },
 }
@@ -42,7 +40,7 @@ pub trait ColumnCommitmentMetadataMapExt {
     /// the widest possible bounds for the column type.
     fn from_column_fields_with_max_bounds(columns: &[ColumnField]) -> Self;
 
-    /// Construct this mapping from an iterator of column identifiers and columns.
+    /// Construct this mapping from an iterator of column ident and columns.
     fn from_columns<'a>(
         columns: impl IntoIterator<Item = (&'a Ident, &'a CommittableColumn<'a>)>,
     ) -> Self

--- a/crates/proof-of-sql/src/base/commitment/mod.rs
+++ b/crates/proof-of-sql/src/base/commitment/mod.rs
@@ -28,9 +28,7 @@ pub use column_commitment_metadata_map::{
 };
 
 mod column_commitments;
-pub use column_commitments::{
-    AppendColumnCommitmentsError, ColumnCommitments, DuplicateIdentifiers,
-};
+pub use column_commitments::{AppendColumnCommitmentsError, ColumnCommitments, DuplicateIdents};
 
 mod table_commitment;
 pub use table_commitment::{

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -30,7 +30,7 @@ pub(crate) enum TableCoercionError {
     ColumnCountMismatch,
 }
 
-/// A table of data, with schema included. This is simply a map from `Identifier` to `OwnedColumn`,
+/// A table of data, with schema included. This is simply a map from `Ident` to `OwnedColumn`,
 /// where columns order matters.
 /// This is primarily used as an internal result that is used before
 /// converting to the final result in either Arrow format or JSON.

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -19,7 +19,7 @@ use alloc::string::String;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use sqlparser::ast::Ident;
 
-/// Creates an [`OwnedTable`] from a list of `(Identifier, OwnedColumn)` pairs.
+/// Creates an [`OwnedTable`] from a list of `(Ident, OwnedColumn)` pairs.
 /// This is a convenience wrapper around [`OwnedTable::try_from_iter`] primarily for use in tests and
 /// intended to be used along with the other methods in this module (e.g. [bigint], [boolean], etc).
 /// The function will panic under a variety of conditions. See [`OwnedTable::try_from_iter`] for more details.
@@ -36,7 +36,7 @@ use sqlparser::ast::Ident;
 ///     decimal75("f", 12, 1, [1, 2, 3]),
 /// ]);
 /// ```
-///
+/// ///
 /// # Panics
 /// - Panics if converting the iterator into an `OwnedTable<S>` fails.
 pub fn owned_table<S: Scalar>(
@@ -45,7 +45,7 @@ pub fn owned_table<S: Scalar>(
     OwnedTable::try_from_iter(iter).unwrap()
 }
 
-/// Creates a (Identifier, `OwnedColumn`) pair for a tinyint column.
+/// Creates a (Ident, `OwnedColumn`) pair for a tinyint column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```
@@ -54,8 +54,6 @@ pub fn owned_table<S: Scalar>(
 ///     tinyint("a", [1_i8, 2, 3]),
 /// ]);
 ///```
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 pub fn tinyint<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i8>>,
@@ -66,7 +64,7 @@ pub fn tinyint<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for a smallint column.
+/// Creates a `(Ident, OwnedColumn)` pair for a smallint column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```rust
@@ -75,8 +73,6 @@ pub fn tinyint<S: Scalar>(
 ///     smallint("a", [1_i16, 2, 3]),
 /// ]);
 /// ```
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 pub fn smallint<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i16>>,
@@ -87,7 +83,7 @@ pub fn smallint<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for an int column.
+/// Creates a `(Ident, OwnedColumn)` pair for an int column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```rust
@@ -96,8 +92,6 @@ pub fn smallint<S: Scalar>(
 ///     int("a", [1, 2, 3]),
 /// ]);
 /// ```
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 pub fn int<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i32>>,
@@ -108,7 +102,7 @@ pub fn int<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for a bigint column.
+/// Creates a `(Ident, OwnedColumn)` pair for a bigint column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```rust
@@ -128,7 +122,7 @@ pub fn bigint<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for a boolean column.
+/// Creates a `(Ident, OwnedColumn)` pair for a boolean column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```
@@ -137,9 +131,6 @@ pub fn bigint<S: Scalar>(
 ///     boolean("a", [true, false, true]),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 pub fn boolean<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<bool>>,
@@ -150,7 +141,7 @@ pub fn boolean<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for a int128 column.
+/// Creates a `(Ident, OwnedColumn)` pair for a int128 column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```
@@ -159,9 +150,6 @@ pub fn boolean<S: Scalar>(
 ///     int128("a", [1, 2, 3]),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 pub fn int128<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i128>>,
@@ -172,7 +160,7 @@ pub fn int128<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for a scalar column.
+/// Creates a `(Ident, OwnedColumn)` pair for a scalar column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```
@@ -181,9 +169,7 @@ pub fn int128<S: Scalar>(
 ///     scalar("a", [1, 2, 3]),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn scalar<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<S>>,
@@ -194,7 +180,7 @@ pub fn scalar<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for a varchar column.
+/// Creates a `(Ident, OwnedColumn)` pair for a varchar column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```
@@ -203,9 +189,7 @@ pub fn scalar<S: Scalar>(
 ///     varchar("a", ["a", "b", "c"]),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn varchar<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<String>>,
@@ -216,7 +200,7 @@ pub fn varchar<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for a decimal75 column.
+/// Creates a `(Ident, OwnedColumn)` pair for a decimal75 column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example
 /// ```
@@ -227,7 +211,6 @@ pub fn varchar<S: Scalar>(
 /// ```
 ///
 /// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 /// - Panics if creating the `Precision` from the specified precision value fails.
 pub fn decimal75<S: Scalar>(
     name: impl Into<Ident>,
@@ -245,7 +228,7 @@ pub fn decimal75<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, OwnedColumn)` pair for a timestamp column.
+/// Creates a `(Ident, OwnedColumn)` pair for a timestamp column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 ///
 /// # Parameters
@@ -266,9 +249,7 @@ pub fn decimal75<S: Scalar>(
 ///     timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![1625072400, 1625076000, 1625079600]),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn timestamptz<S: Scalar>(
     name: impl Into<Ident>,
     time_unit: PoSQLTimeUnit,

--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -35,7 +35,7 @@ pub enum TableError {
     #[snafu(display("Table is empty and no row count is specified"))]
     EmptyTableWithoutSpecifiedRowCount,
 }
-/// A table of data, with schema included. This is simply a map from `Identifier` to `Column`,
+/// A table of data, with schema included. This is simply a map from `Ident` to `Column`,
 /// where columns order matters.
 /// This is primarily used as an internal result that is used before
 /// converting to the final result in either Arrow format or JSON.
@@ -77,14 +77,14 @@ impl<'a, S: Scalar> Table<'a, S> {
         }
     }
 
-    /// Creates a new [`Table`] from an iterator of `(Identifier, Column)` pairs with default [`TableOptions`].
+    /// Creates a new [`Table`] from an iterator of `(Ident, Column)` pairs with default [`TableOptions`].
     pub fn try_from_iter<T: IntoIterator<Item = (Ident, Column<'a, S>)>>(
         iter: T,
     ) -> Result<Self, TableError> {
         Self::try_from_iter_with_options(iter, TableOptions::default())
     }
 
-    /// Creates a new [`Table`] from an iterator of `(Identifier, Column)` pairs with [`TableOptions`].
+    /// Creates a new [`Table`] from an iterator of `(Ident, Column)` pairs with [`TableOptions`].
     pub fn try_from_iter_with_options<T: IntoIterator<Item = (Ident, Column<'a, S>)>>(
         iter: T,
         options: TableOptions,

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -22,7 +22,7 @@ use bumpalo::Bump;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use sqlparser::ast::Ident;
 
-/// Creates an [`Table`] from a list of `(Identifier, Column)` pairs.
+/// Creates an [`Table`] from a list of `(Ident, Column)` pairs.
 /// This is a convenience wrapper around [`Table::try_from_iter`] primarily for use in tests and
 /// intended to be used along with the other methods in this module (e.g. [`borrowed_bigint`],
 /// [`borrowed_boolean`], etc).
@@ -51,7 +51,7 @@ pub fn table<'a, S: Scalar>(
     Table::try_from_iter(iter).unwrap()
 }
 
-/// Creates an [`Table`] from a list of `(Identifier, Column)` pairs with a specified row count.
+/// Creates an [`Table`] from a list of `(Ident, Column)` pairs with a specified row count.
 /// The main reason for this function is to allow for creating tables that may potentially have
 /// no columns, but still have a specified row count.
 ///
@@ -64,7 +64,7 @@ pub fn table_with_row_count<'a, S: Scalar>(
     Table::try_from_iter_with_options(iter, TableOptions::new(Some(row_count))).unwrap()
 }
 
-/// Creates a (Identifier, `Column`) pair for a tinyint column.
+/// Creates a (Ident, `Column`) pair for a tinyint column.
 /// This is primarily intended for use in conjunction with [`table`].
 /// # Example
 /// ```
@@ -75,8 +75,6 @@ pub fn table_with_row_count<'a, S: Scalar>(
 ///     borrowed_tinyint("a", [1_i8, 2, 3], &alloc),
 /// ]);
 ///```
-/// # Panics
-/// - Panics if `name.parse()()` fails to convert the name into an `Identifier`.
 pub fn borrowed_tinyint<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i8>>,
@@ -87,7 +85,7 @@ pub fn borrowed_tinyint<S: Scalar>(
     (name.into(), Column::TinyInt(alloc_data))
 }
 
-/// Creates a `(Identifier, Column)` pair for a smallint column.
+/// Creates a `(Ident, Column)` pair for a smallint column.
 /// This is primarily intended for use in conjunction with [`table`].
 ///
 /// # Example
@@ -100,8 +98,6 @@ pub fn borrowed_tinyint<S: Scalar>(
 /// ]);
 /// ```
 ///
-/// # Panics
-/// - Panics if `name.parse()()` fails to convert the name into an `Identifier`.
 pub fn borrowed_smallint<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i16>>,
@@ -112,7 +108,7 @@ pub fn borrowed_smallint<S: Scalar>(
     (name.into(), Column::SmallInt(alloc_data))
 }
 
-/// Creates a `(Identifier, Column)` pair for an int column.
+/// Creates a `(Ident, Column)` pair for an int column.
 /// This is primarily intended for use in conjunction with [`table`].
 ///
 /// # Example
@@ -125,8 +121,6 @@ pub fn borrowed_smallint<S: Scalar>(
 /// ]);
 /// ```
 ///
-/// # Panics
-/// - Panics if `name.parse()()` fails to convert the name into an `Identifier`.
 pub fn borrowed_int<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i32>>,
@@ -137,7 +131,7 @@ pub fn borrowed_int<S: Scalar>(
     (name.into(), Column::Int(alloc_data))
 }
 
-/// Creates a `(Identifier, Column)` pair for a bigint column.
+/// Creates a `(Ident, Column)` pair for a bigint column.
 /// This is primarily intended for use in conjunction with [`table`].
 ///
 /// # Example
@@ -149,9 +143,7 @@ pub fn borrowed_int<S: Scalar>(
 ///     borrowed_bigint("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn borrowed_bigint<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i64>>,
@@ -162,7 +154,7 @@ pub fn borrowed_bigint<S: Scalar>(
     (name.into(), Column::BigInt(alloc_data))
 }
 
-/// Creates a `(Identifier, Column)` pair for a boolean column.
+/// Creates a `(Ident, Column)` pair for a boolean column.
 /// This is primarily intended for use in conjunction with [`table`].
 ///
 /// # Example
@@ -174,9 +166,7 @@ pub fn borrowed_bigint<S: Scalar>(
 ///     borrowed_boolean("a", [true, false, true], &alloc),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn borrowed_boolean<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<bool>>,
@@ -187,7 +177,7 @@ pub fn borrowed_boolean<S: Scalar>(
     (name.into(), Column::Boolean(alloc_data))
 }
 
-/// Creates a `(Identifier, Column)` pair for an int128 column.
+/// Creates a `(Ident, Column)` pair for an int128 column.
 /// This is primarily intended for use in conjunction with [`table`].
 ///
 /// # Example
@@ -199,9 +189,7 @@ pub fn borrowed_boolean<S: Scalar>(
 ///     borrowed_int128("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn borrowed_int128<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i128>>,
@@ -212,7 +200,7 @@ pub fn borrowed_int128<S: Scalar>(
     (name.into(), Column::Int128(alloc_data))
 }
 
-/// Creates a `(Identifier, Column)` pair for a scalar column.
+/// Creates a `(Ident, Column)` pair for a scalar column.
 /// This is primarily intended for use in conjunction with [`table`].
 ///
 /// # Example
@@ -224,9 +212,7 @@ pub fn borrowed_int128<S: Scalar>(
 ///     borrowed_scalar("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn borrowed_scalar<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<S>>,
@@ -237,7 +223,7 @@ pub fn borrowed_scalar<S: Scalar>(
     (name.into(), Column::Scalar(alloc_data))
 }
 
-/// Creates a `(Identifier, Column)` pair for a varchar column.
+/// Creates a `(Ident, Column)` pair for a varchar column.
 /// This is primarily intended for use in conjunction with [`table`].
 /// # Example
 /// ```
@@ -248,9 +234,7 @@ pub fn borrowed_scalar<S: Scalar>(
 ///     borrowed_varchar("a", ["a", "b", "c"], &alloc),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn borrowed_varchar<'a, S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<String>>,
@@ -269,7 +253,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
     (name.into(), Column::VarChar((alloc_strings, alloc_scalars)))
 }
 
-/// Creates a `(Identifier, Column)` pair for a decimal75 column.
+/// Creates a `(Ident, Column)` pair for a decimal75 column.
 /// This is primarily intended for use in conjunction with [`table`].
 /// # Example
 /// ```
@@ -280,9 +264,7 @@ pub fn borrowed_varchar<'a, S: Scalar>(
 ///     borrowed_decimal75("a", 12, 1, [1, 2, 3], &alloc),
 /// ]);
 /// ```
-///
 /// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
 /// - Panics if creating the `Precision` from the specified precision value fails.
 pub fn borrowed_decimal75<S: Scalar>(
     name: impl Into<Ident>,
@@ -303,7 +285,7 @@ pub fn borrowed_decimal75<S: Scalar>(
     )
 }
 
-/// Creates a `(Identifier, Column)` pair for a timestamp column.
+/// Creates a `(Ident, Column)` pair for a timestamp column.
 /// This is primarily intended for use in conjunction with [`table`].
 ///
 /// # Parameters
@@ -327,9 +309,7 @@ pub fn borrowed_decimal75<S: Scalar>(
 ///     borrowed_timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![1625072400, 1625076000, 1625079600], &alloc),
 /// ]);
 /// ```
-///
-/// # Panics
-/// - Panics if `name.parse()` fails to convert the name into an `Identifier`.
+
 pub fn borrowed_timestamptz<S: Scalar>(
     name: impl Into<Ident>,
     time_unit: PoSQLTimeUnit,

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1582,7 +1582,7 @@ fn we_cannot_use_non_grouped_columns_outside_agg() {
         assert!(matches!(
             result,
             Err(ConversionError::PostprocessingError {
-                source: PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause { .. }
+                source: PostprocessingError::IdentNotInAggregationOperatorOrGroupByClause { .. }
             })
         ));
     }

--- a/crates/proof-of-sql/src/sql/postprocessing/error.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/error.rs
@@ -31,8 +31,8 @@ pub enum PostprocessingError {
     },
     /// GROUP BY clause references a column not in a group by expression outside aggregate functions
     #[snafu(display("Invalid group by: column '{column}' must not appear outside aggregate functions or `GROUP BY` clause."))]
-    IdentifierNotInAggregationOperatorOrGroupByClause {
-        /// The column identifier
+    IdentNotInAggregationOperatorOrGroupByClause {
+        /// The column ident
         column: Ident,
     },
     /// Errors in converting `Ident` to `Identifier`

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -152,7 +152,7 @@ fn check_and_get_aggregation_and_remainder(
             .next()
             .unwrap();
         Err(
-            PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause {
+            PostprocessingError::IdentNotInAggregationOperatorOrGroupByClause {
                 column: diff.clone(),
             },
         )

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing_test.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing_test.rs
@@ -17,7 +17,7 @@ fn we_cannot_have_invalid_group_bys() {
     let res = GroupByPostprocessing::try_new(vec!["a".into()], vec![aliased_expr(expr, "res")]);
     assert!(matches!(
         res,
-        Err(PostprocessingError::IdentifierNotInAggregationOperatorOrGroupByClause { .. })
+        Err(PostprocessingError::IdentNotInAggregationOperatorOrGroupByClause { .. })
     ));
 
     // Nested aggregation

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -7,9 +7,6 @@ use crate::base::{
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use sqlparser::ast::Ident;
 
-/// # Panics
-/// Panics if:
-/// - `name.parse()` fails, which means the provided string could not be parsed into the expected type (usually an `Identifier`).
 pub fn col_ref(tab: TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnRef {
     let name: Ident = name.into();
     let type_col = accessor.lookup_column(tab, name.clone()).unwrap();
@@ -18,7 +15,6 @@ pub fn col_ref(tab: TableRef, name: &str, accessor: &impl SchemaAccessor) -> Col
 
 /// # Panics
 /// Panics if:
-/// - `name.parse()` fails to parse the column name.
 /// - `accessor.lookup_column()` returns `None`, indicating the column is not found.
 pub fn column(tab: TableRef, name: &str, accessor: &impl SchemaAccessor) -> DynProofExpr {
     let name: Ident = name.into();


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

To update docs to reflect the migration of Identifier -> Ident
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

- Updated docs in the proof-of-sql crate with Ident
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Part of  #235 