### PR TITLE
refactor!:  `Expression` to use `Expr`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -1,4 +1,5 @@
 use super::PoSQLTimestampError;
+use crate::alloc::string::ToString;
 use core::fmt;
 use serde::{Deserialize, Serialize};
 
@@ -14,6 +15,21 @@ pub enum PoSQLTimeUnit {
     Microsecond,
     /// Represents nanoseconds with precision 9: ex "2024-06-20 12:34:56.123456789"
     Nanosecond,
+}
+
+impl PoSQLTimeUnit {
+    /// Converts a precision value into a corresponding `PoSQLTimeUnit`.
+    pub fn from_precision(precision: u64) -> Result<Self, PoSQLTimestampError> {
+        match precision {
+            0 => Ok(PoSQLTimeUnit::Second),
+            3 => Ok(PoSQLTimeUnit::Millisecond),
+            6 => Ok(PoSQLTimeUnit::Microsecond),
+            9 => Ok(PoSQLTimeUnit::Nanosecond),
+            _ => Err(PoSQLTimestampError::UnsupportedPrecision {
+                error: precision.to_string(),
+            }),
+        }
+    }
 }
 
 impl From<PoSQLTimeUnit> for u64 {

--- a/crates/proof-of-sql-parser/src/sqlparser.rs
+++ b/crates/proof-of-sql-parser/src/sqlparser.rs
@@ -14,6 +14,7 @@ use alloc::{
     vec,
 };
 use core::fmt::Display;
+use serde::{Deserialize, Serialize};
 use sqlparser::ast::{
     BinaryOperator, DataType, Expr, Function, FunctionArg, FunctionArgExpr, GroupByExpr, Ident,
     ObjectName, Offset, OffsetRows, OrderByExpr, Query, Select, SelectItem, SetExpr, TableFactor,
@@ -31,6 +32,34 @@ where
 /// Convert an [`Identifier`] into a [`Expr`].
 fn id(id: Identifier) -> Expr {
     Expr::Identifier(id.into())
+}
+
+#[must_use]
+/// New `AliasedResultExpr` using sqlparser types
+/// Represents an aliased SQL expression, e.g., `a + 1 AS alias`.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct SqlAliasedResultExpr {
+    /// The SQL expression being aliased (e.g., `a + 1`).
+    pub expr: Box<Expr>,
+    /// The alias for the expression (e.g., `alias` in `a + 1 AS alias`).
+    pub alias: Ident,
+}
+
+impl SqlAliasedResultExpr {
+    /// Creates a new `SqlAliasedResultExpr`.
+    pub fn new(expr: Box<Expr>, alias: Ident) -> Self {
+        Self { expr, alias }
+    }
+
+    /// Try to get the identifier of the expression if it is a column
+    /// Otherwise, return None
+    #[must_use]
+    pub fn try_as_identifier(&self) -> Option<&Ident> {
+        match self.expr.as_ref() {
+            Expr::Identifier(identifier) => Some(identifier),
+            _ => None,
+        }
+    }
 }
 
 /// Provides an extension for the `TimezoneInfo` type for offsets.

--- a/crates/proof-of-sql-parser/src/sqlparser.rs
+++ b/crates/proof-of-sql-parser/src/sqlparser.rs
@@ -175,7 +175,7 @@ impl From<PoSqlOrderBy> for OrderByExpr {
 impl From<Expression> for Expr {
     fn from(expr: Expression) -> Self {
         match expr {
-            Expression::Literal(literal) => literal.into(),
+            Expression::Literal(literal) => Expr::from(literal),
             Expression::Column(identifier) => id(identifier),
             Expression::Unary { op, expr } => Expr::UnaryOp {
                 op: op.into(),

--- a/crates/proof-of-sql/benches/bench_append_rows.rs
+++ b/crates/proof-of-sql/benches/bench_append_rows.rs
@@ -24,8 +24,9 @@ use proof_of_sql::{
         DoryCommitment, DoryProverPublicSetup, DoryScalar, ProverSetup, PublicParameters,
     },
 };
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use rand::Rng;
+use sqlparser::ast::TimezoneInfo;
 
 /// Bench dory performance when appending rows to a table. This includes the computation of
 /// commitments. Chose the number of columns to randomly generate across supported `PoSQL`
@@ -121,7 +122,7 @@ pub fn generate_random_owned_table<S: Scalar>(
             "timestamptz" => columns.push(timestamptz(
                 &*identifier,
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 vec![rng.gen::<i64>(); num_rows],
             )),
             _ => unreachable!(),

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -59,7 +59,7 @@ impl TryFrom<DataType> for ColumnType {
                 };
                 Ok(ColumnType::TimestampTZ(
                     posql_time_unit,
-                    PoSQLTimeZone::try_from(&timezone_option)?,
+                    PoSQLTimeZone::try_from(&timezone_option)?.into(),
                 ))
             }
             DataType::Utf8 => Ok(ColumnType::VarChar),

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -238,7 +238,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
                         PoSQLTimeUnit::Second,
-                        PoSQLTimeZone::try_from(timezone)?,
+                        PoSQLTimeZone::try_from(timezone)?.into(),
                         timestamps,
                     ))
                 }
@@ -252,7 +252,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
                         PoSQLTimeUnit::Millisecond,
-                        PoSQLTimeZone::try_from(timezone)?,
+                        PoSQLTimeZone::try_from(timezone)?.into(),
                         timestamps,
                     ))
                 }
@@ -266,7 +266,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
                         PoSQLTimeUnit::Microsecond,
-                        PoSQLTimeZone::try_from(timezone)?,
+                        PoSQLTimeZone::try_from(timezone)?.into(),
                         timestamps,
                     ))
                 }
@@ -280,7 +280,7 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     let timestamps = array.values().iter().copied().collect::<Vec<i64>>();
                     Ok(OwnedColumn::TimestampTZ(
                         PoSQLTimeUnit::Nanosecond,
-                        PoSQLTimeZone::try_from(timezone)?,
+                        PoSQLTimeZone::try_from(timezone)?.into(),
                         timestamps,
                     ))
                 }

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -312,7 +312,8 @@ mod tests {
     };
     use alloc::{string::String, vec};
     use itertools::Itertools;
-    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+    use sqlparser::ast::TimezoneInfo;
 
     #[test]
     fn we_can_construct_bounds_by_method() {
@@ -563,7 +564,7 @@ mod tests {
 
         let timestamp_column = OwnedColumn::<TestScalar>::TimestampTZ(
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             vec![1_i64, 2, 3, 4],
         );
         let committable_timestamp_column = CommittableColumn::from(&timestamp_column);

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -186,7 +186,8 @@ mod tests {
         scalar::test_scalar::TestScalar,
     };
     use alloc::string::String;
-    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+    use sqlparser::ast::TimezoneInfo;
 
     #[test]
     fn we_can_construct_metadata() {
@@ -257,12 +258,12 @@ mod tests {
 
         assert_eq!(
             ColumnCommitmentMetadata::try_new(
-                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None),
                 ColumnBounds::TimestampTZ(Bounds::Empty),
             )
             .unwrap(),
             ColumnCommitmentMetadata {
-                column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+                column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None),
                 bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
             }
         );
@@ -399,7 +400,7 @@ mod tests {
 
         let timestamp_column: OwnedColumn<TestScalar> = OwnedColumn::<TestScalar>::TimestampTZ(
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [1i64, 2, 3, 4, 5].to_vec(),
         );
         let committable_timestamp_column = CommittableColumn::from(&timestamp_column);
@@ -407,7 +408,7 @@ mod tests {
             ColumnCommitmentMetadata::from_column(&committable_timestamp_column);
         assert_eq!(
             timestamp_metadata.column_type(),
-            &ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc())
+            &ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None)
         );
         if let ColumnBounds::TimestampTZ(Bounds::Sharp(bounds)) = timestamp_metadata.bounds() {
             assert_eq!(bounds.min(), &1);
@@ -583,7 +584,7 @@ mod tests {
             1_625_072_400,
             1_625_065_000,
         ];
-        let timezone = PoSQLTimeZone::utc();
+        let timezone = TimezoneInfo::None;
         let timeunit = PoSQLTimeUnit::Second;
         let timestamp_column_a = CommittableColumn::TimestampTZ(timeunit, timezone, &times[..2]);
         let timestamp_metadata_a = ColumnCommitmentMetadata::from_column(&timestamp_column_a);
@@ -609,7 +610,7 @@ mod tests {
             1_625_072_400,
             1_625_065_000,
         ];
-        let timezone = PoSQLTimeZone::utc();
+        let timezone = TimezoneInfo::None;
         let timeunit = PoSQLTimeUnit::Second;
 
         let timestamp_column_a = CommittableColumn::TimestampTZ(timeunit, timezone, &times[..2]);
@@ -960,12 +961,12 @@ mod tests {
             .is_err());
 
         let timestamp_tz_metadata_a = ColumnCommitmentMetadata {
-            column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None),
             bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
         };
 
         let timestamp_tz_metadata_b = ColumnCommitmentMetadata {
-            column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+            column_type: ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, TimezoneInfo::None),
             bounds: ColumnBounds::TimestampTZ(Bounds::Empty),
         };
 

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -11,9 +11,9 @@ use core::{
     fmt::{Display, Formatter},
     mem::size_of,
 };
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
+use sqlparser::ast::{Ident, TimezoneInfo};
 
 /// Represents a read-only view of a column in an in-memory,
 /// column-oriented database.
@@ -49,7 +49,7 @@ pub enum Column<'a, S: Scalar> {
     /// - the first element maps to the stored `TimeUnit`
     /// - the second element maps to a timezone
     /// - the third element maps to columns of timeunits since unix epoch
-    TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, &'a [i64]),
+    TimestampTZ(PoSQLTimeUnit, TimezoneInfo, &'a [i64]),
 }
 
 impl<'a, S: Scalar> Column<'a, S> {
@@ -313,7 +313,7 @@ pub enum ColumnType {
     Decimal75(Precision, i8),
     /// Mapped to i64
     #[serde(alias = "TIMESTAMP", alias = "timestamp")]
-    TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone),
+    TimestampTZ(PoSQLTimeUnit, TimezoneInfo),
     /// Mapped to `S`
     #[serde(alias = "SCALAR", alias = "scalar")]
     Scalar,
@@ -565,9 +565,9 @@ mod tests {
 
     #[test]
     fn column_type_serializes_to_string() {
-        let column_type = ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc());
+        let column_type = ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None);
         let serialized = serde_json::to_string(&column_type).unwrap();
-        assert_eq!(serialized, r#"{"TimestampTZ":["Second",{"offset":0}]}"#);
+        assert_eq!(serialized, r#"{"TimestampTZ":["Second","None"]}"#);
 
         let column_type = ColumnType::Boolean;
         let serialized = serde_json::to_string(&column_type).unwrap();
@@ -609,9 +609,9 @@ mod tests {
     #[test]
     fn we_can_deserialize_columns_from_valid_strings() {
         let expected_column_type =
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc());
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None);
         let deserialized: ColumnType =
-            serde_json::from_str(r#"{"TimestampTZ":["Second",{"offset":0}]}"#).unwrap();
+            serde_json::from_str(r#"{"TimestampTZ":["Second","None"]}"#).unwrap();
         assert_eq!(deserialized, expected_column_type);
 
         let expected_column_type = ColumnType::Boolean;
@@ -1064,7 +1064,7 @@ mod tests {
         assert_eq!(column.column_type().bit_size(), 256);
 
         let column: Column<'_, DoryScalar> =
-            Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1, 2, 3]);
+            Column::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None, &[1, 2, 3]);
         assert_eq!(column.column_type().byte_size(), 8);
         assert_eq!(column.column_type().bit_size(), 64);
     }

--- a/crates/proof-of-sql/src/base/database/columnar_value.rs
+++ b/crates/proof-of-sql/src/base/database/columnar_value.rs
@@ -1,9 +1,10 @@
 use crate::base::{
-    database::{Column, ColumnType, LiteralValue},
+    database::{Column, ColumnError, ColumnType, ExprExt},
     scalar::Scalar,
 };
 use bumpalo::Bump;
 use snafu::Snafu;
+use sqlparser::ast::Expr as SqlExpr;
 
 /// The result of evaluating an expression.
 ///
@@ -13,7 +14,7 @@ pub enum ColumnarValue<'a, S: Scalar> {
     /// A [ `ColumnarValue::Column` ] is a list of values.
     Column(Column<'a, S>),
     /// A [ `ColumnarValue::Literal` ] is a single value with indeterminate size.
-    Literal(LiteralValue),
+    Literal(SqlExpr),
 }
 
 /// Errors from operations on [`ColumnarValue`]s.
@@ -26,6 +27,19 @@ pub enum ColumnarValueError {
         /// The length we attempted to convert the `[ColumnarValue::Column]` to
         attempt_to_convert_length: usize,
     },
+
+    /// Error during column conversion.
+    #[snafu(display("Error during column conversion: {source}"))]
+    ColumnConversionError {
+        /// The underlying column error.
+        source: ColumnError,
+    },
+}
+
+impl From<ColumnError> for ColumnarValueError {
+    fn from(error: ColumnError) -> Self {
+        ColumnarValueError::ColumnConversionError { source: error }
+    }
 }
 
 impl<'a, S: Scalar> ColumnarValue<'a, S> {
@@ -34,7 +48,7 @@ impl<'a, S: Scalar> ColumnarValue<'a, S> {
     pub fn column_type(&self) -> ColumnType {
         match self {
             Self::Column(column) => column.column_type(),
-            Self::Literal(literal) => literal.column_type(),
+            Self::Literal(expr) => expr.column_type(),
         }
     }
 
@@ -55,8 +69,8 @@ impl<'a, S: Scalar> ColumnarValue<'a, S> {
                     })
                 }
             }
-            Self::Literal(literal) => {
-                Ok(Column::from_literal_with_length(literal, num_rows, alloc))
+            Self::Literal(expr) => {
+                Column::from_literal_with_length(expr, num_rows, alloc).map_err(Into::into)
             }
         }
     }
@@ -67,13 +81,14 @@ mod tests {
     use super::*;
     use crate::base::scalar::test_scalar::TestScalar;
     use core::convert::Into;
+    use sqlparser::ast::{Expr as SqlExpr, Value};
 
     #[test]
     fn we_can_get_column_type_of_columnar_values() {
         let column = ColumnarValue::Column(Column::<TestScalar>::Int(&[1, 2, 3]));
         assert_eq!(column.column_type(), ColumnType::Int);
 
-        let column = ColumnarValue::<TestScalar>::Literal(LiteralValue::Boolean(true));
+        let column = ColumnarValue::<TestScalar>::Literal(SqlExpr::Value(Value::Boolean(true)));
         assert_eq!(column.column_type(), ColumnType::Boolean);
     }
 
@@ -85,12 +100,16 @@ mod tests {
         let column = columnar_value.into_column(3, &bump).unwrap();
         assert_eq!(column, Column::Int(&[1, 2, 3]));
 
-        let columnar_value = ColumnarValue::<TestScalar>::Literal(LiteralValue::Boolean(false));
+        let columnar_value =
+            ColumnarValue::<TestScalar>::Literal(SqlExpr::Value(Value::Boolean(false)));
         let column = columnar_value.into_column(5, &bump).unwrap();
         assert_eq!(column, Column::Boolean(&[false; 5]));
 
         // Check whether it works if `num_rows` is 0
-        let columnar_value = ColumnarValue::<TestScalar>::Literal(LiteralValue::TinyInt(2));
+        let columnar_value = ColumnarValue::<TestScalar>::Literal(SqlExpr::Value(Value::Number(
+            "2".to_string(),
+            false,
+        )));
         let column = columnar_value.into_column(0, &bump).unwrap();
         assert_eq!(column, Column::TinyInt(&[]));
 

--- a/crates/proof-of-sql/src/base/database/expr_utility.rs
+++ b/crates/proof-of-sql/src/base/database/expr_utility.rs
@@ -1,3 +1,4 @@
+use alloc::{boxed::Box, vec};
 use proof_of_sql_parser::{intermediate_ast::Literal, sqlparser::SqlAliasedResultExpr};
 use sqlparser::ast::{
     BinaryOperator, Expr, Function, FunctionArg, FunctionArgExpr, Ident, ObjectName, UnaryOperator,

--- a/crates/proof-of-sql/src/base/database/expr_utility.rs
+++ b/crates/proof-of-sql/src/base/database/expr_utility.rs
@@ -1,0 +1,169 @@
+use proof_of_sql_parser::{intermediate_ast::Literal, sqlparser::SqlAliasedResultExpr};
+use sqlparser::ast::{
+    BinaryOperator, Expr, Function, FunctionArg, FunctionArgExpr, Ident, ObjectName, UnaryOperator,
+};
+
+/// Compute the sum of an expression
+#[must_use]
+pub fn sum(expr: Expr) -> Expr {
+    Expr::Function(Function {
+        name: ObjectName(vec![Ident::new("SUM")]),
+        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(*Box::new(expr)))],
+        filter: None,
+        null_treatment: None,
+        over: None,
+        distinct: false,
+        special: false,
+        order_by: vec![],
+    })
+}
+
+/// Get column from name
+///
+/// # Panics
+///
+/// This function will panic if the name cannot be parsed into a valid column expression as valid [Identifier]s.
+#[must_use]
+pub fn col(name: &str) -> Expr {
+    Expr::Identifier(name.into())
+}
+
+/// Compute the maximum of an expression
+#[must_use]
+pub fn max(expr: Expr) -> Expr {
+    Expr::Function(Function {
+        name: ObjectName(vec![Ident::new("MAX")]),
+        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(*Box::new(expr)))],
+        filter: None,
+        null_treatment: None,
+        over: None,
+        distinct: false,
+        special: false,
+        order_by: vec![],
+    })
+}
+
+/// Construct a new `Expr` A + B
+#[must_use]
+pub fn add(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryOp {
+        op: BinaryOperator::Plus,
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+}
+
+/// Construct a new `Expr` A - B
+#[must_use]
+pub fn sub(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryOp {
+        op: BinaryOperator::Minus,
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+}
+
+/// Get literal from value
+pub fn lit<L>(literal: L) -> Expr
+where
+    L: Into<Literal>,
+{
+    Expr::from(literal.into())
+}
+
+/// Count the amount of non-null entries of an expression
+#[must_use]
+pub fn count(expr: Expr) -> Expr {
+    Expr::Function(Function {
+        name: ObjectName(vec![Ident::new("COUNT")]),
+        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(*Box::new(expr)))],
+        filter: None,
+        null_treatment: None,
+        over: None,
+        distinct: false,
+        special: false,
+        order_by: vec![],
+    })
+}
+
+/// Count the rows
+#[must_use]
+pub fn count_all() -> Expr {
+    count(Expr::Wildcard)
+}
+
+/// Construct a new `Expr` representing A * B
+#[must_use]
+pub fn mul(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryOp {
+        left: Box::new(left),
+        op: BinaryOperator::Multiply,
+        right: Box::new(right),
+    }
+}
+
+/// Compute the minimum of an expression
+#[must_use]
+pub fn min(expr: Expr) -> Expr {
+    Expr::Function(Function {
+        name: ObjectName(vec![Ident::new("MIN")]),
+        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(*Box::new(expr)))],
+        filter: None,
+        null_treatment: None,
+        over: None,
+        distinct: false,
+        special: false,
+        order_by: vec![],
+    })
+}
+
+/// Construct a new `Expr` for NOT P
+#[must_use]
+pub fn not(expr: Expr) -> Expr {
+    Expr::UnaryOp {
+        op: UnaryOperator::Not,
+        expr: Box::new(expr),
+    }
+}
+
+/// Construct a new `Expr` for A >= B
+#[must_use]
+pub fn ge(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryOp {
+        left: Box::new(left),
+        op: BinaryOperator::GtEq,
+        right: Box::new(right),
+    }
+}
+
+/// Construct a new `Expr` for A == B
+#[must_use]
+pub fn equal(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryOp {
+        left: Box::new(left),
+        op: BinaryOperator::Eq,
+        right: Box::new(right),
+    }
+}
+
+/// Construct a new `Expr` for P OR Q
+#[must_use]
+pub fn or(left: Expr, right: Expr) -> Expr {
+    Expr::BinaryOp {
+        left: Box::new(left),
+        op: BinaryOperator::Or,
+        right: Box::new(right),
+    }
+}
+
+/// An expression with an alias, i.e., EXPR AS ALIAS
+///
+/// # Panics
+///
+/// This function will panic if the `alias` cannot be parsed as a valid [Identifier].
+pub fn aliased_expr(expr: Expr, alias: &str) -> SqlAliasedResultExpr {
+    SqlAliasedResultExpr {
+        expr: Box::new(expr),
+        alias: Ident::new(alias),
+    }
+}

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -57,7 +57,7 @@ impl<S: Scalar> OwnedTable<S> {
             Literal::VarChar(s) => Ok(OwnedColumn::VarChar(vec![s.clone(); len])),
             Literal::Timestamp(its) => Ok(OwnedColumn::TimestampTZ(
                 its.timeunit(),
-                its.timezone(),
+                its.timezone().into(),
                 vec![its.timestamp().timestamp(); len],
             )),
         }

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_test.rs
@@ -9,9 +9,10 @@ use crate::base::{
 use bigdecimal::BigDecimal;
 use proof_of_sql_parser::{
     intermediate_ast::Literal,
-    posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
+    posql_time::{PoSQLTimeUnit, PoSQLTimestamp},
     utility::*,
 };
+use sqlparser::ast::TimezoneInfo;
 
 #[test]
 fn we_can_evaluate_a_simple_literal() {
@@ -40,7 +41,7 @@ fn we_can_evaluate_a_simple_literal() {
     let actual_timestamp = 1_646_092_800;
     let expected_column = OwnedColumn::TimestampTZ(
         PoSQLTimeUnit::Second,
-        PoSQLTimeZone::utc(),
+        TimezoneInfo::None,
         vec![actual_timestamp; 5],
     );
     assert_eq!(actual_column, expected_column);

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -4,8 +4,9 @@ use crate::base::{
     scalar::Scalar,
 };
 use alloc::string::String;
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::TimezoneInfo;
 
 /// Represents a literal value.
 ///
@@ -39,7 +40,7 @@ pub enum LiteralValue {
     Scalar([u64; 4]),
     /// `TimeStamp` defined over a unit (s, ms, ns, etc) and timezone with backing store
     /// mapped to i64, which is time units since unix epoch
-    TimeStampTZ(PoSQLTimeUnit, PoSQLTimeZone, i64),
+    TimeStampTZ(PoSQLTimeUnit, TimezoneInfo, i64),
 }
 
 impl LiteralValue {

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -1,8 +1,12 @@
-use crate::base::{
-    database::ColumnType,
-    math::{decimal::Precision, i256::I256},
-    scalar::Scalar,
+use crate::{
+    alloc::string::ToString,
+    base::{
+        database::ColumnType,
+        math::{decimal::Precision, i256::I256},
+        scalar::Scalar,
+    },
 };
+use alloc::vec::Vec;
 use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use sqlparser::ast::{DataType, ExactNumberInfo, Expr, Value};
 
@@ -72,18 +76,6 @@ impl ToScalar for Expr {
                 .unwrap_or_else(|_| panic!("Invalid number: {n}"))
                 .into(),
             Expr::Value(Value::SingleQuotedString(s)) => s.into(),
-            // Expr::TypedString { data_type, value }
-            //     if matches!(data_type, DataType::Decimal(_)) =>
-            // {
-            //     let bigint_value = match num_bigint::BigInt::parse_bytes(value.as_bytes(), 10) {
-            //         Some(bigint) => bigint,
-            //         // Will be handled later
-            //         None => panic!("Failed to parse '{}' as a decimal", value),
-            //     };
-
-            //     let i256_value = I256::from_num_bigint(&bigint_value);
-            //     i256_value.into_scalar()
-            // }
             Expr::TypedString { data_type, value } if data_type.to_string() == "scalar" => {
                 let scalar_str = value.strip_prefix("scalar:").unwrap();
                 let limbs: Vec<u64> = scalar_str

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -40,8 +40,9 @@ pub use table_operation_error::{TableOperationError, TableOperationResult};
 mod columnar_value;
 pub use columnar_value::ColumnarValue;
 
-mod literal_value;
-pub use literal_value::LiteralValue;
+/// TODO: add docs
+pub mod literal_value;
+pub use literal_value::{ExprExt, ToScalar};
 
 mod table_ref;
 #[cfg(feature = "arrow")]
@@ -126,3 +127,5 @@ mod order_by_util_test;
 
 #[allow(dead_code)]
 pub(crate) mod join_util;
+
+pub use column::ColumnError;

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -12,6 +12,9 @@ mod slice_operation;
 
 mod slice_decimal_operation;
 
+/// util functions for `Expr` tests
+pub mod expr_utility;
+
 mod column_type_operation;
 pub use column_type_operation::{
     try_add_subtract_column_types, try_divide_column_types, try_multiply_column_types,

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -16,8 +16,9 @@ use alloc::{
     vec::Vec,
 };
 use itertools::Itertools;
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::TimezoneInfo;
 
 #[derive(Debug, PartialEq, Clone, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -42,7 +43,7 @@ pub enum OwnedColumn<S: Scalar> {
     /// Scalar columns
     Scalar(Vec<S>),
     /// Timestamp columns
-    TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, Vec<i64>),
+    TimestampTZ(PoSQLTimeUnit, TimezoneInfo, Vec<i64>),
 }
 
 impl<S: Scalar> OwnedColumn<S> {

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -8,7 +8,6 @@ use itertools::{EitherOrBoth, Itertools};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use sqlparser::ast::Ident;
-
 /// An error that occurs when working with tables.
 #[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum OwnedTableError {
@@ -198,7 +197,8 @@ mod tests {
         scalar::test_scalar::TestScalar,
     };
     use bumpalo::Bump;
-    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+    use sqlparser::ast::TimezoneInfo;
 
     #[test]
     fn test_conversion_from_table_to_owned_table() {
@@ -229,7 +229,7 @@ mod tests {
             borrowed_timestamptz(
                 "time_stamp",
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 [0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
                 &alloc,
             ),
@@ -247,7 +247,7 @@ mod tests {
             timestamptz(
                 "time_stamp",
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 [0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
             ),
         ]);

--- a/crates/proof-of-sql/src/base/database/owned_table_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test.rs
@@ -6,8 +6,9 @@ use crate::{
     },
     proof_primitive::dory::DoryScalar,
 };
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
-use sqlparser::ast::Ident;
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::{Ident, TimezoneInfo};
+
 #[test]
 fn we_can_create_an_owned_table_with_no_columns() {
     let table = OwnedTable::<TestScalar>::try_new(IndexMap::default()).unwrap();
@@ -44,7 +45,7 @@ fn we_can_create_an_owned_table_with_data() {
         timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
         ),
     ]);
@@ -53,7 +54,7 @@ fn we_can_create_an_owned_table_with_data() {
         Ident::new("time_stamp"),
         OwnedColumn::TimestampTZ(
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [0, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX].into(),
         ),
     );
@@ -111,7 +112,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
         timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [0; 0],
         ),
     ]);
@@ -123,7 +124,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
         timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [0; 0],
         ),
     ]);
@@ -139,7 +140,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
         timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [1_625_072_400],
         ),
     ]);
@@ -151,7 +152,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
         timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [1_625_076_000],
         ),
     ]);

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -10,7 +10,8 @@ use crate::base::{
     database::owned_table_utility::*,
     scalar::test_scalar::TestScalar,
 };
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::TimezoneInfo;
 
 #[test]
 fn we_can_query_the_length_of_a_table() {
@@ -55,7 +56,7 @@ fn we_can_access_the_columns_of_a_table() {
         timestamptz(
             "time",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::WithTimeZone,
             [4, 5, 6, 5],
         ),
     ]);
@@ -116,7 +117,7 @@ fn we_can_access_the_columns_of_a_table() {
     let column = ColumnRef::new(
         table_ref_2,
         "time".into(),
-        ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::WithTimeZone),
     );
     match accessor.get_column(column) {
         Column::TimestampTZ(_, _, col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -16,8 +16,8 @@
 use super::{OwnedColumn, OwnedTable};
 use crate::base::scalar::Scalar;
 use alloc::string::String;
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
-use sqlparser::ast::Ident;
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::{Ident, TimezoneInfo};
 
 /// Creates an [`OwnedTable`] from a list of `(Ident, OwnedColumn)` pairs.
 /// This is a convenience wrapper around [`OwnedTable::try_from_iter`] primarily for use in tests and
@@ -242,18 +242,17 @@ pub fn decimal75<S: Scalar>(
 /// use proof_of_sql::base::{database::owned_table_utility::*,
 ///     scalar::Curve25519Scalar,
 /// };
-/// use proof_of_sql_parser::{
-///    posql_time::{PoSQLTimeZone, PoSQLTimeUnit}};
+/// use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+/// use sqlparser::ast::TimezoneInfo;
 ///
 /// let result = owned_table::<Curve25519Scalar>([
-///     timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![1625072400, 1625076000, 1625079600]),
+///     timestamptz("event_time", PoSQLTimeUnit::Second, TimezoneInfo::WithTimeZone, vec![1625072400, 1625076000, 1625079600]),
 /// ]);
 /// ```
-
 pub fn timestamptz<S: Scalar>(
     name: impl Into<Ident>,
     time_unit: PoSQLTimeUnit,
-    timezone: PoSQLTimeZone,
+    timezone: TimezoneInfo,
     data: impl IntoIterator<Item = i64>,
 ) -> (Ident, OwnedColumn<S>) {
     (

--- a/crates/proof-of-sql/src/base/database/table_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test.rs
@@ -4,8 +4,8 @@ use crate::base::{
     scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
-use sqlparser::ast::Ident;
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::{Ident, TimezoneInfo};
 #[test]
 fn we_can_create_a_table_with_no_columns_specifying_row_count() {
     let table =
@@ -151,7 +151,7 @@ fn we_can_create_a_table_with_data() {
         borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX],
             &alloc,
         ),
@@ -162,7 +162,7 @@ fn we_can_create_a_table_with_data() {
     let time_stamp_data = alloc.alloc_slice_copy(&[0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]);
     expected_table.insert(
         Ident::new("time_stamp"),
-        Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), time_stamp_data),
+        Column::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None, time_stamp_data),
     );
 
     let bigint_data = alloc.alloc_slice_copy(&[0_i64, 1, 2, 3, 4, 5, 6, i64::MIN, i64::MAX]);
@@ -206,7 +206,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
         borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [0_i64; 0],
             &alloc,
         ),
@@ -220,7 +220,7 @@ fn we_get_inequality_between_tables_with_differing_column_order() {
         borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [0_i64; 0],
             &alloc,
         ),
@@ -241,7 +241,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
         borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [1_625_072_400],
             &alloc,
         ),
@@ -255,7 +255,7 @@ fn we_get_inequality_between_tables_with_differing_data() {
         borrowed_timestamptz(
             "time_stamp",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [1_625_076_000],
             &alloc,
         ),

--- a/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor_test.rs
@@ -11,7 +11,8 @@ use crate::base::{
     scalar::test_scalar::TestScalar,
 };
 use bumpalo::Bump;
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::TimezoneInfo;
 
 #[test]
 fn we_can_query_the_length_of_a_table() {
@@ -67,7 +68,7 @@ fn we_can_access_the_columns_of_a_table() {
         borrowed_timestamptz(
             "time",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [4, 5, 6, 5],
             &alloc,
         ),
@@ -129,7 +130,7 @@ fn we_can_access_the_columns_of_a_table() {
     let column = ColumnRef::new(
         table_ref_2,
         "time".into(),
-        ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+        ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None),
     );
     match accessor.get_column(column) {
         Column::TimestampTZ(_, _, col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -19,8 +19,8 @@ use super::{Column, Table, TableOptions};
 use crate::base::scalar::Scalar;
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
-use sqlparser::ast::Ident;
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::{Ident, TimezoneInfo};
 
 /// Creates an [`Table`] from a list of `(Ident, Column)` pairs.
 /// This is a convenience wrapper around [`Table::try_from_iter`] primarily for use in tests and
@@ -301,19 +301,18 @@ pub fn borrowed_decimal75<S: Scalar>(
 /// use proof_of_sql::base::{database::table_utility::*,
 ///     scalar::Curve25519Scalar,
 /// };
-/// use proof_of_sql_parser::{
-///    posql_time::{PoSQLTimeZone, PoSQLTimeUnit}};
-///
+/// use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+/// use sqlparser::ast::TimezoneInfo;
 /// let alloc = Bump::new();
 /// let result = table::<Curve25519Scalar>([
-///     borrowed_timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![1625072400, 1625076000, 1625079600], &alloc),
+///     borrowed_timestamptz("event_time", PoSQLTimeUnit::Second, TimezoneInfo::None,vec![1625072400, 1625076000, 1625079600], &alloc),
 /// ]);
 /// ```
 
 pub fn borrowed_timestamptz<S: Scalar>(
     name: impl Into<Ident>,
     time_unit: PoSQLTimeUnit,
-    timezone: PoSQLTimeZone,
+    timezone: TimezoneInfo,
     data: impl IntoIterator<Item = i64>,
     alloc: &Bump,
 ) -> (Ident, Column<'_, S>) {

--- a/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
+++ b/crates/proof-of-sql/src/base/math/big_decimal_ext.rs
@@ -3,6 +3,7 @@ use bigdecimal::BigDecimal;
 use num_bigint::BigInt;
 
 pub trait BigDecimalExt {
+    #[allow(dead_code)]
     fn precision(&self) -> u64;
     fn scale(&self) -> i64;
     fn try_into_bigint_with_precision_and_scale(
@@ -14,6 +15,7 @@ pub trait BigDecimalExt {
 impl BigDecimalExt for BigDecimal {
     /// Get the precision of the fixed-point representation of this intermediate decimal.
     #[must_use]
+    #[allow(dead_code)]
     fn precision(&self) -> u64 {
         self.normalized().digits()
     }

--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -1,4 +1,5 @@
 use crate::base::scalar::Scalar;
+use alloc::vec::Vec;
 use ark_ff::BigInteger;
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -1,8 +1,7 @@
 use crate::base::scalar::Scalar;
-use alloc::vec::Vec;
+use alloc::{fmt, format, string::String, vec::Vec};
 use ark_ff::BigInteger;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// A 256-bit data type with some conversions implemented that interpret it as a signed integer.
 ///

--- a/crates/proof-of-sql/src/evm_compatibility/dyn_proof_plan_serializer/error.rs
+++ b/crates/proof-of-sql/src/evm_compatibility/dyn_proof_plan_serializer/error.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use snafu::Snafu;
 
 /// Errors that can occur during proof plan serialization.

--- a/crates/proof-of-sql/src/evm_compatibility/dyn_proof_plan_serializer/error.rs
+++ b/crates/proof-of-sql/src/evm_compatibility/dyn_proof_plan_serializer/error.rs
@@ -22,4 +22,8 @@ pub enum ProofPlanSerializationError {
     /// Error indicating that the column was not found.
     #[snafu(display("Column not found"))]
     ColumnNotFound,
+
+    /// Error indicating as an invalid number format.
+    #[snafu(display("Invalid number format: {value:?}"))]
+    InvalidNumberFormat { value: String },
 }

--- a/crates/proof-of-sql/src/evm_compatibility/dyn_proof_plan_serializer/serialize_proof_plan.rs
+++ b/crates/proof-of-sql/src/evm_compatibility/dyn_proof_plan_serializer/serialize_proof_plan.rs
@@ -69,18 +69,22 @@ impl<S: Scalar> DynProofPlanSerializer<S> {
 mod tests {
     use super::*;
     use crate::{
-        base::{database::LiteralValue, map::indexset, scalar::test_scalar::TestScalar},
+        base::{map::indexset, scalar::test_scalar::TestScalar},
         sql::proof_exprs::{DynProofExpr, LiteralExpr},
     };
     use core::iter;
     use itertools::Itertools;
+    use sqlparser::ast::{Expr as SqlExpr, Value};
 
     #[test]
     fn we_can_serialize_an_aliased_dyn_proof_expr() {
         let serializer =
             DynProofPlanSerializer::<TestScalar>::try_new(indexset! {}, indexset! {}).unwrap();
 
-        let expr = DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(4200)));
+        let expr = DynProofExpr::Literal(LiteralExpr::new(SqlExpr::Value(Value::Number(
+            "4200".to_string(),
+            false,
+        ))));
         let expr_bytes = serializer
             .clone()
             .serialize_dyn_proof_expr(&expr)
@@ -150,9 +154,18 @@ mod tests {
             DynProofPlanSerializer::<TestScalar>::try_new(indexset! { table_ref }, indexset! {})
                 .unwrap();
 
-        let expr_a = DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(4200)));
-        let expr_b = DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(4200)));
-        let expr_c = DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(4200)));
+        let expr_a = DynProofExpr::Literal(LiteralExpr::new(SqlExpr::Value(Value::Number(
+            "4200".to_string(),
+            false,
+        ))));
+        let expr_b = DynProofExpr::Literal(LiteralExpr::new(SqlExpr::Value(Value::Number(
+            "4200".to_string(),
+            false,
+        ))));
+        let expr_c = DynProofExpr::Literal(LiteralExpr::new(SqlExpr::Value(Value::Number(
+            "4200".to_string(),
+            false,
+        ))));
         let aliased_expr_0 = AliasedDynProofExpr {
             expr: expr_a.clone(),
             alias: "alias_0".into(),

--- a/crates/proof-of-sql/src/evm_compatibility/serialize_query_expr.rs
+++ b/crates/proof-of-sql/src/evm_compatibility/serialize_query_expr.rs
@@ -4,7 +4,6 @@ use crate::{
     sql::{parse::QueryExpr, proof::ProofPlan},
 };
 use alloc::vec::Vec;
-
 /// Serializes a `QueryExpr` into a vector of bytes.
 ///
 /// This function takes a `QueryExpr` and attempts to serialize it into a vector of bytes.
@@ -45,7 +44,7 @@ pub fn serialize_query_expr<S: Scalar>(
 mod tests {
     use crate::{
         base::{
-            database::{ColumnRef, ColumnType, LiteralValue},
+            database::{ColumnRef, ColumnType},
             map::indexset,
             scalar::test_scalar::TestScalar,
         },
@@ -66,6 +65,7 @@ mod tests {
     };
     use core::iter;
     use itertools::Itertools;
+    use sqlparser::ast::{Expr as SqlExpr, Value};
 
     #[test]
     fn we_can_generate_serialized_proof_plan_for_query_expr() {
@@ -74,11 +74,17 @@ mod tests {
 
         let plan = DynProofPlan::Filter(FilterExec::new(
             vec![AliasedDynProofExpr {
-                expr: DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(1001))),
+                expr: DynProofExpr::Literal(LiteralExpr::new(SqlExpr::Value(Value::Number(
+                    "1001".to_string(),
+                    false,
+                )))),
                 alias: identifier_alias,
             }],
             TableExpr { table_ref },
-            DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(1002))),
+            DynProofExpr::Literal(LiteralExpr::new(SqlExpr::Value(Value::Number(
+                "1001".to_string(),
+                false,
+            )))),
         ));
 
         // Serializing a query expression without postprocessing steps should succeed and
@@ -136,9 +142,9 @@ mod tests {
             TableExpr { table_ref },
             DynProofExpr::Equals(EqualsExpr::new(
                 Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a))),
-                Box::new(DynProofExpr::Literal(LiteralExpr::new(
-                    LiteralValue::BigInt(5),
-                ))),
+                Box::new(DynProofExpr::Literal(LiteralExpr::new(SqlExpr::Value(
+                    Value::Number("5".to_string(), false),
+                )))),
             )),
         ));
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -291,7 +291,8 @@ pub fn create_blitzar_metadata_tables(
 mod tests {
     use super::*;
     use crate::base::math::decimal::Precision;
-    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+    use sqlparser::ast::TimezoneInfo;
 
     fn assert_blitzar_metadata(
         committable_columns: &[CommittableColumn],
@@ -633,7 +634,7 @@ mod tests {
             CommittableColumn::Decimal75(Precision::new(1).unwrap(), 0, vec![[6, 0, 0, 0]]),
             CommittableColumn::Scalar(vec![[7, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[8, 0, 0, 0]]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[9]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None, &[9]),
             CommittableColumn::Boolean(&[true]),
         ];
 
@@ -667,7 +668,7 @@ mod tests {
             CommittableColumn::Decimal75(Precision::new(1).unwrap(), 0, vec![[6, 0, 0, 0]]),
             CommittableColumn::Scalar(vec![[7, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[8, 0, 0, 0]]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[9]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None, &[9]),
             CommittableColumn::Boolean(&[true]),
         ];
 
@@ -709,7 +710,7 @@ mod tests {
             CommittableColumn::Decimal75(Precision::new(1).unwrap(), 0, vec![[6, 0, 0, 0]]),
             CommittableColumn::Scalar(vec![[7, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[8, 0, 0, 0]]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[9]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None, &[9]),
             CommittableColumn::Boolean(&[true]),
         ];
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -7,7 +7,8 @@ use crate::{
 use ark_ec::pairing::Pairing;
 use ark_std::test_rng;
 use num_traits::Zero;
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::TimezoneInfo;
 
 #[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
@@ -414,7 +415,7 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_fewer_ro
             CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 &[17, 18, 19, 20],
             ),
         ],
@@ -491,7 +492,7 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
             CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 &[17, 18, 19, 20],
             ),
         ],
@@ -567,7 +568,7 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_signed_v
             CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 &[-18, -17, 17, 18],
             ),
         ],
@@ -656,7 +657,7 @@ fn we_can_compute_a_dory_commitment_with_mixed_committable_columns_with_an_offse
             CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 &[-18, -17, 17, 18],
             ),
         ],

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_compute_commitments_test.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 use ark_ec::pairing::Pairing;
 use num_traits::Zero;
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::TimezoneInfo;
 
 #[test]
 fn we_can_handle_calling_with_an_empty_committable_column() {
@@ -247,7 +248,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns() {
             CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 &[17, 18, 19, 20],
             ),
         ],
@@ -322,7 +323,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
             CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 &[17, 18, 19, 20],
             ),
         ],
@@ -397,7 +398,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
             CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 &[-18, -17, 17, 18],
             ),
         ],
@@ -485,7 +486,7 @@ fn we_can_compute_a_dynamic_dory_commitment_with_mixed_committable_columns_with_
             CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 &[-18, -17, 17, 18],
             ),
         ],

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -468,7 +468,8 @@ pub fn bit_table_and_scalars_for_packed_msm(
 mod tests {
     use super::*;
     use crate::base::math::decimal::Precision;
-    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+    use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+    use sqlparser::ast::TimezoneInfo;
 
     #[test]
     fn we_can_get_a_bit_table() {
@@ -491,7 +492,7 @@ mod tests {
             CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0], [4, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]]),
             CommittableColumn::Boolean(&[true, false]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::WithTimeZone, &[1]),
         ];
 
         let offset = 0;
@@ -526,7 +527,7 @@ mod tests {
             CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0], [4, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]]),
             CommittableColumn::Boolean(&[true, false]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::WithTimeZone, &[1]),
         ];
 
         let offset = 1;
@@ -561,7 +562,7 @@ mod tests {
             CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0], [4, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]]),
             CommittableColumn::Boolean(&[true, false]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::WithTimeZone, &[1]),
         ];
 
         let offset = 0;
@@ -601,7 +602,7 @@ mod tests {
             CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0], [4, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]]),
             CommittableColumn::Boolean(&[true, false]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::WithTimeZone, &[1]),
         ];
 
         let offset = 2;
@@ -641,7 +642,7 @@ mod tests {
             CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0], [4, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]]),
             CommittableColumn::Boolean(&[true, false]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::WithTimeZone, &[1]),
         ];
 
         let offset = 0;
@@ -681,7 +682,7 @@ mod tests {
             CommittableColumn::Scalar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0], [4, 0, 0, 0]]),
             CommittableColumn::VarChar(vec![[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]]),
             CommittableColumn::Boolean(&[true, false]),
-            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1]),
+            CommittableColumn::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::WithTimeZone, &[1]),
         ];
 
         let offset = 1;
@@ -1023,7 +1024,7 @@ mod tests {
             CommittableColumn::Boolean(&[true, false, true, false, true]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::WithTimeZone,
                 &[1, 2, 3, 4, 5],
             ),
         ];
@@ -1062,7 +1063,7 @@ mod tests {
             CommittableColumn::Boolean(&[true, false, true, false, true]),
             CommittableColumn::TimestampTZ(
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::WithTimeZone,
                 &[1, 2, 3, 4, 5],
             ),
         ];

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{database::ColumnRef, map::IndexMap, math::i256::I256},
     sql::proof_exprs::{ColumnExpr, DynProofExpr, ProofExpr},
 };
-use alloc::{boxed::Box, format, string::ToString, vec::Vec};
+use alloc::{boxed::Box, format, string::ToString, vec, vec::Vec};
 use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use sqlparser::ast::{
     BinaryOperator, DataType, ExactNumberInfo, Expr, FunctionArg, FunctionArgExpr, Ident,

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -121,10 +121,9 @@ impl DynProofExprBuilder<'_> {
                     PoSQLTimeUnit::Millisecond => its.timestamp().timestamp_millis(),
                     PoSQLTimeUnit::Second => its.timestamp().timestamp(),
                 };
-
                 Ok(DynProofExpr::new_literal(LiteralValue::TimeStampTZ(
                     its.timeunit(),
-                    its.timezone(),
+                    its.timezone().into(),
                     timestamp,
                 )))
             }

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -27,8 +27,9 @@ impl EnrichedExpr {
     pub fn new(expression: AliasedResultExpr, column_mapping: &IndexMap<Ident, ColumnRef>) -> Self {
         // TODO: Using new_agg (ironically) disables aggregations in `QueryExpr` for now.
         // Re-enable aggregations when we add `GroupByExec` generalizations.
+        let converted_expr = (*expression.expr).clone().into();
         let res_dyn_proof_expr =
-            DynProofExprBuilder::new_agg(column_mapping).build(&expression.expr);
+            DynProofExprBuilder::new_agg(column_mapping).build(&converted_expr);
         match res_dyn_proof_expr {
             Ok(dyn_proof_expr) => {
                 let alias = expression.alias;

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -153,6 +153,54 @@ pub enum ConversionError {
         /// The underlying error message
         error: String,
     },
+
+    #[snafu(display("Invalid number format: {value:?}"))]
+    /// Represents an error due to an invalid number format.
+    InvalidNumberFormat {
+        /// The invalid number value as a string.
+        value: String,
+    },
+
+    #[snafu(display(
+        "Invalid decimal format: {value:?} with precision {precision} and scale {scale}"
+    ))]
+    /// Represents an error due to an invalid decimal format.
+    InvalidDecimalFormat {
+        /// The invalid decimal value as a string.
+        value: String,
+        /// The precision of the decimal value.
+        precision: u8,
+        /// The scale of the decimal value.
+        scale: i8,
+    },
+
+    #[snafu(display("Unsupported literal type: {literal:?}"))]
+    /// The literal type is not supported.
+    UnsupportedLiteral {
+        /// The unsupported literal type as a string.
+        literal: String,
+    },
+
+    #[snafu(display("Unsupported data type: {data_type:?}"))]
+    /// The data type is not supported.
+    UnsupportedDataType {
+        /// The unsupported data type as a string.
+        data_type: String,
+    },
+
+    #[snafu(display("Invalid timestamp format: {value:?}"))]
+    /// The timestamp format is invalid.
+    InvalidTimestampFormat {
+        /// The invalid timestamp value as a string.
+        value: String,
+    },
+
+    #[snafu(display("Timestamp out of range: {value:?}"))]
+    /// The timestamp value is out of the allowed range.
+    TimestampOutOfRange {
+        /// The out-of-range timestamp value as a string.
+        value: String,
+    },
 }
 
 impl From<String> for ConversionError {

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -40,6 +40,27 @@ pub enum ConversionError {
         actual: ColumnType,
     },
 
+    #[snafu(display("Unsupported expression: {error}"))]
+    /// The expression is unsupported
+    UnsupportedExpr {
+        /// The error for unsupported expression
+        error: String,
+    },
+
+    #[snafu(display("Invalid precision value: {precision}"))]
+    /// Precision value is invalid
+    InvalidPrecision {
+        /// The invalid precision value
+        precision: String,
+    },
+
+    #[snafu(display("Invalid scale value: {scale}"))]
+    /// Scale value is invalid
+    InvalidScale {
+        /// The invalid scale value
+        scale: String,
+    },
+
     #[snafu(display("Left side has '{left_type}' type but right side has '{right_type}' type"))]
     /// Data types do not match
     DataTypeMismatch {

--- a/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
@@ -57,7 +57,7 @@ impl FilterExecBuilder {
             if let Some(plan) = &enriched_expr.dyn_proof_expr {
                 self.filter_result_expr_list.push(AliasedDynProofExpr {
                     expr: plan.clone(),
-                    alias: enriched_expr.residue_expression.alias.into(),
+                    alias: enriched_expr.residue_expression.alias.clone(),
                 });
             } else {
                 has_nonprovable_column = true;

--- a/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
@@ -1,7 +1,7 @@
 use super::{where_expr_builder::WhereExprBuilder, ConversionError, EnrichedExpr};
 use crate::{
     base::{
-        database::{ColumnRef, LiteralValue, TableRef},
+        database::{ColumnRef, TableRef},
         map::IndexMap,
     },
     sql::{
@@ -12,7 +12,8 @@ use crate::{
 use alloc::{boxed::Box, vec, vec::Vec};
 use itertools::Itertools;
 use proof_of_sql_parser::intermediate_ast::Expression;
-use sqlparser::ast::Ident;
+use sqlparser::ast::{Expr, Ident, Value};
+
 pub struct FilterExecBuilder {
     table_expr: Option<TableExpr>,
     where_expr: Option<DynProofExpr>,
@@ -82,7 +83,7 @@ impl FilterExecBuilder {
             self.filter_result_expr_list,
             self.table_expr.expect("Table expr is required"),
             self.where_expr
-                .unwrap_or_else(|| DynProofExpr::new_literal(LiteralValue::Boolean(true))),
+                .unwrap_or_else(|| DynProofExpr::new_literal(Expr::Value(Value::Boolean(true)))),
         )
     }
 }

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -291,8 +291,9 @@ impl TryFrom<&QueryContext> for Option<GroupByExec> {
                     ..
                 } = (*res.expr).clone()
                 {
+                    let converted_expr = (*res.expr).clone().into();
                     let res_dyn_proof_expr =
-                        DynProofExprBuilder::new(&value.column_mapping).build(&res.expr);
+                        DynProofExprBuilder::new(&value.column_mapping).build(&converted_expr);
                     res_dyn_proof_expr
                         .ok()
                         .map(|dyn_proof_expr| AliasedDynProofExpr {

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{ColumnRef, LiteralValue, TableRef},
+        database::{ColumnRef, TableRef},
         map::{IndexMap, IndexSet},
     },
     sql::{
@@ -13,7 +13,7 @@ use alloc::{borrow::ToOwned, boxed::Box, string::ToString, vec::Vec};
 use proof_of_sql_parser::intermediate_ast::{
     AggregationOperator, AliasedResultExpr, Expression, OrderBy, Slice,
 };
-use sqlparser::ast::Ident;
+use sqlparser::ast::{Expr, Ident, Value};
 
 #[derive(Default, Debug)]
 pub struct QueryContext {
@@ -236,7 +236,7 @@ impl TryFrom<&QueryContext> for Option<GroupByExec> {
     fn try_from(value: &QueryContext) -> Result<Option<GroupByExec>, Self::Error> {
         let where_clause = WhereExprBuilder::new(&value.column_mapping)
             .build(value.where_expr.clone())?
-            .unwrap_or_else(|| DynProofExpr::new_literal(LiteralValue::Boolean(true)));
+            .unwrap_or_else(|| DynProofExpr::new_literal(Expr::Value(Value::Boolean(true))));
         let table = value.table.map(|table_ref| TableExpr { table_ref }).ok_or(
             ConversionError::InvalidExpression {
                 expression: "QueryContext has no table_ref".to_owned(),

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -253,7 +253,11 @@ impl<'a> QueryContextBuilder<'a> {
                     })?,
                 ))
             }
-            Literal::Timestamp(its) => Ok(ColumnType::TimestampTZ(its.timeunit(), its.timezone())),
+
+            Literal::Timestamp(its) => Ok(ColumnType::TimestampTZ(
+                its.timeunit(),
+                its.timezone().into(),
+            )),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -1,7 +1,13 @@
 use super::ConversionError;
 use crate::{
     base::{
-        database::{ColumnType, TableRef, TestSchemaAccessor},
+        database::{
+            expr_utility::{
+                add as padd, aliased_expr, col, count, count_all, lit, max, min, mul as pmul,
+                sub as psub, sum,
+            },
+            ColumnType, TableRef, TestSchemaAccessor,
+        },
         map::{indexmap, IndexMap, IndexSet},
     },
     sql::{
@@ -15,10 +21,10 @@ use itertools::Itertools;
 use proof_of_sql_parser::{
     intermediate_ast::OrderByDirection::*,
     sql::SelectStatementParser,
-    utility::{
-        add as padd, aliased_expr, col, count, count_all, lit, max, min, mul as pmul, sub as psub,
-        sum,
-    },
+    // utility::{
+    //     add as padd, aliased_expr, col, count, count_all, lit, max, min, mul as pmul, sub as psub,
+    //     sum,
+    // },
 };
 use sqlparser::ast::Ident;
 

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -30,7 +30,8 @@ impl<'a> WhereExprBuilder<'a> {
     ) -> Result<Option<DynProofExpr>, ConversionError> {
         where_expr
             .map(|where_expr| {
-                let expr_plan = self.builder.build(&where_expr)?;
+                let converted_expr = (*where_expr).into();
+                let expr_plan = self.builder.build(&converted_expr)?;
                 // Ensure that the expression is a boolean expression
                 match expr_plan.data_type() {
                     ColumnType::Boolean => Ok(expr_plan),

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{ColumnRef, ColumnType, LiteralValue, TestSchemaAccessor},
+        database::{ColumnRef, ColumnType, TestSchemaAccessor},
         map::{indexmap, IndexMap},
         math::decimal::Precision,
     },
@@ -16,7 +16,7 @@ use proof_of_sql_parser::{
     utility::*,
     SelectStatement,
 };
-use sqlparser::ast::{Ident, TimezoneInfo};
+use sqlparser::ast::{Expr, Ident, TimezoneInfo, Value};
 
 /// # Panics
 ///
@@ -149,7 +149,10 @@ fn we_can_directly_check_whether_bigint_columns_ge_int128() {
             "bigint_column".into(),
             ColumnType::BigInt,
         ))),
-        DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
+        DynProofExpr::Literal(LiteralExpr::new(Expr::Value(Value::Number(
+            "-12345".to_string(),
+            false,
+        )))),
         false,
     )
     .unwrap();
@@ -171,7 +174,10 @@ fn we_can_directly_check_whether_bigint_columns_le_int128() {
             "bigint_column".into(),
             ColumnType::BigInt,
         ))),
-        DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Int128(-12345))),
+        DynProofExpr::Literal(LiteralExpr::new(Expr::Value(Value::Number(
+            "-12345".to_string(),
+            false,
+        )))),
         true,
     )
     .unwrap();

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -12,11 +12,11 @@ use crate::{
 use bigdecimal::BigDecimal;
 use core::str::FromStr;
 use proof_of_sql_parser::{
-    posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestamp},
+    posql_time::{PoSQLTimeUnit, PoSQLTimestamp},
     utility::*,
     SelectStatement,
 };
-use sqlparser::ast::Ident;
+use sqlparser::ast::{Ident, TimezoneInfo};
 
 /// # Panics
 ///
@@ -61,7 +61,7 @@ fn get_column_mappings_for_testing() -> IndexMap<Ident, ColumnRef> {
         ColumnRef::new(
             tab_ref,
             "timestamp_second_column".into(),
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, TimezoneInfo::None),
         ),
     );
     column_mapping.insert(
@@ -69,7 +69,7 @@ fn get_column_mappings_for_testing() -> IndexMap<Ident, ColumnRef> {
         ColumnRef::new(
             tab_ref,
             "timestamp_millisecond_column".into(),
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Millisecond, TimezoneInfo::None),
         ),
     );
     column_mapping.insert(
@@ -77,7 +77,7 @@ fn get_column_mappings_for_testing() -> IndexMap<Ident, ColumnRef> {
         ColumnRef::new(
             tab_ref,
             "timestamp_microsecond_column".into(),
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Microsecond, TimezoneInfo::None),
         ),
     );
     column_mapping.insert(
@@ -85,7 +85,7 @@ fn get_column_mappings_for_testing() -> IndexMap<Ident, ColumnRef> {
         ColumnRef::new(
             tab_ref,
             "timestamp_nanosecond_column".into(),
-            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, PoSQLTimeZone::utc()),
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Nanosecond, TimezoneInfo::None),
         ),
     );
     column_mapping

--- a/crates/proof-of-sql/src/sql/postprocessing/error.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/error.rs
@@ -41,6 +41,12 @@ pub enum PostprocessingError {
         /// The underlying error message
         error: String,
     },
+    /// Unsupported expression encountered during postprocessing
+    #[snafu(display("Unsupported expression: {error}"))]
+    UnsupportedExpr {
+        /// The underlying error message
+        error: String,
+    },
     /// Errors in aggregate columns
     #[snafu(transparent)]
     AggregateColumnsError {

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing_test.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing_test.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{owned_table_utility::*, OwnedTable},
+        database::{expr_utility::*, owned_table_utility::*, OwnedTable},
         scalar::Curve25519Scalar,
     },
     sql::postprocessing::{
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 use bigdecimal::BigDecimal;
-use proof_of_sql_parser::{intermediate_ast::AggregationOperator, utility::*};
+use sqlparser::ast::Ident;
 #[test]
 fn we_cannot_have_invalid_group_bys() {
     // Column in result but not in group by or aggregation
@@ -48,17 +48,16 @@ fn we_can_make_group_by_postprocessing() {
             aliased_expr(col("__col_agg_1"), "c1"),
         ]
     );
-    assert_eq!(
-        res.aggregation_exprs(),
-        &[
-            (AggregationOperator::Sum, *col("a"), "__col_agg_0".into()),
-            (
-                AggregationOperator::Sum,
-                *add(col("b"), col("a")),
-                "__col_agg_1".into()
-            ),
-        ]
-    );
+
+    let expected_aggregation_exprs = vec![
+        ("SUM".to_string(), col("a"), Ident::new("__col_agg_0")),
+        (
+            "SUM".to_string(),
+            add(col("b"), col("a")),
+            Ident::new("__col_agg_1"),
+        ),
+    ];
+    assert_eq!(res.aggregation_exprs(), &expected_aggregation_exprs);
 }
 
 #[allow(clippy::too_many_lines)]

--- a/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
@@ -5,7 +5,7 @@ use crate::base::{
     scalar::Scalar,
 };
 use alloc::vec::Vec;
-use proof_of_sql_parser::intermediate_ast::AliasedResultExpr;
+use proof_of_sql_parser::sqlparser::SqlAliasedResultExpr;
 use serde::{Deserialize, Serialize};
 use sqlparser::ast::{Expr, Ident};
 
@@ -13,13 +13,13 @@ use sqlparser::ast::{Expr, Ident};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SelectPostprocessing {
     /// The aliased result expressions we select
-    aliased_result_exprs: Vec<AliasedResultExpr>,
+    aliased_result_exprs: Vec<SqlAliasedResultExpr>,
 }
 
 impl SelectPostprocessing {
     /// Create a new `SelectPostprocessing` node.
     #[must_use]
-    pub fn new(aliased_result_exprs: Vec<AliasedResultExpr>) -> Self {
+    pub fn new(aliased_result_exprs: Vec<SqlAliasedResultExpr>) -> Self {
         Self {
             aliased_result_exprs,
         }
@@ -34,9 +34,9 @@ impl<S: Scalar> PostprocessingStep<S> for SelectPostprocessing {
             .iter()
             .map(
                 |aliased_result_expr| -> PostprocessingResult<(Ident, OwnedColumn<S>)> {
-                    let sql_expr: Expr = (*aliased_result_expr.expr).clone().into();
+                    let sql_expr: Expr = (*aliased_result_expr.expr).clone();
                     let result_column = owned_table.evaluate(&sql_expr)?;
-                    Ok((aliased_result_expr.alias.into(), result_column))
+                    Ok((aliased_result_expr.alias.clone(), result_column))
                 },
             )
             .collect::<PostprocessingResult<_>>()?;

--- a/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing.rs
@@ -7,7 +7,7 @@ use crate::base::{
 use alloc::vec::Vec;
 use proof_of_sql_parser::intermediate_ast::AliasedResultExpr;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::Ident;
+use sqlparser::ast::{Expr, Ident};
 
 /// The select expression used to select, reorder, and apply alias transformations
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -34,7 +34,8 @@ impl<S: Scalar> PostprocessingStep<S> for SelectPostprocessing {
             .iter()
             .map(
                 |aliased_result_expr| -> PostprocessingResult<(Ident, OwnedColumn<S>)> {
-                    let result_column = owned_table.evaluate(&aliased_result_expr.expr)?;
+                    let sql_expr: Expr = (*aliased_result_expr.expr).clone().into();
+                    let result_column = owned_table.evaluate(&sql_expr)?;
                     Ok((aliased_result_expr.alias.into(), result_column))
                 },
             )

--- a/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing_test.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/select_postprocessing_test.rs
@@ -1,11 +1,10 @@
 use crate::{
     base::{
-        database::{owned_table_utility::*, OwnedTable},
+        database::{expr_utility::*, owned_table_utility::*, OwnedTable},
         scalar::Curve25519Scalar,
     },
     sql::postprocessing::{apply_postprocessing_steps, test_utility::*, OwnedTablePostprocessing},
 };
-use proof_of_sql_parser::utility::*;
 
 #[test]
 fn we_can_filter_out_owned_table_columns() {

--- a/crates/proof-of-sql/src/sql/postprocessing/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/test_utility.rs
@@ -1,11 +1,14 @@
 use super::*;
-use proof_of_sql_parser::intermediate_ast::{AliasedResultExpr, OrderBy, OrderByDirection};
+use proof_of_sql_parser::{
+    intermediate_ast::{OrderBy, OrderByDirection},
+    sqlparser::SqlAliasedResultExpr,
+};
 use sqlparser::ast::Ident;
 
 #[must_use]
 pub fn group_by_postprocessing(
     cols: &[&str],
-    result_exprs: &[AliasedResultExpr],
+    result_exprs: &[SqlAliasedResultExpr],
 ) -> OwnedTablePostprocessing {
     let ids: Vec<Ident> = cols.iter().map(|col| (*col).into()).collect();
     OwnedTablePostprocessing::new_group_by(
@@ -18,7 +21,7 @@ pub fn group_by_postprocessing(
 ///
 /// This function may panic if the internal structures cannot be created properly, although this is unlikely under normal circumstances.
 #[must_use]
-pub fn select_expr(result_exprs: &[AliasedResultExpr]) -> OwnedTablePostprocessing {
+pub fn select_expr(result_exprs: &[SqlAliasedResultExpr]) -> OwnedTablePostprocessing {
     OwnedTablePostprocessing::new_select(SelectPostprocessing::new(result_exprs.to_vec()))
 }
 

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -24,6 +24,7 @@ use alloc::{string::String, vec, vec::Vec};
 use bumpalo::Bump;
 use core::cmp;
 use num_traits::Zero;
+use proof_of_sql_parser::sqlparser::TimezoneInfoExt;
 use serde::{Deserialize, Serialize};
 
 /// Return the row number range of tables referenced in the Query
@@ -514,9 +515,9 @@ fn extend_transcript_with_owned_table<S: Scalar, T: Transcript>(
             OwnedColumn::Scalar(col) => {
                 transcript.extend_as_be(col.iter().map(|&s| Into::<[u64; 4]>::into(s)));
             }
-            OwnedColumn::TimestampTZ(po_sqltime_unit, po_sqltime_zone, col) => {
+            OwnedColumn::TimestampTZ(po_sqltime_unit, timezone_info, col) => {
                 transcript.extend_as_be([u64::from(*po_sqltime_unit)]);
-                transcript.extend_as_be([po_sqltime_zone.offset()]);
+                transcript.extend_as_be([timezone_info.offset(Some("+00:00"))]);
                 transcript.extend_as_be_from_refs(col);
             }
         }

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregation.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregation.rs
@@ -1,5 +1,8 @@
+use alloc::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
 
 /// Aggregation operators
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/aggregation.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aggregation.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display, Formatter};
+
+/// Aggregation operators
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+/// Aggregation operators
+pub enum AggOperator {
+    /// Maximum
+    Max,
+    /// Minimum
+    Min,
+    /// Sum
+    Sum,
+    /// Count
+    Count,
+    /// Return the first value
+    First,
+}
+
+impl Display for AggOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            AggOperator::Max => write!(f, "max"),
+            AggOperator::Min => write!(f, "min"),
+            AggOperator::Sum => write!(f, "sum"),
+            AggOperator::Count => write!(f, "count"),
+            AggOperator::First => write!(f, "first"),
+        }
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -161,7 +161,7 @@ impl DynProofExpr {
     }
 
     /// Create a new aggregate expression
-    pub fn new_aggregate(op: String, expr: DynProofExpr) -> Result<Self, ConversionError> {
+    pub fn new_aggregate(op: &str, expr: DynProofExpr) -> Result<Self, ConversionError> {
         let aggregation_operator = match op.to_uppercase().as_str() {
             "SUM" => AggregationOperator::Sum,
             "COUNT" => AggregationOperator::Count,

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnRef, ColumnType, Table},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -19,7 +19,7 @@ use bumpalo::Bump;
 use core::fmt::Debug;
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::BinaryOperator;
+use sqlparser::ast::{BinaryOperator, Expr as SqlExpr};
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -69,8 +69,8 @@ impl DynProofExpr {
         Ok(Self::Not(NotExpr::new(Box::new(expr))))
     }
     /// Create CONST expression
-    pub fn new_literal(value: LiteralValue) -> Self {
-        Self::Literal(LiteralExpr::new(value))
+    pub fn new_literal(expr: SqlExpr) -> Self {
+        Self::Literal(LiteralExpr::new(expr))
     }
     /// Create a new equals expression
     pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -161,8 +161,22 @@ impl DynProofExpr {
     }
 
     /// Create a new aggregate expression
-    pub fn new_aggregate(op: AggregationOperator, expr: DynProofExpr) -> Self {
-        Self::Aggregate(AggregateExpr::new(op, Box::new(expr)))
+    pub fn new_aggregate(op: String, expr: DynProofExpr) -> Result<Self, ConversionError> {
+        let aggregation_operator = match op.to_uppercase().as_str() {
+            "SUM" => AggregationOperator::Sum,
+            "COUNT" => AggregationOperator::Count,
+            "MAX" => AggregationOperator::Max,
+            "MIN" => AggregationOperator::Min,
+            _ => {
+                return Err(ConversionError::Unprovable {
+                    error: format!("Unsupported aggregation operator: {op}"),
+                })
+            }
+        };
+        Ok(Self::Aggregate(AggregateExpr::new(
+            aggregation_operator,
+            Box::new(expr),
+        )))
     }
 
     /// Check that the plan has the correct data type

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -14,7 +14,7 @@ use crate::{
         proof::{FinalRoundBuilder, VerificationBuilder},
     },
 };
-use alloc::{boxed::Box, string::ToString};
+use alloc::{boxed::Box, format, string::ToString};
 use bumpalo::Bump;
 use core::fmt::Debug;
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -16,19 +16,20 @@ use crate::{
 };
 use bumpalo::Bump;
 use itertools::{multizip, MultiUnzip};
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
 use rand::{
     distributions::{Distribution, Uniform},
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use sqlparser::ast::TimezoneInfo;
 
 #[test]
 fn we_can_compare_columns_with_small_timestamp_values_gte() {
     let data: OwnedTable<Curve25519Scalar> = owned_table([timestamptz(
         "a",
         PoSQLTimeUnit::Second,
-        PoSQLTimeZone::utc(),
+        TimezoneInfo::WithTimeZone,
         vec![-1, 0, 1],
     )]);
     let t = "sxt.t".parse().unwrap();
@@ -40,7 +41,7 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
             column(t, "a", &accessor),
             DynProofExpr::new_literal(LiteralValue::TimeStampTZ(
                 PoSQLTimeUnit::Nanosecond,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::WithTimeZone,
                 1,
             )),
         ),
@@ -51,7 +52,7 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
     let expected_res = owned_table([timestamptz(
         "a",
         PoSQLTimeUnit::Second,
-        PoSQLTimeZone::utc(),
+        TimezoneInfo::WithTimeZone,
         vec![1],
     )]);
     assert_eq!(res, expected_res);
@@ -62,7 +63,7 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
     let data: OwnedTable<Curve25519Scalar> = owned_table([timestamptz(
         "a",
         PoSQLTimeUnit::Second,
-        PoSQLTimeZone::utc(),
+        TimezoneInfo::WithTimeZone,
         vec![-1, 0, 1],
     )]);
     let t = "sxt.t".parse().unwrap();
@@ -74,7 +75,7 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
             column(t, "a", &accessor),
             DynProofExpr::new_literal(LiteralValue::TimeStampTZ(
                 PoSQLTimeUnit::Nanosecond,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::WithTimeZone,
                 1,
             )),
         ),
@@ -85,7 +86,7 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
     let expected_res = owned_table([timestamptz(
         "a",
         PoSQLTimeUnit::Second,
-        PoSQLTimeZone::utc(),
+        TimezoneInfo::WithTimeZone,
         vec![-1, 0],
     )]);
     assert_eq!(res, expected_res);

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -2,8 +2,8 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, table_utility::*, Column, LiteralValue, OwnedTable,
-            OwnedTableTestAccessor, TableTestAccessor, TestAccessor,
+            owned_table_utility::*, table_utility::*, Column, OwnedTable, OwnedTableTestAccessor,
+            TableTestAccessor, TestAccessor,
         },
         scalar::{Curve25519Scalar, Scalar, ScalarExt},
     },
@@ -22,7 +22,7 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
-use sqlparser::ast::TimezoneInfo;
+use sqlparser::ast::{DataType, Expr, TimezoneInfo};
 
 #[test]
 fn we_can_compare_columns_with_small_timestamp_values_gte() {
@@ -39,11 +39,10 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
         tab(t),
         gte(
             column(t, "a", &accessor),
-            DynProofExpr::new_literal(LiteralValue::TimeStampTZ(
-                PoSQLTimeUnit::Nanosecond,
-                TimezoneInfo::WithTimeZone,
-                1,
-            )),
+            DynProofExpr::new_literal(Expr::TypedString {
+                data_type: DataType::Timestamp(Some(1), TimezoneInfo::WithTimeZone),
+                value: "1".to_string(),
+            }),
         ),
     );
 
@@ -73,11 +72,10 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
         tab(t),
         lte(
             column(t, "a", &accessor),
-            DynProofExpr::new_literal(LiteralValue::TimeStampTZ(
-                PoSQLTimeUnit::Nanosecond,
-                TimezoneInfo::WithTimeZone,
-                1,
-            )),
+            DynProofExpr::new_literal(Expr::TypedString {
+                data_type: DataType::Timestamp(Some(1), TimezoneInfo::WithTimeZone),
+                value: "1".to_string(),
+            }),
         ),
     );
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -1,7 +1,7 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnRef, ColumnType, ExprExt, Table, ToScalar},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -11,7 +11,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
-
+use sqlparser::ast::Expr;
 /// Provable CONST expression
 ///
 /// This node allows us to easily represent queries like
@@ -25,12 +25,12 @@ use serde::{Deserialize, Serialize};
 /// changes, and the performance is sufficient for present.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiteralExpr {
-    pub(crate) value: LiteralValue,
+    pub(crate) value: Expr,
 }
 
 impl LiteralExpr {
     /// Create literal expression
-    pub fn new(value: LiteralValue) -> Self {
+    pub fn new(value: Expr) -> Self {
         Self { value }
     }
 }
@@ -52,7 +52,7 @@ impl ProofExpr for LiteralExpr {
 
         log::log_memory_usage("End");
 
-        res
+        res.expect("Failed to evaluate literal expression")
     }
 
     #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]
@@ -69,7 +69,7 @@ impl ProofExpr for LiteralExpr {
 
         log::log_memory_usage("End");
 
-        res
+        res.expect("Failed to evaluate literal expression")
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -14,6 +14,7 @@ mod add_subtract_expr_test;
 
 mod aggregate_expr;
 pub(crate) use aggregate_expr::AggregateExpr;
+mod aggregation;
 
 mod multiply_expr;
 use multiply_expr::MultiplyExpr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -2,6 +2,7 @@ use crate::base::{
     database::{literal_value::ToScalar, Column, ColumnError, ColumnarValue},
     scalar::{Scalar, ScalarExt},
 };
+use alloc::{format, vec};
 use bumpalo::Bump;
 use core::cmp::Ordering;
 use sqlparser::ast::{DataType, Expr as SqlExpr, ObjectName};

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -4,7 +4,6 @@ use crate::base::{
     math::i256::I256,
     scalar::Scalar,
 };
-use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use sqlparser::ast::{DataType, ExactNumberInfo, Expr, Ident, ObjectName, Value};
 
 pub fn col_ref(tab: TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnRef {
@@ -217,7 +216,8 @@ pub fn cols_expr(tab: TableRef, names: &[&str], accessor: &impl SchemaAccessor) 
 /// - `alias.parse()` fails to parse the provided alias string.
 pub fn sum_expr(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
     AliasedDynProofExpr {
-        expr: DynProofExpr::new_aggregate(AggregationOperator::Sum, expr),
+        expr: DynProofExpr::new_aggregate("SUM".to_string(), expr)
+            .expect("Failed to create aggregate expression"),
         alias: alias.into(),
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -216,7 +216,7 @@ pub fn cols_expr(tab: TableRef, names: &[&str], accessor: &impl SchemaAccessor) 
 /// - `alias.parse()` fails to parse the provided alias string.
 pub fn sum_expr(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
     AliasedDynProofExpr {
-        expr: DynProofExpr::new_aggregate("SUM".to_string(), expr)
+        expr: DynProofExpr::new_aggregate("SUM", expr)
             .expect("Failed to create aggregate expression"),
         alias: alias.into(),
     }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -3,8 +3,7 @@ use crate::{
     base::{
         database::{
             owned_table_utility::*, table_utility::*, ColumnField, ColumnRef, ColumnType,
-            LiteralValue, OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor,
-            TestAccessor,
+            OwnedTable, OwnedTableTestAccessor, TableRef, TableTestAccessor, TestAccessor,
         },
         map::{indexmap, IndexMap, IndexSet},
         math::decimal::Precision,
@@ -21,7 +20,7 @@ use crate::{
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
 use proof_of_sql_parser::ResourceId;
-use sqlparser::ast::Ident;
+use sqlparser::ast::{Expr, Ident, Value};
 
 #[test]
 fn we_can_correctly_fetch_the_query_result_schema() {
@@ -54,7 +53,10 @@ fn we_can_correctly_fetch_the_query_result_schema() {
                 Ident::new("c"),
                 ColumnType::BigInt,
             ))),
-            DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(123))),
+            DynProofExpr::Literal(LiteralExpr::new(Expr::Value(Value::Number(
+                "123".to_string(),
+                false,
+            )))),
         )
         .unwrap(),
     );
@@ -102,7 +104,10 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                         Ident::new("f"),
                         ColumnType::BigInt,
                     ))),
-                    DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(45))),
+                    DynProofExpr::Literal(LiteralExpr::new(Expr::Value(Value::Number(
+                        "45".to_string(),
+                        false,
+                    )))),
                 )
                 .unwrap(),
                 DynProofExpr::try_new_equals(
@@ -111,7 +116,10 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                         Ident::new("c"),
                         ColumnType::BigInt,
                     ))),
-                    DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(-2))),
+                    DynProofExpr::Literal(LiteralExpr::new(Expr::Value(Value::Number(
+                        "-2".to_string(),
+                        false,
+                    )))),
                 )
                 .unwrap(),
             ),
@@ -121,7 +129,10 @@ fn we_can_correctly_fetch_all_the_referenced_columns() {
                     Ident::new("b"),
                     ColumnType::BigInt,
                 ))),
-                DynProofExpr::Literal(LiteralExpr::new(LiteralValue::BigInt(3))),
+                DynProofExpr::Literal(LiteralExpr::new(Expr::Value(Value::Number(
+                    "3".to_string(),
+                    false,
+                )))),
             )
             .unwrap(),
         )),

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -11,7 +11,8 @@ use proof_of_sql::{
     },
     sql::{parse::QueryExpr, proof::VerifiableQueryResult},
 };
-use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+use proof_of_sql_parser::posql_time::PoSQLTimeUnit;
+use sqlparser::ast::TimezoneInfo;
 
 #[test]
 fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
@@ -34,7 +35,7 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
             timestamptz(
                 "times",
                 PoSQLTimeUnit::Second,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 [i64::MIN, 0, i64::MAX],
             ),
         ]),
@@ -60,7 +61,7 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
     let expected_result = owned_table([timestamptz(
         "times",
         PoSQLTimeUnit::Second,
-        PoSQLTimeZone::utc(),
+        TimezoneInfo::None,
         [0],
     )]);
     assert_eq!(owned_table_result, expected_result);
@@ -81,7 +82,7 @@ fn run_timestamp_query_test(
         owned_table([timestamptz(
             "times",
             PoSQLTimeUnit::Second,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             test_timestamps,
         )]),
         0,
@@ -100,7 +101,7 @@ fn run_timestamp_query_test(
     let expected_result = owned_table([timestamptz(
         "times",
         PoSQLTimeUnit::Second,
-        PoSQLTimeZone::utc(),
+        TimezoneInfo::None,
         expected_timestamps,
     )]);
 
@@ -396,7 +397,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
             timestamptz(
                 "a",
                 PoSQLTimeUnit::Nanosecond,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 [
                     i64::MIN,
                     2,
@@ -411,7 +412,7 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
             timestamptz(
                 "b",
                 PoSQLTimeUnit::Nanosecond,
-                PoSQLTimeZone::utc(),
+                TimezoneInfo::None,
                 [
                     i64::MAX,
                     -2,
@@ -447,13 +448,13 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         timestamptz(
             "a",
             PoSQLTimeUnit::Nanosecond,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [i64::MIN, -1, -2],
         ),
         timestamptz(
             "b",
             PoSQLTimeUnit::Nanosecond,
-            PoSQLTimeZone::utc(),
+            TimezoneInfo::None,
             [i64::MAX, -1, 1],
         ),
         boolean("res", [true, true, true]),


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
Depends on #451 and #454
# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
