### PR TITLE
fix: mismatch between comments and code regarding data types

### DIFF
--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn test_unix_epoch_time_timezone() {
-        let unix_time = 1_231_006_505; // Unix time as string
+        let unix_time = 1_231_006_505; // Unix time as integer
         let expected_timezone = PoSQLTimeZone::utc(); // Unix time should always be UTC
         let result = PoSQLTimestamp::to_timestamp(unix_time).unwrap();
         assert_eq!(result.timezone, expected_timezone);
@@ -158,7 +158,7 @@ mod tests {
         let unix_time = 1_231_006_505; // Example Unix timestamp (seconds since epoch)
         let expected_datetime = Utc.timestamp_opt(unix_time, 0).unwrap();
         let expected_unit = PoSQLTimeUnit::Second; // Assuming basic second precision for Unix timestamp
-        let input = unix_time; // Simulate input as string since Unix times are often transmitted as strings
+        let input = unix_time; // Simulate input as integer since Unix times are often transmitted as strings
         let result = PoSQLTimestamp::to_timestamp(input).unwrap();
 
         assert_eq!(result.timestamp, expected_datetime);

--- a/crates/proof-of-sql-parser/src/utility.rs
+++ b/crates/proof-of-sql-parser/src/utility.rs
@@ -10,7 +10,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 ///
 /// # Panics
 ///
-/// This function will panic if`name`(if provided) cannot be parsed.
+/// This function will panic if `name` (if provided) cannot be parsed.
 /// Construct an identifier from a str
 #[must_use]
 pub fn ident(name: &str) -> Identifier {


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
Some comments don't really line up with the code hence I fixed it.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.


 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above.

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
N/A