### PR TITLE
fix: bump Rust to 1.84.0 and related fixes

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
@@ -16,7 +16,7 @@ pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
     let abs_scalar = if is_negative { -*val } else { *val };
     let limbs: [u64; 4] = abs_scalar.into();
 
-    let low = (limbs[0] as u128) | ((limbs[1] as u128) << 64);
+    let low = u128::from(limbs[0]) | (u128::from(limbs[1]) << 64);
     let high = i128::from(limbs[2]) | (i128::from(limbs[3]) << 64);
 
     let abs_i256 = i256::from_parts(low, high);

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -48,7 +48,7 @@ pub enum CommittableColumn<'a> {
     RangeCheckWord(&'a [u8]),
 }
 
-impl<'a> CommittableColumn<'a> {
+impl CommittableColumn<'_> {
     /// Returns the length of the column.
     #[must_use]
     pub fn len(&self) -> usize {

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -169,7 +169,6 @@ pub fn int128<S: Scalar>(
 ///     scalar("a", [1, 2, 3]),
 /// ]);
 /// ```
-
 pub fn scalar<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<S>>,
@@ -189,7 +188,6 @@ pub fn scalar<S: Scalar>(
 ///     varchar("a", ["a", "b", "c"]),
 /// ]);
 /// ```
-
 pub fn varchar<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<String>>,
@@ -249,7 +247,6 @@ pub fn decimal75<S: Scalar>(
 ///     timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![1625072400, 1625076000, 1625079600]),
 /// ]);
 /// ```
-
 pub fn timestamptz<S: Scalar>(
     name: impl Into<Ident>,
     time_unit: PoSQLTimeUnit,

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -143,7 +143,6 @@ pub fn borrowed_int<S: Scalar>(
 ///     borrowed_bigint("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
-
 pub fn borrowed_bigint<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i64>>,
@@ -166,7 +165,6 @@ pub fn borrowed_bigint<S: Scalar>(
 ///     borrowed_boolean("a", [true, false, true], &alloc),
 /// ]);
 /// ```
-
 pub fn borrowed_boolean<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<bool>>,
@@ -189,7 +187,6 @@ pub fn borrowed_boolean<S: Scalar>(
 ///     borrowed_int128("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
-
 pub fn borrowed_int128<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i128>>,
@@ -212,7 +209,6 @@ pub fn borrowed_int128<S: Scalar>(
 ///     borrowed_scalar("a", [1, 2, 3], &alloc),
 /// ]);
 /// ```
-
 pub fn borrowed_scalar<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<S>>,
@@ -234,7 +230,6 @@ pub fn borrowed_scalar<S: Scalar>(
 ///     borrowed_varchar("a", ["a", "b", "c"], &alloc),
 /// ]);
 /// ```
-
 pub fn borrowed_varchar<'a, S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<String>>,
@@ -309,7 +304,6 @@ pub fn borrowed_decimal75<S: Scalar>(
 ///     borrowed_timestamptz("event_time", PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), vec![1625072400, 1625076000, 1625079600], &alloc),
 /// ]);
 /// ```
-
 pub fn borrowed_timestamptz<S: Scalar>(
     name: impl Into<Ident>,
     time_unit: PoSQLTimeUnit,

--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -77,13 +77,13 @@ pub fn read_u256_varint(buf: &[u8]) -> Option<(U256, usize)> {
         // we write the `next 7 bits` at the [shift_amount..shift_amount + 7)
         // bit positions of val u256 number
         match shift_amount.cmp(&126_u32) {
-            Ordering::Less => val.low |= ((*next_byte & 0b0111_1111) as u128) << shift_amount,
+            Ordering::Less => val.low |= (u128::from(*next_byte & 0b0111_1111)) << shift_amount,
             Ordering::Equal => {
-                val.low |= ((*next_byte & 0b0000_0011) as u128) << shift_amount;
-                val.high |= ((*next_byte & 0b0111_1100) as u128) >> 2;
+                val.low |= (u128::from(*next_byte & 0b0000_0011)) << shift_amount;
+                val.high |= (u128::from(*next_byte & 0b0111_1100)) >> 2;
             }
             Ordering::Greater => {
-                val.high |= ((*next_byte & 0b0111_1111) as u128) << (shift_amount - 128);
+                val.high |= (u128::from(*next_byte & 0b0111_1111)) << (shift_amount - 128);
             }
         }
 

--- a/crates/proof-of-sql/src/base/encode/u256.rs
+++ b/crates/proof-of-sql/src/base/encode/u256.rs
@@ -22,8 +22,8 @@ impl U256 {
 impl<T: MontConfig<4>> From<&MontScalar<T>> for U256 {
     fn from(val: &MontScalar<T>) -> Self {
         let buf: [u64; 4] = val.into();
-        let low: u128 = (buf[0] as u128) | (buf[1] as u128) << 64;
-        let high: u128 = (buf[2] as u128) | (buf[3] as u128) << 64;
+        let low: u128 = u128::from(buf[0]) | u128::from(buf[1]) << 64;
+        let high: u128 = u128::from(buf[2]) | u128::from(buf[3]) << 64;
         U256::from_words(low, high)
     }
 }

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -437,7 +437,7 @@ fn we_can_encode_and_decode_u64_and_u128_the_same() {
     let mut rng = rand::thread_rng();
     test_encode_and_decode_types_align::<u64, u128>(
         &rng.gen::<[_; 32]>(),
-        &[u64::MAX as u128 + 1, u64::MAX as u128 * 1000],
+        &[u128::from(u64::MAX) + 1, u128::from(u64::MAX) * 1000],
         100,
     );
 }

--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -15,7 +15,6 @@ use num_traits::{Inv, One, Zero};
 // Allow missing panics documentation because the function should not panic under normal conditions.
 /// unless x is one of 0,1,...,d, in which case, f(x) is already known.
 #[allow(dead_code, clippy::missing_panics_doc)]
-
 pub fn interpolate_uni_poly<F>(polynomial: &[F], x: F) -> F
 where
     F: Copy

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -576,7 +576,7 @@ where
                 error: format!("{value} is too large to fit in an i128"),
             });
         }
-        let val: u128 = (abs[1] as u128) << 64 | (abs[0] as u128);
+        let val: u128 = u128::from(abs[1]) << 64 | u128::from(abs[0]);
         match (sign, val) {
             (1, v) if v <= i128::MAX as u128 => Ok(v as i128),
             (-1, v) if v <= i128::MAX as u128 => Ok(-(v as i128)),

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -16,6 +16,9 @@ impl Scalar for TestScalar {
     const TEN: Self = Self(ark_ff::MontFp!("10"));
 }
 
+/// An implementation of `MontConfig` intended for use in testing when a concrete implementation is required.
+///
+/// Ultimately, a wrapper type around the field element `ark_curve25519::FrConfig` and should be used in place of `ark_curve25519::FrConfig`.
 pub struct TestMontConfig(pub ark_curve25519::FrConfig);
 
 impl MontConfig<4> for TestMontConfig {

--- a/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/batch_inverse.rs
@@ -44,10 +44,8 @@ where
             // Divide the vector v evenly between all available cores, but make sure that each
             // core has at least MIN_RAYON_LEN elements to work on
             let num_cpus_available = max(1, rayon::current_num_threads());
-            let num_elem_per_thread = max(
-                (v.len() + num_cpus_available - 1) / num_cpus_available,
-                super::MIN_RAYON_LEN,
-            );
+            let num_elem_per_thread =
+                max(v.len().div_ceil(num_cpus_available), super::MIN_RAYON_LEN);
 
             // Batch invert in parallel, without copying the vector
             v.par_chunks_mut(num_elem_per_thread).for_each(|chunk| {

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -23,7 +23,7 @@ pub fn num_sub_commits(
     offset: usize,
     num_matrix_commitment_columns: usize,
 ) -> usize {
-    (column.len() + offset + num_matrix_commitment_columns - 1) / num_matrix_commitment_columns
+    (column.len() + offset).div_ceil(num_matrix_commitment_columns)
 }
 
 /// Returns a bit table vector related to each of the committable columns data size.

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -12,6 +12,7 @@ use alloc::{vec, vec::Vec};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
+#[allow(clippy::ref_option)]
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn prove_round<S: Scalar>(prover_state: &mut ProverState<S>, r_maybe: &Option<S>) -> Vec<S> {
     log::log_memory_usage("Start");

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -51,6 +51,7 @@ impl QueryContext {
         self.where_expr = where_expr;
     }
 
+    #[allow(clippy::ref_option)]
     pub fn get_where_expr(&self) -> &Option<Box<Expression>> {
         &self.where_expr
     }
@@ -209,6 +210,7 @@ impl QueryContext {
         Ok(self.order_by_exprs.clone())
     }
 
+    #[allow(clippy::ref_option)]
     pub fn get_slice_expr(&self) -> &Option<Slice> {
         &self.slice_expr
     }

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -102,7 +102,7 @@ impl<'a> QueryContextBuilder<'a> {
 }
 
 // Private interface
-impl<'a> QueryContextBuilder<'a> {
+impl QueryContextBuilder<'_> {
     #[allow(
         clippy::missing_panics_doc,
         reason = "The assertion ensures there is at least one column, and this is a fundamental requirement for schema retrieval."

--- a/crates/proof-of-sql/src/sql/postprocessing/mod.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/mod.rs
@@ -8,6 +8,7 @@ mod postprocessing_step;
 pub use owned_table_postprocessing::{apply_postprocessing_steps, OwnedTablePostprocessing};
 pub use postprocessing_step::PostprocessingStep;
 #[cfg(test)]
+/// Utility functions for testing postprocessing steps.
 pub mod test_utility;
 
 mod group_by_postprocessing;

--- a/crates/proof-of-sql/src/sql/postprocessing/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/test_utility.rs
@@ -3,6 +3,7 @@ use proof_of_sql_parser::intermediate_ast::{AliasedResultExpr, OrderBy, OrderByD
 use sqlparser::ast::Ident;
 
 #[must_use]
+/// Producing a postprocessing object that represents a group by operation.
 pub fn group_by_postprocessing(
     cols: &[&str],
     result_exprs: &[AliasedResultExpr],
@@ -13,7 +14,7 @@ pub fn group_by_postprocessing(
     )
 }
 
-///
+/// Producing a postprocessing object that represents a select operation.
 /// # Panics
 ///
 /// This function may panic if the internal structures cannot be created properly, although this is unlikely under normal circumstances.
@@ -22,11 +23,13 @@ pub fn select_expr(result_exprs: &[AliasedResultExpr]) -> OwnedTablePostprocessi
     OwnedTablePostprocessing::new_select(SelectPostprocessing::new(result_exprs.to_vec()))
 }
 
+/// Producing a postprocessing object that represents a slice operation.
 #[must_use]
 pub fn slice(limit: Option<u64>, offset: Option<i64>) -> OwnedTablePostprocessing {
     OwnedTablePostprocessing::new_slice(SlicePostprocessing::new(limit, offset))
 }
 
+/// Producing a postprocessing object that represents an order by operation.
 #[must_use]
 pub fn orders(cols: &[&str], directions: &[OrderByDirection]) -> OwnedTablePostprocessing {
     let by_exprs = cols

--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -13,7 +13,6 @@ pub trait ProvableResultElement<'a> {
 }
 
 /// Implement encode and decode for integer types
-
 impl<T: VarInt> ProvableResultElement<'_> for T {
     fn required_bytes(&self) -> usize {
         self.required_space()

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -5,8 +5,8 @@ use bitwise_verification::{verify_constant_abs_decomposition, verify_constant_si
 mod bitwise_verification_test;
 mod sign_expr;
 pub(crate) use sign_expr::{prover_evaluate_sign, result_evaluate_sign, verifier_evaluate_sign};
-pub mod range_check;
+pub(crate) mod range_check;
 #[cfg(all(test, feature = "blitzar"))]
-pub mod range_check_test;
+mod range_check_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod sign_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -26,13 +26,14 @@ use crate::{
         FinalRoundBuilder, FirstRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder,
     },
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
 use bytemuck::cast_slice;
 use core::{cmp::max, iter::repeat};
 
 /// Update the max range length for the range check.
-pub fn first_round_evaluate_range_check<'a, S: Scalar + 'a>(
+#[allow(dead_code)]
+pub(crate) fn first_round_evaluate_range_check<'a, S: Scalar + 'a>(
     builder: &mut FirstRoundBuilder<'a, S>,
     scalars: &[S],
     alloc: &'a Bump,
@@ -62,7 +63,8 @@ pub fn first_round_evaluate_range_check<'a, S: Scalar + 'a>(
 
 /// Prove that a word-wise decomposition of a collection of scalars
 /// are all within the range 0 to 2^248.
-pub fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
+#[allow(dead_code)]
+pub(crate) fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
     builder: &mut FinalRoundBuilder<'a, S>,
     scalars: &[S],
     table_length: usize,
@@ -126,6 +128,7 @@ pub fn final_round_evaluate_range_check<'a, S: Scalar + 'a>(
 /// |  w₂,₀      |  w₂,₁      |  w₂,₂      | ... |  w₂,₃₁      |
 /// ------------------------------------------------------------
 /// ```
+#[allow(dead_code)]
 fn decompose_scalar_to_words<'a, S: Scalar + 'a>(
     scalars: &[S],
     word_columns: &mut [&mut [u8]],
@@ -176,6 +179,7 @@ fn decompose_scalar_to_words<'a, S: Scalar + 'a>(
 ///       v              v              v                    v          
 ///    Int. MLE      Int. MLE      Int. MLE             Int. MLE     
 /// ```
+#[allow(dead_code)]
 fn get_logarithmic_derivative<'a, S: Scalar + 'a>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
@@ -254,9 +258,11 @@ fn get_logarithmic_derivative<'a, S: Scalar + 'a>(
 /// ```
 /// Finally, argue that (`word_values` + α)⁻¹ * (`word_values` + α) - 1 = 0
 ///
-use alloc::vec;
-#[allow(clippy::missing_panics_doc)]
-#[allow(clippy::cast_possible_truncation)]
+#[allow(
+    dead_code,
+    clippy::missing_panics_doc,
+    clippy::cast_possible_truncation
+)]
 fn prove_word_values<'a, S: Scalar + 'a>(
     alloc: &'a Bump,
     scalars: &[S],
@@ -362,7 +368,8 @@ fn prove_row_zero_sum<'a, S: Scalar + 'a>(
 /// # Panics
 ///
 /// if a column contains values outside of the selected range.
-pub fn verifier_evaluate_range_check<S: Scalar>(
+#[allow(dead_code)]
+pub(crate) fn verifier_evaluate_range_check<S: Scalar>(
     builder: &mut VerificationBuilder<'_, S>,
     input_ones_eval: S,
     input_column_eval: S,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -17,8 +17,8 @@ use bumpalo::Bump;
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
-pub struct RangeCheckTestPlan {
-    pub column: ColumnRef,
+struct RangeCheckTestPlan {
+    column: ColumnRef,
 }
 
 impl ProverEvaluate for RangeCheckTestPlan {

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util.rs
@@ -7,7 +7,6 @@ use crate::base::{polynomial::MultilinearExtension, scalar::Scalar};
 /// where each column is padded with 0s as needed.
 ///
 /// This is similar to adding `mul * fold_vals(beta,...)` on each row.
-
 pub fn fold_columns<S: Scalar>(
     res: &mut [S],
     mul: S,

--- a/crates/proof-of-sql/tests/decimal_integration_tests.rs
+++ b/crates/proof-of-sql/tests/decimal_integration_tests.rs
@@ -1,3 +1,4 @@
+//! Decimal integration tests for the proof-of-sql crate.
 #![cfg(feature = "test")]
 #![cfg_attr(test, allow(clippy::missing_panics_doc))]
 #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -1,3 +1,4 @@
+//! Other integration tests for the proof-of-sql crate.
 #![cfg(feature = "test")]
 #![cfg_attr(test, allow(clippy::missing_panics_doc))]
 use ark_std::test_rng;

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -1,3 +1,4 @@
+//! Timestamp-related integration tests for the proof-of-sql crate.
 #![cfg(feature = "test")]
 #![cfg_attr(test, allow(clippy::missing_panics_doc))]
 use ark_std::test_rng;

--- a/crates/proof-of-sql/utils/commitment-utility/main.rs
+++ b/crates/proof-of-sql/utils/commitment-utility/main.rs
@@ -69,26 +69,22 @@ fn main() -> CommitUtilityResult<()> {
     let cli = Cli::parse();
 
     // Read input data
-    let input_data = match &cli.input {
-        Some(input_file) => {
-            let mut file =
-                File::open(input_file).map_err(|_| CommitUtilityError::OpenInputFile {
-                    filename: input_file.clone(),
-                })?;
-            let mut buffer = Vec::new();
-            file.read_to_end(&mut buffer)
-                .map_err(|_| CommitUtilityError::ReadInputFile {
-                    filename: input_file.clone(),
-                })?;
-            buffer
-        }
-        None => {
-            let mut buffer = Vec::new();
-            io::stdin()
-                .read_to_end(&mut buffer)
-                .map_err(|_| CommitUtilityError::ReadStdin)?;
-            buffer
-        }
+    let input_data = if let Some(input_file) = &cli.input {
+        let mut file = File::open(input_file).map_err(|_| CommitUtilityError::OpenInputFile {
+            filename: input_file.clone(),
+        })?;
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)
+            .map_err(|_| CommitUtilityError::ReadInputFile {
+                filename: input_file.clone(),
+            })?;
+        buffer
+    } else {
+        let mut buffer = Vec::new();
+        io::stdin()
+            .read_to_end(&mut buffer)
+            .map_err(|_| CommitUtilityError::ReadStdin)?;
+        buffer
     };
 
     // Deserialize commitment based on the scheme

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.84.0"


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
udeps stop working after an update. Hence let's bump Rust to get CI to work again.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- bump Rust to 1.84.0
- clippy fixes
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests should pass.