### PR TITLE
fix: add sumcheck range length field

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
@@ -8,6 +8,8 @@ pub struct FirstRoundBuilder {
     num_post_result_challenges: usize,
     /// The extra one evaluation lengths used in the proof.
     one_evaluation_lengths: Vec<usize>,
+    /// The extra sumcheck range lengths used in the proof.
+    sumcheck_range_lengths: Vec<usize>,
 }
 
 impl Default for FirstRoundBuilder {
@@ -21,12 +23,19 @@ impl FirstRoundBuilder {
         Self {
             num_post_result_challenges: 0,
             one_evaluation_lengths: Vec::new(),
+            sumcheck_range_lengths: Vec::new(),
         }
     }
 
     /// Get the one evaluation lengths used in the proof.
+    #[allow(dead_code)]
     pub(crate) fn one_evaluation_lengths(&self) -> &[usize] {
         &self.one_evaluation_lengths
+    }
+
+    /// Get the sumcheck range lengths used in the proof.
+    pub(crate) fn sumcheck_range_lengths(&self) -> &[usize] {
+        &self.sumcheck_range_lengths
     }
 
     /// Append the length to the list of one evaluation lengths.

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -104,6 +104,8 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let query_result = expr.first_round_evaluate(&mut first_round_builder, &alloc, &table_map);
         let owned_table_result = OwnedTable::from(&query_result);
         let provable_result = query_result.into();
+
+        let one_evaluation_lengths = first_round_builder.one_evaluation_lengths();
         let range_evaluation_lengths = first_round_builder.sumcheck_range_lengths();
 
         let range_length = range_evaluation_lengths
@@ -123,7 +125,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             &owned_table_result,
             range_length,
             min_row_num,
-            range_evaluation_lengths,
+            one_evaluation_lengths,
             post_result_challenge_count,
         );
 
@@ -206,7 +208,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         let proof = Self {
             bit_distributions: builder.bit_distributions().to_vec(),
-            one_evaluation_lengths: range_evaluation_lengths.to_vec(),
+            one_evaluation_lengths: one_evaluation_lengths.to_vec(),
             commitments,
             sumcheck_proof,
             pcs_proof_evaluations,

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -104,9 +104,9 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let query_result = expr.first_round_evaluate(&mut first_round_builder, &alloc, &table_map);
         let owned_table_result = OwnedTable::from(&query_result);
         let provable_result = query_result.into();
-        let one_evaluation_lengths = first_round_builder.one_evaluation_lengths();
+        let range_evaluation_lengths = first_round_builder.sumcheck_range_lengths();
 
-        let range_length = one_evaluation_lengths
+        let range_length = range_evaluation_lengths
             .iter()
             .copied()
             .chain(core::iter::once(initial_range_length))
@@ -123,7 +123,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             &owned_table_result,
             range_length,
             min_row_num,
-            one_evaluation_lengths,
+            range_evaluation_lengths,
             post_result_challenge_count,
         );
 
@@ -206,7 +206,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
 
         let proof = Self {
             bit_distributions: builder.bit_distributions().to_vec(),
-            one_evaluation_lengths: one_evaluation_lengths.to_vec(),
+            one_evaluation_lengths: range_evaluation_lengths.to_vec(),
             commitments,
             sumcheck_proof,
             pcs_proof_evaluations,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
