### PR TITLE
refactor!: replace `ResourceId` with `sqlparser` `Ident`s in the `proof-of-sql` crate

### DIFF
--- a/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
+++ b/crates/proof-of-sql/benches/scaffold/benchmark_accessor.rs
@@ -27,7 +27,7 @@ impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {
         setup: &C::PublicSetup<'_>,
     ) {
         self.table_schemas.insert(
-            table_ref,
+            table_ref.clone(),
             columns
                 .iter()
                 .map(|(id, col)| (id.clone(), col.column_type()))
@@ -44,15 +44,17 @@ impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {
         let mut length = None;
         for (column, commitment) in columns.iter().zip(commitments) {
             self.columns.insert(
-                ColumnRef::new(table_ref, column.0.clone(), column.1.column_type()),
+                ColumnRef::new(table_ref.clone(), column.0.clone(), column.1.column_type()),
                 column.1,
             );
             self.commitments.insert(
-                ColumnRef::new(table_ref, column.0.clone(), column.1.column_type()),
+                ColumnRef::new(table_ref.clone(), column.0.clone(), column.1.column_type()),
                 commitment,
             );
-            self.column_types
-                .insert((table_ref, column.0.clone()), column.1.column_type());
+            self.column_types.insert(
+                (table_ref.clone(), column.0.clone()),
+                column.1.column_type(),
+            );
 
             if let Some(len) = length {
                 assert!(len == column.1.len());
@@ -76,10 +78,10 @@ impl<C: Commitment> MetadataAccessor for BenchmarkAccessor<'_, C> {
     /// # Panics
     ///
     /// Will panic if the table reference does not exist in the lengths map.
-    fn get_length(&self, table_ref: TableRef) -> usize {
+    fn get_length(&self, table_ref: &TableRef) -> usize {
         *self.lengths.get(&table_ref).unwrap()
     }
-    fn get_offset(&self, _table_ref: TableRef) -> usize {
+    fn get_offset(&self, _table_ref: &TableRef) -> usize {
         0
     }
 }

--- a/crates/proof-of-sql/benches/scaffold/mod.rs
+++ b/crates/proof-of-sql/benches/scaffold/mod.rs
@@ -11,7 +11,6 @@ use benchmark_accessor::BenchmarkAccessor;
 pub mod querys;
 mod random_util;
 use random_util::{generate_random_columns, OptionalRandBound};
-
 /// # Panics
 ///
 /// Will panic if:

--- a/crates/proof-of-sql/examples/albums/main.rs
+++ b/crates/proof-of-sql/examples/albums/main.rs
@@ -9,7 +9,7 @@ use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -87,7 +87,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "albums.collection".parse().unwrap(),
+        TableRef::new("albums", "collection"),
         OwnedTable::try_from(albums_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/avocado-prices/main.rs
+++ b/crates/proof-of-sql/examples/avocado-prices/main.rs
@@ -6,7 +6,7 @@
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
-    base::database::{OwnedTable, OwnedTableTestAccessor},
+    base::database::{OwnedTable, OwnedTableTestAccessor, TableRef},
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
@@ -88,7 +88,7 @@ fn main() {
 
     // Load the table into an "Accessor" so that the prover and verifier can access the data/commitments.
     let accessor = OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_from_table(
-        "avocado.prices".parse().unwrap(),
+        TableRef::new("avocado", "prices"),
         OwnedTable::try_from(data_batch).unwrap(),
         0,
         &prover_setup,

--- a/crates/proof-of-sql/examples/books/main.rs
+++ b/crates/proof-of-sql/examples/books/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --release --example books --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -88,7 +87,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "books.books".parse().unwrap(),
+        TableRef::new("books", "books"),
         OwnedTable::try_from(books_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/brands/main.rs
+++ b/crates/proof-of-sql/examples/brands/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --release --example brands --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -88,7 +87,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "brands.global_brands".parse().unwrap(),
+        TableRef::new("brands", "global_brands"),
         OwnedTable::try_from(brands_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/census/main.rs
+++ b/crates/proof-of-sql/examples/census/main.rs
@@ -9,7 +9,7 @@
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
-    base::database::{OwnedTable, OwnedTableTestAccessor},
+    base::database::{OwnedTable, OwnedTableTestAccessor, TableRef},
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
@@ -19,7 +19,6 @@ use proof_of_sql::{
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
-
 // We generate the public parameters and the setups used by the prover and verifier for the Dory PCS.
 // The `max_nu` should be set such that the maximum table size is less than `2^(2*max_nu-1)`.
 // For a sampling:
@@ -91,7 +90,7 @@ fn main() {
 
     // Load the table into an "Accessor" so that the prover and verifier can access the data/commitments.
     let accessor = OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_from_table(
-        "census.income".parse().unwrap(),
+        TableRef::new("census", "income"),
         OwnedTable::try_from(census_income_batch).unwrap(),
         0,
         &prover_setup,

--- a/crates/proof-of-sql/examples/countries/main.rs
+++ b/crates/proof-of-sql/examples/countries/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --release --example countries --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -89,7 +88,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "countries.countries".parse().unwrap(),
+        TableRef::new("countries", "countries"),
         OwnedTable::try_from(countries_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/dinosaurs/main.rs
+++ b/crates/proof-of-sql/examples/dinosaurs/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --release --example dinosaurs --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -89,7 +88,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "dinosaurs.dinosaurs".parse().unwrap(),
+        TableRef::new("dinosaurs", "dinosaurs"),
         OwnedTable::try_from(dinosaurs_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql/examples/dog_breeds/main.rs
@@ -3,11 +3,10 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --release --example dog_breeds --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
-    base::database::{OwnedTable, OwnedTableTestAccessor, TestAccessor},
+    base::database::{OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor},
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
@@ -84,7 +83,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "dog_breeds.breeds".parse().unwrap(),
+        TableRef::new("dog_breeds", "breeds"),
         OwnedTable::try_from(dog_breeds_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/hello_world/main.rs
+++ b/crates/proof-of-sql/examples/hello_world/main.rs
@@ -3,7 +3,7 @@ use ark_std::test_rng;
 use proof_of_sql::{
     base::database::{
         owned_table_utility::{bigint, owned_table, varchar},
-        OwnedTableTestAccessor, TestAccessor,
+        OwnedTableTestAccessor, TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -14,7 +14,6 @@ use std::{
     io::{stdout, Write},
     time::Instant,
 };
-
 /// # Panics
 ///
 /// Will panic if flushing the output fails, which can happen due to issues with the underlying output stream.
@@ -53,7 +52,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             bigint("a", [1, 2, 3, 2]),
             varchar("b", ["hi", "hello", "there", "world"]),

--- a/crates/proof-of-sql/examples/plastics/main.rs
+++ b/crates/proof-of-sql/examples/plastics/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --release --example plastics --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -87,7 +86,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "plastics.types".parse().unwrap(),
+        TableRef::new("plastics", "types"),
         OwnedTable::try_from(plastics_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/posql_db/commit_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/commit_accessor.rs
@@ -26,10 +26,10 @@ impl<C: Commitment + Serialize + for<'a> Deserialize<'a>> CommitAccessor<C> {
         fs::write(path, postcard::to_allocvec(commit)?)?;
         Ok(())
     }
-    pub fn load_commit(&mut self, table_ref: TableRef) -> Result<(), Box<dyn Error>> {
+    pub fn load_commit(&mut self, table_ref: &TableRef) -> Result<(), Box<dyn Error>> {
         let path = self.base_path.join(format!("{table_ref}.commit"));
         let commit = postcard::from_bytes(&fs::read(path)?)?;
-        self.inner.insert(table_ref, commit);
+        self.inner.insert(table_ref.clone(), commit);
         Ok(())
     }
     pub fn get_commit(&self, table_ref: &TableRef) -> Option<&TableCommitment<C>> {
@@ -43,11 +43,11 @@ impl<C: Commitment> CommitmentAccessor<C> for CommitAccessor<C> {
     }
 }
 impl<C: Commitment> MetadataAccessor for CommitAccessor<C> {
-    fn get_length(&self, table_ref: proof_of_sql::base::database::TableRef) -> usize {
+    fn get_length(&self, table_ref: &proof_of_sql::base::database::TableRef) -> usize {
         self.inner.get_length(table_ref)
     }
 
-    fn get_offset(&self, table_ref: proof_of_sql::base::database::TableRef) -> usize {
+    fn get_offset(&self, table_ref: &proof_of_sql::base::database::TableRef) -> usize {
         self.inner.get_offset(table_ref)
     }
 }

--- a/crates/proof-of-sql/examples/posql_db/csv_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/csv_accessor.rs
@@ -85,10 +85,10 @@ impl<S: Scalar> DataAccessor<S> for CsvDataAccessor {
     }
 }
 impl MetadataAccessor for CsvDataAccessor {
-    fn get_length(&self, table_ref: TableRef) -> usize {
+    fn get_length(&self, table_ref: &TableRef) -> usize {
         self.inner.get_length(table_ref)
     }
-    fn get_offset(&self, table_ref: TableRef) -> usize {
+    fn get_offset(&self, table_ref: &TableRef) -> usize {
         self.inner.get_offset(table_ref)
     }
 }

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -199,12 +199,12 @@ fn main() {
                 CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let csv_accessor = CsvDataAccessor::new(PathBuf::from(args.path));
             commit_accessor
-                .load_commit(table_name)
+                .load_commit(&table_name)
                 .expect("Failed to load commit");
             let mut table_commitment = commit_accessor.get_commit(&table_name).unwrap().clone();
             let schema = Schema::new(
                 commit_accessor
-                    .lookup_schema(table_name)
+                    .lookup_schema(table_name.clone())
                     .iter()
                     .map(|(i, t)| Field::new(i.value.as_str(), t.into(), false))
                     .collect::<Vec<_>>(),
@@ -212,7 +212,7 @@ fn main() {
             let append_batch =
                 read_record_batch_from_csv(schema, &file_path).expect("Failed to read csv file.");
             csv_accessor
-                .append_batch(&table_name, &append_batch)
+                .append_batch(&table_name.clone(), &append_batch)
                 .expect("Failed to write batch");
             let timer = start_timer("Updating Commitment");
             table_commitment
@@ -228,19 +228,19 @@ fn main() {
                 CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let mut csv_accessor = CsvDataAccessor::new(PathBuf::from(args.path.clone()));
             let tables = query.get_table_references("example".parse().unwrap());
-            for table in tables.into_iter().map(TableRef::new) {
+            for table in tables.into_iter().map(Into::into) {
                 commit_accessor
-                    .load_commit(table)
+                    .load_commit(&table)
                     .expect("Failed to load commit");
                 let schema = Schema::new(
                     commit_accessor
-                        .lookup_schema(table)
+                        .lookup_schema(table.clone())
                         .iter()
                         .map(|(i, t)| Field::new(i.value.as_str(), t.into(), false))
                         .collect::<Vec<_>>(),
                 );
                 csv_accessor
-                    .load_table(table, schema)
+                    .load_table(table.clone(), schema)
                     .expect("Failed to load table");
             }
             let query = QueryExpr::try_new(query, "example".into(), &commit_accessor).unwrap();
@@ -262,9 +262,9 @@ fn main() {
                 CommitAccessor::<DynamicDoryCommitment>::new(PathBuf::from(args.path.clone()));
             let table_refs = query.get_table_references("example".parse().unwrap());
             for table_ref in table_refs {
-                let table_name = TableRef::new(table_ref);
+                let table_name: TableRef = table_ref.into();
                 commit_accessor
-                    .load_commit(table_name)
+                    .load_commit(&table_name)
                     .expect("Failed to load commit");
             }
             let query = QueryExpr::try_new(query, "example".into(), &commit_accessor).unwrap();

--- a/crates/proof-of-sql/examples/posql_db/record_batch_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/record_batch_accessor.rs
@@ -44,14 +44,14 @@ impl<S: Scalar> DataAccessor<S> for RecordBatchAccessor {
     }
 }
 impl MetadataAccessor for RecordBatchAccessor {
-    fn get_length(&self, table_ref: TableRef) -> usize {
+    fn get_length(&self, table_ref: &TableRef) -> usize {
         self.tables
             .get(&table_ref)
             .expect("Table not found.")
             .num_rows()
     }
 
-    fn get_offset(&self, table_ref: TableRef) -> usize {
+    fn get_offset(&self, table_ref: &TableRef) -> usize {
         assert!(self.tables.contains_key(&table_ref), "Table not found.");
         0
     }

--- a/crates/proof-of-sql/examples/programming_books/main.rs
+++ b/crates/proof-of-sql/examples/programming_books/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --example programming_books --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -86,7 +85,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "programming_books.books".parse().unwrap(),
+        TableRef::new("programming_books", "books"),
         OwnedTable::try_from(books_extra_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/rockets/main.rs
+++ b/crates/proof-of-sql/examples/rockets/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --release --example rockets --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -88,7 +87,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "rockets.launch_vehicles".parse().unwrap(),
+        TableRef::new("rockets", "launch_vehicles"),
         OwnedTable::try_from(rockets_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/space/main.rs
+++ b/crates/proof-of-sql/examples/space/main.rs
@@ -7,11 +7,10 @@
 // Note: the space_travellers.csv file was obtained from
 // https://www.kaggle.com/datasets/kaushiksinghrawat/humans-to-have-visited-space
 // under the Apache 2.0 license.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
-    base::database::{OwnedTable, OwnedTableTestAccessor, TestAccessor},
+    base::database::{OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor},
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
@@ -100,12 +99,12 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "space.travellers".parse().unwrap(),
+        TableRef::new("space", "travellers"),
         OwnedTable::try_from(space_travellers_batch).unwrap(),
         0,
     );
     accessor.add_table(
-        "space.planets".parse().unwrap(),
+        TableRef::new("space", "planets"),
         OwnedTable::try_from(planets_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/stocks/main.rs
+++ b/crates/proof-of-sql/examples/stocks/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run cargo run --release --example stocks --no-default-features --features="arrow cpu-perf" instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -87,7 +86,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "stocks.stocks".parse().unwrap(),
+        TableRef::new("stocks", "stocks"),
         OwnedTable::try_from(stocks_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/sushi/main.rs
+++ b/crates/proof-of-sql/examples/sushi/main.rs
@@ -6,7 +6,7 @@
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
-    base::database::{OwnedTable, OwnedTableTestAccessor, TestAccessor},
+    base::database::{OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor},
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
@@ -14,7 +14,6 @@ use proof_of_sql::{
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::{fs::File, time::Instant};
-
 const DORY_SETUP_MAX_NU: usize = 8;
 const DORY_SEED: [u8; 32] = *b"sushi-is-the-best-food-available";
 
@@ -74,7 +73,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "sushi.fish".parse().unwrap(),
+        TableRef::new("sushi", "fish"),
         OwnedTable::try_from(fish_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/vehicles/main.rs
+++ b/crates/proof-of-sql/examples/vehicles/main.rs
@@ -9,7 +9,7 @@ use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -88,7 +88,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "vehicles.vehicles".parse().unwrap(),
+        TableRef::new("vehicles", "vehicles"),
         OwnedTable::try_from(vehicles_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/examples/wood_types/main.rs
+++ b/crates/proof-of-sql/examples/wood_types/main.rs
@@ -3,13 +3,12 @@
 //!
 //! NOTE: If this doesn't work because you do not have the appropriate GPU drivers installed,
 //! you can run `cargo run --release --example wood_types --no-default-features --features="arrow cpu-perf"` instead. It will be slower for proof generation.
-
 use arrow::datatypes::SchemaRef;
 use arrow_csv::{infer_schema_from_files, ReaderBuilder};
 use proof_of_sql::{
     base::database::{
         arrow_schema_utility::get_posql_compatible_schema, OwnedTable, OwnedTableTestAccessor,
-        TestAccessor,
+        TableRef, TestAccessor,
     },
     proof_primitive::dory::{
         DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
@@ -89,7 +88,7 @@ fn main() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "wood_types.woods".parse().unwrap(),
+        TableRef::new("wood_types", "woods"),
         OwnedTable::try_from(wood_types_batch).unwrap(),
         0,
     );

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -52,7 +52,7 @@ pub struct ColumnCommitments<C> {
 impl<C: Commitment> ColumnCommitments<C> {
     /// Create a new [`ColumnCommitments`] for a table from a commitment accessor.
     pub fn from_accessor_with_max_bounds(
-        table: TableRef,
+        table: &TableRef,
         columns: &[ColumnField],
         accessor: &impl CommitmentAccessor<C>,
     ) -> Self {
@@ -60,7 +60,9 @@ impl<C: Commitment> ColumnCommitments<C> {
             ColumnCommitmentMetadataMap::from_column_fields_with_max_bounds(columns);
         let commitments = columns
             .iter()
-            .map(|c| accessor.get_commitment(ColumnRef::new(table, c.name(), c.data_type())))
+            .map(|c| {
+                accessor.get_commitment(ColumnRef::new(table.clone(), c.name(), c.data_type()))
+            })
             .collect();
         ColumnCommitments {
             commitments,

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -47,37 +47,36 @@ impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
                 },
             )
             .into_iter()
-            .map(|(table_ref, columns)| {
-                (
-                    table_ref,
-                    TableCommitment::from_accessor_with_max_bounds(
-                        table_ref,
-                        accessor
-                            .lookup_schema(table_ref)
+            .map(|(table_ref, column_fields)| {
+                let selected_column_fields = accessor
+                    .lookup_schema(table_ref.clone())
+                    .into_iter()
+                    .filter_map(|(ident, _)| {
+                        column_fields
                             .iter()
-                            .filter_map(|c| {
-                                columns.iter().find(|x| x.name() == c.0.clone()).cloned()
-                            })
-                            .collect::<Vec<_>>()
-                            .as_slice(),
-                        accessor,
-                    ),
-                )
+                            .find(|column_field| column_field.name() == ident)
+                            .cloned()
+                    })
+                    .collect::<Vec<_>>();
+                let table_commitment = TableCommitment::from_accessor_with_max_bounds(
+                    &table_ref,
+                    &selected_column_fields,
+                    accessor,
+                );
+                (table_ref, table_commitment)
             })
             .collect()
     }
 }
 
 impl<C: Commitment> MetadataAccessor for QueryCommitments<C> {
-    fn get_length(&self, table_ref: crate::base::database::TableRef) -> usize {
+    fn get_length(&self, table_ref: &TableRef) -> usize {
         let table_commitment = self.get(&table_ref).unwrap();
-
         table_commitment.num_rows()
     }
 
-    fn get_offset(&self, table_ref: crate::base::database::TableRef) -> usize {
+    fn get_offset(&self, table_ref: &TableRef) -> usize {
         let table_commitment = self.get(&table_ref).unwrap();
-
         table_commitment.range().start
     }
 }
@@ -159,10 +158,10 @@ mod tests {
 
         let offset_commitment =
             TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_a, 2, &());
-        let offset_table_id = "off.table".parse().unwrap();
+        let offset_table_id = TableRef::new("off", "table");
 
         let no_offset_commitment = TableCommitment::from_owned_table_with_offset(&table_b, 0, &());
-        let no_offset_id = "no.off".parse().unwrap();
+        let no_offset_id = TableRef::new("no", "off");
 
         let no_columns_commitment = TableCommitment::try_from_columns_with_offset(
             Vec::<(&Ident, &OwnedColumn<TestScalar>)>::new(),
@@ -170,7 +169,7 @@ mod tests {
             &(),
         )
         .unwrap();
-        let no_columns_id = "no.columns".parse().unwrap();
+        let no_columns_id = TableRef::new("no", "columns");
 
         let no_rows_commitment = TableCommitment::try_from_columns_with_offset(
             [(
@@ -181,26 +180,26 @@ mod tests {
             &(),
         )
         .unwrap();
-        let no_rows_id = "no.rows".parse().unwrap();
+        let no_rows_id = TableRef::new("no", "rows");
 
         let query_commitments = QueryCommitments::from_iter([
-            (offset_table_id, offset_commitment),
-            (no_offset_id, no_offset_commitment),
-            (no_columns_id, no_columns_commitment),
-            (no_rows_id, no_rows_commitment),
+            (offset_table_id.clone(), offset_commitment),
+            (no_offset_id.clone(), no_offset_commitment),
+            (no_columns_id.clone(), no_columns_commitment),
+            (no_rows_id.clone(), no_rows_commitment),
         ]);
 
-        assert_eq!(query_commitments.get_offset(offset_table_id), 2);
-        assert_eq!(query_commitments.get_length(offset_table_id), 4);
+        assert_eq!(query_commitments.get_offset(&offset_table_id), 2);
+        assert_eq!(query_commitments.get_length(&offset_table_id), 4);
 
-        assert_eq!(query_commitments.get_offset(no_offset_id), 0);
-        assert_eq!(query_commitments.get_length(no_offset_id), 2);
+        assert_eq!(query_commitments.get_offset(&no_offset_id), 0);
+        assert_eq!(query_commitments.get_length(&no_offset_id), 2);
 
-        assert_eq!(query_commitments.get_offset(no_columns_id), 0);
-        assert_eq!(query_commitments.get_length(no_columns_id), 0);
+        assert_eq!(query_commitments.get_offset(&no_columns_id), 0);
+        assert_eq!(query_commitments.get_length(&no_columns_id), 0);
 
-        assert_eq!(query_commitments.get_offset(no_rows_id), 3);
-        assert_eq!(query_commitments.get_length(no_rows_id), 0);
+        assert_eq!(query_commitments.get_offset(&no_rows_id), 3);
+        assert_eq!(query_commitments.get_length(&no_rows_id), 0);
     }
 
     #[allow(clippy::similar_names)]
@@ -221,19 +220,19 @@ mod tests {
 
         let table_a_commitment =
             TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_a, 2, &());
-        let table_a_id = "table.a".parse().unwrap();
+        let table_a_id = TableRef::new("table", "a");
 
         let table_b_commitment = TableCommitment::from_owned_table_with_offset(&table_b, 0, &());
-        let table_b_id = "table.b".parse().unwrap();
+        let table_b_id = TableRef::new("table", "b");
 
         let query_commitments = QueryCommitments::from_iter([
-            (table_a_id, table_a_commitment.clone()),
-            (table_b_id, table_b_commitment.clone()),
+            (table_a_id.clone(), table_a_commitment.clone()),
+            (table_b_id.clone(), table_b_commitment.clone()),
         ]);
 
         assert_eq!(
             query_commitments.get_commitment(ColumnRef::new(
-                table_a_id,
+                table_a_id.clone(),
                 column_a_id.clone(),
                 ColumnType::BigInt
             )),
@@ -275,10 +274,10 @@ mod tests {
 
         let table_a_commitment =
             TableCommitment::<NaiveCommitment>::from_owned_table_with_offset(&table_a, 2, &());
-        let table_a_id = "table.a".parse().unwrap();
+        let table_a_id = TableRef::new("table", "a");
 
         let table_b_commitment = TableCommitment::from_owned_table_with_offset(&table_b, 0, &());
-        let table_b_id = "table.b".parse().unwrap();
+        let table_b_id = TableRef::new("table", "b");
 
         let no_columns_commitment = TableCommitment::try_from_columns_with_offset(
             Vec::<(&Ident, &OwnedColumn<TestScalar>)>::new(),
@@ -286,23 +285,23 @@ mod tests {
             &(),
         )
         .unwrap();
-        let no_columns_id = "no.columns".parse().unwrap();
+        let no_columns_id = TableRef::new("no", "columns");
 
         let query_commitments = QueryCommitments::from_iter([
-            (table_a_id, table_a_commitment),
-            (table_b_id, table_b_commitment),
-            (no_columns_id, no_columns_commitment),
+            (table_a_id.clone(), table_a_commitment),
+            (table_b_id.clone(), table_b_commitment),
+            (no_columns_id.clone(), no_columns_commitment),
         ]);
 
         assert_eq!(
             query_commitments
-                .lookup_column(table_a_id, column_a_id.clone())
+                .lookup_column(table_a_id.clone(), column_a_id.clone())
                 .unwrap(),
             ColumnType::BigInt
         );
         assert_eq!(
             query_commitments
-                .lookup_column(table_a_id, column_b_id.clone())
+                .lookup_column(table_a_id.clone(), column_b_id.clone())
                 .unwrap(),
             ColumnType::VarChar
         );
@@ -316,12 +315,12 @@ mod tests {
 
         assert_eq!(
             query_commitments
-                .lookup_column(table_b_id, column_a_id.clone())
+                .lookup_column(table_b_id.clone(), column_a_id.clone())
                 .unwrap(),
             ColumnType::Scalar
         );
         assert_eq!(
-            query_commitments.lookup_column(table_b_id, column_b_id),
+            query_commitments.lookup_column(table_b_id.clone(), column_b_id),
             None
         );
         assert_eq!(
@@ -330,7 +329,7 @@ mod tests {
         );
 
         assert_eq!(
-            query_commitments.lookup_column(no_columns_id, column_a_id),
+            query_commitments.lookup_column(no_columns_id.clone(), column_a_id),
             None
         );
         assert_eq!(query_commitments.lookup_schema(no_columns_id), vec![]);
@@ -360,7 +359,7 @@ mod tests {
 
         let mut table_a_commitment =
             TableCommitment::from_owned_table_with_offset(&table_a, 0, &setup);
-        let table_a_id = "table.a".parse().unwrap();
+        let table_a_id = TableRef::new("table", "a");
         *table_a_commitment
             .column_commitments_mut()
             .column_metadata_mut()
@@ -370,7 +369,7 @@ mod tests {
 
         let mut table_b_commitment =
             TableCommitment::from_owned_table_with_offset(&table_b, 0, &setup);
-        let table_b_id = "table.b".parse().unwrap();
+        let table_b_id = TableRef::new("table", "b");
         *table_b_commitment
             .column_commitments_mut()
             .column_metadata_mut()
@@ -379,19 +378,19 @@ mod tests {
             .bounds_mut() = ColumnBounds::Int128(Bounds::bounded(i128::MIN, i128::MAX).unwrap());
 
         let expected_query_commitments = QueryCommitments::from_iter([
-            (table_a_id, table_a_commitment.clone()),
-            (table_b_id, table_b_commitment.clone()),
+            (table_a_id.clone(), table_a_commitment.clone()),
+            (table_b_id.clone(), table_b_commitment.clone()),
         ]);
 
         let mut accessor =
             OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(setup);
-        accessor.add_table(table_a_id, table_a, 0);
-        accessor.add_table(table_b_id, table_b, 0);
+        accessor.add_table(table_a_id.clone(), table_a, 0);
+        accessor.add_table(table_b_id.clone(), table_b, 0);
 
         let query_commitments = QueryCommitments::<DoryCommitment>::from_accessor_with_max_bounds(
             [
-                ColumnRef::new(table_a_id, column_a_id.clone(), ColumnType::BigInt),
-                ColumnRef::new(table_b_id, column_a_id, ColumnType::Scalar),
+                ColumnRef::new(table_a_id.clone(), column_a_id.clone(), ColumnType::BigInt),
+                ColumnRef::new(table_b_id.clone(), column_a_id, ColumnType::Scalar),
                 ColumnRef::new(table_a_id, column_b_id.clone(), ColumnType::VarChar),
                 ColumnRef::new(table_b_id, column_b_id, ColumnType::Int128),
             ],

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -97,7 +97,7 @@ impl<C: Commitment> TableCommitment<C> {
         reason = "The assertion ensures that from_accessor should not create columns with a negative range"
     )]
     pub fn from_accessor_with_max_bounds(
-        table_ref: TableRef,
+        table_ref: &TableRef,
         columns: &[ColumnField],
         accessor: &impl CommitmentAccessor<C>,
     ) -> Self {

--- a/crates/proof-of-sql/src/base/database/accessor.rs
+++ b/crates/proof-of-sql/src/base/database/accessor.rs
@@ -15,13 +15,13 @@ use sqlparser::ast::Ident;
 /// will only be accessing information about tables that exist in the database.
 pub trait MetadataAccessor {
     /// Return the data span's length in the table (not the full table length)
-    fn get_length(&self, table_ref: TableRef) -> usize;
+    fn get_length(&self, table_ref: &TableRef) -> usize;
 
     /// Return the data span's offset in the table
     ///
     /// If the data span has its first row starting at the ith table row,
     /// this `get_offset` should then return `i`.
-    fn get_offset(&self, table_ref: TableRef) -> usize;
+    fn get_offset(&self, table_ref: &TableRef) -> usize;
 }
 
 /// Access commitments of database columns.
@@ -95,7 +95,7 @@ pub trait DataAccessor<S: Scalar>: MetadataAccessor {
     /// Column length mismatches can occur in theory. In practice, this should not happen.
     fn get_table(&self, table_ref: TableRef, column_refs: &IndexSet<ColumnRef>) -> Table<S> {
         if column_refs.is_empty() {
-            let input_length = self.get_length(table_ref);
+            let input_length = self.get_length(&table_ref);
             Table::<S>::try_new_with_options(
                 IndexMap::default(),
                 TableOptions::new(Some(input_length)),

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -572,7 +572,7 @@ impl ColumnRef {
     /// Returns the table reference of this column
     #[must_use]
     pub fn table_ref(&self) -> TableRef {
-        self.table_ref
+        self.table_ref.clone()
     }
 
     /// Returns the column identifier of this column

--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -1,0 +1,14 @@
+use alloc::string::String;
+use snafu::Snafu;
+
+/// Errors encountered during the parsing process
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, Snafu, Eq, PartialEq)]
+pub enum ParseError {
+    #[snafu(display("Invalid table reference: {}", table_reference))]
+    /// Cannot parse the `TableRef`
+    InvalidTableReference {
+        /// The underlying error
+        table_reference: String,
+    },
+}

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -41,6 +41,8 @@ pub use columnar_value::ColumnarValue;
 mod literal_value;
 pub use literal_value::LiteralValue;
 
+mod error;
+
 mod table_ref;
 #[cfg(feature = "arrow")]
 pub use crate::base::arrow::{

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -54,7 +54,7 @@ impl<CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment>
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating
     /// that an invalid reference was provided.
-    fn get_column_names(&self, table_ref: TableRef) -> Vec<&str> {
+    fn get_column_names(&self, table_ref: &TableRef) -> Vec<&str> {
         self.tables
             .get(&table_ref)
             .unwrap()
@@ -68,7 +68,7 @@ impl<CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment>
     /// # Panics
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
-    fn update_offset(&mut self, table_ref: TableRef, new_offset: usize) {
+    fn update_offset(&mut self, table_ref: &TableRef, new_offset: usize) {
         self.tables.get_mut(&table_ref).unwrap().1 = new_offset;
     }
 }
@@ -138,14 +138,14 @@ impl<CP: CommitmentEvaluationProof> MetadataAccessor for OwnedTableTestAccessor<
     /// # Panics
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
-    fn get_length(&self, table_ref: TableRef) -> usize {
+    fn get_length(&self, table_ref: &TableRef) -> usize {
         self.tables.get(&table_ref).unwrap().0.num_rows()
     }
     ///
     /// # Panics
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
-    fn get_offset(&self, table_ref: TableRef) -> usize {
+    fn get_offset(&self, table_ref: &TableRef) -> usize {
         self.tables.get(&table_ref).unwrap().1
     }
 }

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -7,7 +7,7 @@ use crate::base::{
         naive_commitment::NaiveCommitment, naive_evaluation_proof::NaiveEvaluationProof,
         Commitment, CommittableColumn,
     },
-    database::owned_table_utility::*,
+    database::{owned_table_utility::*, TableRef},
     scalar::test_scalar::TestScalar,
 };
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
@@ -15,31 +15,31 @@ use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 #[test]
 fn we_can_query_the_length_of_a_table() {
     let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
-    let table_ref_1 = "sxt.test".parse().unwrap();
-    let table_ref_2 = "sxt.test2".parse().unwrap();
+    let table_ref_1 = TableRef::new("sxt", "test1");
+    let table_ref_2 = TableRef::new("sxt", "test2");
 
     let data1 = owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 5, 6])]);
-    accessor.add_table(table_ref_1, data1, 0_usize);
+    accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
-    assert_eq!(accessor.get_length(table_ref_1), 3);
+    assert_eq!(accessor.get_length(&table_ref_1), 3);
 
     let data2 = owned_table([bigint("a", [1, 2, 3, 4]), bigint("b", [4, 5, 6, 5])]);
-    accessor.add_table(table_ref_2, data2, 0_usize);
+    accessor.add_table(table_ref_2.clone(), data2, 0_usize);
 
-    assert_eq!(accessor.get_length(table_ref_1), 3);
-    assert_eq!(accessor.get_length(table_ref_2), 4);
+    assert_eq!(accessor.get_length(&table_ref_1), 3);
+    assert_eq!(accessor.get_length(&table_ref_2), 4);
 }
 
 #[test]
 fn we_can_access_the_columns_of_a_table() {
     let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
-    let table_ref_1 = "sxt.test".parse().unwrap();
-    let table_ref_2 = "sxt.test2".parse().unwrap();
+    let table_ref_1 = TableRef::new("sxt", "test1");
+    let table_ref_2 = TableRef::new("sxt", "test2");
 
     let data1 = owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 5, 6])]);
-    accessor.add_table(table_ref_1, data1, 0_usize);
+    accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1, "b".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_1.clone(), "b".into(), ColumnType::BigInt);
     match accessor.get_column(column) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6]),
         _ => panic!("Invalid column type"),
@@ -59,21 +59,21 @@ fn we_can_access_the_columns_of_a_table() {
             [4, 5, 6, 5],
         ),
     ]);
-    accessor.add_table(table_ref_2, data2, 0_usize);
+    accessor.add_table(table_ref_2.clone(), data2, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1, "a".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_1.clone(), "a".into(), ColumnType::BigInt);
     match accessor.get_column(column) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![1, 2, 3]),
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2, "b".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_2.clone(), "b".into(), ColumnType::BigInt);
     match accessor.get_column(column) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2, "c128".into(), ColumnType::Int128);
+    let column = ColumnRef::new(table_ref_2.clone(), "c128".into(), ColumnType::Int128);
     match accessor.get_column(column) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
         _ => panic!("Invalid column type"),
@@ -84,7 +84,7 @@ fn we_can_access_the_columns_of_a_table() {
         .iter()
         .map(core::convert::Into::into)
         .collect();
-    let column = ColumnRef::new(table_ref_2, "varchar".into(), ColumnType::VarChar);
+    let column = ColumnRef::new(table_ref_2.clone(), "varchar".into(), ColumnType::VarChar);
     match accessor.get_column(column) {
         Column::VarChar((col, scals)) => {
             assert_eq!(col.to_vec(), col_slice);
@@ -93,7 +93,7 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2, "scalar".into(), ColumnType::Scalar);
+    let column = ColumnRef::new(table_ref_2.clone(), "scalar".into(), ColumnType::Scalar);
     match accessor.get_column(column) {
         Column::Scalar(col) => assert_eq!(
             col.to_vec(),
@@ -107,14 +107,14 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2, "boolean".into(), ColumnType::Boolean);
+    let column = ColumnRef::new(table_ref_2.clone(), "boolean".into(), ColumnType::Boolean);
     match accessor.get_column(column) {
         Column::Boolean(col) => assert_eq!(col.to_vec(), vec![true, false, true, false]),
         _ => panic!("Invalid column type"),
     };
 
     let column = ColumnRef::new(
-        table_ref_2,
+        table_ref_2.clone(),
         "time".into(),
         ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
     );
@@ -127,13 +127,13 @@ fn we_can_access_the_columns_of_a_table() {
 #[test]
 fn we_can_access_the_commitments_of_table_columns() {
     let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
-    let table_ref_1 = "sxt.test".parse().unwrap();
-    let table_ref_2 = "sxt.test2".parse().unwrap();
+    let table_ref_1 = TableRef::new("sxt", "test1");
+    let table_ref_2 = TableRef::new("sxt", "test2");
 
     let data1 = owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 5, 6])]);
-    accessor.add_table(table_ref_1, data1, 0_usize);
+    accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1, "b".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_1.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
         NaiveCommitment::compute_commitments(
@@ -144,9 +144,9 @@ fn we_can_access_the_commitments_of_table_columns() {
     );
 
     let data2 = owned_table([bigint("a", [1, 2, 3, 4]), bigint("b", [4, 5, 6, 5])]);
-    accessor.add_table(table_ref_2, data2, 0_usize);
+    accessor.add_table(table_ref_2.clone(), data2, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1, "a".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_1.clone(), "a".into(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
         NaiveCommitment::compute_commitments(
@@ -156,7 +156,7 @@ fn we_can_access_the_commitments_of_table_columns() {
         )[0]
     );
 
-    let column = ColumnRef::new(table_ref_2, "b".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_2.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
         accessor.get_commitment(column),
         NaiveCommitment::compute_commitments(
@@ -170,39 +170,39 @@ fn we_can_access_the_commitments_of_table_columns() {
 #[test]
 fn we_can_access_the_type_of_table_columns() {
     let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
-    let table_ref_1 = "sxt.test".parse().unwrap();
-    let table_ref_2 = "sxt.test2".parse().unwrap();
+    let table_ref_1 = TableRef::new("sxt", "test1");
+    let table_ref_2 = TableRef::new("sxt", "test2");
 
     let data1 = owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 5, 6])]);
-    accessor.add_table(table_ref_1, data1, 0_usize);
+    accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1, "b".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_1.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
         accessor.lookup_column(column.table_ref(), column.column_id()),
         Some(ColumnType::BigInt)
     );
 
-    let column = ColumnRef::new(table_ref_1, "c".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_1.clone(), "c".into(), ColumnType::BigInt);
     assert!(accessor
         .lookup_column(column.table_ref(), column.column_id())
         .is_none());
 
     let data2 = owned_table([bigint("a", [1, 2, 3, 4]), bigint("b", [4, 5, 6, 5])]);
-    accessor.add_table(table_ref_2, data2, 0_usize);
+    accessor.add_table(table_ref_2.clone(), data2, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1, "a".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_1.clone(), "a".into(), ColumnType::BigInt);
     assert_eq!(
         accessor.lookup_column(column.table_ref(), column.column_id()),
         Some(ColumnType::BigInt)
     );
 
-    let column = ColumnRef::new(table_ref_2, "b".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_2.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
         accessor.lookup_column(column.table_ref(), column.column_id()),
         Some(ColumnType::BigInt)
     );
 
-    let column = ColumnRef::new(table_ref_2, "c".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref_2.clone(), "c".into(), ColumnType::BigInt);
     assert!(accessor
         .lookup_column(column.table_ref(), column.column_id())
         .is_none());
@@ -211,60 +211,60 @@ fn we_can_access_the_type_of_table_columns() {
 #[test]
 fn we_can_access_schema_and_column_names() {
     let mut accessor = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
-    let table_ref_1 = "sxt.test".parse().unwrap();
+    let table_ref_1 = TableRef::new("sxt", "test1");
 
     let data1 = owned_table([bigint("a", [1, 2, 3]), varchar("b", ["x", "y", "z"])]);
-    accessor.add_table(table_ref_1, data1, 0_usize);
+    accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
     assert_eq!(
-        accessor.lookup_schema(table_ref_1),
+        accessor.lookup_schema(table_ref_1.clone()),
         vec![
             ("a".into(), ColumnType::BigInt),
             ("b".into(), ColumnType::VarChar)
         ]
     );
-    assert_eq!(accessor.get_column_names(table_ref_1), vec!["a", "b"]);
+    assert_eq!(accessor.get_column_names(&table_ref_1), vec!["a", "b"]);
 }
 
 #[test]
 fn we_can_correctly_update_offsets() {
     let mut accessor1 = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
-    let table_ref = "sxt.test".parse().unwrap();
+    let table_ref = TableRef::new("sxt", "test1");
 
     let data = owned_table([bigint("a", [1, 2, 3]), bigint("b", [123, 5, 123])]);
-    accessor1.add_table(table_ref, data.clone(), 0_usize);
+    accessor1.add_table(table_ref.clone(), data.clone(), 0_usize);
 
     let offset = 123;
     let mut accessor2 = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
-    accessor2.add_table(table_ref, data, offset);
+    accessor2.add_table(table_ref.clone(), data, offset);
 
-    let column = ColumnRef::new(table_ref, "a".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref.clone(), "a".into(), ColumnType::BigInt);
     assert_ne!(
         accessor1.get_commitment(column.clone()),
         accessor2.get_commitment(column)
     );
-    let column = ColumnRef::new(table_ref, "b".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
     assert_ne!(
         accessor1.get_commitment(column.clone()),
         accessor2.get_commitment(column)
     );
 
-    assert_eq!(accessor1.get_offset(table_ref), 0);
-    assert_eq!(accessor2.get_offset(table_ref), offset);
+    assert_eq!(accessor1.get_offset(&table_ref), 0);
+    assert_eq!(accessor2.get_offset(&table_ref), offset);
 
-    accessor1.update_offset(table_ref, offset);
+    accessor1.update_offset(&table_ref, offset);
 
-    let column = ColumnRef::new(table_ref, "a".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref.clone(), "a".into(), ColumnType::BigInt);
     assert_eq!(
         accessor1.get_commitment(column.clone()),
         accessor2.get_commitment(column)
     );
-    let column = ColumnRef::new(table_ref, "b".into(), ColumnType::BigInt);
+    let column = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
         accessor1.get_commitment(column.clone()),
         accessor2.get_commitment(column)
     );
 
-    assert_eq!(accessor1.get_offset(table_ref), offset);
-    assert_eq!(accessor2.get_offset(table_ref), offset);
+    assert_eq!(accessor1.get_offset(&table_ref), offset);
+    assert_eq!(accessor2.get_offset(&table_ref), offset);
 }

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -1,55 +1,138 @@
-use alloc::string::ToString;
+use crate::base::database::error::ParseError;
+use alloc::{string::ToString, vec::Vec};
 use core::{
     fmt,
     fmt::{Display, Formatter},
     str::FromStr,
 };
+use indexmap::Equivalent;
 use proof_of_sql_parser::{impl_serde_from_str, ResourceId};
 use sqlparser::ast::Ident;
 
 /// Expression for an SQL table
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableRef {
-    resource_id: ResourceId,
+    schema_name: Option<Ident>,
+    table_name: Ident,
 }
 
 impl TableRef {
-    /// Creates a new table reference from a resource id
+    /// Creates a new table reference from schema and table names.
+    /// If the schema name is empty or None, only the table name is used.
     #[must_use]
-    pub fn new(resource_id: ResourceId) -> Self {
-        Self { resource_id }
+    pub fn new(schema_name: impl AsRef<str>, table_name: impl AsRef<str>) -> Self {
+        let schema = schema_name.as_ref();
+        let table = table_name.as_ref();
+
+        Self {
+            schema_name: if schema.is_empty() {
+                None
+            } else {
+                Some(Ident::new(schema.to_string()))
+            },
+            table_name: Ident::new(table.to_string()),
+        }
     }
 
     /// Returns the identifier of the schema
+    /// # Panics
+    #[allow(clippy::get_first)]
     #[must_use]
-    pub fn schema_id(&self) -> Ident {
-        self.resource_id.schema().into()
+    pub fn schema_id(&self) -> Option<&Ident> {
+        self.schema_name.as_ref()
     }
 
     /// Returns the identifier of the table
+    /// # Panics
     #[must_use]
-    pub fn table_id(&self) -> Ident {
-        self.resource_id.object_name().into()
+    pub fn table_id(&self) -> &Ident {
+        &self.table_name
     }
 
-    /// Returns the underlying resource id of the table
+    /// Creates a new table reference from an optional schema and table name.
     #[must_use]
-    pub fn resource_id(&self) -> ResourceId {
-        self.resource_id
+    pub fn from_names(schema_name: Option<&str>, table_name: &str) -> Self {
+        Self {
+            schema_name: schema_name.map(|s| Ident::new(s.to_string())),
+            table_name: Ident::new(table_name.to_string()),
+        }
+    }
+
+    /// Creates a `TableRef` directly from `Option<Ident>` for schema and `Ident` for table.
+    #[must_use]
+    pub fn from_idents(schema_name: Option<Ident>, table_name: Ident) -> Self {
+        Self {
+            schema_name,
+            table_name,
+        }
+    }
+
+    /// Creates a `TableRef` from a slice of string components.
+    pub fn from_strs<S: AsRef<str>>(components: &[S]) -> Result<Self, ParseError> {
+        match components.len() {
+            1 => Ok(Self::from_names(None, components[0].as_ref())),
+            2 => Ok(Self::from_names(
+                Some(components[0].as_ref()),
+                components[1].as_ref(),
+            )),
+            _ => Err(ParseError::InvalidTableReference {
+                table_reference: components
+                    .iter()
+                    .map(AsRef::as_ref)
+                    .collect::<Vec<_>>()
+                    .join(","),
+            }),
+        }
+    }
+}
+
+/// Creates a `TableRef` from a dot-separated string.
+impl TryFrom<&str> for TableRef {
+    type Error = ParseError;
+
+    fn try_from(s: &str) -> Result<Self, <Self as TryFrom<&str>>::Error> {
+        let components: Vec<_> = s.split('.').map(ToString::to_string).collect();
+        match components.len() {
+            1 => Ok(Self::from_names(None, &components[0])),
+            2 => Ok(Self::from_names(Some(&components[0]), &components[1])),
+            _ => Err(ParseError::InvalidTableReference {
+                table_reference: s.to_string(),
+            }),
+        }
+    }
+}
+
+/// Note: We just need this conversion trait until `SelectStatement` refactor is done
+impl From<ResourceId> for TableRef {
+    fn from(id: ResourceId) -> Self {
+        TableRef {
+            schema_name: Some(Ident::from(id.schema())),
+            table_name: Ident::from(id.object_name()),
+        }
     }
 }
 
 impl FromStr for TableRef {
-    type Err = proof_of_sql_parser::ParseError;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::new(s.parse()?))
+        Self::try_from(s)
+    }
+}
+
+impl Equivalent<TableRef> for &TableRef {
+    fn equivalent(&self, key: &TableRef) -> bool {
+        self.schema_name == key.schema_name && self.table_name == key.table_name
     }
 }
 
 impl Display for TableRef {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.resource_id.fmt(f)
+        if let Some(schema) = &self.schema_name {
+            write!(f, "{}.{}", schema.value, self.table_name.value)
+        } else {
+            write!(f, "{}", self.table_name.value)
+        }
     }
 }
 

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -49,7 +49,7 @@ impl<'a, CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment> for TableTe
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating
     /// that an invalid reference was provided.
-    fn get_column_names(&self, table_ref: TableRef) -> Vec<&str> {
+    fn get_column_names(&self, table_ref: &TableRef) -> Vec<&str> {
         self.tables
             .get(&table_ref)
             .unwrap()
@@ -63,7 +63,7 @@ impl<'a, CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment> for TableTe
     /// # Panics
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
-    fn update_offset(&mut self, table_ref: TableRef, new_offset: usize) {
+    fn update_offset(&mut self, table_ref: &TableRef, new_offset: usize) {
         self.tables.get_mut(&table_ref).unwrap().1 = new_offset;
     }
 }
@@ -110,14 +110,14 @@ impl<CP: CommitmentEvaluationProof> MetadataAccessor for TableTestAccessor<'_, C
     /// # Panics
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
-    fn get_length(&self, table_ref: TableRef) -> usize {
+    fn get_length(&self, table_ref: &TableRef) -> usize {
         self.tables.get(&table_ref).unwrap().0.num_rows()
     }
     ///
     /// # Panics
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
-    fn get_offset(&self, table_ref: TableRef) -> usize {
+    fn get_offset(&self, table_ref: &TableRef) -> usize {
         self.tables.get(&table_ref).unwrap().1
     }
 }

--- a/crates/proof-of-sql/src/base/database/test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_accessor.rs
@@ -21,8 +21,8 @@ pub trait TestAccessor<C: Commitment>:
     fn add_table(&mut self, table_ref: TableRef, data: Self::Table, table_offset: usize);
 
     /// Get the column names for a given table
-    fn get_column_names(&self, table_ref: TableRef) -> Vec<&str>;
+    fn get_column_names(&self, table_ref: &TableRef) -> Vec<&str>;
 
     /// Update the table offset alongside its column commitments
-    fn update_offset(&mut self, table_ref: TableRef, new_offset: usize);
+    fn update_offset(&mut self, table_ref: &TableRef, new_offset: usize);
 }

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -34,8 +34,8 @@ mod tests {
     use crate::base::map::indexmap;
 
     fn sample_test_schema_accessor() -> TestSchemaAccessor {
-        let table1: TableRef = TableRef::new("schema.table1".parse().unwrap());
-        let table2: TableRef = TableRef::new("schema.table2".parse().unwrap());
+        let table1 = TableRef::new("schema", "table1");
+        let table2 = TableRef::new("schema", "table2");
         TestSchemaAccessor::new(indexmap! {
             table1 => indexmap! {
                 "col1".into() => ColumnType::BigInt,
@@ -50,27 +50,36 @@ mod tests {
     #[test]
     fn test_lookup_column() {
         let accessor = sample_test_schema_accessor();
-        let table1: TableRef = TableRef::new("schema.table1".parse().unwrap());
-        let table2: TableRef = TableRef::new("schema.table2".parse().unwrap());
-        let not_a_table: TableRef = TableRef::new("schema.not_a_table".parse().unwrap());
+        let table1 = TableRef::new("schema", "table1");
+        let table2 = TableRef::new("schema", "table2");
+        let not_a_table = TableRef::new("schema", "not_a_table");
         assert_eq!(
-            accessor.lookup_column(table1, "col1".into()),
+            accessor.lookup_column(table1.clone(), "col1".into()),
             Some(ColumnType::BigInt)
         );
         assert_eq!(
-            accessor.lookup_column(table1, "col2".into()),
+            accessor.lookup_column(table1.clone(), "col2".into()),
             Some(ColumnType::VarChar)
         );
-        assert_eq!(accessor.lookup_column(table1, "not_a_col".into()), None);
         assert_eq!(
-            accessor.lookup_column(table2, "col1".into()),
+            accessor.lookup_column(table1.clone(), "not_a_col".into()),
+            None
+        );
+        assert_eq!(
+            accessor.lookup_column(table2.clone(), "col1".into()),
             Some(ColumnType::BigInt)
         );
-        assert_eq!(accessor.lookup_column(table2, "col2".into()), None);
-        assert_eq!(accessor.lookup_column(not_a_table, "col1".into()), None);
-        assert_eq!(accessor.lookup_column(not_a_table, "col2".into()), None);
+        assert_eq!(accessor.lookup_column(table2.clone(), "col2".into()), None);
         assert_eq!(
-            accessor.lookup_column(not_a_table, "not_a_col".into()),
+            accessor.lookup_column(not_a_table.clone(), "col1".into()),
+            None
+        );
+        assert_eq!(
+            accessor.lookup_column(not_a_table.clone(), "col2".into()),
+            None
+        );
+        assert_eq!(
+            accessor.lookup_column(not_a_table.clone(), "not_a_col".into()),
             None
         );
     }
@@ -78,9 +87,9 @@ mod tests {
     #[test]
     fn test_lookup_schema() {
         let accessor = sample_test_schema_accessor();
-        let table1: TableRef = TableRef::new("schema.table1".parse().unwrap());
-        let table2: TableRef = TableRef::new("schema.table2".parse().unwrap());
-        let not_a_table: TableRef = TableRef::new("schema.not_a_table".parse().unwrap());
+        let table1 = TableRef::new("schema", "table1");
+        let table2 = TableRef::new("schema", "table2");
+        let not_a_table = TableRef::new("schema", "not_a_table");
         assert_eq!(
             accessor.lookup_schema(table1),
             vec![

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    base::database::{ColumnRef, ColumnType, LiteralValue},
+    base::database::{ColumnRef, ColumnType, LiteralValue, TableRef},
     sql::{
         evm_proof_plan::EVMProofPlan,
         proof_exprs::{
@@ -24,13 +24,13 @@ fn we_cannot_generate_serialized_proof_plan_for_unsupported_plan() {
 
 #[test]
 fn we_can_generate_serialized_proof_plan_for_simple_filter() {
-    let table_ref = "namespace.table".parse().unwrap();
+    let table_ref: TableRef = "namespace.table".parse().unwrap();
     let identifier_a = "a".into();
     let identifier_b = "b".into();
     let identifier_alias = "alias".into();
 
-    let column_ref_a = ColumnRef::new(table_ref, identifier_a, ColumnType::BigInt);
-    let column_ref_b = ColumnRef::new(table_ref, identifier_b, ColumnType::BigInt);
+    let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
+    let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
 
     let plan = DynProofPlan::Filter(FilterExec::new(
         vec![AliasedDynProofExpr {

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -1,5 +1,5 @@
 use crate::base::{
-    database::{ColumnOperationError, ColumnType},
+    database::{ColumnOperationError, ColumnType, TableRef},
     math::decimal::{DecimalError, IntermediateDecimalError},
 };
 use alloc::{
@@ -8,20 +8,27 @@ use alloc::{
     string::{String, ToString},
 };
 use core::result::Result;
-use proof_of_sql_parser::{posql_time::PoSQLTimestampError, ResourceId};
+use proof_of_sql_parser::posql_time::PoSQLTimestampError;
 use snafu::Snafu;
-use sqlparser::ast::Ident;
+use sqlparser::ast::{Ident, ObjectName};
 
 /// Errors from converting an intermediate AST into a provable AST.
 #[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum ConversionError {
-    #[snafu(display("Column '{identifier}' was not found in table '{resource_id}'"))]
+    #[snafu(display("Column '{identifier}' was not found in table '{table_ref}'"))]
     /// The column is missing in the table
     MissingColumn {
         /// The missing column identifier
         identifier: Box<Ident>,
-        /// The table resource id
-        resource_id: Box<ResourceId>,
+        /// The table ref
+        table_ref: TableRef,
+    },
+
+    #[snafu(display("Missing schema or table identifier in ObjectName"))]
+    /// Missing schema or table identifier
+    MissingSchemaOrTable {
+        /// The `ObjectName`
+        object_name: ObjectName,
     },
 
     #[snafu(display("Column '{identifier}' was not found"))]

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -112,7 +112,7 @@ impl ProofPlan for TrivialTestProofPlan {
         indexset! {}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {TableRef::new("sxt.test".parse().unwrap())}
+        indexset![TableRef::new("sxt", "test")]
     }
 }
 
@@ -124,7 +124,7 @@ fn verify_a_trivial_query_proof_with_given_offset(n: usize, offset_generators: u
     };
     let column: Vec<i64> = vec![0_i64; n];
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("a1", column.clone())]),
         offset_generators,
         (),
@@ -164,7 +164,7 @@ fn verify_fails_if_the_summation_in_sumcheck_isnt_zero() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [123_i64; 2])]),
         0,
         (),
@@ -182,7 +182,7 @@ fn verify_fails_if_the_sumcheck_evaluation_isnt_correct() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [123_i64; 2])]),
         0,
         (),
@@ -200,7 +200,7 @@ fn verify_fails_if_counts_dont_match() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [0_i64; 2])]),
         0,
         (),
@@ -216,7 +216,7 @@ fn verify_fails_if_the_number_of_bit_distributions_is_not_enough() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [0_i64; 2])]),
         0,
         (),
@@ -235,7 +235,7 @@ fn verify_fails_if_a_bit_distribution_is_invalid() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [0_i64; 2])]),
         0,
         (),
@@ -278,7 +278,7 @@ impl ProverEvaluate for SquareTestProofPlan {
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         let x = *table_map
-            .get(&TableRef::new("sxt.test".parse().unwrap()))
+            .get(&TableRef::new("sxt", "test"))
             .unwrap()
             .inner_table()
             .get(&Ident::new("x"))
@@ -306,7 +306,7 @@ impl ProofPlan for SquareTestProofPlan {
         let x_eval = S::from(self.anchored_commit_multiplier)
             * *accessor
                 .get(&ColumnRef::new(
-                    "sxt.test".parse().unwrap(),
+                    TableRef::new("sxt", "test"),
                     "x".into(),
                     ColumnType::BigInt,
                 ))
@@ -327,13 +327,13 @@ impl ProofPlan for SquareTestProofPlan {
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         indexset! {ColumnRef::new(
-            "sxt.test".parse().unwrap(),
-            "x".into(),
-            ColumnType::BigInt,
-        )}
+        TableRef::new("sxt", "test"),
+              "x".into(),
+              ColumnType::BigInt,
+          )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {TableRef::new("sxt.test".parse().unwrap())}
+        indexset![TableRef::new("sxt", "test")]
     }
 }
 
@@ -345,7 +345,7 @@ fn verify_a_proof_with_an_anchored_commitment_and_given_offset(offset_generators
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         offset_generators,
         (),
@@ -364,7 +364,7 @@ fn verify_a_proof_with_an_anchored_commitment_and_given_offset(offset_generators
 
     // invalid offset will fail to verify
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         offset_generators + 1,
         (),
@@ -394,7 +394,7 @@ fn verify_fails_if_the_result_doesnt_satisfy_an_anchored_equation() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         0,
         (),
@@ -413,7 +413,7 @@ fn verify_fails_if_the_anchored_commitment_doesnt_match() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         0,
         (),
@@ -457,7 +457,7 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         let x = *table_map
-            .get(&TableRef::new("sxt.test".parse().unwrap()))
+            .get(&TableRef::new("sxt", "test"))
             .unwrap()
             .inner_table()
             .get(&Ident::new("x"))
@@ -497,7 +497,7 @@ impl ProofPlan for DoubleSquareTestProofPlan {
     ) -> Result<TableEvaluation<S>, ProofError> {
         let x_eval = *accessor
             .get(&ColumnRef::new(
-                "sxt.test".parse().unwrap(),
+                TableRef::new("sxt", "test"),
                 "x".into(),
                 ColumnType::BigInt,
             ))
@@ -528,13 +528,13 @@ impl ProofPlan for DoubleSquareTestProofPlan {
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         indexset! {ColumnRef::new(
-            "sxt.test".parse().unwrap(),
-            "x".into(),
-            ColumnType::BigInt,
-        )}
+        TableRef::new("sxt", "test"),
+              "x".into(),
+              ColumnType::BigInt,
+          )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {TableRef::new("sxt.test".parse().unwrap())}
+        indexset![TableRef::new("sxt", "test")]
     }
 }
 
@@ -547,7 +547,7 @@ fn verify_a_proof_with_an_intermediate_commitment_and_given_offset(offset_genera
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         offset_generators,
         (),
@@ -566,7 +566,7 @@ fn verify_a_proof_with_an_intermediate_commitment_and_given_offset(offset_genera
 
     // invalid offset will fail to verify
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         offset_generators + 1,
         (),
@@ -594,7 +594,7 @@ fn verify_fails_if_an_intermediate_commitment_doesnt_match() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         0,
         (),
@@ -617,7 +617,7 @@ fn verify_fails_if_an_intermediate_equation_isnt_satified() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 4])]),
         0,
         (),
@@ -639,7 +639,7 @@ fn verify_fails_the_result_doesnt_satisfy_an_intermediate_equation() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         0,
         (),
@@ -669,7 +669,7 @@ impl ProverEvaluate for ChallengeTestProofPlan {
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         let x = *table_map
-            .get(&TableRef::new("sxt.test".parse().unwrap()))
+            .get(&TableRef::new("sxt", "test"))
             .unwrap()
             .inner_table()
             .get(&Ident::new("x"))
@@ -700,7 +700,7 @@ impl ProofPlan for ChallengeTestProofPlan {
         let _beta = builder.try_consume_post_result_challenge()?;
         let x_eval = *accessor
             .get(&ColumnRef::new(
-                "sxt.test".parse().unwrap(),
+                TableRef::new("sxt", "test"),
                 "x".into(),
                 ColumnType::BigInt,
             ))
@@ -721,13 +721,13 @@ impl ProofPlan for ChallengeTestProofPlan {
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         indexset! {ColumnRef::new(
-            "sxt.test".parse().unwrap(),
+            TableRef::new("sxt", "test"),
             "x".into(),
             ColumnType::BigInt,
         )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {TableRef::new("sxt.test".parse().unwrap())}
+        indexset![TableRef::new("sxt", "test")]
     }
 }
 
@@ -738,7 +738,7 @@ fn verify_a_proof_with_a_post_result_challenge_and_given_offset(offset_generator
     // additionally, we will have a second challenge beta, that is unused
     let expr = ChallengeTestProofPlan {};
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         offset_generators,
         (),
@@ -757,7 +757,7 @@ fn verify_a_proof_with_a_post_result_challenge_and_given_offset(offset_generator
 
     // invalid offset will fail to verify
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         offset_generators + 1,
         (),
@@ -811,7 +811,7 @@ impl ProverEvaluate for FirstRoundSquareTestProofPlan {
         table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         let x = *table_map
-            .get(&TableRef::new("sxt.test".parse().unwrap()))
+            .get(&TableRef::new("sxt", "test"))
             .unwrap()
             .inner_table()
             .get(&Ident::new("x"))
@@ -839,7 +839,7 @@ impl ProofPlan for FirstRoundSquareTestProofPlan {
         let x_eval = S::from(self.anchored_commit_multiplier)
             * *accessor
                 .get(&ColumnRef::new(
-                    "sxt.test".parse().unwrap(),
+                    TableRef::new("sxt", "test"),
                     "x".into(),
                     ColumnType::BigInt,
                 ))
@@ -862,13 +862,13 @@ impl ProofPlan for FirstRoundSquareTestProofPlan {
     }
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         indexset! {ColumnRef::new(
-            "sxt.test".parse().unwrap(),
+            TableRef::new("sxt", "test"),
             "x".into(),
             ColumnType::BigInt,
         )}
     }
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {TableRef::new("sxt.test".parse().unwrap())}
+        indexset![TableRef::new("sxt", "test")]
     }
 }
 
@@ -880,7 +880,7 @@ fn verify_a_proof_with_a_commitment_and_given_offset(offset_generators: usize) {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         offset_generators,
         (),
@@ -899,7 +899,7 @@ fn verify_a_proof_with_a_commitment_and_given_offset(offset_generators: usize) {
 
     // invalid offset will fail to verify
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         offset_generators + 1,
         (),
@@ -929,7 +929,7 @@ fn verify_fails_if_the_result_doesnt_satisfy_an_equation() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         0,
         (),
@@ -948,7 +948,7 @@ fn verify_fails_if_the_commitment_doesnt_match() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("x", [3, 5])]),
         0,
         (),

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -97,7 +97,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         let table_refs = expr.get_table_references();
         if table_refs
             .into_iter()
-            .all(|table_ref| accessor.get_length(table_ref) == 0)
+            .all(|table_ref| accessor.get_length(&table_ref) == 0)
         {
             return VerifiableQueryResult {
                 result: None,
@@ -146,7 +146,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
                 if expr
                     .get_table_references()
                     .into_iter()
-                    .all(|table_ref| accessor.get_length(table_ref) == 0) =>
+                    .all(|table_ref| accessor.get_length(&table_ref) == 0) =>
             {
                 let result_fields = expr.get_column_result_fields();
                 make_empty_query_result(&result_fields)

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -87,7 +87,7 @@ impl ProofPlan for EmptyTestQueryExpr {
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {TableRef::new("sxt.test".parse().unwrap())}
+        indexset![TableRef::new("sxt", "test")]
     }
 }
 
@@ -98,7 +98,7 @@ fn we_can_verify_queries_on_an_empty_table() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [0_i64; 0])]),
         0,
         (),
@@ -119,7 +119,7 @@ fn empty_verification_fails_if_the_result_contains_non_null_members() {
         ..Default::default()
     };
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        "sxt.test".parse().unwrap(),
+        TableRef::new("sxt", "test"),
         owned_table([bigint("a1", [0_i64; 0])]),
         0,
         (),

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -25,7 +25,7 @@ pub fn exercise_verification(
     res: &VerifiableQueryResult<InnerProductProof>,
     expr: &(impl ProofPlan + Serialize),
     accessor: &impl TestAccessor<RistrettoPoint>,
-    table_ref: TableRef,
+    table_ref: &TableRef,
 ) {
     res.clone()
         .verify(expr, accessor, &())

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -1,7 +1,7 @@
 use crate::{
     base::{
         commitment::InnerProductProof,
-        database::{owned_table_utility::*, OwnedTableTestAccessor},
+        database::{owned_table_utility::*, OwnedTableTestAccessor, TableRef},
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
@@ -13,11 +13,12 @@ use crate::{
 #[test]
 fn we_can_prove_a_query_with_a_single_selected_row() {
     let data = owned_table([boolean("a", [true, false])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
-    let ast = projection(cols_expr_plan(t, &["a"], &accessor), tab(t));
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = projection(cols_expr_plan(&t, &["a"], &accessor), tab(&t));
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([boolean("a", [true, false])]);
     assert_eq!(res, expected_res);

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -3,7 +3,7 @@ use crate::{
         commitment::InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, OwnedTable, OwnedTableTestAccessor,
-            Table, TableTestAccessor,
+            Table, TableRef, TableTestAccessor,
         },
         scalar::{Curve25519Scalar, Scalar},
     },
@@ -29,15 +29,16 @@ fn we_can_prove_an_equality_query_with_no_rows() {
         varchar("d", [""; 0]),
         decimal75("e", 75, 0, [0; 0]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "d"], &accessor),
-        tab(t),
-        equal(column(t, "b", &accessor), const_bigint(0_i64)),
+        cols_expr_plan(&t, &["a", "d"], &accessor),
+        tab(&t),
+        equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("a", [0; 0]), varchar("d", [""; 0])]);
     assert_eq!(res, expected_res);
@@ -51,15 +52,16 @@ fn we_can_prove_another_equality_query_with_no_rows() {
         varchar("d", [""; 0]),
         decimal75("e", 75, 0, [0; 0]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "d"], &accessor),
-        tab(t),
-        equal(column(t, "a", &accessor), column(t, "b", &accessor)),
+        cols_expr_plan(&t, &["a", "d"], &accessor),
+        tab(&t),
+        equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("a", [0; 0]), varchar("d", [""; 0])]);
     assert_eq!(res, expected_res);
@@ -74,18 +76,19 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
         varchar("c", ["t"; 0]),
         decimal75("e", 75, 0, [0; 0]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b", "c", "e"], &accessor),
-        tab(t),
+        cols_expr_plan(&t, &["b", "c", "e"], &accessor),
+        tab(&t),
         equal(
-            column(t, "bool", &accessor),
-            equal(column(t, "a", &accessor), column(t, "b", &accessor)),
+            column(&t, "bool", &accessor),
+            equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("b", [1; 0]),
@@ -103,15 +106,16 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
         varchar("d", ["abc"]),
         decimal75("e", 75, 0, [0]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["d", "a"], &accessor),
-        tab(t),
-        equal(column(t, "b", &accessor), const_bigint(0_i64)),
+        cols_expr_plan(&t, &["d", "a"], &accessor),
+        tab(&t),
+        equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([varchar("d", ["abc"]), bigint("a", [123_i64])]);
     assert_eq!(res, expected_res);
@@ -125,15 +129,16 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
         varchar("d", ["abc"]),
         decimal75("e", 75, 0, [0]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["d", "a"], &accessor),
-        tab(t),
-        equal(column(t, "a", &accessor), column(t, "b", &accessor)),
+        cols_expr_plan(&t, &["d", "a"], &accessor),
+        tab(&t),
+        equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([varchar("d", ["abc"]), bigint("a", [123_i64])]);
     assert_eq!(res, expected_res);
@@ -147,15 +152,16 @@ fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
         varchar("d", ["abc"]),
         decimal75("e", 75, 0, [Curve25519Scalar::MAX_SIGNED]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "d", "e"], &accessor),
-        tab(t),
-        equal(column(t, "b", &accessor), const_bigint(0_i64)),
+        cols_expr_plan(&t, &["a", "d", "e"], &accessor),
+        tab(&t),
+        equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [0; 0]),
@@ -183,15 +189,16 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
             ],
         ),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "c", "e"], &accessor),
-        tab(t),
-        equal(column(t, "b", &accessor), const_bigint(0_i64)),
+        cols_expr_plan(&t, &["a", "c", "e"], &accessor),
+        tab(&t),
+        equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [1, 3]),
@@ -220,18 +227,19 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
             ],
         ),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "c", "e"], &accessor),
-        tab(t),
+        cols_expr_plan(&t, &["a", "c", "e"], &accessor),
+        tab(&t),
         equal(
-            column(t, "bool", &accessor),
-            equal(column(t, "a", &accessor), column(t, "b", &accessor)),
+            column(&t, "bool", &accessor),
+            equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [1, 2]),
@@ -260,15 +268,16 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
             ],
         ),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "c", "e"], &accessor),
-        tab(t),
-        equal(column(t, "b", &accessor), const_bigint(123_i64)),
+        cols_expr_plan(&t, &["a", "c", "e"], &accessor),
+        tab(&t),
+        equal(column(&t, "b", &accessor), const_bigint(123_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [1, 3]),
@@ -298,15 +307,16 @@ fn we_can_prove_an_equality_query_with_a_string_comparison() {
             ],
         ),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "b", "e"], &accessor),
-        tab(t),
-        equal(column(t, "c", &accessor), const_varchar("ghi")),
+        cols_expr_plan(&t, &["a", "b", "e"], &accessor),
+        tab(&t),
+        equal(column(&t, "c", &accessor), const_varchar("ghi")),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [2, 5]),
@@ -339,23 +349,23 @@ fn test_random_tables_with_given_offset(offset: usize) {
         let filter_val = format!("s{}", dist.sample(&mut rng));
 
         // Create and verify proof
-        let t = "sxt.t".parse().unwrap();
+        let t = TableRef::new("sxt", "t");
         let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-            t,
+            t.clone(),
             data.clone(),
             offset,
             (),
         );
         let ast = filter(
-            cols_expr_plan(t, &["a", "d"], &accessor),
-            tab(t),
+            cols_expr_plan(&t, &["a", "d"], &accessor),
+            tab(&t),
             equal(
-                column(t, "b", &accessor),
+                column(&t, "b", &accessor),
                 const_varchar(filter_val.as_str()),
             ),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-        exercise_verification(&verifiable_res, &ast, &accessor, t);
+        exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
 
         // Calculate/compare expected result
@@ -409,10 +419,11 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
             &alloc,
         ),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t, data.clone(), 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
     let equals_expr: DynProofExpr = equal(
-        column(t, "e", &accessor),
+        column(&t, "e", &accessor),
         const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ZERO),
     );
     let res = equals_expr.result_evaluate(&alloc, &data);

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -3,7 +3,7 @@ use crate::{
         commitment::InnerProductProof,
         database::{
             owned_table_utility::*, table_utility::*, Column, LiteralValue, OwnedTable,
-            OwnedTableTestAccessor, TableTestAccessor, TestAccessor,
+            OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         scalar::{Curve25519Scalar, Scalar, ScalarExt},
     },
@@ -31,13 +31,14 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
         PoSQLTimeZone::utc(),
         vec![-1, 0, 1],
     )]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a"], &accessor),
-        tab(t),
+        cols_expr_plan(&t, &["a"], &accessor),
+        tab(&t),
         gte(
-            column(t, "a", &accessor),
+            column(&t, "a", &accessor),
             DynProofExpr::new_literal(LiteralValue::TimeStampTZ(
                 PoSQLTimeUnit::Nanosecond,
                 PoSQLTimeZone::utc(),
@@ -65,13 +66,14 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
         PoSQLTimeZone::utc(),
         vec![-1, 0, 1],
     )]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a"], &accessor),
-        tab(t),
+        cols_expr_plan(&t, &["a"], &accessor),
+        tab(&t),
         lte(
-            column(t, "a", &accessor),
+            column(&t, "a", &accessor),
             DynProofExpr::new_literal(LiteralValue::TimeStampTZ(
                 PoSQLTimeUnit::Nanosecond,
                 PoSQLTimeZone::utc(),
@@ -94,15 +96,16 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
 #[test]
 fn we_can_compare_a_constant_column() {
     let data = owned_table([bigint("a", [123_i64, 123, 123]), bigint("b", [1_i64, 2, 3])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(5)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [0; 0])]);
     assert_eq!(res, expected_res);
@@ -111,15 +114,16 @@ fn we_can_compare_a_constant_column() {
 #[test]
 fn we_can_compare_a_varying_column_with_constant_sign() {
     let data = owned_table([bigint("a", [123_i64, 567, 8]), bigint("b", [1_i64, 2, 3])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(5)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [0; 0])]);
     assert_eq!(res, expected_res);
@@ -134,27 +138,28 @@ fn we_can_compare_columns_with_extreme_values() {
         int128("int128_b", [i128::MAX, i128::MIN, i128::MAX]),
         boolean("boolean", [true, false, true]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["bigint_b"], &accessor),
-        tab(t),
+        cols_expr_plan(&t, &["bigint_b"], &accessor),
+        tab(&t),
         lte(
             lte(
                 lte(
-                    column(t, "bigint_a", &accessor),
-                    column(t, "bigint_b", &accessor),
+                    column(&t, "bigint_a", &accessor),
+                    column(&t, "bigint_b", &accessor),
                 ),
                 gte(
-                    column(t, "int128_a", &accessor),
-                    column(t, "int128_b", &accessor),
+                    column(&t, "int128_a", &accessor),
+                    column(&t, "int128_b", &accessor),
                 ),
             ),
-            column(t, "boolean", &accessor),
+            column(&t, "boolean", &accessor),
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("bigint_b", [i64::MAX, i64::MIN])]);
     assert_eq!(res, expected_res);
@@ -170,15 +175,16 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
         varchar("d", ["abc", "de"]),
         decimal75("e", 38, 0, [scalar_pos, scalar_neg]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "d", "e"], &accessor),
-        tab(t),
-        lte(column(t, "e", &accessor), const_bigint(0_i64)),
+        cols_expr_plan(&t, &["a", "d", "e"], &accessor),
+        tab(&t),
+        lte(column(&t, "e", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [25]),
@@ -199,15 +205,16 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
         decimal75("e", 38, 0, [scalar_pos, scalar_neg]),
         decimal75("f", 38, 38, [scalar_neg, scalar_pos]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "d", "e", "f"], &accessor),
-        tab(t),
-        lte(column(t, "f", &accessor), const_bigint(0_i64)),
+        cols_expr_plan(&t, &["a", "d", "e", "f"], &accessor),
+        tab(&t),
+        lte(column(&t, "f", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [123]),
@@ -229,15 +236,16 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
         decimal75("e", 38, 0, [scalar_pos, scalar_neg]),
         decimal75("f", 38, 38, [scalar_neg, scalar_pos]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "d", "e", "f"], &accessor),
-        tab(t),
-        gte(column(t, "f", &accessor), const_bigint(0_i64)),
+        cols_expr_plan(&t, &["a", "d", "e", "f"], &accessor),
+        tab(&t),
+        gte(column(&t, "f", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [25]),
@@ -262,15 +270,16 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
             [Curve25519Scalar::MAX_SIGNED, scalar_min_signed],
         ),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["a", "d", "e"], &accessor),
-        tab(t),
-        lte(column(t, "b", &accessor), const_bigint(0_i64)),
+        cols_expr_plan(&t, &["a", "d", "e"], &accessor),
+        tab(&t),
+        lte(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [25]),
@@ -294,11 +303,12 @@ fn we_cannot_compare_columns_filtering_on_extreme_decimal_values() {
             [Curve25519Scalar::MAX_SIGNED, scalar_min_signed],
         ),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     assert!(matches!(
         DynProofExpr::try_new_inequality(
-            column(t, "e", &accessor),
+            column(&t, "e", &accessor),
             const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ONE),
             false
         ),
@@ -309,15 +319,16 @@ fn we_cannot_compare_columns_filtering_on_extreme_decimal_values() {
 #[test]
 fn we_can_compare_two_columns() {
     let data = owned_table([bigint("a", [1_i64, 5, 8]), bigint("b", [1_i64, 7, 3])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), column(t, "b", &accessor)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [1_i64, 7])]);
     assert_eq!(res, expected_res);
@@ -329,15 +340,16 @@ fn we_can_compare_a_varying_column_with_constant_absolute_value() {
         bigint("a", [-123_i64, 123, -123]),
         bigint("b", [1_i64, 2, 3]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(0)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
@@ -349,15 +361,16 @@ fn we_can_compare_a_constant_column_of_negative_columns() {
         bigint("a", [-123_i64, -123, -123]),
         bigint("b", [1_i64, 2, 3]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(5)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
@@ -369,15 +382,16 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
         bigint("a", [-123_i64, -133, -823]),
         bigint("b", [1_i64, 2, 3]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(5)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(5)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
@@ -386,15 +400,16 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
 #[test]
 fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
     let data = owned_table([bigint("a", [-1_i64, 9, 0]), bigint("b", [1_i64, 2, 3])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(1)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(1)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
@@ -403,15 +418,16 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
 #[test]
 fn we_can_compare_column_with_greater_than_or_equal() {
     let data = owned_table([bigint("a", [-1_i64, 9, 0]), bigint("b", [1_i64, 2, 3])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        gte(column(t, "a", &accessor), const_bigint(1)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        gte(column(&t, "a", &accessor), const_bigint(1)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [2_i64])]);
     assert_eq!(res, expected_res);
@@ -424,18 +440,19 @@ fn we_can_run_nested_comparison() {
         bigint("b", [1_i64, 2, 3]),
         boolean("boolean", [false, false, true]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
         equal(
-            gte(column(t, "a", &accessor), column(t, "b", &accessor)),
-            column(t, "boolean", &accessor),
+            gte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
+            column(&t, "boolean", &accessor),
         ),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
@@ -444,15 +461,16 @@ fn we_can_run_nested_comparison() {
 #[test]
 fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant_bit() {
     let data = owned_table([bigint("a", [-2_i64, 3, 2]), bigint("b", [1_i64, 2, 3])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(0)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [1_i64])]);
     assert_eq!(res, expected_res);
@@ -461,15 +479,16 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant
 #[test]
 fn we_can_compare_a_constant_column_of_zeros() {
     let data = owned_table([bigint("a", [0_i64, 0, 0]), bigint("b", [1_i64, 2, 3])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(0)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
@@ -478,15 +497,16 @@ fn we_can_compare_a_constant_column_of_zeros() {
 #[test]
 fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
     let data = owned_table([bigint("a", [0_i64, 0, 0]), bigint("b", [1_i64, 2, 3])]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = filter(
-        cols_expr_plan(t, &["b"], &accessor),
-        tab(t),
-        lte(column(t, "a", &accessor), const_bigint(0)),
+        cols_expr_plan(&t, &["b"], &accessor),
+        tab(&t),
+        lte(column(&t, "a", &accessor), const_bigint(0)),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected);
@@ -510,20 +530,20 @@ fn test_random_tables_with_given_offset(offset: usize) {
         let filter_val = dist.sample(&mut rng);
 
         // Create and verify proof
-        let t = "sxt.t".parse().unwrap();
+        let t = TableRef::new("sxt", "t");
         let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-            t,
+            t.clone(),
             data.clone(),
             offset,
             (),
         );
         let ast = filter(
-            cols_expr_plan(t, &["a", "b"], &accessor),
-            tab(t),
-            lte(column(t, "a", &accessor), const_bigint(filter_val)),
+            cols_expr_plan(&t, &["a", "b"], &accessor),
+            tab(&t),
+            lte(column(&t, "a", &accessor), const_bigint(filter_val)),
         );
         let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-        exercise_verification(&verifiable_res, &ast, &accessor, t);
+        exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
 
         // Calculate/compare expected result
@@ -561,10 +581,10 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
         borrowed_bigint("b", [1, 2, 3], &alloc),
     ]);
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    let t = "sxt.t".parse().unwrap();
-    accessor.add_table(t, data.clone(), 0);
-    let lhs_expr: DynProofExpr = column(t, "a", &accessor);
-    let rhs_expr = column(t, "b", &accessor);
+    let t = TableRef::new("sxt", "t");
+    accessor.add_table(t.clone(), data.clone(), 0);
+    let lhs_expr: DynProofExpr = column(&t, "a", &accessor);
+    let rhs_expr = column(&t, "b", &accessor);
     let lte_expr = lte(lhs_expr, rhs_expr);
     let res = lte_expr.result_evaluate(&alloc, &data);
     let expected_res = Column::Boolean(&[true, false, true]);
@@ -579,9 +599,9 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
         borrowed_bigint("b", [1, 2, 3], &alloc),
     ]);
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    let t = "sxt.t".parse().unwrap();
-    accessor.add_table(t, data.clone(), 0);
-    let col_expr: DynProofExpr = column(t, "a", &accessor);
+    let t = TableRef::new("sxt", "t");
+    accessor.add_table(t.clone(), data.clone(), 0);
+    let col_expr: DynProofExpr = column(&t, "a", &accessor);
     let lit_expr = const_bigint(1);
     let gte_expr = gte(col_expr, lit_expr);
     let res = gte_expr.result_evaluate(&alloc, &data);

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -1,7 +1,7 @@
 use super::{test_utility::*, DynProofExpr, ProofExpr};
 use crate::base::{
     commitment::InnerProductProof,
-    database::{table_utility::*, Column, TableTestAccessor, TestAccessor},
+    database::{table_utility::*, Column, TableRef, TableTestAccessor, TestAccessor},
 };
 use bumpalo::Bump;
 
@@ -31,15 +31,15 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
         ),
     ]);
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    let t = "sxt.t".parse().unwrap();
-    accessor.add_table(t, data.clone(), 0);
+    let t = TableRef::new("sxt", "t");
+    accessor.add_table(t.clone(), data.clone(), 0);
     // (a <= 5 || b == "g") && c != 3
     let bool_expr: DynProofExpr = and(
         or(
-            lte(column(t, "a", &accessor), const_bigint(5)),
-            equal(column(t, "b", &accessor), const_varchar("g")),
+            lte(column(&t, "a", &accessor), const_bigint(5)),
+            equal(column(&t, "b", &accessor), const_varchar("g")),
         ),
-        not(equal(column(t, "c", &accessor), const_int128(3))),
+        not(equal(column(&t, "c", &accessor), const_int128(3))),
     );
     let res = bool_expr.result_evaluate(&alloc, &data);
     let expected_res = Column::Boolean(&[

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -150,7 +150,7 @@ impl ProofPlan for MembershipCheckTestPlan {
 
     #[doc = "Return all the tables referenced in the Query"]
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {self.source_table, self.candidate_table}
+        indexset! {self.source_table.clone(), self.candidate_table.clone()}
     }
 
     #[doc = "Form components needed to verify and proof store into `VerificationBuilder`"]
@@ -204,18 +204,18 @@ mod tests {
         let alloc = Bump::new();
         let source_table = table([borrowed_bigint("a", [1, 2, 3], &alloc)]);
         let candidate_table = table([borrowed_bigint("c", [1, 2, 2, 1, 2], &alloc)]);
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = MembershipCheckTestPlan {
-            source_table: source_table_ref,
-            candidate_table: candidate_table_ref,
+            source_table: source_table_ref.clone(),
+            candidate_table: candidate_table_ref.clone(),
             source_columns: vec![ColumnRef::new(
                 source_table_ref,
                 "a".into(),
@@ -248,26 +248,26 @@ mod tests {
             borrowed_boolean("e", [true, false, true, true, false], &alloc),
             borrowed_bigint("f", [5, 6, 7, 8, 9], &alloc),
         ]);
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = MembershipCheckTestPlan {
-            source_table: source_table_ref,
-            candidate_table: candidate_table_ref,
+            source_table: source_table_ref.clone(),
+            candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref, "b".into(), ColumnType::VarChar),
+                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
                 ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref, "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref, "d".into(), ColumnType::VarChar),
+                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
+                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
                 ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
@@ -292,26 +292,26 @@ mod tests {
             borrowed_boolean("e", [true; 0], &alloc),
             borrowed_bigint("f", [0_i64; 0], &alloc),
         ]);
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = MembershipCheckTestPlan {
-            source_table: source_table_ref,
-            candidate_table: candidate_table_ref,
+            source_table: source_table_ref.clone(),
+            candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
-                ColumnRef::new(source_table_ref, "b".into(), ColumnType::VarChar),
+                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
                 ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
             ],
             candidate_columns: vec![
-                ColumnRef::new(candidate_table_ref, "c".into(), ColumnType::BigInt),
-                ColumnRef::new(candidate_table_ref, "d".into(), ColumnType::VarChar),
+                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
+                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
                 ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
@@ -330,20 +330,20 @@ mod tests {
             borrowed_bigint("b", [3, 4], &alloc),
         ]);
         let candidate_table = table([borrowed_bigint("a", [1, 2, 1, 1, 2], &alloc)]);
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = MembershipCheckTestPlan {
-            source_table: source_table_ref,
-            candidate_table: candidate_table_ref,
+            source_table: source_table_ref.clone(),
+            candidate_table: candidate_table_ref.clone(),
             source_columns: vec![
-                ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
+                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
                 ColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
             ],
             candidate_columns: vec![ColumnRef::new(
@@ -368,15 +368,15 @@ mod tests {
             TableOptions { row_count: Some(4) },
         )
         .unwrap();
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = MembershipCheckTestPlan {
             source_table: source_table_ref,
             candidate_table: candidate_table_ref,
@@ -401,15 +401,15 @@ mod tests {
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = MembershipCheckTestPlan {
             source_table: source_table_ref,
             candidate_table: candidate_table_ref,
@@ -433,15 +433,15 @@ mod tests {
             TableOptions { row_count: Some(0) },
         )
         .unwrap();
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = MembershipCheckTestPlan {
             source_table: source_table_ref,
             candidate_table: candidate_table_ref,
@@ -466,15 +466,15 @@ mod tests {
             borrowed_bigint("a", [1, 2, 1, 1, 2], &alloc),
             borrowed_bigint("b", [3, 4, 3, 3, 4], &alloc),
         ]);
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
         let plan = MembershipCheckTestPlan {
             source_table: source_table_ref,
             candidate_table: candidate_table_ref,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -211,29 +211,35 @@ mod tests {
     ) {
         let precision = Precision::new(50).unwrap();
         check_monotonic::<STRICT, ASC>(
-            table_ref,
+            table_ref.clone(),
             accessor,
             "smallint",
             ColumnType::SmallInt,
             shall_error,
         );
-        check_monotonic::<STRICT, ASC>(table_ref, accessor, "int", ColumnType::Int, shall_error);
         check_monotonic::<STRICT, ASC>(
-            table_ref,
+            table_ref.clone(),
+            accessor,
+            "int",
+            ColumnType::Int,
+            shall_error,
+        );
+        check_monotonic::<STRICT, ASC>(
+            table_ref.clone(),
             accessor,
             "bigint",
             ColumnType::BigInt,
             shall_error,
         );
         check_monotonic::<STRICT, ASC>(
-            table_ref,
+            table_ref.clone(),
             accessor,
             "boolean",
             ColumnType::Boolean,
             shall_error,
         );
         check_monotonic::<STRICT, ASC>(
-            table_ref,
+            table_ref.clone(),
             accessor,
             "decimal",
             ColumnType::Decimal75(precision, 1),
@@ -253,21 +259,21 @@ mod tests {
         table: Table<Curve25519Scalar>,
         expected_monotonicity: &Monotonicity,
     ) {
-        let table_ref = "sxt.table".parse().unwrap();
+        let table_ref: TableRef = "sxt.table".parse().unwrap();
         let accessor =
-            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref, table, 0, ());
+            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref.clone(), table, 0, ());
         check_monotonic_for_table::<true, true>(
-            table_ref,
+            table_ref.clone(),
             &accessor,
             !expected_monotonicity.is_strict_asc(),
         );
         check_monotonic_for_table::<false, true>(
-            table_ref,
+            table_ref.clone(),
             &accessor,
             !expected_monotonicity.is_asc(),
         );
         check_monotonic_for_table::<true, false>(
-            table_ref,
+            table_ref.clone(),
             &accessor,
             !expected_monotonicity.is_strict_desc(),
         );

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -236,17 +236,18 @@ mod tests {
             ),
         ]);
 
-        let t = "sxt.t".parse().unwrap();
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let t: TableRef = "sxt.t".parse().unwrap();
+        let accessor =
+            OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
 
-        check_range(t, "uint8", ColumnType::Uint8, &accessor);
-        check_range(t, "tinyint", ColumnType::TinyInt, &accessor);
-        check_range(t, "smallint", ColumnType::SmallInt, &accessor);
-        check_range(t, "int", ColumnType::Int, &accessor);
-        check_range(t, "bigint", ColumnType::BigInt, &accessor);
-        check_range(t, "int128", ColumnType::Int128, &accessor);
+        check_range(t.clone(), "uint8", ColumnType::Uint8, &accessor);
+        check_range(t.clone(), "tinyint", ColumnType::TinyInt, &accessor);
+        check_range(t.clone(), "smallint", ColumnType::SmallInt, &accessor);
+        check_range(t.clone(), "int", ColumnType::Int, &accessor);
+        check_range(t.clone(), "bigint", ColumnType::BigInt, &accessor);
+        check_range(t.clone(), "int128", ColumnType::Int128, &accessor);
         check_range(
-            t,
+            t.clone(),
             "decimal75",
             ColumnType::Decimal75(Precision::new(74).unwrap(), 0),
             &accessor,
@@ -265,10 +266,11 @@ mod tests {
     )]
     fn we_cannot_successfully_verify_invalid_range() {
         let data = owned_table([scalar("a", -2..254)]);
-        let t = "sxt.t".parse().unwrap();
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let t = TableRef::new("sxt", "t");
+        let accessor =
+            OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t, "a".into(), ColumnType::Scalar),
+            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
         };
         let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
         let _ = verifiable_res.verify(&ast, &accessor, &());
@@ -294,10 +296,11 @@ mod tests {
                 .collect::<Vec<_>>(),
         )]);
 
-        let t = "sxt.t".parse().unwrap();
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let t = TableRef::new("sxt", "t");
+        let accessor =
+            OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t, "a".into(), ColumnType::Scalar),
+            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
         };
         let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
         let res: Result<
@@ -331,10 +334,11 @@ mod tests {
                 .collect::<Vec<_>>(),
         )]);
 
-        let t = "sxt.t".parse().unwrap();
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let t = TableRef::new("sxt", "t");
+        let accessor =
+            OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
-            column: ColumnRef::new(t, "a".into(), ColumnType::Scalar),
+            column: ColumnRef::new(t.clone(), "a".into(), ColumnType::Scalar),
         };
         let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
         let res: Result<
@@ -370,8 +374,9 @@ mod tests {
                 .collect::<Vec<_>>(),
         )]);
 
-        let t = "sxt.t".parse().unwrap();
-        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+        let t: TableRef = "sxt.t".parse().unwrap();
+        let accessor =
+            OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
         let ast = RangeCheckTestPlan {
             column: ColumnRef::new(t, "a".into(), ColumnType::Scalar),
         };

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
@@ -153,21 +153,21 @@ mod tests {
             borrowed_varchar("d", ["", "Space", "and", "Time"], &alloc),
             borrowed_boolean("e", [false, true, false, true], &alloc),
         ]);
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
 
         // BigInt column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
+            column: ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
             candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref,
+                candidate_table_ref.clone(),
                 "c".into(),
                 ColumnType::BigInt,
             ),
@@ -179,9 +179,9 @@ mod tests {
 
         // Varchar column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "b".into(), ColumnType::VarChar),
+            column: ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
             candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref,
+                candidate_table_ref.clone(),
                 "d".into(),
                 ColumnType::VarChar,
             ),
@@ -221,21 +221,21 @@ mod tests {
             borrowed_boolean("e", [true, true, false, true], &alloc),
             borrowed_bigint("f", [0, 5, 6, 7], &alloc),
         ]);
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
 
         // BigInt column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
+            column: ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
             candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref,
+                candidate_table_ref.clone(),
                 "c".into(),
                 ColumnType::BigInt,
             ),
@@ -246,9 +246,9 @@ mod tests {
 
         // Varchar column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "b".into(), ColumnType::VarChar),
+            column: ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
             candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref,
+                candidate_table_ref.clone(),
                 "d".into(),
                 ColumnType::VarChar,
             ),
@@ -259,9 +259,9 @@ mod tests {
 
         // Boolean column
         let plan = ShiftTestPlan {
-            column: ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+            column: ColumnRef::new(source_table_ref.clone(), "c".into(), ColumnType::Boolean),
             candidate_shifted_column: ColumnRef::new(
-                candidate_table_ref,
+                candidate_table_ref.clone(),
                 "e".into(),
                 ColumnType::Boolean,
             ),
@@ -294,15 +294,15 @@ mod tests {
             [102, 101, 102, 103, 104, 105, 106, -102],
             &alloc,
         )]);
-        let source_table_ref = "sxt.source_table".parse().unwrap();
-        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let source_table_ref: TableRef = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref: TableRef = "sxt.candidate_table".parse().unwrap();
         let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-            source_table_ref,
+            source_table_ref.clone(),
             source_table,
             0,
             (),
         );
-        accessor.add_table(candidate_table_ref, candidate_table, 0);
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
 
         // BigInt column
         let plan = ShiftTestPlan {

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -91,7 +91,8 @@ mod tests {
     fn we_can_create_and_prove_a_demo_mock_plan() {
         let table_ref = "namespace.table_name".parse::<TableRef>().unwrap();
         let table = owned_table([bigint("column_name", [0, 1, 2, 3])]);
-        let column_ref = ColumnRef::new(table_ref, "column_name".into(), ColumnType::BigInt);
+        let column_ref =
+            ColumnRef::new(table_ref.clone(), "column_name".into(), ColumnType::BigInt);
         let plan = DemoMockPlan { column: column_ref };
         let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
             table_ref,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -134,7 +134,7 @@ where
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        IndexSet::from_iter([self.table.table_ref])
+        IndexSet::from_iter([self.table.table_ref.clone()])
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -172,13 +172,13 @@ fn we_fail_to_verify_a_basic_filter_with_a_dishonest_prover() {
         varchar("d", ["1", "2", "3", "4", "5"]),
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
+    accessor.add_table(t.clone(), data, 0);
     let expr = DishonestFilterExec::new(
-        cols_expr_plan(t, &["b", "c", "d", "e"], &accessor),
-        tab(t),
-        equal(column(t, "a", &accessor), const_int128(105_i128)),
+        cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
+        tab(&t),
+        equal(column(&t, "a", &accessor), const_int128(105_i128)),
     );
     let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
     assert!(matches!(

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -186,7 +186,7 @@ impl ProofPlan for GroupByExec {
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        IndexSet::from_iter([self.table.table_ref])
+        IndexSet::from_iter([self.table.table_ref.clone()])
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -83,7 +83,7 @@ impl ProofPlan for ProjectionExec {
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        IndexSet::from_iter([self.table.table_ref])
+        IndexSet::from_iter([self.table.table_ref.clone()])
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -27,15 +27,16 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
         bigint("a", [1_i64, 2, 3, 4, 5]),
         varchar("b", ["1", "2", "3", "4", "5"]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let ast = slice_exec(
-        projection(cols_expr_plan(t, &["a", "b"], &accessor), tab(t)),
+        projection(cols_expr_plan(&t, &["a", "b"], &accessor), tab(&t)),
         1,
         Some(2),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("a", [2_i64, 3]), varchar("b", ["2", "3"])]);
     assert_eq!(res, expected_res);
@@ -47,20 +48,21 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
         bigint("a", [1_i64, 2, 3, 4, 5]),
         varchar("b", ["1", "2", "3", "4", "5"]),
     ]);
-    let t = "sxt.t".parse().unwrap();
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t, data, 0, ());
-    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(2));
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(2));
     let ast = slice_exec(
         filter(
-            cols_expr_plan(t, &["a", "b"], &accessor),
-            tab(t),
+            cols_expr_plan(&t, &["a", "b"], &accessor),
+            tab(&t),
             where_clause,
         ),
         1,
         Some(2),
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("a", [0_i64; 0]), varchar("b", [""; 0])]);
     assert_eq!(res, expected_res);
@@ -77,17 +79,17 @@ fn we_can_get_an_empty_result_from_a_slice_on_an_empty_table_using_first_round_e
         borrowed_scalar("e", [0; 0], &alloc),
     ]);
     let data_length = data.num_rows();
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
-        t => data.clone()
+        t.clone() => data.clone()
     };
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
-    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(999));
+    accessor.add_table(t.clone(), data, 0);
+    let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let expr = slice_exec(
         filter(
-            cols_expr_plan(t, &["b", "c", "d", "e"], &accessor),
-            tab(t),
+            cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
+            tab(&t),
             where_clause,
         ),
         1,
@@ -132,17 +134,17 @@ fn we_can_get_an_empty_result_from_a_slice_using_first_round_evaluate() {
         borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
-        t => data.clone()
+        t.clone() => data.clone()
     };
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
-    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(999));
+    accessor.add_table(t.clone(), data, 0);
+    let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(999));
     let expr = slice_exec(
         filter(
-            cols_expr_plan(t, &["b", "c", "d", "e"], &accessor),
-            tab(t),
+            cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
+            tab(&t),
             where_clause,
         ),
         1,
@@ -187,15 +189,15 @@ fn we_can_get_no_columns_from_a_slice_with_empty_input_using_first_round_evaluat
         borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
-        t => data.clone()
+        t.clone() => data.clone()
     };
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
-    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(5));
+    accessor.add_table(t.clone(), data, 0);
+    let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let expr = slice_exec(
-        filter(cols_expr_plan(t, &[], &accessor), tab(t), where_clause),
+        filter(cols_expr_plan(&t, &[], &accessor), tab(&t), where_clause),
         2,
         None,
     );
@@ -223,17 +225,17 @@ fn we_can_get_the_correct_result_from_a_slice_using_first_round_evaluate() {
         borrowed_scalar("e", [1, 2, 3, 4, 5], &alloc),
     ]);
     let data_length = data.num_rows();
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let table_map = indexmap! {
-        t => data.clone()
+        t.clone() => data.clone()
     };
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
-    let where_clause: DynProofExpr = equal(column(t, "a", &accessor), const_int128(5));
+    accessor.add_table(t.clone(), data, 0);
+    let where_clause: DynProofExpr = equal(column(&t, "a", &accessor), const_int128(5));
     let expr = slice_exec(
         filter(
-            cols_expr_plan(t, &["b", "c", "d", "e"], &accessor),
-            tab(t),
+            cols_expr_plan(&t, &["b", "c", "d", "e"], &accessor),
+            tab(&t),
             where_clause,
         ),
         1,
@@ -274,30 +276,30 @@ fn we_can_prove_a_slice_exec() {
         varchar("d", ["1", "2", "3", "4", "5"]),
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
+    accessor.add_table(t.clone(), data, 0);
     let expr = slice_exec(
         filter(
             vec![
-                col_expr_plan(t, "b", &accessor),
-                col_expr_plan(t, "c", &accessor),
-                col_expr_plan(t, "d", &accessor),
-                col_expr_plan(t, "e", &accessor),
+                col_expr_plan(&t, "b", &accessor),
+                col_expr_plan(&t, "c", &accessor),
+                col_expr_plan(&t, "d", &accessor),
+                col_expr_plan(&t, "e", &accessor),
                 aliased_plan(const_int128(105), "const"),
                 aliased_plan(
-                    equal(column(t, "b", &accessor), column(t, "c", &accessor)),
+                    equal(column(&t, "b", &accessor), column(&t, "c", &accessor)),
                     "bool",
                 ),
             ],
-            tab(t),
-            equal(column(t, "a", &accessor), const_int128(105)),
+            tab(&t),
+            equal(column(&t, "a", &accessor), const_int128(105)),
         ),
         2,
         Some(1),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &());
-    exercise_verification(&res, &expr, &accessor, t);
+    exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &()).unwrap().table;
     let expected = owned_table([
         bigint("b", [4]),
@@ -319,25 +321,25 @@ fn we_can_prove_a_nested_slice_exec() {
         varchar("d", ["1", "2", "3", "4", "5"]),
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
+    accessor.add_table(t.clone(), data, 0);
     let expr = slice_exec(
         slice_exec(
             filter(
                 vec![
-                    col_expr_plan(t, "b", &accessor),
-                    col_expr_plan(t, "c", &accessor),
-                    col_expr_plan(t, "d", &accessor),
-                    col_expr_plan(t, "e", &accessor),
+                    col_expr_plan(&t, "b", &accessor),
+                    col_expr_plan(&t, "c", &accessor),
+                    col_expr_plan(&t, "d", &accessor),
+                    col_expr_plan(&t, "e", &accessor),
                     aliased_plan(const_int128(105), "const"),
                     aliased_plan(
-                        equal(column(t, "b", &accessor), column(t, "c", &accessor)),
+                        equal(column(&t, "b", &accessor), column(&t, "c", &accessor)),
                         "bool",
                     ),
                 ],
-                tab(t),
-                equal(column(t, "a", &accessor), const_int128(105)),
+                tab(&t),
+                equal(column(&t, "a", &accessor), const_int128(105)),
             ),
             1,
             Some(3),
@@ -346,7 +348,7 @@ fn we_can_prove_a_nested_slice_exec() {
         Some(1),
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &());
-    exercise_verification(&res, &expr, &accessor, t);
+    exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &()).unwrap().table;
     let expected = owned_table([
         bigint("b", [4]),
@@ -368,25 +370,25 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         varchar("d", ["1", "2", "3", "4", "5"]),
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
+    accessor.add_table(t.clone(), data, 0);
     let expr = slice_exec(
         slice_exec(
             filter(
                 vec![
-                    col_expr_plan(t, "b", &accessor),
-                    col_expr_plan(t, "c", &accessor),
-                    col_expr_plan(t, "d", &accessor),
-                    col_expr_plan(t, "e", &accessor),
+                    col_expr_plan(&t, "b", &accessor),
+                    col_expr_plan(&t, "c", &accessor),
+                    col_expr_plan(&t, "d", &accessor),
+                    col_expr_plan(&t, "e", &accessor),
                     aliased_plan(const_int128(105), "const"),
                     aliased_plan(
-                        equal(column(t, "b", &accessor), column(t, "c", &accessor)),
+                        equal(column(&t, "b", &accessor), column(&t, "c", &accessor)),
                         "bool",
                     ),
                 ],
-                tab(t),
-                equal(column(t, "a", &accessor), const_int128(105)),
+                tab(&t),
+                equal(column(&t, "a", &accessor), const_int128(105)),
             ),
             1,
             Some(3),
@@ -395,7 +397,7 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         None,
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &());
-    exercise_verification(&res, &expr, &accessor, t);
+    exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &()).unwrap().table;
     let expected = owned_table([
         bigint("b", [0; 0]),
@@ -417,25 +419,25 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         varchar("d", ["1", "2", "3", "4", "5"]),
         scalar("e", [1, 2, 3, 4, 5]),
     ]);
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
+    accessor.add_table(t.clone(), data, 0);
     let expr = slice_exec(
         slice_exec(
             filter(
                 vec![
-                    col_expr_plan(t, "b", &accessor),
-                    col_expr_plan(t, "c", &accessor),
-                    col_expr_plan(t, "d", &accessor),
-                    col_expr_plan(t, "e", &accessor),
+                    col_expr_plan(&t, "b", &accessor),
+                    col_expr_plan(&t, "c", &accessor),
+                    col_expr_plan(&t, "d", &accessor),
+                    col_expr_plan(&t, "e", &accessor),
                     aliased_plan(const_int128(105), "const"),
                     aliased_plan(
-                        equal(column(t, "b", &accessor), column(t, "c", &accessor)),
+                        equal(column(&t, "b", &accessor), column(&t, "c", &accessor)),
                         "bool",
                     ),
                 ],
-                tab(t),
-                equal(column(t, "a", &accessor), const_int128(105)),
+                tab(&t),
+                equal(column(&t, "a", &accessor), const_int128(105)),
             ),
             6,
             Some(3),
@@ -444,7 +446,7 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         None,
     );
     let res = VerifiableQueryResult::new(&expr, &accessor, &());
-    exercise_verification(&res, &expr, &accessor, t);
+    exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &()).unwrap().table;
     let expected = owned_table([
         bigint("b", [0; 0]),
@@ -460,10 +462,10 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
 #[test]
 fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
     let alloc = Bump::new();
-    let table_ref = TableRef::new("namespace.table_name".parse().unwrap());
+    let table_ref = TableRef::new("namespace", "table_name");
     let plan = slice_exec(
         table_exec(
-            table_ref,
+            table_ref.clone(),
             vec![
                 ColumnField::new("language_rank".into(), ColumnType::BigInt),
                 ColumnField::new("language_name".into(), ColumnType::VarChar),
@@ -474,7 +476,7 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         Some(4),
     );
     let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-        table_ref,
+        table_ref.clone(),
         table([
             borrowed_bigint("language_rank", [0_i64, 1, 2, 3], &alloc),
             borrowed_varchar(
@@ -497,7 +499,7 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         (),
     );
     let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &());
-    exercise_verification(&verifiable_res, &plan, &accessor, table_ref);
+    exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let res = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
     let expected = owned_table([
         bigint("language_rank", [1_i64, 2, 3]),
@@ -513,11 +515,11 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
 #[test]
 fn we_can_create_and_prove_a_slice_exec_on_top_of_an_empty_exec() {
     let empty_table = owned_table([]);
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let expr = slice_exec(empty_exec(), 3, Some(2));
     let res = VerifiableQueryResult::new(&expr, &accessor, &());
-    exercise_verification(&res, &expr, &accessor, t);
+    exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &()).unwrap().table;
     assert_eq!(res, empty_table);
 }
@@ -529,16 +531,16 @@ fn we_cannot_prove_a_slice_exec_if_it_has_groupby_as_input_for_now() {
         bigint("b", [99, 99, 99, 99, 0]),
         bigint("c", [101, 102, 103, 104, 105]),
     ]);
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
+    accessor.add_table(t.clone(), data, 0);
     let expr = slice_exec(
         group_by(
-            cols_expr(t, &["a"], &accessor),
-            vec![sum_expr(column(t, "c", &accessor), "sum_c")],
+            cols_expr(&t, &["a"], &accessor),
+            vec![sum_expr(column(&t, "c", &accessor), "sum_c")],
             "__count__",
-            tab(t),
-            equal(column(t, "b", &accessor), const_int128(99)),
+            tab(&t),
+            equal(column(&t, "b", &accessor), const_int128(99)),
         ),
         2,
         None,

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -46,7 +46,8 @@ impl ProofPlan for TableExec {
             .schema
             .iter()
             .map(|field| {
-                let column_ref = ColumnRef::new(self.table_ref, field.name(), field.data_type());
+                let column_ref =
+                    ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type());
                 *accessor.get(&column_ref).expect("Column does not exist")
             })
             .collect::<Vec<_>>();
@@ -63,12 +64,12 @@ impl ProofPlan for TableExec {
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         self.schema
             .iter()
-            .map(|field| ColumnRef::new(self.table_ref, field.name(), field.data_type()))
+            .map(|field| ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type()))
             .collect()
     }
 
     fn get_table_references(&self) -> IndexSet<TableRef> {
-        indexset! {self.table_ref}
+        indexset! {self.table_ref.clone()}
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -12,19 +12,19 @@ use bumpalo::Bump;
 #[test]
 fn we_can_create_and_prove_an_empty_table_exec() {
     let alloc = Bump::new();
-    let table_ref = TableRef::new("namespace.table_name".parse().unwrap());
+    let table_ref = TableRef::new("namespace", "table_name");
     let plan = table_exec(
-        table_ref,
+        table_ref.clone(),
         vec![ColumnField::new("a".into(), ColumnType::BigInt)],
     );
     let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-        table_ref,
+        table_ref.clone(),
         table([borrowed_bigint("a", [0_i64; 0], &alloc)]),
         0_usize,
         (),
     );
     let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &());
-    exercise_verification(&verifiable_res, &plan, &accessor, table_ref);
+    exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let res = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
     let expected = owned_table([bigint("a", [0_i64; 0])]);
     assert_eq!(res, expected);
@@ -33,9 +33,9 @@ fn we_can_create_and_prove_an_empty_table_exec() {
 #[test]
 fn we_can_create_and_prove_a_table_exec() {
     let alloc = Bump::new();
-    let table_ref = TableRef::new("namespace.table_name".parse().unwrap());
+    let table_ref = TableRef::new("namespace", "table_name");
     let plan = table_exec(
-        table_ref,
+        table_ref.clone(),
         vec![
             ColumnField::new("language_rank".into(), ColumnType::BigInt),
             ColumnField::new("language_name".into(), ColumnType::VarChar),
@@ -43,7 +43,7 @@ fn we_can_create_and_prove_a_table_exec() {
         ],
     );
     let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
-        table_ref,
+        table_ref.clone(),
         table([
             borrowed_bigint("language_rank", [0_i64, 1, 2, 3], &alloc),
             borrowed_varchar(
@@ -66,7 +66,7 @@ fn we_can_create_and_prove_a_table_exec() {
         (),
     );
     let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &());
-    exercise_verification(&verifiable_res, &plan, &accessor, table_ref);
+    exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let res = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
     let expected = owned_table([
         bigint("language_rank", [0, 1, 2, 3]),

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         database::{
             owned_table_utility::*, table_utility::*, ColumnType, OwnedTable,
-            OwnedTableTestAccessor, TableTestAccessor, TestAccessor,
+            OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         map::indexmap,
         scalar::Curve25519Scalar,
@@ -42,14 +42,14 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_with_one_table() {
         bigint("a0", [0_i64, 1, 2, 3, 4]),
         varchar("b0", ["", "1", "2", "3", "4"]),
     ]);
-    let t = "sxt.t".parse().unwrap();
+    let t = TableRef::new("sxt", "t");
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t, data, 0);
+    accessor.add_table(t.clone(), data, 0);
     let ast = union_exec(
         vec![filter(
-            cols_expr_plan(t, &["a0"], &accessor),
-            tab(t),
-            gte(column(t, "a0", &accessor), const_int128(2_i128)),
+            cols_expr_plan(&t, &["a0"], &accessor),
+            tab(&t),
+            gte(column(&t, "a0", &accessor), const_int128(2_i128)),
         )],
         vec![column_field("a", ColumnType::BigInt)],
     );
@@ -63,21 +63,21 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_with_one_table() {
 #[test]
 fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
     let data0 = owned_table([bigint("a0", [0_i64; 0])]);
-    let t0 = "sxt.t0".parse().unwrap();
+    let t0 = TableRef::new("sxt", "t0");
     let data1 = owned_table([bigint("a1", [0_i64; 0])]);
-    let t1 = "sxt.t1".parse().unwrap();
+    let t1 = TableRef::new("sxt", "t1");
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t0, data0, 0);
-    accessor.add_table(t1, data1, 0);
+    accessor.add_table(t0.clone(), data0, 0);
+    accessor.add_table(t1.clone(), data1, 0);
     let ast = union_exec(
         vec![
-            projection(cols_expr_plan(t1, &["a1"], &accessor), tab(t1)),
-            projection(cols_expr_plan(t0, &["a0"], &accessor), tab(t0)),
+            projection(cols_expr_plan(&t1, &["a1"], &accessor), tab(&t1)),
+            projection(cols_expr_plan(&t0, &["a0"], &accessor), tab(&t0)),
         ],
         vec![column_field("a", ColumnType::BigInt)],
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t0);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("a", [0_i64; 0])]);
     assert_eq!(res, expected_res);
@@ -90,18 +90,18 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
         borrowed_bigint("a0", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar("b0", ["1", "2", "3", "4", "5"], &alloc),
     ]);
-    let t0 = "sxt.t0".parse().unwrap();
+    let t0 = TableRef::new("sxt", "t0");
     let data1 = table([
         borrowed_bigint("a1", [2_i64, 3, 4, 5, 6], &alloc),
         borrowed_varchar("b1", ["2", "3", "4", "5", "6"], &alloc),
     ]);
-    let t1 = "sxt.t1".parse().unwrap();
+    let t1 = TableRef::new("sxt", "t1");
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t0, data0, 0);
-    accessor.add_table(t1, data1, 0);
+    accessor.add_table(t0.clone(), data0, 0);
+    accessor.add_table(t1.clone(), data1, 0);
     let ast = union_exec(
         vec![
-            projection(cols_expr_plan(t0, &["a0", "b0"], &accessor), tab(t0)),
+            projection(cols_expr_plan(&t0, &["a0", "b0"], &accessor), tab(&t0)),
             table_exec(
                 t1,
                 vec![
@@ -116,7 +116,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
         ],
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t0);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [1_i64, 2, 3, 4, 5, 2, 3, 4, 5, 6]),
@@ -133,57 +133,57 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
         borrowed_bigint("a0", [1_i64, 2, 3, 4, 5], &alloc),
         borrowed_varchar("b0", ["1", "2", "3", "4", "5"], &alloc),
     ]);
-    let t0 = "sxt.t0".parse().unwrap();
+    let t0 = TableRef::new("sxt", "t0");
     let data1 = table([
         borrowed_bigint("a1", [2_i64, 3, 4, 5, 6], &alloc),
         borrowed_varchar("b1", ["2", "3", "4", "5", "6"], &alloc),
     ]);
-    let t1 = "sxt.t1".parse().unwrap();
+    let t1 = TableRef::new("sxt", "t1");
     let data2 = table([
         borrowed_bigint("a2", [3_i64, 4, 5, 6, 7], &alloc),
         borrowed_varchar("b2", ["3", "4", "5", "6", "7"], &alloc),
     ]);
-    let t2 = "sxt.t2".parse().unwrap();
+    let t2 = TableRef::new("sxt", "t2");
     let data3 = table([
         borrowed_bigint("a3", [4_i64, 5, 6, 7, 8], &alloc),
         borrowed_varchar("b3", ["4", "5", "6", "7", "8"], &alloc),
     ]);
-    let t3 = "sxt.t3".parse().unwrap();
+    let t3 = TableRef::new("sxt", "t3");
     let data4 = table([
         borrowed_bigint("a4", [0_i64; 0], &alloc),
         borrowed_varchar("b4", [""; 0], &alloc),
     ]);
-    let t4 = "sxt.t4".parse().unwrap();
+    let t4 = TableRef::new("sxt", "t4");
     let data5 = table([
         borrowed_bigint("a5", [5_i64, 6, 7, 8], &alloc),
         borrowed_varchar("b5", ["5", "6", "7", "8"], &alloc),
     ]);
-    let t5 = "sxt.t5".parse().unwrap();
+    let t5 = TableRef::new("sxt", "t5");
     let data6 = table([
         borrowed_bigint("a6", [7_i64, 8, 9, 10], &alloc),
         borrowed_varchar("b6", ["8", "9", "10", "11"], &alloc),
     ]);
-    let t6 = "sxt.t6".parse().unwrap();
+    let t6 = TableRef::new("sxt", "t6");
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t0, data0, 0);
-    accessor.add_table(t1, data1, 0);
-    accessor.add_table(t2, data2, 0);
-    accessor.add_table(t3, data3, 0);
-    accessor.add_table(t4, data4, 0);
-    accessor.add_table(t5, data5, 0);
-    accessor.add_table(t6, data6, 0);
+    accessor.add_table(t0.clone(), data0, 0);
+    accessor.add_table(t1.clone(), data1, 0);
+    accessor.add_table(t2.clone(), data2, 0);
+    accessor.add_table(t3.clone(), data3, 0);
+    accessor.add_table(t4.clone(), data4, 0);
+    accessor.add_table(t5.clone(), data5, 0);
+    accessor.add_table(t6.clone(), data6, 0);
     let ast = union_exec(
         vec![
             slice_exec(
                 union_exec(
                     vec![
-                        projection(cols_expr_plan(t0, &["a0", "b0"], &accessor), tab(t0)),
-                        projection(cols_expr_plan(t1, &["a1", "b1"], &accessor), tab(t1)),
+                        projection(cols_expr_plan(&t0, &["a0", "b0"], &accessor), tab(&t0)),
+                        projection(cols_expr_plan(&t1, &["a1", "b1"], &accessor), tab(&t1)),
                         slice_exec(
                             filter(
-                                cols_expr_plan(t2, &["a2", "b2"], &accessor),
-                                tab(t2),
-                                gte(column(t2, "a2", &accessor), const_smallint(5_i16)),
+                                cols_expr_plan(&t2, &["a2", "b2"], &accessor),
+                                tab(&t2),
+                                gte(column(&t2, "a2", &accessor), const_smallint(5_i16)),
                             ),
                             2,
                             None,
@@ -191,12 +191,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
                         filter(
                             vec![
                                 aliased_plan(const_bigint(105_i64), "const"),
-                                col_expr_plan(t3, "b3", &accessor),
+                                col_expr_plan(&t3, "b3", &accessor),
                             ],
-                            tab(t3),
-                            equal(column(t3, "a3", &accessor), const_int128(6_i128)),
+                            tab(&t3),
+                            equal(column(&t3, "a3", &accessor), const_int128(6_i128)),
                         ),
-                        projection(cols_expr_plan(t4, &["a4", "b4"], &accessor), tab(t4)),
+                        projection(cols_expr_plan(&t4, &["a4", "b4"], &accessor), tab(&t4)),
                         table_exec(
                             t5,
                             vec![
@@ -227,7 +227,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
         ],
     );
     let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, t0);
+    exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("a", [5_i64, 2, 3, 4, 5, 6, 7, 105, 5, 6, 7, 7, 8, 9, 10]),
@@ -249,15 +249,16 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
         borrowed_varchar("b0", ["1", "2", "3", "4", "5"], &alloc),
     ]);
     let len_0 = data0.num_rows();
-    let t0 = "sxt.t0".parse().unwrap();
+    let t0 = TableRef::new("sxt", "t0");
     let data1 = table([
         borrowed_bigint("a1", [2_i64, 3, 4, 5, 6], &alloc),
         borrowed_varchar("b1", ["2", "3", "4", "5", "6"], &alloc),
     ]);
-    let t1 = "sxt.t1".parse().unwrap();
+    let t1 = TableRef::new("sxt", "t1");
+
     let table_map = indexmap! {
-        t0 => data0.clone(),
-        t1 => data1.clone()
+        t0.clone() => data0.clone(),
+        t1.clone() => data1.clone()
     };
 
     let len_1 = data1.num_rows();
@@ -265,16 +266,16 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
     let data_length = std::cmp::max(len_0, len_1);
 
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
-    accessor.add_table(t0, data0, 0);
-    accessor.add_table(t1, data1, 0);
+    accessor.add_table(t0.clone(), data0, 0);
+    accessor.add_table(t1.clone(), data1, 0);
     let fields = vec![
         column_field("a", ColumnType::BigInt),
         column_field("b", ColumnType::VarChar),
     ];
     let ast = union_exec(
         vec![
-            projection(cols_expr_plan(t0, &["a0", "b0"], &accessor), tab(t0)),
-            projection(cols_expr_plan(t1, &["a1", "b1"], &accessor), tab(t1)),
+            projection(cols_expr_plan(&t0, &["a0", "b0"], &accessor), tab(&t0)),
+            projection(cols_expr_plan(&t1, &["a1", "b1"], &accessor), tab(&t1)),
         ],
         fields.clone(),
     );
@@ -286,6 +287,7 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
     ))
     .to_owned_table(&fields)
     .unwrap();
+
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("a", [1_i64, 2, 3, 4, 5, 2, 3, 4, 5, 6]),
         varchar("b", ["1", "2", "3", "4", "5", "2", "3", "4", "5", "6"]),

--- a/crates/proof-of-sql/tests/decimal_integration_tests.rs
+++ b/crates/proof-of-sql/tests/decimal_integration_tests.rs
@@ -5,7 +5,7 @@
 use blitzar::proof::InnerProductProof;
 #[cfg(feature = "blitzar")]
 use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar as S};
-use proof_of_sql::sql::postprocessing::apply_postprocessing_steps;
+use proof_of_sql::{base::database::TableRef, sql::postprocessing::apply_postprocessing_steps};
 
 #[cfg(feature = "blitzar")]
 fn run_query(
@@ -28,7 +28,7 @@ fn run_query(
         decimal75("c", expected_precision, expected_scale, test_decimal_values),
     ]);
 
-    accessor.add_table("sxt.table".parse().unwrap(), data, 0);
+    accessor.add_table(TableRef::new("sxt", "table"), data, 0);
 
     let query = QueryExpr::try_new(query_str.parse().unwrap(), "sxt".into(), &accessor).unwrap();
     let proof = VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -6,7 +6,9 @@ use ark_std::test_rng;
 use proof_of_sql::base::commitment::InnerProductProof;
 use proof_of_sql::{
     base::{
-        database::{owned_table_utility::*, OwnedTable, OwnedTableTestAccessor, TestAccessor},
+        database::{
+            owned_table_utility::*, OwnedTable, OwnedTableTestAccessor, TableRef, TestAccessor,
+        },
         scalar::Curve25519Scalar,
     },
     proof_primitive::{
@@ -28,7 +30,7 @@ use proof_of_sql::{
 fn we_can_prove_a_minimal_filter_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([boolean("a", [true, false])]),
         0,
     );
@@ -59,7 +61,7 @@ fn we_can_prove_a_minimal_filter_query_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([boolean("a", [true, false])]),
         0,
     );
@@ -91,7 +93,7 @@ fn we_can_prove_a_minimal_filter_query_with_dynamic_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([boolean("a", [true, false])]),
         0,
     );
@@ -119,7 +121,7 @@ fn we_can_prove_a_minimal_filter_query_with_dynamic_dory() {
 fn we_can_prove_a_basic_equality_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([bigint("a", [1, 2, 3]), bigint("b", [1, 0, 1])]),
         0,
     );
@@ -150,7 +152,7 @@ fn we_can_prove_a_basic_equality_query_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([bigint("a", [1, 2, 3]), bigint("b", [1, 0, 1])]),
         0,
     );
@@ -210,7 +212,7 @@ fn we_can_prove_a_basic_equality_query_with_hyperkzg() {
 fn we_can_prove_a_basic_inequality_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([bigint("a", [1, 2, 3]), bigint("b", [1, 0, 2])]),
         0,
     );
@@ -235,7 +237,7 @@ fn we_can_prove_a_basic_inequality_query_with_curve25519() {
 fn we_can_prove_a_basic_query_containing_extrema_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             tinyint("tinyint", [i8::MIN, 0, i8::MAX]),
             smallint("smallint", [i16::MIN, 0, i16::MAX]),
@@ -278,7 +280,7 @@ fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             tinyint("tinyint", [i8::MIN, 0, i8::MAX]),
             smallint("smallint", [i16::MIN, 0, i16::MAX]),
@@ -318,7 +320,7 @@ fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
 fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 1, 2])]),
         0,
     );
@@ -350,7 +352,7 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([bigint("a", [1, -1, 3]), bigint("b", [0, 0, 2])]),
         0,
     );
@@ -378,7 +380,7 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
 fn we_can_prove_a_basic_equality_with_out_of_order_results_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "public.test_table".parse().unwrap(),
+        TableRef::new("public", "test_table"),
         owned_table([
             int128("amount", [115, -79]),
             varchar("primes", ["-f34", "abcd"]),
@@ -416,7 +418,7 @@ fn we_can_prove_a_basic_inequality_query_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([bigint("a", [1, 2, 3]), bigint("b", [1, 0, 4])]),
         0,
     );
@@ -444,7 +446,7 @@ fn we_can_prove_a_basic_inequality_query_with_dory() {
 fn decimal_type_issues_should_cause_provable_ast_to_fail() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([decimal75("d0", 12, 0, [10])]),
         0,
     );
@@ -461,7 +463,7 @@ fn decimal_type_issues_should_cause_provable_ast_to_fail() {
 fn we_can_prove_a_complex_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             smallint("a", [1_i16, 2, 3]),
             int("b", [1_i32, 4, 3]),
@@ -478,8 +480,7 @@ fn we_can_prove_a_complex_query_with_curve25519() {
         "SELECT a + (b * c) + 1 as t, 45.7 as g, (a = b) or f as h, d0 * d1 + 1.4 as dr FROM table WHERE (a >= b) = (c < d) and (e = 'e') = f;"
             .parse()
             .unwrap(),
-        "sxt".into(),
-        &accessor,
+            "sxt".into(),        &accessor,
     )
     .unwrap();
     let verifiable_result =
@@ -508,7 +509,7 @@ fn we_can_prove_a_complex_query_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             smallint("a", [1_i16, 2, 3]),
             int("b", [1, 0, 1]),
@@ -525,7 +526,7 @@ fn we_can_prove_a_complex_query_with_dory() {
         "SELECT 0.5 + a * b * c - d as res, 32 as g, (c >= d) and f as h, (a + 1) * (b + 1 + c + d + d0 - d1 + 0.5) as res2 FROM table WHERE (a < b) = (c <= d) and e <> 'f' and f and 100000 * d1 * d0 + a = 1.3"
             .parse()
             .unwrap(),
-        "sxt".into(),
+         "sxt".into(),
         &accessor,
     )
     .unwrap();
@@ -553,7 +554,7 @@ fn we_can_prove_a_complex_query_with_dory() {
 fn we_can_prove_a_minimal_group_by_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([bigint("a", [1, 1, 2, 2, 3]), bigint("b", [1, 0, 2, 3, 4])]),
         0,
     );
@@ -583,7 +584,7 @@ fn we_can_prove_a_minimal_group_by_query_with_curve25519() {
 fn we_can_prove_a_basic_group_by_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             bigint("a", [1, 1, 2, 3, 2]),
             bigint("b", [1, 0, 4, 2, 3]),
@@ -618,7 +619,7 @@ fn we_can_prove_a_basic_group_by_query_with_curve25519() {
 fn we_can_prove_a_cat_group_by_query_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.cats".parse().unwrap(),
+        TableRef::new("sxt", "cats"),
         owned_table([
             int("id", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
             varchar(
@@ -658,8 +659,7 @@ fn we_can_prove_a_cat_group_by_query_with_curve25519() {
         "select human, sum(age + 0.1) as total_adjusted_cat_age, count(*) as num_cats from sxt.cats where is_female group by human order by human"
             .parse()
             .unwrap(),
-        "sxt".into(),
-        &accessor,
+            "sxt".into(),        &accessor,
     )
     .unwrap();
     let verifiable_result =
@@ -685,7 +685,7 @@ fn we_can_prove_a_cat_group_by_query_with_dynamic_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DynamicDoryEvaluationProof>::new_empty_with_setup(&prover_setup);
     accessor.add_table(
-        "sxt.cats".parse().unwrap(),
+        TableRef::new("sxt", "cats"),
         owned_table([
             int("id", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
             varchar(
@@ -730,8 +730,7 @@ fn we_can_prove_a_cat_group_by_query_with_dynamic_dory() {
         "select diff_from_ideal_weight, count(*) as num_cats from sxt.cats where is_female group by diff_from_ideal_weight order by diff_from_ideal_weight"
             .parse()
             .unwrap(),
-        "sxt".into(),
-        &accessor,
+    "sxt".into(),        &accessor,
     )
     .unwrap();
     let verifiable_result = VerifiableQueryResult::<DynamicDoryEvaluationProof>::new(
@@ -761,7 +760,7 @@ fn we_can_prove_a_basic_group_by_query_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             bigint("a", [1, 1, 2, 3, 2]),
             bigint("b", [1, 0, 4, 2, 3]),
@@ -800,7 +799,7 @@ fn we_can_prove_a_basic_group_by_query_with_dory() {
 fn we_can_prove_a_query_with_overflow_with_curve25519() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([smallint("a", [i16::MAX]), smallint("b", [1_i16])]),
         0,
     );
@@ -829,7 +828,7 @@ fn we_can_prove_a_query_with_overflow_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([bigint("a", [i64::MIN]), smallint("b", [1_i16])]),
         0,
     );
@@ -855,7 +854,7 @@ fn we_can_prove_a_query_with_overflow_with_dory() {
 fn we_can_perform_arithmetic_and_conditional_operations_on_tinyint() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             tinyint("a", [3_i8, 5, 2, 1]),
             tinyint("b", [2_i8, 1, 3, 4]),

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -5,7 +5,7 @@ use ark_std::test_rng;
 #[cfg(feature = "blitzar")]
 use proof_of_sql::base::commitment::InnerProductProof;
 use proof_of_sql::{
-    base::database::{owned_table_utility::*, OwnedTableTestAccessor, TestAccessor},
+    base::database::{owned_table_utility::*, OwnedTableTestAccessor, TableRef, TestAccessor},
     proof_primitive::dory::{
         DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup,
         PublicParameters, VerifierSetup,
@@ -25,7 +25,7 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             tinyint("tinyint", [i8::MIN, 0, i8::MAX]),
             smallint("smallint", [i16::MIN, 0, i16::MAX]),
@@ -78,7 +78,7 @@ fn run_timestamp_query_test(
 
     // Setting up a table specifically for timestamps
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([timestamptz(
             "times",
             PoSQLTimeUnit::Second,
@@ -392,7 +392,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
     let mut accessor =
         OwnedTableTestAccessor::<DoryEvaluationProof>::new_empty_with_setup(dory_prover_setup);
     accessor.add_table(
-        "sxt.table".parse().unwrap(),
+        TableRef::new("sxt", "table"),
         owned_table([
             timestamptz(
                 "a",


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This PR addresses the need to replace the `proof_of_sql_parser::ResourceId` with the `sqlparser::ast::ObjectName` in the `proof-of-sql` crate as part of a larger transition toward integrating the `sqlparser` .

This change is a subtask of issue #235, with the main goal of streamlining the repository by switching to the `sqlparser` crate and gradually replacing intermediary constructs like `proof_of_sql_parser::intermediate_ast` with `sqlparser::ast`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- All instances of `proof_of_sql_parser::ResourceId` have been replaced with `sqlparser::ast::ObjectName`
- A few of them required a ResourceId  (e.g. Select etc..), which depends on the ResourceId and will be migrated at the refactoring of Exprs.
-  Every usage of `ResourceId` has been updated to maintain the original functionality, ensuring no changes to the logic or behavior.
-  The breaking change here is that `ObjectName`  doesn't support `Copy` trait so we have needed few clones in the places where values are moved

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

Part of #235 
Fixes #352 
