### PR TITLE
feat: range check arbitrary size word columns

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -5,6 +5,7 @@ use bitwise_verification::{verify_constant_abs_decomposition, verify_constant_si
 mod bitwise_verification_test;
 mod sign_expr;
 pub(crate) use sign_expr::{prover_evaluate_sign, result_evaluate_sign, verifier_evaluate_sign};
+#[allow(clippy::needless_range_loop)] // keep the loop for readability for  now
 pub mod range_check;
 #[cfg(all(test, feature = "blitzar"))]
 pub mod range_check_test;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -389,11 +389,11 @@ fn prove_row_zero_sum<'a, S: Scalar + 'a>(
 /// if a column contains values outside of the selected range.
 pub fn verifier_evaluate_range_check<S: Scalar>(
     builder: &mut VerificationBuilder<'_, S>,
-    input_ones_eval: S,
     input_column_eval: S,
 ) -> Result<(), ProofSizeMismatch> {
     // Retrieve the post-result challenge α
     let alpha = builder.try_consume_post_result_challenge()?;
+    let input_ones_eval = builder.try_consume_one_evaluation()?;
 
     // We will accumulate ∑(wᵢ * 256ⁱ) in `sum`.
     // Additionally, we'll collect all (wᵢ + α)⁻¹ evaluations in `w_plus_alpha_inv_evals`

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -47,7 +47,7 @@ pub fn first_round_evaluate_range_check<'a, S: Scalar + 'a>(
     // Initialize a vector to count occurrences of each byte (0-255).
     // The vector has 256 elements padded with zeros to match the length of the word columns
     // The size is the larger of 256 or the number of scalars.
-    let word_counts: &mut [i64] = alloc.alloc_slice_fill_copy(max(256, scalars.len()), 0);
+    let word_counts: &mut [i64] = alloc.alloc_slice_fill_copy(256, 0);
 
     decompose_scalar_to_words(scalars, &mut word_columns, word_counts);
 
@@ -84,7 +84,7 @@ pub fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
     // Initialize a vector to count occurrences of each byte (0-255).
     // The vector has 256 elements padded with zeros to match the length of the word columns
     // The size is the larger of 256 or the number of scalars.
-    let word_counts: &mut [i64] = alloc.alloc_slice_fill_with(max(256, scalars.len()), |_| 0);
+    let word_counts: &mut [i64] = alloc.alloc_slice_fill_with(256, |_| 0);
 
     decompose_scalar_to_words(scalars, &mut word_columns, word_counts);
 
@@ -101,7 +101,7 @@ pub fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
     );
 
     // Produce an MLE over the word values
-    prove_word_values(alloc, scalars, alpha, table_length, builder);
+    prove_word_values(alloc, alpha, builder);
 
     // Argue that the sum of all words in each row, minus the count of each
     // word multiplied by the inverted word value, is zero.
@@ -272,20 +272,18 @@ use alloc::vec;
 #[allow(clippy::cast_possible_truncation)]
 fn prove_word_values<'a, S: Scalar + 'a>(
     alloc: &'a Bump,
-    scalars: &[S],
     alpha: S,
-    table_length: usize,
     builder: &mut FinalRoundBuilder<'a, S>,
 ) {
     // Allocate from 0 to 255
-    let word_values: &mut [S] = alloc.alloc_slice_fill_with(max(256, scalars.len()), |_| S::ZERO);
+    let word_values: &mut [S] = alloc.alloc_slice_fill_with(256, |_| S::ZERO);
 
     for i in 0..256 {
         word_values[i] = S::try_from(i.into()).expect("word value will always fit into S");
     }
 
     // Allocate a slice filled with zeros, with length equal to the larger of 256 or scalars.len()
-    let word_vals_inv: &mut [S] = alloc.alloc_slice_fill_with(max(256, scalars.len()), |_| S::ZERO);
+    let word_vals_inv: &mut [S] = alloc.alloc_slice_fill_with(256, |_| S::ZERO);
 
     // Set elements 0 to 255 to their respective values
     for i in 0..256 {
@@ -296,7 +294,7 @@ fn prove_word_values<'a, S: Scalar + 'a>(
     slice_ops::batch_inversion(&mut word_vals_inv[..]);
     builder.produce_intermediate_mle(word_vals_inv as &[_]);
 
-    let input_ones = alloc.alloc_slice_fill_copy(table_length, true);
+    let input_ones = alloc.alloc_slice_fill_copy(256, true);
 
     // Argument:
     // (word_values + α)⁻¹ * (word_values + α) - 1 = 0
@@ -354,8 +352,7 @@ fn prove_row_zero_sum<'a, S: Scalar + 'a>(
         Box::new(alloc.alloc_slice_copy(row_sums) as &[_]) as Box<dyn MultilinearExtension<S>>;
 
     // Allocate and initialize the array for (w + α)⁻¹ over [0..255]
-    let word_vals_plus_alpha_inv: &mut [S] =
-        alloc.alloc_slice_fill_with(max(256, scalars.len()), |_| S::ZERO);
+    let word_vals_plus_alpha_inv: &mut [S] = alloc.alloc_slice_fill_with(256, |_| S::ZERO);
     for i in 0..256 {
         word_vals_plus_alpha_inv[i] =
             S::try_from(i.into()).expect("word value will always fit into S");

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -333,7 +333,7 @@ mod tests {
         let data: OwnedTable<DoryScalar> = owned_table([scalar(
             "a",
             (0..2u32.pow(20))
-                .map(|i| upper_bound - DoryScalar::from(i as u64)) // Count backward from 2^248
+                .map(|i| upper_bound - DoryScalar::from(u64::from(i))) // Count backward from 2^248
                 .collect::<Vec<_>>(),
         )]);
 


### PR DESCRIPTION
# Rationale for this change

Currently, it is possible to argue the correct ranges of scalars up to the word value size, but anything below or beyond this value (currently 256 for byte sized words) will fail to verify. This PR expands range check on a scalar column to arbitrary lengths.

# What changes are included in this PR?

- [x] arbitrary lengths beyond maximum word value
- [ ] arbitrary lengths below maximum word value
- benches were carried out in criterion
- refactored inner functions to make the loops more readable, will move back to idiomatic representations before marking this ready for merge

## Benchmarks
- Attempted to introduce rayon to optimize word decomposition and some of the matrix operations in the log deriv function, but this attempt didnt seem to yield any benefits:

- **2^16 Columns**:
  - **Change in Mean Execution Time**: **+0.2633%**
  - **Observation**: Within the noise threshold; no significant performance impact observed.

- **2^20 Columns**:
  - **Change in Mean Execution Time**: **+1.8316%**
  - **Observation**: Statistically significant regression (p < 0.05), indicating a measurable performance degradation.

The cost of range check is likely dominated by the many inversions that take place, and these are already optimized with rayon. Will try and find other areas of the current code to optimize.

# Are these changes tested?

- [x] test can range check up to 2^248 boundary
- [x] test cannot range check past 2^ 248 boundary
- [x] test cannot range check below 0
- [x] range check with dory
- [ ] range check with ipa - currently failing for unknown reason, see #464 


# Benching analysis

## Analysis: Scaling from 2^16 to 2^20 in Dory Range Check Proofs

### Key Metrics
- **Columns up to 2^16**:
  - Mean Execution Time: **10.586 seconds**
- **Columns up to 2^20**:
  - Mean Execution Time: **24.448 seconds**

### Scaling Analysis
- **Increase in Column Size**: 
  - $2^{20} / 2^{16} = 2^4 = 16$ → A **16x increase** in the number of scalars.
- **Increase in Runtime**:
  - 24.448 / 10.586  ≈ 2.31 → A **2.31x increase** in runtime.

### Observations
- The runtime scales **sub-linearly** with respect to column size, as a 16x increase in column size resulted in only a 2.31x increase in execution time.

