### PR TITLE
refactor: replace `Commitment::append_to_transcript` with `to_transcript_bytes`

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -97,8 +97,10 @@ impl Commitment for DoryCommitment {
         super::compute_dory_commitments(committable_columns, offset, setup)
     }
 
-    fn append_to_transcript(&self, transcript: &mut impl crate::base::proof::Transcript) {
-        transcript.extend_canonical_serialize_as_le(&self.0);
+    fn to_transcript_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.0.compressed_size());
+        self.0.serialize_compressed(&mut buf).unwrap();
+        buf
     }
 }
 
@@ -109,7 +111,6 @@ mod tests {
         base::{
             commitment::{Commitment, NumColumnsMismatch, VecCommitmentExt},
             database::{Column, OwnedColumn},
-            proof::{Keccak256Transcript, Transcript},
         },
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };
@@ -493,17 +494,13 @@ mod tests {
     }
 
     #[test]
-    fn we_can_append_different_dory_commitments_and_get_different_transcripts() {
+    fn we_get_different_transcript_bytes_from_different_dory_commitments() {
         let mut rng = StdRng::seed_from_u64(42);
         let commitment1 = DoryCommitment(GT::rand(&mut rng));
         let commitment2 = DoryCommitment(GT::rand(&mut rng));
-
-        let mut transcript1 = Keccak256Transcript::new();
-        let mut transcript2 = Keccak256Transcript::new();
-
-        commitment1.append_to_transcript(&mut transcript1);
-        commitment2.append_to_transcript(&mut transcript2);
-
-        assert_ne!(transcript1.challenge_as_le(), transcript2.challenge_as_le());
+        assert_ne!(
+            commitment1.to_transcript_bytes(),
+            commitment2.to_transcript_bytes()
+        );
     }
 }

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -145,8 +145,8 @@ impl Commitment for HyperKZGCommitment {
             })
             .collect()
     }
-    fn append_to_transcript(&self, transcript: &mut impl crate::base::proof::Transcript) {
-        transcript.extend_as_le(self.commitment.to_transcript_bytes());
+    fn to_transcript_bytes(&self) -> Vec<u8> {
+        self.commitment.to_transcript_bytes()
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -477,7 +477,7 @@ fn make_transcript<C: Commitment, T: Transcript>(
     transcript.extend_serialize_as_le(one_evaluation_lengths);
     transcript.extend_serialize_as_le(&post_result_challenge_count);
     for commitment in first_round_commitments {
-        commitment.append_to_transcript(&mut transcript);
+        transcript.extend_as_le(commitment.to_transcript_bytes());
     }
     transcript
 }
@@ -538,7 +538,7 @@ fn extend_transcript_with_commitments<C: Commitment>(
     bit_distributions: &[BitDistribution],
 ) {
     for commitment in final_round_commitments {
-        commitment.append_to_transcript(transcript);
+        transcript.extend_as_le(commitment.to_transcript_bytes());
     }
     transcript.extend_serialize_as_le(bit_distributions);
 }


### PR DESCRIPTION
# Rationale for this change

We will want to serialize commitments in a manner compatible with the transcript. This facilitates doing this without duplicating code.

# What changes are included in this PR?

`Commitment::append_to_transcript` is removed and `to_transcript_bytes` is added instead. Usage is replaced as well.

# Are these changes tested?

Yes.