### PR TITLE
refactor!: `proof_of_sql_parser::intermediate_ast::OrderBy` with `sqlparser::ast::OrderByExpr` in the proof-of-sql crate

### DIFF
--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -7,7 +7,6 @@ use crate::{
     proof_primitive::dory::DoryScalar,
 };
 use core::cmp::Ordering;
-use proof_of_sql_parser::intermediate_ast::OrderByDirection;
 
 #[test]
 fn we_can_compare_indexes_by_columns_with_no_columns() {
@@ -266,11 +265,7 @@ fn we_can_compare_columns_with_direction() {
             .map(|&i| TestScalar::from(i))
             .collect(),
     );
-    let order_by_pairs = vec![
-        (col1, OrderByDirection::Asc),
-        (col2, OrderByDirection::Desc),
-        (col3, OrderByDirection::Asc),
-    ];
+    let order_by_pairs = vec![(col1, true), (col2, false), (col3, true)];
     // Equal on col1 and col2, less on col3
     assert_eq!(
         compare_indexes_by_owned_columns_with_direction(&order_by_pairs, 0, 1),

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -130,6 +130,11 @@ impl<S: Scalar> OwnedTable<S> {
     pub fn column_names(&self) -> impl Iterator<Item = &Ident> {
         self.table.keys()
     }
+    /// Returns the column with the given position.
+    #[must_use]
+    pub fn column_by_index(&self, index: usize) -> Option<&OwnedColumn<S>> {
+        self.table.get_index(index).map(|(_, v)| v)
+    }
 
     pub(crate) fn mle_evaluations(&self, evaluation_point: &[S]) -> Vec<S> {
         let mut evaluation_vector = vec![S::ZERO; self.num_rows()];

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{ColumnRef, LiteralValue, TableRef},
+        database::{order_by_util::OrderIndexDirectionPairs, ColumnRef, LiteralValue, TableRef},
         map::{IndexMap, IndexSet},
     },
     sql::{
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloc::{borrow::ToOwned, boxed::Box, string::ToString, vec::Vec};
 use proof_of_sql_parser::intermediate_ast::{
-    AggregationOperator, AliasedResultExpr, Expression, OrderBy, Slice,
+    AggregationOperator, AliasedResultExpr, Expression, Slice,
 };
 use sqlparser::ast::Ident;
 
@@ -24,7 +24,7 @@ pub struct QueryContext {
     table: Option<TableRef>,
     in_result_scope: bool,
     has_visited_group_by: bool,
-    order_by_exprs: Vec<OrderBy>,
+    order_by_exprs: OrderIndexDirectionPairs,
     group_by_exprs: Vec<Ident>,
     where_expr: Option<Box<Expression>>,
     result_column_set: IndexSet<Ident>,
@@ -137,7 +137,7 @@ impl QueryContext {
         self.has_visited_group_by = true;
     }
 
-    pub fn set_order_by_exprs(&mut self, order_by_exprs: Vec<OrderBy>) {
+    pub fn set_order_by_exprs(&mut self, order_by_exprs: OrderIndexDirectionPairs) {
         self.order_by_exprs = order_by_exprs;
     }
 
@@ -196,18 +196,8 @@ impl QueryContext {
         Ok(&self.res_aliased_exprs)
     }
 
-    pub fn get_order_by_exprs(&self) -> ConversionResult<Vec<OrderBy>> {
-        // Order by must reference only aliases in the result schema
-        for by_expr in &self.order_by_exprs {
-            self.res_aliased_exprs
-                .iter()
-                .find(|col| col.alias == by_expr.expr)
-                .ok_or(ConversionError::InvalidOrderBy {
-                    alias: by_expr.expr.as_str().to_string(),
-                })?;
-        }
-
-        Ok(self.order_by_exprs.clone())
+    pub fn get_order_by_exprs(&self) -> &[(usize, bool)] {
+        &self.order_by_exprs
     }
 
     #[allow(clippy::ref_option)]

--- a/crates/proof-of-sql/src/sql/parse/query_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr.rs
@@ -62,7 +62,7 @@ impl QueryExpr {
                 .visit_group_by_exprs(group_by.into_iter().map(Ident::from).collect())?
                 .visit_result_exprs(result_exprs)?
                 .visit_where_expr(where_expr)?
-                .visit_order_by_exprs(ast.order_by)
+                .visit_order_by_exprs(ast.order_by.into_iter().map(Into::into).collect())?
                 .visit_slice_expr(ast.slice)
                 .build()?,
         };
@@ -70,10 +70,10 @@ impl QueryExpr {
         let group_by = context.get_group_by_exprs();
         // Figure out the basic postprocessing steps.
         let mut postprocessing = vec![];
-        let order_bys = context.get_order_by_exprs()?;
+        let order_bys = context.get_order_by_exprs();
         if !order_bys.is_empty() {
             postprocessing.push(OwnedTablePostprocessing::new_order_by(
-                OrderByPostprocessing::new(order_bys.clone()),
+                OrderByPostprocessing::new(order_bys.to_vec()),
             ));
         }
         if let Some(slice) = context.get_slice_expr() {

--- a/crates/proof-of-sql/src/sql/postprocessing/error.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/error.rs
@@ -17,6 +17,12 @@ pub enum PostprocessingError {
         /// The column which is not found
         column: String,
     },
+    /// Index out of bounds
+    #[snafu(display("Index out of bounds: {index}"))]
+    IndexOutOfBounds {
+        /// The index which is out of bounds
+        index: usize,
+    },
     /// Errors in evaluation of `Expression`s
     #[snafu(transparent)]
     ExpressionEvaluationError {

--- a/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing.rs
@@ -1,56 +1,62 @@
 use super::{PostprocessingError, PostprocessingResult, PostprocessingStep};
 use crate::base::{
     database::{
-        order_by_util::compare_indexes_by_owned_columns_with_direction, OwnedColumn, OwnedTable,
+        order_by_util::{
+            compare_indexes_by_owned_columns_with_direction, OrderIndexDirectionPairs,
+        },
+        OwnedTable,
     },
     math::permutation::Permutation,
     scalar::Scalar,
 };
-use alloc::{string::ToString, vec::Vec};
-use proof_of_sql_parser::intermediate_ast::{OrderBy, OrderByDirection};
+use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 /// A node representing a list of `OrderBy` expressions.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OrderByPostprocessing {
-    by_exprs: Vec<OrderBy>,
+    index_direction_pairs: OrderIndexDirectionPairs,
 }
 
 impl OrderByPostprocessing {
     /// Create a new `OrderByPostprocessing` node.
     #[must_use]
-    pub fn new(by_exprs: Vec<OrderBy>) -> Self {
-        Self { by_exprs }
+    pub fn new(index_direction_pairs: OrderIndexDirectionPairs) -> Self {
+        Self {
+            index_direction_pairs,
+        }
     }
 }
 
 impl<S: Scalar> PostprocessingStep<S> for OrderByPostprocessing {
     /// Apply the slice transformation to the given `OwnedTable`.
     fn apply(&self, owned_table: OwnedTable<S>) -> PostprocessingResult<OwnedTable<S>> {
-        // Evaluate the columns by which we order
-        // Once we allow OrderBy for general aggregation-free expressions here we will need to call eval()
-        let order_by_pairs: Vec<(OwnedColumn<S>, OrderByDirection)> = self
-            .by_exprs
+        let opt_max_index = self
+            .index_direction_pairs
             .iter()
-            .map(
-                |order_by| -> PostprocessingResult<(OwnedColumn<S>, OrderByDirection)> {
-                    let identifier: sqlparser::ast::Ident = order_by.expr.into();
-                    Ok((
-                        owned_table
-                            .inner_table()
-                            .get(&identifier)
-                            .ok_or(PostprocessingError::ColumnNotFound {
-                                column: order_by.expr.to_string(),
-                            })?
-                            .clone(),
-                        order_by.direction,
-                    ))
-                },
-            )
-            .collect::<PostprocessingResult<Vec<(OwnedColumn<S>, OrderByDirection)>>>()?;
+            .map(|(index, _)| index)
+            .max();
+        if let Some(max_index) = opt_max_index {
+            if *max_index >= owned_table.num_columns() {
+                return Err(PostprocessingError::IndexOutOfBounds { index: *max_index });
+            }
+        }
+        let column_direction_pairs = self
+            .index_direction_pairs
+            .iter()
+            .map(|(index, direction)| {
+                (
+                    owned_table
+                        .column_by_index(*index)
+                        .expect("The index should be valid here")
+                        .clone(),
+                    *direction,
+                )
+            })
+            .collect::<Vec<_>>();
         // Define the ordering
         let permutation = Permutation::unchecked_new_from_cmp(owned_table.num_rows(), |&a, &b| {
-            compare_indexes_by_owned_columns_with_direction(&order_by_pairs, a, b)
+            compare_indexes_by_owned_columns_with_direction(&column_direction_pairs, a, b)
         });
         // Apply the ordering
         Ok(

--- a/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing_test.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/order_by_postprocessing_test.rs
@@ -5,7 +5,6 @@ use crate::{
     },
     sql::postprocessing::{apply_postprocessing_steps, test_utility::*, OwnedTablePostprocessing},
 };
-use proof_of_sql_parser::intermediate_ast::OrderByDirection::{Asc, Desc};
 use rand::{seq::SliceRandom, Rng};
 
 #[test]
@@ -14,7 +13,7 @@ fn we_can_transform_a_result_using_a_single_order_by_in_ascending_direction() {
         bigint("c", [1_i64, -5, i64::MAX]),
         varchar("a", ["a", "d", "b"]),
     ]);
-    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&["a"], &[Asc])];
+    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&[1_usize], &[true])];
     let expected_table: OwnedTable<Curve25519Scalar> = owned_table([
         bigint("c", [1_i64, i64::MAX, -5]),
         varchar("a", ["a", "b", "d"]),
@@ -29,7 +28,7 @@ fn we_can_transform_a_result_using_a_single_order_by_in_descending_direction() {
         int128("c", [1_i128, i128::MIN, i128::MAX]),
         varchar("a", ["a", "d", "b"]),
     ]);
-    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&["c"], &[Desc])];
+    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&[0_usize], &[false])];
     let expected_table: OwnedTable<Curve25519Scalar> = owned_table([
         int128("c", [i128::MAX, 1, i128::MIN]),
         varchar("a", ["b", "a", "d"]),
@@ -44,7 +43,7 @@ fn we_can_transform_a_result_ordering_by_the_first_column_then_the_second_column
         int("a", [123_i32, 342, i32::MIN, i32::MAX, 123, 34]),
         varchar("d", ["alfa", "beta", "abc", "f", "kl", "f"]),
     ]);
-    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&["a", "d"], &[Desc, Desc])];
+    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&[0_usize, 1], &[false, false])];
     let expected_table: OwnedTable<Curve25519Scalar> = owned_table([
         int("a", [i32::MAX, 342, 123, 123, 34, i32::MIN]),
         varchar("d", ["f", "beta", "kl", "alfa", "f", "abc"]),
@@ -59,7 +58,7 @@ fn we_can_transform_a_result_ordering_by_the_second_column_then_the_first_column
         smallint("a", [123_i16, 342, -234, i16::MAX, 123, i16::MIN]),
         varchar("d", ["alfa", "beta", "abc", "f", "kl", "f"]),
     ]);
-    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&["d", "a"], &[Desc, Asc])];
+    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&[1_usize, 0], &[false, true])];
     let expected_table: OwnedTable<Curve25519Scalar> = owned_table([
         smallint("a", [123_i16, i16::MIN, i16::MAX, 342, 123, -234]),
         varchar("d", ["kl", "f", "f", "beta", "alfa", "abc"]),
@@ -89,7 +88,7 @@ fn we_can_use_int128_columns_inside_order_by_in_desc_order() {
     ];
 
     let table: OwnedTable<Curve25519Scalar> = owned_table([int128("h", s), int128("j", s)]);
-    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&["j", "h"], &[Desc, Asc])];
+    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&[1_usize, 0], &[false, true])];
     let actual_table = apply_postprocessing_steps(table, &postprocessing).unwrap();
 
     let mut sorted_s = s;
@@ -124,7 +123,7 @@ fn we_can_use_int128_columns_inside_order_by_in_asc_order() {
     ];
 
     let table: OwnedTable<Curve25519Scalar> = owned_table([int128("h", s), int128("j", s)]);
-    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&["j", "h"], &[Asc, Desc])];
+    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&[1_usize, 0], &[true, false])];
     let actual_table = apply_postprocessing_steps(table, &postprocessing).unwrap();
 
     let mut sorted_s = s;
@@ -155,7 +154,7 @@ fn we_can_do_order_by_with_random_i128_data() {
 
     let table: OwnedTable<Curve25519Scalar> = owned_table([int128("h", shuffled_data)]);
     let expected_table: OwnedTable<Curve25519Scalar> = owned_table([int128("h", sorted_data)]);
-    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&["h"], &[Asc])];
+    let postprocessing: [OwnedTablePostprocessing; 1] = [orders(&[0_usize], &[true])];
     let actual_table = apply_postprocessing_steps(table, &postprocessing).unwrap();
     assert_eq!(actual_table, expected_table);
 }

--- a/crates/proof-of-sql/src/sql/postprocessing/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/test_utility.rs
@@ -1,5 +1,5 @@
 use super::*;
-use proof_of_sql_parser::intermediate_ast::{AliasedResultExpr, OrderBy, OrderByDirection};
+use proof_of_sql_parser::intermediate_ast::AliasedResultExpr;
 use sqlparser::ast::Ident;
 
 #[must_use]
@@ -31,14 +31,11 @@ pub fn slice(limit: Option<u64>, offset: Option<i64>) -> OwnedTablePostprocessin
 
 /// Producing a postprocessing object that represents an order by operation.
 #[must_use]
-pub fn orders(cols: &[&str], directions: &[OrderByDirection]) -> OwnedTablePostprocessing {
-    let by_exprs = cols
+pub fn orders(indexes: &[usize], directions: &[bool]) -> OwnedTablePostprocessing {
+    let index_direction_pairs: Vec<(usize, bool)> = indexes
         .iter()
-        .zip(directions.iter())
-        .map(|(col, direction)| OrderBy {
-            expr: col.parse().unwrap(),
-            direction: *direction,
-        })
+        .copied()
+        .zip(directions.iter().copied())
         .collect();
-    OwnedTablePostprocessing::new_order_by(OrderByPostprocessing::new(by_exprs))
+    OwnedTablePostprocessing::new_order_by(OrderByPostprocessing::new(index_direction_pairs))
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This PR addresses the need to replace the `proof_of_sql_parser::OrderBy` with the `sqlparser::ast::OrderByExpr` in the `proof-of-sql` crate as part of a larger transition toward integrating the `sqlparser` .

This change is a subtask of issue #235, with the main goal of streamlining the repository by switching to the `sqlparser` crate and gradually replacing intermediary constructs like `proof_of_sql_parser::intermediate_ast` with `sqlparser::ast`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

- All instances of `proof_of_sql_parser::OrderBy` have been replaced with `sqlparser::ast::OrderByExpr`
-  Every usage of `OrderBy` has been updated to maintain the original functionality, ensuring no changes to the logic or behavior.

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

Part of #235 
