### PR TITLE
fix: clarify error message for UnsupportedPrecision

### DIFF
--- a/crates/proof-of-sql-parser/src/posql_time/error.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/error.rs
@@ -2,7 +2,7 @@ use alloc::string::{String, ToString};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
-/// Errors related to time operations, including timezone and timestamp conversions.s
+/// Errors related to time operations, including timezone and timestamp conversions.
 #[allow(clippy::module_name_repetitions)]
 #[derive(Snafu, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PoSQLTimestampError {
@@ -47,7 +47,7 @@ pub enum PoSQLTimestampError {
 
     /// Represents a failure to parse a provided time unit precision value, `PoSQL` supports
     /// Seconds, Milliseconds, Microseconds, and Nanoseconds
-    #[snafu(display("Timestamp parsing error: {error}"))]
+    #[snafu(display("Unsupported precision for timestamp:: {error}"))]
     UnsupportedPrecision {
         /// The underlying error
         error: String,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

If do not replace the description for UnsupportedPrecision, both ParsingError and UnsupportedPrecision will display the same error message.

# What changes are included in this PR?
Updated the #[snafu(display(...))] attribute for the UnsupportedPrecision variant to provide a more specific error message.

The same error message will be used for different types of errors, making it difficult to understand the specific cause of the failure. When analyzing errors, it will be difficult to determine which specific error occurred — a general parsing issue or specifically an unsupported precision.

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
N/A since it is message-only