### PR TITLE
feat: add scalar wrapper for BN254

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license-file = "LICENSE"
 ahash = { version = "0.8.11", default-features = false }
 alloy-sol-types = { version = "0.8.5" }
 ark-bls12-381 = { version = "0.5.0" }
+ark-bn254 = { version = "0.5.0" }
 ark-curve25519 = { version = "0.5.0" }
 ark-ec = { version = "0.5.0" }
 ark-ff = { version = "0.5.0" }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -16,6 +16,7 @@ test = true
 [dependencies]
 ahash = { workspace = true }
 ark-bls12-381 = { workspace = true }
+ark-bn254 = { workspace = true }
 ark-curve25519 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -6,9 +6,8 @@ pub use error::ScalarConversionError;
 mod mont_scalar;
 #[cfg(test)]
 mod mont_scalar_test;
-pub use mont_scalar::BN254Scalar;
-pub use mont_scalar::Curve25519Scalar;
 pub(crate) use mont_scalar::MontScalar;
+pub use mont_scalar::{BN254Scalar, Curve25519Scalar};
 /// Module for a test Scalar
 #[cfg(test)]
 pub mod test_scalar;

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -6,6 +6,7 @@ pub use error::ScalarConversionError;
 mod mont_scalar;
 #[cfg(test)]
 mod mont_scalar_test;
+pub use mont_scalar::BN254Scalar;
 pub use mont_scalar::Curve25519Scalar;
 pub(crate) use mont_scalar::MontScalar;
 /// Module for a test Scalar

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -185,6 +185,11 @@ where
 /// Using the `Scalar` trait rather than this type is encouraged to allow for easier switching of the underlying field.
 pub type Curve25519Scalar = MontScalar<ark_curve25519::FrConfig>;
 
+/// A wrapper type around the field element `ark_bn254::Fr` and should be used in place of `ark_bn254::Fr`.
+///
+/// Using the `Scalar` trait rather than this type is encouraged to allow for easier switching of the underlying field.
+pub type BN254Scalar = MontScalar<ark_bn254::FrConfig>;
+
 impl<T: MontConfig<4>> MontScalar<T> {
     /// Convenience function for creating a new `MontScalar<T>` from the underlying `Fp256<MontBackend<T, 4>>`. Should only be used in tests.
     #[cfg(test)]
@@ -426,6 +431,16 @@ impl<T: MontConfig<4>> Display for MontScalar<T> {
 impl super::Scalar for Curve25519Scalar {
     const MAX_SIGNED: Self = Self(ark_ff::MontFp!(
         "3618502788666131106986593281521497120428558179689953803000975469142727125494"
+    ));
+    const ZERO: Self = Self(ark_ff::MontFp!("0"));
+    const ONE: Self = Self(ark_ff::MontFp!("1"));
+    const TWO: Self = Self(ark_ff::MontFp!("2"));
+    const TEN: Self = Self(ark_ff::MontFp!("10"));
+}
+
+impl super::Scalar for BN254Scalar {
+    const MAX_SIGNED: Self = Self(ark_ff::MontFp!(
+        "10944121435919637611123202872628637544274182200208017171849102093287904247808"
     ));
     const ZERO: Self = Self(ark_ff::MontFp!("0"));
     const ONE: Self = Self(ark_ff::MontFp!("1"));

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -1,6 +1,9 @@
 use crate::base::{
     map::IndexSet,
-    scalar::{test_scalar::TestScalar, Curve25519Scalar, Scalar, ScalarConversionError},
+    scalar::{
+        mont_scalar::BN254Scalar, test_scalar::TestScalar, Curve25519Scalar, Scalar,
+        ScalarConversionError,
+    },
 };
 use alloc::{format, string::ToString, vec::Vec};
 use byte_slice_cast::AsByteSlice;
@@ -31,7 +34,7 @@ fn test_dalek_interop_m1() {
 }
 
 #[test]
-fn test_add() {
+fn test_curve25519_add() {
     let one = Curve25519Scalar::from(1u64);
     let two = Curve25519Scalar::from(2u64);
     let sum = one + two;
@@ -40,13 +43,143 @@ fn test_add() {
 }
 
 #[test]
-fn test_mod() {
+fn test_bn254_add() {
+    let one = BN254Scalar::from(1u64);
+    let two = BN254Scalar::from(2u64);
+    let sum = one + two;
+    let expected_sum = BN254Scalar::from(3u64);
+    assert_eq!(sum, expected_sum);
+}
+
+#[test]
+fn test_bn254_add_assign() {
+    let mut sum = BN254Scalar::from(1u64);
+    sum += BN254Scalar::from(1u64);
+    let expected_sum = BN254Scalar::from(2u64);
+    assert_eq!(sum, expected_sum);
+}
+
+#[test]
+fn test_bn254_sub() {
+    let three = BN254Scalar::from(3u64);
+    let two = BN254Scalar::from(2u64);
+    let diff = three - two;
+    let expected_diff = BN254Scalar::from(1u64);
+    assert_eq!(diff, expected_diff);
+}
+
+#[test]
+fn test_bn254_sub_assign() {
+    let mut sum = BN254Scalar::from(1u64);
+    sum -= BN254Scalar::from(1u64);
+    let expected_sum = BN254Scalar::from(0u64);
+    assert_eq!(sum, expected_sum);
+}
+
+#[test]
+fn test_bn254_mul() {
+    let two = BN254Scalar::from(2u64);
+    let product = two * two;
+    let expected_product = BN254Scalar::from(4u64);
+    assert_eq!(product, expected_product);
+}
+
+#[test]
+fn test_bn254_mul_assign() {
+    let mut product = BN254Scalar::from(2u64);
+    product *= BN254Scalar::from(2u64);
+    let expected_product = BN254Scalar::from(4u64);
+    assert_eq!(product, expected_product);
+}
+
+#[test]
+fn test_bn254_neg() {
+    let one = BN254Scalar::from(1u64);
+    let neg_one = -one;
+    let sum = one + neg_one;
+    let expected_sum = BN254Scalar::from(0u64);
+    assert_eq!(sum, expected_sum);
+}
+
+#[test]
+fn test_bn254_sum() {
+    // Test sum of an empty iterator
+    let values: Vec<BN254Scalar> = vec![];
+    let sum: BN254Scalar = values.into_iter().sum();
+    let expected_sum = BN254Scalar::from(0u64);
+    assert_eq!(sum, expected_sum, "Sum of empty iterator is zero");
+
+    // Test sum of a single element
+    let values = vec![BN254Scalar::from(1u64)];
+    let sum: BN254Scalar = values.into_iter().sum();
+    let expected_sum = BN254Scalar::from(1u64);
+    assert_eq!(sum, expected_sum, "Sum of single element is the element");
+
+    // Test sum of multiple elements
+    let values = vec![
+        BN254Scalar::from(1u64),
+        BN254Scalar::from(2u64),
+        BN254Scalar::from(3u64),
+    ];
+    let sum: BN254Scalar = values.into_iter().sum();
+    let expected_sum = BN254Scalar::from(6u64);
+    assert_eq!(
+        sum, expected_sum,
+        "Sum of multiple elements is the sum of the elements"
+    );
+}
+
+#[test]
+fn test_bn254_product() {
+    // Test sum of an empty iterator
+    let values: Vec<BN254Scalar> = vec![];
+    let sum: BN254Scalar = values.into_iter().product();
+    let expected_sum = BN254Scalar::from(1u64);
+    assert_eq!(sum, expected_sum, "Product of empty iterator is one");
+
+    // Test sum of a single element
+    let values = vec![BN254Scalar::from(1u64)];
+    let sum: BN254Scalar = values.into_iter().sum();
+    let expected_sum = BN254Scalar::from(1u64);
+    assert_eq!(
+        sum, expected_sum,
+        "Product of single element is the element"
+    );
+
+    // Test sum of multiple elements
+    let values = vec![
+        BN254Scalar::from(1u64),
+        BN254Scalar::from(2u64),
+        BN254Scalar::from(3u64),
+    ];
+    let sum: BN254Scalar = values.into_iter().sum();
+    let expected_sum = BN254Scalar::from(6u64);
+    assert_eq!(
+        sum, expected_sum,
+        "Product of multiple elements is the product of the elements"
+    );
+}
+
+#[test]
+fn test_curve25519_mod() {
     let pm1: ark_ff::BigInt<4> = ark_ff::BigInt!(
         "7237005577332262213973186563042994240857116359379907606001950938285454250988"
     );
     let x = Curve25519Scalar::from(pm1.0);
     let one = Curve25519Scalar::from(1u64);
     let zero = Curve25519Scalar::from(0u64);
+    let xp1 = x + one;
+    assert_eq!(xp1, zero);
+}
+
+#[test]
+fn test_bn254_mod() {
+    let pm1: ark_ff::BigInt<4> = ark_ff::BigInt!(
+        "21888242871839275222246405745257275088548364400416034343698204186575808495616"
+    );
+    let x = BN254Scalar::from(pm1.0);
+    let one = BN254Scalar::from(1u64);
+    let zero = BN254Scalar::from(0u64);
     let xp1 = x + one;
     assert_eq!(xp1, zero);
 }
@@ -67,6 +200,25 @@ fn test_curve25519_scalar_serialization() {
     ];
     let serialized = serde_json::to_string(&s).unwrap();
     let deserialized: [Curve25519Scalar; 10] = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(s, deserialized);
+}
+
+#[test]
+fn test_bn254_scalar_serialization() {
+    let s = [
+        BN254Scalar::from(1u8),
+        -BN254Scalar::from(1u8),
+        BN254Scalar::from(123),
+        BN254Scalar::from(0),
+        BN254Scalar::from(255),
+        BN254Scalar::from(1234),
+        BN254Scalar::from(12345),
+        BN254Scalar::from(2357),
+        BN254Scalar::from(999),
+        BN254Scalar::from(123_456_789),
+    ];
+    let serialized = serde_json::to_string(&s).unwrap();
+    let deserialized: [BN254Scalar; 10] = serde_json::from_str(&serialized).unwrap();
     assert_eq!(s, deserialized);
 }
 
@@ -107,6 +259,42 @@ fn test_curve25519_scalar_display() {
 }
 
 #[test]
+fn test_bn254_scalar_display() {
+    assert_eq!(
+        "0000000000000000000000000000000000000000000000000000000000ABC123",
+        format!("{}", BN254Scalar::from(0x00AB_C123))
+    );
+    assert_eq!(
+        "30644E72E131A029B85045B68181585D2833E84879B9709143E1F593EF543EDE",
+        format!("{}", BN254Scalar::from(-0x00AB_C123))
+    );
+    assert_eq!(
+        "0x0000...C123",
+        format!("{:#}", BN254Scalar::from(0x00AB_C123))
+    );
+    assert_eq!(
+        "0x3064...3EDE",
+        format!("{:#}", BN254Scalar::from(-0x00AB_C123))
+    );
+    assert_eq!(
+        "+0000000000000000000000000000000000000000000000000000000000ABC123",
+        format!("{:+}", BN254Scalar::from(0x00AB_C123))
+    );
+    assert_eq!(
+        "-0000000000000000000000000000000000000000000000000000000000ABC123",
+        format!("{:+}", BN254Scalar::from(-0x00AB_C123))
+    );
+    assert_eq!(
+        "+0x0000...C123",
+        format!("{:+#}", BN254Scalar::from(0x00AB_C123))
+    );
+    assert_eq!(
+        "-0x0000...C123",
+        format!("{:+#}", BN254Scalar::from(-0x00AB_C123))
+    );
+}
+
+#[test]
 fn test_curve25519_scalar_mid() {
     assert_eq!(
         Curve25519Scalar::MAX_SIGNED,
@@ -115,9 +303,29 @@ fn test_curve25519_scalar_mid() {
 }
 
 #[test]
+fn test_bn254_scalar_mid() {
+    assert_eq!(
+        BN254Scalar::MAX_SIGNED,
+        -BN254Scalar::one() * BN254Scalar::from(2).inv().unwrap()
+    );
+}
+
+#[test]
+fn test_bn254_scalar_impl() {
+    assert_eq!(BN254Scalar::ZERO, BN254Scalar::zero());
+    assert_eq!(BN254Scalar::ONE, BN254Scalar::one());
+}
+
+#[test]
 fn test_curve25519_scalar_to_bool() {
     assert!(!bool::try_from(Curve25519Scalar::ZERO).unwrap());
     assert!(bool::try_from(Curve25519Scalar::ONE).unwrap());
+}
+
+#[test]
+fn test_bn254_scalar_to_bool() {
+    assert!(!bool::try_from(BN254Scalar::ZERO).unwrap());
+    assert!(bool::try_from(BN254Scalar::ONE).unwrap());
 }
 
 #[test]
@@ -132,6 +340,22 @@ fn test_curve25519_scalar_to_bool_overflow() {
     );
     matches!(
         bool::try_from(Curve25519Scalar::from(-2)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+}
+
+#[test]
+fn test_bn254_scalar_to_bool_overflow() {
+    matches!(
+        bool::try_from(BN254Scalar::from(2)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+    matches!(
+        bool::try_from(BN254Scalar::from(-1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+    matches!(
+        bool::try_from(BN254Scalar::from(-2)),
         Err(ScalarConversionError::Overflow { .. })
     );
 }
@@ -152,6 +376,15 @@ fn test_curve25519_scalar_to_i8() {
 }
 
 #[test]
+fn test_bn254_scalar_to_i8() {
+    assert_eq!(i8::try_from(BN254Scalar::from(0)).unwrap(), 0);
+    assert_eq!(i8::try_from(BN254Scalar::ONE).unwrap(), 1);
+    assert_eq!(i8::try_from(BN254Scalar::from(-1)).unwrap(), -1);
+    assert_eq!(i8::try_from(BN254Scalar::from(i8::MAX)).unwrap(), i8::MAX);
+    assert_eq!(i8::try_from(BN254Scalar::from(i8::MIN)).unwrap(), i8::MIN);
+}
+
+#[test]
 fn test_curve25519_scalar_to_i8_overflow() {
     matches!(
         i8::try_from(Curve25519Scalar::from(i128::from(i8::MAX) + 1)),
@@ -159,6 +392,18 @@ fn test_curve25519_scalar_to_i8_overflow() {
     );
     matches!(
         i8::try_from(Curve25519Scalar::from(i128::from(i8::MIN) - 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+}
+
+#[test]
+fn test_bn254_scalar_to_i8_overflow() {
+    matches!(
+        i8::try_from(BN254Scalar::from(i128::from(i8::MAX) + 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+    matches!(
+        i8::try_from(BN254Scalar::from(i128::from(i8::MIN) - 1)),
         Err(ScalarConversionError::Overflow { .. })
     );
 }
@@ -179,6 +424,21 @@ fn test_curve25519_scalar_to_i16() {
 }
 
 #[test]
+fn test_bn254_scalar_to_i16() {
+    assert_eq!(i16::try_from(BN254Scalar::from(0)).unwrap(), 0);
+    assert_eq!(i16::try_from(BN254Scalar::ONE).unwrap(), 1);
+    assert_eq!(i16::try_from(BN254Scalar::from(-1)).unwrap(), -1);
+    assert_eq!(
+        i16::try_from(BN254Scalar::from(i16::MAX)).unwrap(),
+        i16::MAX
+    );
+    assert_eq!(
+        i16::try_from(BN254Scalar::from(i16::MIN)).unwrap(),
+        i16::MIN
+    );
+}
+
+#[test]
 fn test_curve25519_scalar_to_i16_overflow() {
     matches!(
         i16::try_from(Curve25519Scalar::from(i128::from(i16::MAX) + 1)),
@@ -186,6 +446,18 @@ fn test_curve25519_scalar_to_i16_overflow() {
     );
     matches!(
         i16::try_from(Curve25519Scalar::from(i128::from(i16::MIN) - 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+}
+
+#[test]
+fn test_bn254_scalar_to_i16_overflow() {
+    matches!(
+        i16::try_from(BN254Scalar::from(i128::from(i16::MAX) + 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+    matches!(
+        i16::try_from(BN254Scalar::from(i128::from(i16::MIN) - 1)),
         Err(ScalarConversionError::Overflow { .. })
     );
 }
@@ -206,6 +478,21 @@ fn test_curve25519_scalar_to_i32() {
 }
 
 #[test]
+fn test_bn254_scalar_to_i32() {
+    assert_eq!(i32::try_from(BN254Scalar::from(0)).unwrap(), 0);
+    assert_eq!(i32::try_from(BN254Scalar::ONE).unwrap(), 1);
+    assert_eq!(i32::try_from(BN254Scalar::from(-1)).unwrap(), -1);
+    assert_eq!(
+        i32::try_from(BN254Scalar::from(i32::MAX)).unwrap(),
+        i32::MAX
+    );
+    assert_eq!(
+        i32::try_from(BN254Scalar::from(i32::MIN)).unwrap(),
+        i32::MIN
+    );
+}
+
+#[test]
 fn test_curve25519_scalar_to_i32_overflow() {
     matches!(
         i32::try_from(Curve25519Scalar::from(i128::from(i32::MAX) + 1)),
@@ -213,6 +500,18 @@ fn test_curve25519_scalar_to_i32_overflow() {
     );
     matches!(
         i32::try_from(Curve25519Scalar::from(i128::from(i32::MIN) - 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+}
+
+#[test]
+fn test_bn254_scalar_to_i32_overflow() {
+    matches!(
+        i32::try_from(BN254Scalar::from(i128::from(i32::MAX) + 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+    matches!(
+        i32::try_from(BN254Scalar::from(i128::from(i32::MIN) - 1)),
         Err(ScalarConversionError::Overflow { .. })
     );
 }
@@ -233,6 +532,21 @@ fn test_curve25519_scalar_to_i64() {
 }
 
 #[test]
+fn test_bn254_scalar_to_i64() {
+    assert_eq!(i64::try_from(BN254Scalar::from(0)).unwrap(), 0);
+    assert_eq!(i64::try_from(BN254Scalar::ONE).unwrap(), 1);
+    assert_eq!(i64::try_from(BN254Scalar::from(-1)).unwrap(), -1);
+    assert_eq!(
+        i64::try_from(BN254Scalar::from(i64::MAX)).unwrap(),
+        i64::MAX
+    );
+    assert_eq!(
+        i64::try_from(BN254Scalar::from(i64::MIN)).unwrap(),
+        i64::MIN
+    );
+}
+
+#[test]
 fn test_curve25519_scalar_to_i64_overflow() {
     matches!(
         i64::try_from(Curve25519Scalar::from(i128::from(i64::MAX) + 1)),
@@ -240,6 +554,18 @@ fn test_curve25519_scalar_to_i64_overflow() {
     );
     matches!(
         i64::try_from(Curve25519Scalar::from(i128::from(i64::MIN) - 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+}
+
+#[test]
+fn test_bn254_scalar_to_i64_overflow() {
+    matches!(
+        i64::try_from(BN254Scalar::from(i128::from(i64::MAX) + 1)),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+    matches!(
+        i64::try_from(BN254Scalar::from(i128::from(i64::MIN) - 1)),
         Err(ScalarConversionError::Overflow { .. })
     );
 }
@@ -260,6 +586,21 @@ fn test_curve25519_scalar_to_i128() {
 }
 
 #[test]
+fn test_bn254_scalar_to_i128() {
+    assert_eq!(i128::try_from(BN254Scalar::from(0)).unwrap(), 0);
+    assert_eq!(i128::try_from(BN254Scalar::ONE).unwrap(), 1);
+    assert_eq!(i128::try_from(BN254Scalar::from(-1)).unwrap(), -1);
+    assert_eq!(
+        i128::try_from(BN254Scalar::from(i128::MAX)).unwrap(),
+        i128::MAX
+    );
+    assert_eq!(
+        i128::try_from(BN254Scalar::from(i128::MIN)).unwrap(),
+        i128::MIN
+    );
+}
+
+#[test]
 fn test_curve25519_scalar_to_i128_overflow() {
     matches!(
         i128::try_from(Curve25519Scalar::from(i128::MAX) + Curve25519Scalar::ONE),
@@ -267,6 +608,18 @@ fn test_curve25519_scalar_to_i128_overflow() {
     );
     matches!(
         i128::try_from(Curve25519Scalar::from(i128::MIN) - Curve25519Scalar::ONE),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+}
+
+#[test]
+fn test_bn254_scalar_to_i128_overflow() {
+    matches!(
+        i128::try_from(BN254Scalar::from(i128::MAX) + BN254Scalar::ONE),
+        Err(ScalarConversionError::Overflow { .. })
+    );
+    matches!(
+        i128::try_from(BN254Scalar::from(i128::MIN) - BN254Scalar::ONE),
         Err(ScalarConversionError::Overflow { .. })
     );
 }
@@ -282,6 +635,21 @@ fn test_curve25519_scalar_to_bigint() {
     );
     assert_eq!(
         BigInt::from(Curve25519Scalar::from(i128::MIN)),
+        BigInt::from(i128::MIN)
+    );
+}
+
+#[test]
+fn test_bn254_scalar_to_bigint() {
+    assert_eq!(BigInt::from(BN254Scalar::ZERO), BigInt::from(0_i8));
+    assert_eq!(BigInt::from(BN254Scalar::ONE), BigInt::from(1_i8));
+    assert_eq!(BigInt::from(-BN254Scalar::ONE), BigInt::from(-1_i8));
+    assert_eq!(
+        BigInt::from(BN254Scalar::from(i128::MAX)),
+        BigInt::from(i128::MAX)
+    );
+    assert_eq!(
+        BigInt::from(BN254Scalar::from(i128::MIN)),
         BigInt::from(i128::MIN)
     );
 }
@@ -303,7 +671,23 @@ fn test_curve25519_scalar_from_bigint() {
 }
 
 #[test]
-fn the_zero_integer_maps_to_the_zero_scalar() {
+fn test_bn254_scalar_from_bigint() {
+    assert_eq!(
+        BN254Scalar::try_from(BigInt::from(0_i8)).unwrap(),
+        BN254Scalar::ZERO
+    );
+    assert_eq!(
+        BN254Scalar::try_from(BigInt::from(1_i8)).unwrap(),
+        BN254Scalar::ONE
+    );
+    assert_eq!(
+        BN254Scalar::try_from(BigInt::from(-1_i8)).unwrap(),
+        -BN254Scalar::ONE
+    );
+}
+
+#[test]
+fn the_zero_integer_maps_to_the_curve25519_zero_scalar() {
     assert_eq!(Curve25519Scalar::from(0_u32), Curve25519Scalar::zero());
     assert_eq!(Curve25519Scalar::from(0_u64), Curve25519Scalar::zero());
     assert_eq!(Curve25519Scalar::from(0_u128), Curve25519Scalar::zero());
@@ -313,13 +697,29 @@ fn the_zero_integer_maps_to_the_zero_scalar() {
 }
 
 #[test]
+fn the_zero_integer_maps_to_the_bn254_zero_scalar() {
+    assert_eq!(BN254Scalar::from(0_u32), BN254Scalar::zero());
+    assert_eq!(BN254Scalar::from(0_u64), BN254Scalar::zero());
+    assert_eq!(BN254Scalar::from(0_u128), BN254Scalar::zero());
+    assert_eq!(BN254Scalar::from(0_i32), BN254Scalar::zero());
+    assert_eq!(BN254Scalar::from(0_i64), BN254Scalar::zero());
+    assert_eq!(BN254Scalar::from(0_i128), BN254Scalar::zero());
+}
+
+#[test]
 fn bools_map_to_curve25519_scalar_properly() {
     assert_eq!(Curve25519Scalar::from(true), Curve25519Scalar::one());
     assert_eq!(Curve25519Scalar::from(false), Curve25519Scalar::zero());
 }
 
 #[test]
-fn the_one_integer_maps_to_the_zero_scalar() {
+fn bools_map_to_bn254_scalar_properly() {
+    assert_eq!(BN254Scalar::from(true), BN254Scalar::one());
+    assert_eq!(BN254Scalar::from(false), BN254Scalar::zero());
+}
+
+#[test]
+fn the_one_integer_maps_to_the_curve25519_one_scalar() {
     assert_eq!(Curve25519Scalar::from(1_u32), Curve25519Scalar::one());
     assert_eq!(Curve25519Scalar::from(1_u64), Curve25519Scalar::one());
     assert_eq!(Curve25519Scalar::from(1_u128), Curve25519Scalar::one());
@@ -329,7 +729,17 @@ fn the_one_integer_maps_to_the_zero_scalar() {
 }
 
 #[test]
-fn the_zero_scalar_is_the_additive_identity() {
+fn the_one_integer_maps_to_the_bn254_one_scalar() {
+    assert_eq!(BN254Scalar::from(1_u32), BN254Scalar::one());
+    assert_eq!(BN254Scalar::from(1_u64), BN254Scalar::one());
+    assert_eq!(BN254Scalar::from(1_u128), BN254Scalar::one());
+    assert_eq!(BN254Scalar::from(1_i32), BN254Scalar::one());
+    assert_eq!(BN254Scalar::from(1_i64), BN254Scalar::one());
+    assert_eq!(BN254Scalar::from(1_i128), BN254Scalar::one());
+}
+
+#[test]
+fn the_curve25519_zero_scalar_is_the_additive_identity() {
     let mut rng = StdRng::seed_from_u64(0u64);
     for _ in 0..1000 {
         let a = Curve25519Scalar::from(rng.gen::<i128>());
@@ -345,7 +755,23 @@ fn the_zero_scalar_is_the_additive_identity() {
 }
 
 #[test]
-fn the_one_scalar_is_the_multiplicative_identity() {
+fn the_bn254_zero_scalar_is_the_additive_identity() {
+    let mut rng = StdRng::seed_from_u64(0u64);
+    for _ in 0..1000 {
+        let a = BN254Scalar::from(rng.gen::<i128>());
+        let b = BN254Scalar::from(rng.gen::<i128>());
+        assert_eq!(a + b, b + a);
+        assert_eq!(a + BN254Scalar::zero(), a);
+        assert_eq!(b + BN254Scalar::zero(), b);
+        assert_eq!(
+            BN254Scalar::zero() + BN254Scalar::zero(),
+            BN254Scalar::zero()
+        );
+    }
+}
+
+#[test]
+fn the_curve25519_one_scalar_is_the_multiplicative_identity() {
     let mut rng = StdRng::seed_from_u64(0u64);
     for _ in 0..1000 {
         let a = Curve25519Scalar::from(rng.gen::<i128>());
@@ -361,7 +787,20 @@ fn the_one_scalar_is_the_multiplicative_identity() {
 }
 
 #[test]
-fn the_empty_string_will_be_mapped_to_the_zero_scalar() {
+fn the_bn254_one_scalar_is_the_multiplicative_identity() {
+    let mut rng = StdRng::seed_from_u64(0u64);
+    for _ in 0..1000 {
+        let a = BN254Scalar::from(rng.gen::<i128>());
+        let b = BN254Scalar::from(rng.gen::<i128>());
+        assert_eq!(a * b, b * a);
+        assert_eq!(a * BN254Scalar::one(), a);
+        assert_eq!(b * BN254Scalar::one(), b);
+        assert_eq!(BN254Scalar::one() * BN254Scalar::one(), BN254Scalar::one());
+    }
+}
+
+#[test]
+fn the_empty_string_will_be_mapped_to_the_curve25519_zero_scalar() {
     assert_eq!(Curve25519Scalar::from(""), Curve25519Scalar::zero());
     assert_eq!(
         Curve25519Scalar::from(<&str>::default()),
@@ -370,20 +809,29 @@ fn the_empty_string_will_be_mapped_to_the_zero_scalar() {
 }
 
 #[test]
+fn the_empty_string_will_be_mapped_to_the_bn254_zero_scalar() {
+    assert_eq!(BN254Scalar::from(""), BN254Scalar::zero());
+    assert_eq!(BN254Scalar::from(<&str>::default()), BN254Scalar::zero());
+}
+
+#[test]
 fn two_different_strings_map_to_different_scalars() {
     let s = "abc12";
     assert_ne!(Curve25519Scalar::from(s), Curve25519Scalar::zero());
     assert_ne!(Curve25519Scalar::from(s), Curve25519Scalar::from("abc123"));
+    assert_ne!(BN254Scalar::from(s), BN254Scalar::zero());
+    assert_ne!(BN254Scalar::from(s), BN254Scalar::from("abc123"));
 }
 
 #[test]
 fn the_empty_buffer_will_be_mapped_to_the_zero_scalar() {
     let buf = Vec::<u8>::default();
     assert_eq!(Curve25519Scalar::from(&buf[..]), Curve25519Scalar::zero());
+    assert_eq!(BN254Scalar::from(&buf[..]), BN254Scalar::zero());
 }
 
 #[test]
-fn byte_arrays_with_the_same_content_but_different_types_map_to_different_scalars() {
+fn byte_arrays_with_the_same_content_but_different_types_map_to_different_curve25519_scalars() {
     let array = [1_u8, 2_u8, 34_u8];
     assert_ne!(
         Curve25519Scalar::from(array.as_byte_slice()),
@@ -396,7 +844,20 @@ fn byte_arrays_with_the_same_content_but_different_types_map_to_different_scalar
 }
 
 #[test]
-fn strings_of_arbitrary_size_map_to_different_scalars() {
+fn byte_arrays_with_the_same_content_but_different_types_map_to_different_bn254_scalars() {
+    let array = [1_u8, 2_u8, 34_u8];
+    assert_ne!(
+        BN254Scalar::from(array.as_byte_slice()),
+        BN254Scalar::zero()
+    );
+    assert_ne!(
+        BN254Scalar::from(array.as_byte_slice()),
+        BN254Scalar::from([1_u32, 2_u32, 34_u32].as_byte_slice())
+    );
+}
+
+#[test]
+fn strings_of_arbitrary_size_map_to_different_curve25519_scalars() {
     let mut prev_scalars = IndexSet::default();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let dist = Uniform::new(1, 100);
@@ -412,9 +873,26 @@ fn strings_of_arbitrary_size_map_to_different_scalars() {
     }
 }
 
+#[test]
+fn strings_of_arbitrary_size_map_to_different_bn254_scalars() {
+    let mut prev_scalars = IndexSet::default();
+    let mut rng = StdRng::from_seed([0u8; 32]);
+    let dist = Uniform::new(1, 100);
+
+    for i in 0..100 {
+        let s = format!(
+            "{}_{}_{}",
+            dist.sample(&mut rng),
+            i,
+            "testing string to scalar".repeat(dist.sample(&mut rng))
+        );
+        assert!(prev_scalars.insert(BN254Scalar::from(s.as_str())));
+    }
+}
+
 #[allow(clippy::cast_sign_loss)]
 #[test]
-fn byte_arrays_of_arbitrary_size_map_to_different_scalars() {
+fn byte_arrays_of_arbitrary_size_map_to_different_curve25519_scalars() {
     let mut prev_scalars = IndexSet::default();
     let mut rng = StdRng::from_seed([0u8; 32]);
     let dist = Uniform::new(1, 100);
@@ -427,8 +905,23 @@ fn byte_arrays_of_arbitrary_size_map_to_different_scalars() {
     }
 }
 
+#[allow(clippy::cast_sign_loss)]
 #[test]
-fn the_string_hash_implementation_uses_the_full_range_of_bits() {
+fn byte_arrays_of_arbitrary_size_map_to_different_bn254_scalars() {
+    let mut prev_scalars = IndexSet::default();
+    let mut rng = StdRng::from_seed([0u8; 32]);
+    let dist = Uniform::new(1, 100);
+
+    for _ in 0..100 {
+        let v = (0..dist.sample(&mut rng))
+            .map(|_v| (dist.sample(&mut rng) % 255) as u8)
+            .collect::<Vec<u8>>();
+        assert!(prev_scalars.insert(BN254Scalar::from(&v[..])));
+    }
+}
+
+#[test]
+fn the_curve25519_string_hash_implementation_uses_the_full_range_of_bits() {
     let max_iters = 20;
     let mut rng = StdRng::from_seed([0u8; 32]);
     let dist = Uniform::new(1, i32::MAX);
@@ -439,6 +932,37 @@ fn the_string_hash_implementation_uses_the_full_range_of_bits() {
 
         loop {
             let s: Curve25519Scalar = dist.sample(&mut rng).to_string().as_str().into();
+            let bytes = s.to_bytes_le(); //Note: this is the only spot that these tests are different from the to_curve25519_scalar tests.
+
+            let is_ith_bit_set = bytes[i / 8] & (1 << (i % 8)) != 0;
+
+            bset.insert(is_ith_bit_set);
+
+            if bset == IndexSet::from_iter([false, true]) {
+                break;
+            }
+
+            // this guarantees that, if the above test fails,
+            // we'll be able to identify it's failing
+            assert!(curr_iters <= max_iters);
+
+            curr_iters += 1;
+        }
+    }
+}
+
+#[test]
+fn the_bn254_string_hash_implementation_uses_the_full_range_of_bits() {
+    let max_iters = 20;
+    let mut rng = StdRng::from_seed([0u8; 32]);
+    let dist = Uniform::new(1, i32::MAX);
+
+    for i in 0..252 {
+        let mut curr_iters = 0;
+        let mut bset = IndexSet::default();
+
+        loop {
+            let s: BN254Scalar = dist.sample(&mut rng).to_string().as_str().into();
             let bytes = s.to_bytes_le(); //Note: this is the only spot that these tests are different from the to_curve25519_scalar tests.
 
             let is_ith_bit_set = bytes[i / 8] & (1 << (i % 8)) != 0;

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -27,3 +27,30 @@ impl MontConfig<4> for TestMontConfig {
     const TWO_ADIC_ROOT_OF_UNITY: ark_ff::Fp<ark_ff::MontBackend<Self, 4>, 4> =
         Fp::new(<ark_curve25519::FrConfig as MontConfig<4>>::TWO_ADIC_ROOT_OF_UNITY.0);
 }
+
+/// An implementation of `Scalar` intended for use in testing when a concrete implementation is required.
+///
+/// Ultimately, a wrapper type around the field element `ark_bn254::Fr` and should be used in place of `ark_bn254::Fr`.
+pub type TestBN254Scalar = MontScalar<TestBN254MontConfig>;
+
+impl Scalar for TestBN254Scalar {
+    const MAX_SIGNED: Self = Self(ark_ff::MontFp!(
+        "10944121435919637611123202872628637544274182200208017171849102093287904247808"
+    ));
+    const ZERO: Self = Self(ark_ff::MontFp!("0"));
+    const ONE: Self = Self(ark_ff::MontFp!("1"));
+    const TWO: Self = Self(ark_ff::MontFp!("2"));
+    const TEN: Self = Self(ark_ff::MontFp!("10"));
+}
+
+pub struct TestBN254MontConfig(pub ark_bn254::FrConfig);
+
+impl MontConfig<4> for TestBN254MontConfig {
+    const MODULUS: ark_ff::BigInt<4> = <ark_bn254::FrConfig as MontConfig<4>>::MODULUS;
+
+    const GENERATOR: Fp<MontBackend<Self, 4>, 4> =
+        Fp::new(<ark_bn254::FrConfig as MontConfig<4>>::GENERATOR.0);
+
+    const TWO_ADIC_ROOT_OF_UNITY: ark_ff::Fp<ark_ff::MontBackend<Self, 4>, 4> =
+        Fp::new(<ark_bn254::FrConfig as MontConfig<4>>::TWO_ADIC_ROOT_OF_UNITY.0);
+}

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/proof_test.rs
@@ -8,28 +8,25 @@ use crate::{
     base::{
         polynomial::CompositePolynomial,
         proof::Transcript as _,
-        scalar::{test_scalar::TestScalar, Curve25519Scalar, MontScalar, Scalar},
+        scalar::{
+            test_scalar::{TestBN254Scalar, TestScalar},
+            BN254Scalar, Curve25519Scalar, MontScalar, Scalar,
+        },
     },
     proof_primitive::sumcheck::{ProverState, SumcheckProof},
 };
 use alloc::rc::Rc;
-use ark_std::UniformRand;
 use merlin::Transcript;
-use num_traits::{One, Zero};
 
-#[test]
-fn test_create_verify_proof() {
+fn test_create_verify_proof<S: Scalar + From<u64>>() {
     let num_vars = 1;
-    let mut evaluation_point: [Curve25519Scalar; 1] = [Curve25519Scalar::zero(); 1];
+    let mut evaluation_point: [S; 1] = [S::zero(); 1];
 
     // create a proof
     let mut poly = CompositePolynomial::new(num_vars);
-    let a_vec: [Curve25519Scalar; 2] = [
-        Curve25519Scalar::from(123u64),
-        Curve25519Scalar::from(456u64),
-    ];
+    let a_vec: [S; 2] = [S::from(123u64), S::from(456u64)];
     let fa = Rc::new(a_vec.to_vec());
-    poly.add_product([fa], Curve25519Scalar::from(1u64));
+    poly.add_product([fa], S::from(1u64));
     let mut transcript = Transcript::new(b"sumchecktest");
     let mut proof = SumcheckProof::create(
         &mut transcript,
@@ -40,11 +37,7 @@ fn test_create_verify_proof() {
     // verify proof
     let mut transcript = Transcript::new(b"sumchecktest");
     let subclaim = proof
-        .verify_without_evaluation(
-            &mut transcript,
-            poly.num_variables,
-            &Curve25519Scalar::from(579u64),
-        )
+        .verify_without_evaluation(&mut transcript, poly.num_variables, &S::from(579u64))
         .expect("verify failed");
     assert_eq!(subclaim.evaluation_point, evaluation_point);
     assert_eq!(
@@ -56,48 +49,48 @@ fn test_create_verify_proof() {
     let mut transcript = Transcript::new(b"sumchecktest");
     transcript.extend_serialize_as_le(&123u64);
     let subclaim = proof
-        .verify_without_evaluation(
-            &mut transcript,
-            poly.num_variables,
-            &Curve25519Scalar::from(579u64),
-        )
+        .verify_without_evaluation(&mut transcript, poly.num_variables, &S::from(579u64))
         .expect("verify failed");
     assert_ne!(subclaim.evaluation_point, evaluation_point);
 
     // verify fails if sum is wrong
     let mut transcript = Transcript::new(b"sumchecktest");
-    let subclaim = proof.verify_without_evaluation(
-        &mut transcript,
-        poly.num_variables,
-        &Curve25519Scalar::from(123u64),
-    );
+    let subclaim =
+        proof.verify_without_evaluation(&mut transcript, poly.num_variables, &S::from(123u64));
     assert!(subclaim.is_err());
 
     // verify fails if evaluations are changed
-    proof.coefficients[0] += Curve25519Scalar::from(3u64);
-    let subclaim = proof.verify_without_evaluation(
-        &mut transcript,
-        poly.num_variables,
-        &Curve25519Scalar::from(579u64),
-    );
+    proof.coefficients[0] += S::from(3u64);
+    let subclaim =
+        proof.verify_without_evaluation(&mut transcript, poly.num_variables, &S::from(579u64));
     assert!(subclaim.is_err());
 }
 
-fn random_product(
+#[test]
+fn test_create_verify_proof_with_curve25519_scalar() {
+    test_create_verify_proof::<Curve25519Scalar>();
+}
+
+#[test]
+fn test_create_verify_proof_with_bn254_scalar() {
+    test_create_verify_proof::<BN254Scalar>();
+}
+
+fn random_product<S: Scalar>(
     nv: usize,
     num_multiplicands: usize,
     rng: &mut ark_std::rand::rngs::StdRng,
-) -> (Vec<Rc<Vec<Curve25519Scalar>>>, Curve25519Scalar) {
+) -> (Vec<Rc<Vec<S>>>, S) {
     let mut multiplicands = Vec::with_capacity(num_multiplicands);
     for _ in 0..num_multiplicands {
         multiplicands.push(Vec::with_capacity(1 << nv));
     }
-    let mut sum = Curve25519Scalar::zero();
+    let mut sum = S::zero();
 
     for _ in 0..(1 << nv) {
-        let mut product = Curve25519Scalar::one();
+        let mut product = S::one();
         for multiplicand in multiplicands.iter_mut().take(num_multiplicands) {
-            let val = Curve25519Scalar::rand(rng);
+            let val = S::rand(rng);
             multiplicand.push(val);
             product *= val;
         }
@@ -107,19 +100,19 @@ fn random_product(
     (multiplicands.into_iter().map(Rc::new).collect(), sum)
 }
 
-fn random_polynomial(
+fn random_polynomial<S: Scalar>(
     nv: usize,
     num_multiplicands_range: (usize, usize),
     num_products: usize,
     rng: &mut ark_std::rand::rngs::StdRng,
-) -> (CompositePolynomial<Curve25519Scalar>, Curve25519Scalar) {
+) -> (CompositePolynomial<S>, S) {
     use ark_std::rand::Rng;
-    let mut sum = Curve25519Scalar::zero();
+    let mut sum = S::zero();
     let mut poly = CompositePolynomial::new(nv);
     for _ in 0..num_products {
         let num_multiplicands = rng.gen_range(num_multiplicands_range.0..num_multiplicands_range.1);
         let (product, product_sum) = random_product(nv, num_multiplicands, rng);
-        let coefficient = Curve25519Scalar::rand(rng);
+        let coefficient = S::rand(rng);
         poly.add_product(product.into_iter(), coefficient);
         sum += product_sum * coefficient;
     }
@@ -127,14 +120,18 @@ fn random_polynomial(
     (poly, sum)
 }
 
-fn test_polynomial(nv: usize, num_multiplicands_range: (usize, usize), num_products: usize) {
+fn test_polynomial<S: Scalar>(
+    nv: usize,
+    num_multiplicands_range: (usize, usize),
+    num_products: usize,
+) {
     let mut rng = <ark_std::rand::rngs::StdRng as ark_std::rand::SeedableRng>::from_seed([0u8; 32]);
     let (poly, asserted_sum) =
         random_polynomial(nv, num_multiplicands_range, num_products, &mut rng);
 
     // create a proof
     let mut transcript = Transcript::new(b"sumchecktest");
-    let mut evaluation_point = vec![Curve25519Scalar::zero(); poly.num_variables];
+    let mut evaluation_point = vec![S::zero(); poly.num_variables];
     let proof = SumcheckProof::create(
         &mut transcript,
         &mut evaluation_point,
@@ -154,25 +151,43 @@ fn test_polynomial(nv: usize, num_multiplicands_range: (usize, usize), num_produ
 }
 
 #[test]
-fn test_trivial_polynomial() {
+fn test_trivial_polynomial_with_curve25519_scalar() {
     let nv = 1;
     let num_multiplicands_range = (4, 13);
     let num_products = 5;
 
-    test_polynomial(nv, num_multiplicands_range, num_products);
+    test_polynomial::<Curve25519Scalar>(nv, num_multiplicands_range, num_products);
 }
 
 #[test]
-fn test_normal_polynomial() {
+fn test_trivial_polynomial_with_bn254_scalar() {
+    let nv = 1;
+    let num_multiplicands_range = (4, 13);
+    let num_products = 5;
+
+    test_polynomial::<BN254Scalar>(nv, num_multiplicands_range, num_products);
+}
+
+#[test]
+fn test_normal_polynomial_with_curve25519_scalar() {
     let nv = 7;
     let num_multiplicands_range = (4, 9);
     let num_products = 5;
 
-    test_polynomial(nv, num_multiplicands_range, num_products);
+    test_polynomial::<Curve25519Scalar>(nv, num_multiplicands_range, num_products);
 }
 
 #[test]
-fn we_can_verify_many_random_test_cases() {
+fn test_normal_polynomial_with_bn254_scalar() {
+    let nv = 7;
+    let num_multiplicands_range = (4, 9);
+    let num_products = 5;
+
+    test_polynomial::<BN254Scalar>(nv, num_multiplicands_range, num_products);
+}
+
+#[test]
+fn we_can_verify_many_random_cureve25519_test_cases() {
     let mut rng = ark_std::test_rng();
 
     for test_case in sumcheck_test_cases::<TestScalar>(&mut rng) {
@@ -223,6 +238,68 @@ fn we_can_verify_many_random_test_cases() {
 
         let mut modified_proof = proof;
         modified_proof.coefficients[0] += TestScalar::ONE;
+        let mut transcript = Transcript::new(b"sumchecktest");
+        assert!(
+            modified_proof
+                .verify_without_evaluation(&mut transcript, test_case.num_vars, &test_case.sum,)
+                .is_err(),
+            "verification should fail when the proof is modified"
+        );
+    }
+}
+
+#[test]
+fn we_can_verify_many_random_bn254_test_cases() {
+    let mut rng = ark_std::test_rng();
+
+    for test_case in sumcheck_test_cases::<TestBN254Scalar>(&mut rng) {
+        let mut transcript = Transcript::new(b"sumchecktest");
+        let mut evaluation_point = vec![MontScalar::default(); test_case.num_vars];
+        let proof = SumcheckProof::create(
+            &mut transcript,
+            &mut evaluation_point,
+            ProverState::create(&test_case.polynomial),
+        );
+
+        let mut transcript = Transcript::new(b"sumchecktest");
+        let subclaim = proof
+            .verify_without_evaluation(&mut transcript, test_case.num_vars, &test_case.sum)
+            .expect("verification should succeed with the correct setup");
+        assert_eq!(
+            subclaim.evaluation_point, evaluation_point,
+            "the prover's evaluation point should match the verifier's"
+        );
+        assert_eq!(
+            test_case.polynomial.evaluate(&evaluation_point),
+            subclaim.expected_evaluation,
+            "the claimed evaluation should match the actual evaluation"
+        );
+
+        let mut transcript = Transcript::new(b"sumchecktest");
+        transcript.extend_serialize_as_le(&123u64);
+        let verify_result =
+            proof.verify_without_evaluation(&mut transcript, test_case.num_vars, &test_case.sum);
+        if let Ok(subclaim) = verify_result {
+            assert_ne!(
+                subclaim.evaluation_point, evaluation_point,
+                "either verification should fail or we should have a different evaluation point with a different transcript"
+            );
+        }
+
+        let mut transcript = Transcript::new(b"sumchecktest");
+        assert!(
+            proof
+                .verify_without_evaluation(
+                    &mut transcript,
+                    test_case.num_vars,
+                    &(test_case.sum + TestBN254Scalar::ONE),
+                )
+                .is_err(),
+            "verification should fail when the sum is wrong"
+        );
+
+        let mut modified_proof = proof;
+        modified_proof.coefficients[0] += TestBN254Scalar::ONE;
         let mut transcript = Transcript::new(b"sumchecktest");
         assert!(
             modified_proof


### PR DESCRIPTION
# Rationale for this change
Currently this project has a scalar wrapper for `curve25519` scalar field elements. This PR introduces a wrapper for `bn254` scalar field elements. This work is required to move sum check to the GPU, which is being implemented in the blitzar project.

# What changes are included in this PR?
- `BN254Scalar` is added to the `mont_scalar` module that wraps `ark-bn254::fr`.

# Are these changes tested?
Yes