### PR TITLE
refactor!: reverse `post_result_challenges` consumption

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     utils::log,
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, collections::VecDeque, vec::Vec};
 
 /// Track components used to form a query's proof
 pub struct FinalRoundBuilder<'a, S: Scalar> {
@@ -24,11 +24,11 @@ pub struct FinalRoundBuilder<'a, S: Scalar> {
     ///
     /// Note: this vector is treated as a stack and the first
     /// challenge is the last entry in the vector.
-    post_result_challenges: Vec<S>,
+    post_result_challenges: VecDeque<S>,
 }
 
 impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
-    pub fn new(num_sumcheck_variables: usize, post_result_challenges: Vec<S>) -> Self {
+    pub fn new(num_sumcheck_variables: usize, post_result_challenges: VecDeque<S>) -> Self {
         Self {
             num_sumcheck_variables,
             bit_distributions: Vec::new(),
@@ -151,6 +151,6 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
     ///
     /// Will panic if there are no post-result challenges available to pop from the stack.
     pub fn consume_post_result_challenge(&mut self) -> S {
-        self.post_result_challenges.pop().unwrap()
+        self.post_result_challenges.pop_front().unwrap()
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder_test.rs
@@ -4,7 +4,7 @@ use crate::base::{
     database::{Column, ColumnField, ColumnType},
     scalar::Curve25519Scalar,
 };
-use alloc::sync::Arc;
+use alloc::{collections::VecDeque, sync::Arc};
 #[cfg(feature = "arrow")]
 use arrow::{
     array::Int64Array,
@@ -17,7 +17,7 @@ use curve25519_dalek::RistrettoPoint;
 fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(1, Vec::new());
+    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(1, VecDeque::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 0_usize;
@@ -36,7 +36,7 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_zero_offset() {
 fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(1, Vec::new());
+    let mut builder = FinalRoundBuilder::<Curve25519Scalar>::new(1, VecDeque::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let offset_generators = 123_usize;
@@ -55,7 +55,7 @@ fn we_can_compute_commitments_for_intermediate_mles_using_a_non_zero_offset() {
 fn we_can_evaluate_pcs_proof_mles() {
     let mle1 = [1, 2];
     let mle2 = [10i64, 20];
-    let mut builder = FinalRoundBuilder::new(1, Vec::new());
+    let mut builder = FinalRoundBuilder::new(1, VecDeque::new());
     builder.produce_anchored_mle(&mle1);
     builder.produce_intermediate_mle(&mle2[..]);
     let evaluation_vec = [
@@ -107,14 +107,15 @@ fn we_can_form_the_provable_query_result() {
 fn we_can_consume_post_result_challenges_in_proof_builder() {
     let mut builder = FinalRoundBuilder::new(
         0,
-        vec![
+        [
             Curve25519Scalar::from(123),
             Curve25519Scalar::from(456),
             Curve25519Scalar::from(789),
-        ],
+        ]
+        .into(),
     );
     assert_eq!(
-        Curve25519Scalar::from(789),
+        Curve25519Scalar::from(123),
         builder.consume_post_result_challenge()
     );
     assert_eq!(
@@ -122,7 +123,7 @@ fn we_can_consume_post_result_challenges_in_proof_builder() {
         builder.consume_post_result_challenge()
     );
     assert_eq!(
-        Curve25519Scalar::from(123),
+        Curve25519Scalar::from(789),
         builder.consume_post_result_challenge()
     );
 }

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -1,6 +1,6 @@
 use super::{SumcheckMleEvaluations, SumcheckSubpolynomialType};
 use crate::base::{bit::BitDistribution, proof::ProofSizeMismatch, scalar::Scalar};
-use alloc::vec::Vec;
+use alloc::{collections::VecDeque, vec::Vec};
 use core::iter;
 
 /// Track components used to verify a query's proof
@@ -21,7 +21,7 @@ pub struct VerificationBuilder<'a, S: Scalar> {
     ///
     /// Note: this vector is treated as a stack and the first
     /// challenge is the last entry in the vector.
-    post_result_challenges: Vec<S>,
+    post_result_challenges: VecDeque<S>,
     one_evaluation_length_queue: Vec<usize>,
     subpolynomial_max_multiplicands: usize,
 }
@@ -36,7 +36,7 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
         mle_evaluations: SumcheckMleEvaluations<'a, S>,
         bit_distributions: &'a [BitDistribution],
         subpolynomial_multipliers: &'a [S],
-        post_result_challenges: Vec<S>,
+        post_result_challenges: VecDeque<S>,
         one_evaluation_length_queue: Vec<usize>,
         subpolynomial_max_multiplicands: usize,
     ) -> Self {
@@ -199,7 +199,7 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
     /// as it attempts to pop an element from the vector and unwraps the result.
     pub fn try_consume_post_result_challenge(&mut self) -> Result<S, ProofSizeMismatch> {
         self.post_result_challenges
-            .pop()
+            .pop_front()
             .ok_or(ProofSizeMismatch::PostResultCountMismatch)
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder_test.rs
@@ -1,5 +1,6 @@
 use super::{SumcheckMleEvaluations, VerificationBuilder};
 use crate::{base::scalar::Curve25519Scalar, sql::proof::SumcheckSubpolynomialType};
+use alloc::collections::VecDeque;
 use num_traits::Zero;
 
 #[test]
@@ -13,7 +14,7 @@ fn an_empty_sumcheck_polynomial_evaluates_to_zero() {
         mle_evaluations,
         &[][..],
         &[][..],
-        Vec::new(),
+        VecDeque::new(),
         Vec::new(),
         0,
     );
@@ -35,7 +36,7 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
         mle_evaluations,
         &[][..],
         &subpolynomial_multipliers,
-        Vec::new(),
+        VecDeque::new(),
         Vec::new(),
         1,
     );
@@ -59,22 +60,23 @@ fn we_build_up_a_sumcheck_polynomial_evaluation_from_subpolynomial_evaluations()
 }
 
 #[test]
-fn we_can_consume_post_result_challenges_in_proof_builder() {
+fn we_can_consume_post_result_challenges_in_verification_builder() {
     let mut builder = VerificationBuilder::new(
         0,
         SumcheckMleEvaluations::default(),
         &[][..],
         &[][..],
-        vec![
+        [
             Curve25519Scalar::from(123),
             Curve25519Scalar::from(456),
             Curve25519Scalar::from(789),
-        ],
+        ]
+        .into(),
         Vec::new(),
         0,
     );
     assert_eq!(
-        Curve25519Scalar::from(789),
+        Curve25519Scalar::from(123),
         builder.try_consume_post_result_challenge().unwrap()
     );
     assert_eq!(
@@ -82,7 +84,7 @@ fn we_can_consume_post_result_challenges_in_proof_builder() {
         builder.try_consume_post_result_challenge().unwrap()
     );
     assert_eq!(
-        Curve25519Scalar::from(123),
+        Curve25519Scalar::from(789),
         builder.try_consume_post_result_challenge().unwrap()
     );
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check.rs
@@ -436,6 +436,7 @@ mod tests {
         base::scalar::{Curve25519Scalar as S, Scalar},
         sql::proof::FinalRoundBuilder,
     };
+    use alloc::collections::VecDeque;
     use bumpalo::Bump;
     use num_traits::Inv;
 
@@ -561,7 +562,7 @@ mod tests {
             .collect();
 
         let alloc = Bump::new();
-        let mut builder = FinalRoundBuilder::new(2, Vec::new());
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
 
         get_logarithmic_derivative(
             &mut builder,
@@ -660,7 +661,7 @@ mod tests {
             .collect();
 
         let alloc = Bump::new();
-        let mut builder = FinalRoundBuilder::new(2, Vec::new());
+        let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
         get_logarithmic_derivative(
             &mut builder,
             &alloc,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -5,6 +5,7 @@ use crate::{
         FinalRoundBuilder, SumcheckMleEvaluations, SumcheckRandomScalars, VerificationBuilder,
     },
 };
+use alloc::collections::VecDeque;
 use bumpalo::Bump;
 use num_traits::Zero;
 
@@ -14,7 +15,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_constant_column() {
     let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
     let alloc = Bump::new();
     let data: Vec<Curve25519Scalar> = data.into_iter().map(Curve25519Scalar::from).collect();
-    let mut builder = FinalRoundBuilder::new(2, Vec::new());
+    let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
     let sign = prover_evaluate_sign(&mut builder, &alloc, &data, false);
     assert_eq!(sign, [false; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
@@ -26,7 +27,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_negative_constant_colum
     let dist = BitDistribution::new::<Curve25519Scalar, _>(&data);
     let alloc = Bump::new();
     let data: Vec<Curve25519Scalar> = data.into_iter().map(Curve25519Scalar::from).collect();
-    let mut builder = FinalRoundBuilder::new(2, Vec::new());
+    let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
     let sign = prover_evaluate_sign(&mut builder, &alloc, &data, false);
     assert_eq!(sign, [true; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
@@ -56,7 +57,7 @@ fn we_can_verify_a_constant_decomposition() {
         sumcheck_evaluations,
         &dists,
         &[],
-        Vec::new(),
+        VecDeque::new(),
         Vec::new(),
         3,
     );
@@ -89,7 +90,7 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
         sumcheck_evaluations,
         &dists,
         &[],
-        Vec::new(),
+        VecDeque::new(),
         Vec::new(),
         3,
     );


### PR DESCRIPTION
# Rationale for this change

Currently, `post_result_challenges` is treated as a stack instead of a queue. For the EVM verifier, it is simpler to work with the challenges as a queue.

# What changes are included in this PR?

`VecDeque` and `pop_front` is used instead of `Vec` and `pop` respectively for the `post_result_challenges`.

# Are these changes tested?

Yes, by existing tests.