### PR TITLE
docs: Improved Consistency in Fork Instructions Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ In order to contribute it is necessary to fork the repository. Follow the steps 
      cd sxt-proof-of-sql
      ```
 
-5. Add the original repository as a remote (optional but recommended).
+5. Add the original repository as a remote (optional but recommended):
    - This allows you to keep your fork up to date with changes from the original repository:
      ```bash
      git remote add upstream https://github.com/spaceandtimelabs/sxt-proof-of-sql.git


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

### Description
While reviewing the contribution guide, I noticed a minor inconsistency in the formatting of the "Fork the Repository" section. Specifically, the sentence "Add the original repository as a remote (optional but recommended)." ended with a period, whereas other similar instructions use a colon for clarity and flow.  

I've replaced the period with a colon to ensure uniformity throughout the guide.
This small tweak helps maintain a consistent style and makes the instructions easier to follow.  
