### PR TITLE
feat: u256 conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3", default-features = false }
 blitzar = { version = "4.0.0" }
+bnum = { version = "0.3.0" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
 byte-slice-cast = { version = "1.2.1", default-features = false }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -27,6 +27,7 @@ bit-iter = { workspace = true }
 bigdecimal = { workspace = true }
 blake3 = { workspace = true }
 blitzar = { workspace = true, optional = true }
+bnum = { workspace = true }
 bumpalo = { workspace = true, features = ["collections"] }
 bytemuck = { workspace = true }
 byte-slice-cast = { workspace = true }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -1,4 +1,5 @@
 use super::Scalar;
+use bnum::types::U256;
 use core::cmp::Ordering;
 
 /// Extention trait for blanket implementations for `Scalar` types.
@@ -17,7 +18,20 @@ pub trait ScalarExt: Scalar {
             _ => Ordering::Greater,
         }
     }
+
+    #[must_use]
+    /// Converts a U256 to Scalar, wrapping as needed
+    fn from_wrapping(value: U256) -> Self {
+        let value_as_limbs: [u64; 4] = value.into();
+        Self::from(value_as_limbs)
+    }
+
+    /// Converts a Scalar to U256. Note that any values above `MAX_SIGNED` shall remain positive, even if they are representative of negative values.
+    fn into_u256_wrapping(self) -> U256 {
+        U256::from(Into::<[u64; 4]>::into(self))
+    }
 }
+
 impl<S: Scalar> ScalarExt for S {}
 
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
@@ -1,5 +1,11 @@
+use super::ScalarExt;
 use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+use bnum::types::U256;
+use core::str::FromStr;
 use num_traits::Inv;
+
+const MAX_TEST_SCALAR_SIGNED_VALUE_AS_STRING: &str =
+    "3618502788666131106986593281521497120428558179689953803000975469142727125494";
 
 #[test]
 fn we_can_get_test_scalar_constants_from_z_p() {
@@ -9,4 +15,56 @@ fn we_can_get_test_scalar_constants_from_z_p() {
     // -1/2 == least upper bound
     assert_eq!(-TestScalar::TWO.inv().unwrap(), TestScalar::MAX_SIGNED);
     assert_eq!(TestScalar::from(10), TestScalar::TEN);
+}
+
+#[test]
+fn we_can_convert_u256_to_test_scalar_with_wrapping() {
+    // ARRANGE
+    let u256_value = U256::TWO;
+
+    // ACT
+    let test_scalar = TestScalar::from_wrapping(u256_value);
+
+    // ASSERT
+    assert_eq!(test_scalar, TestScalar::TWO);
+}
+
+#[test]
+fn we_can_convert_u256_to_test_scalar_with_wrapping_of_large_value() {
+    // ARRANGE
+    let u256_value =
+        U256::from_str(MAX_TEST_SCALAR_SIGNED_VALUE_AS_STRING).unwrap() * U256::TWO + U256::ONE;
+
+    // ACT
+    let test_scalar = TestScalar::from_wrapping(u256_value);
+
+    // ASSERT
+    assert_eq!(test_scalar, TestScalar::ZERO);
+}
+
+#[test]
+fn we_can_convert_test_scalar_to_u256_with_wrapping() {
+    // ARRANGE
+    let test_scalar = TestScalar::TWO;
+
+    // ACT
+    let u256_value = test_scalar.into_u256_wrapping();
+
+    // ASSERT
+    assert_eq!(u256_value, U256::TWO);
+}
+
+#[test]
+fn we_can_convert_test_scalar_to_256_with_wrapping_of_negative_value() {
+    // ARRANGE
+    let test_scalar = -TestScalar::ONE;
+
+    // ACT
+    let u256: bnum::BUint<4> = test_scalar.into_u256_wrapping();
+
+    // ASSERT
+    assert_eq!(
+        u256,
+        U256::from_str(MAX_TEST_SCALAR_SIGNED_VALUE_AS_STRING).unwrap() * U256::TWO
+    );
 }

--- a/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
@@ -3,9 +3,17 @@ use crate::base::scalar::{test_scalar::TestScalar, Scalar};
 use bnum::types::U256;
 use core::str::FromStr;
 use num_traits::Inv;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 const MAX_TEST_SCALAR_SIGNED_VALUE_AS_STRING: &str =
     "3618502788666131106986593281521497120428558179689953803000975469142727125494";
+
+fn random_u256(seed: u64) -> U256 {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut bytes = [0u64; 4];
+    rng.fill(&mut bytes);
+    U256::from(bytes)
+}
 
 #[test]
 fn we_can_get_test_scalar_constants_from_z_p() {
@@ -55,7 +63,7 @@ fn we_can_convert_test_scalar_to_u256_with_wrapping() {
 }
 
 #[test]
-fn we_can_convert_test_scalar_to_256_with_wrapping_of_negative_value() {
+fn we_can_convert_test_scalar_to_u256_with_wrapping_of_negative_value() {
     // ARRANGE
     let test_scalar = -TestScalar::ONE;
 
@@ -67,4 +75,20 @@ fn we_can_convert_test_scalar_to_256_with_wrapping_of_negative_value() {
         u256,
         U256::from_str(MAX_TEST_SCALAR_SIGNED_VALUE_AS_STRING).unwrap() * U256::TWO
     );
+}
+
+#[test]
+fn we_can_convert_u256_to_test_scalar_with_wrapping_of_random_u256() {
+    // ARRANGE
+    let random_u256 = random_u256(100);
+    let random_u256_after_wrapping = random_u256
+        % (U256::from_str(MAX_TEST_SCALAR_SIGNED_VALUE_AS_STRING).unwrap() * U256::TWO + U256::ONE);
+    assert_ne!(random_u256, random_u256_after_wrapping);
+
+    // ACT
+    let test_scalar = TestScalar::from_wrapping(random_u256);
+    let expected_scalar = TestScalar::from_wrapping(random_u256_after_wrapping);
+
+    // ASSERT
+    assert_eq!(test_scalar, expected_scalar);
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

There is a need for conversions between `Scalar`s and `U256`, so there is not a need to use limbs (`[u64; 4]`).

# What changes are included in this PR?

There will be two new functions for converting a `Scalar` to `U256` and vice versa, allowing wrapping.

# Are these changes tested?

These functions are tested using `TestScalar`.
