### PR TITLE
refactor!: update scalar challenges to use mask

### DIFF
--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -56,7 +56,11 @@ impl<T: TranscriptCore> Transcript for T {
         self.extend_as_be::<[u64; 4]>(messages.into_iter().map(RefInto::ref_into));
     }
     fn scalar_challenge_as_be<S: Scalar>(&mut self) -> S {
-        receive_challenge_as_be::<[u64; 4]>(self).into()
+        let mut challenge = receive_challenge_as_be::<[u64; 4]>(self);
+        for (c, m) in challenge.iter_mut().zip(S::CHALLENGE_MASK) {
+            *c &= m;
+        }
+        challenge.into()
     }
     fn challenge_as_le(&mut self) -> [u8; 32] {
         self.raw_challenge()

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -1,5 +1,9 @@
 use super::Transcript;
-use crate::base::{ref_into::RefInto, scalar::Scalar};
+use crate::base::{
+    ref_into::RefInto,
+    scalar::{Scalar, ScalarExt},
+};
+use bnum::types::U256;
 use zerocopy::{AsBytes, FromBytes};
 
 /// A trait used to facilitate implementation of [Transcript](super::Transcript).
@@ -56,11 +60,9 @@ impl<T: TranscriptCore> Transcript for T {
         self.extend_as_be::<[u64; 4]>(messages.into_iter().map(RefInto::ref_into));
     }
     fn scalar_challenge_as_be<S: Scalar>(&mut self) -> S {
-        let mut challenge = receive_challenge_as_be::<[u64; 4]>(self);
-        for (c, m) in challenge.iter_mut().zip(S::CHALLENGE_MASK) {
-            *c &= m;
-        }
-        challenge.into()
+        ScalarExt::from_wrapping(
+            U256::from(receive_challenge_as_be::<[u64; 4]>(self)) & S::CHALLENGE_MASK,
+        )
     }
     fn challenge_as_le(&mut self) -> [u8; 32] {
         self.raw_challenge()

--- a/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
@@ -1,6 +1,6 @@
 use super::{transcript_core::TranscriptCore, Keccak256Transcript as T, Transcript};
-use crate::base::scalar::{scalar::Scalar, test_scalar::TestScalar as S};
-use zerocopy::AsBytes;
+use crate::base::scalar::{test_scalar::TestScalar as S, Scalar, ScalarExt};
+use bnum::types::U256;
 #[test]
 fn we_can_add_values_to_the_transcript_in_big_endian_form() {
     let mut transcript1: T = TranscriptCore::new();
@@ -65,17 +65,14 @@ fn we_can_add_scalars_to_the_transcript_in_big_endian_form() {
 #[test]
 fn we_can_get_challenge_as_scalar_interpreted_as_big_endian() {
     let mut transcript1: T = TranscriptCore::new();
-    let scalar: S = transcript1.scalar_challenge_as_be();
-
     let mut transcript2: T = TranscriptCore::new();
-    let mut bytes = transcript2.raw_challenge();
-    bytes.reverse();
-    let mut limbs: [u64; 4] = scalar.into();
-    limbs.as_bytes_mut().copy_from_slice(&bytes);
-    for (c, m) in limbs.iter_mut().zip(S::CHALLENGE_MASK) {
-        *c &= m;
-    }
-    assert_eq!(scalar, limbs.into());
+
+    assert_eq!(
+        transcript1.scalar_challenge_as_be::<S>(),
+        S::from_wrapping(
+            U256::from_be_slice(&transcript2.raw_challenge()).unwrap() & S::CHALLENGE_MASK
+        )
+    );
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core_test.rs
@@ -1,5 +1,5 @@
 use super::{transcript_core::TranscriptCore, Keccak256Transcript as T, Transcript};
-use crate::base::scalar::test_scalar::TestScalar as S;
+use crate::base::scalar::{scalar::Scalar, test_scalar::TestScalar as S};
 use zerocopy::AsBytes;
 #[test]
 fn we_can_add_values_to_the_transcript_in_big_endian_form() {
@@ -72,7 +72,9 @@ fn we_can_get_challenge_as_scalar_interpreted_as_big_endian() {
     bytes.reverse();
     let mut limbs: [u64; 4] = scalar.into();
     limbs.as_bytes_mut().copy_from_slice(&bytes);
-
+    for (c, m) in limbs.iter_mut().zip(S::CHALLENGE_MASK) {
+        *c &= m;
+    }
     assert_eq!(scalar, limbs.into());
 }
 

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -1,5 +1,5 @@
 /// This module contains the definition of the `Scalar` trait, which is used to represent the scalar field used in Proof of SQL.
-mod scalar;
+pub(crate) mod scalar;
 pub use scalar::Scalar;
 mod error;
 pub use error::ScalarConversionError;

--- a/crates/proof-of-sql/src/base/scalar/mod.rs
+++ b/crates/proof-of-sql/src/base/scalar/mod.rs
@@ -1,5 +1,5 @@
 /// This module contains the definition of the `Scalar` trait, which is used to represent the scalar field used in Proof of SQL.
-pub(crate) mod scalar;
+mod scalar;
 pub use scalar::Scalar;
 mod error;
 pub use error::ScalarConversionError;
@@ -15,4 +15,6 @@ pub mod test_scalar;
 mod test_scalar_test;
 
 mod scalar_ext;
+#[cfg(test)]
+pub(crate) use scalar_ext::test_scalar_constants;
 pub use scalar_ext::ScalarExt;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -6,6 +6,7 @@ use alloc::{
 };
 use ark_ff::{AdditiveGroup, BigInteger, Field, Fp, Fp256, MontBackend, MontConfig, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use bnum::types::U256;
 use bytemuck::TransparentWrapper;
 use core::{
     cmp::Ordering,
@@ -432,17 +433,17 @@ where
     const ONE: Self = Self(Fp::ONE);
     const TWO: Self = Self(Fp::new(ark_ff::BigInt([2, 0, 0, 0])));
     const TEN: Self = Self(Fp::new(ark_ff::BigInt([10, 0, 0, 0])));
-    const CHALLENGE_MASK: [u64; 4] = {
+    const CHALLENGE_MASK: U256 = {
         assert!(
             T::MODULUS.0[3].leading_zeros() < 64,
             "modulus expected to be larger than 1 << (64*3)"
         );
-        [
+        U256::from_digits([
             u64::MAX,
             u64::MAX,
             u64::MAX,
             u64::MAX >> (T::MODULUS.0[3].leading_zeros() + 1),
-        ]
+        ])
     };
 }
 

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -4,7 +4,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use ark_ff::{BigInteger, Field, Fp, Fp256, MontBackend, MontConfig, PrimeField};
+use ark_ff::{AdditiveGroup, BigInteger, Field, Fp, Fp256, MontBackend, MontConfig, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use bytemuck::TransparentWrapper;
 use core::{
@@ -423,14 +423,27 @@ impl<T: MontConfig<4>> Display for MontScalar<T> {
     }
 }
 
-impl super::Scalar for Curve25519Scalar {
-    const MAX_SIGNED: Self = Self(ark_ff::MontFp!(
-        "3618502788666131106986593281521497120428558179689953803000975469142727125494"
-    ));
-    const ZERO: Self = Self(ark_ff::MontFp!("0"));
-    const ONE: Self = Self(ark_ff::MontFp!("1"));
-    const TWO: Self = Self(ark_ff::MontFp!("2"));
-    const TEN: Self = Self(ark_ff::MontFp!("10"));
+impl<T> Scalar for MontScalar<T>
+where
+    T: MontConfig<4>,
+{
+    const MAX_SIGNED: Self = Self(Fp::new(T::MODULUS.divide_by_2_round_down()));
+    const ZERO: Self = Self(Fp::ZERO);
+    const ONE: Self = Self(Fp::ONE);
+    const TWO: Self = Self(Fp::new(ark_ff::BigInt([2, 0, 0, 0])));
+    const TEN: Self = Self(Fp::new(ark_ff::BigInt([10, 0, 0, 0])));
+    const CHALLENGE_MASK: [u64; 4] = {
+        assert!(
+            T::MODULUS.0[3].leading_zeros() < 64,
+            "modulus expected to be larger than 1 << (64*3)"
+        );
+        [
+            u64::MAX,
+            u64::MAX,
+            u64::MAX,
+            u64::MAX >> (T::MODULUS.0[3].leading_zeros() + 1),
+        ]
+    };
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -1,6 +1,9 @@
 use crate::base::{
     map::IndexSet,
-    scalar::{test_scalar::TestScalar, Curve25519Scalar, Scalar, ScalarConversionError},
+    scalar::{
+        scalar::test_scalar_constants, test_scalar::TestScalar, Curve25519Scalar, Scalar,
+        ScalarConversionError,
+    },
 };
 use alloc::{format, string::ToString, vec::Vec};
 use byte_slice_cast::AsByteSlice;
@@ -12,6 +15,11 @@ use rand::{
     Rng,
 };
 use rand_core::SeedableRng;
+
+#[test]
+fn we_have_correct_constants_for_curve_25519_scalar() {
+    test_scalar_constants::<Curve25519Scalar>();
+}
 
 #[test]
 fn test_dalek_interop_1() {

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -1,7 +1,7 @@
 use crate::base::{
     map::IndexSet,
     scalar::{
-        scalar::test_scalar_constants, test_scalar::TestScalar, Curve25519Scalar, Scalar,
+        test_scalar::TestScalar, test_scalar_constants, Curve25519Scalar, Scalar,
         ScalarConversionError,
     },
 };

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -2,6 +2,7 @@
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
 use alloc::string::String;
+use bnum::types::U256;
 use core::ops::Sub;
 use num_bigint::BigInt;
 
@@ -73,28 +74,5 @@ pub trait Scalar:
     const TEN: Self;
     /// The value to mask the challenge with to ensure it is in the field.
     /// This one less than the largest power of 2 that is less than the field modulus.
-    const CHALLENGE_MASK: [u64; 4];
-}
-
-#[cfg(test)]
-pub(crate) fn test_scalar_constants<S: Scalar>() {
-    assert_eq!(S::from(0), S::ZERO);
-    assert_eq!(S::from(1), S::ONE);
-    assert_eq!(S::from(2), S::TWO);
-    // -1/2 == least upper bound
-    assert_eq!(-S::TWO.inv().unwrap(), S::MAX_SIGNED);
-    assert_eq!(S::from(10), S::TEN);
-
-    // Check the challenge mask
-    let mid_point_limbs: [u64; 4] = S::MAX_SIGNED.into();
-    let modulus_minus_one_limbs: [u64; 4] = (-S::ONE).into();
-    assert_eq!(S::CHALLENGE_MASK[0], u64::MAX);
-    assert_eq!(S::CHALLENGE_MASK[1], u64::MAX);
-    assert_eq!(S::CHALLENGE_MASK[2], u64::MAX);
-    assert_eq!(
-        S::CHALLENGE_MASK[3],
-        u64::MAX >> S::CHALLENGE_MASK[3].leading_zeros()
-    );
-    assert!(mid_point_limbs[3] < S::CHALLENGE_MASK[3]);
-    assert!(modulus_minus_one_limbs[3] > S::CHALLENGE_MASK[3]);
+    const CHALLENGE_MASK: U256;
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -71,4 +71,30 @@ pub trait Scalar:
     const TWO: Self;
     /// 2 + 2 + 2 + 2 + 2
     const TEN: Self;
+    /// The value to mask the challenge with to ensure it is in the field.
+    /// This one less than the largest power of 2 that is less than the field modulus.
+    const CHALLENGE_MASK: [u64; 4];
+}
+
+#[cfg(test)]
+pub(crate) fn test_scalar_constants<S: Scalar>() {
+    assert_eq!(S::from(0), S::ZERO);
+    assert_eq!(S::from(1), S::ONE);
+    assert_eq!(S::from(2), S::TWO);
+    // -1/2 == least upper bound
+    assert_eq!(-S::TWO.inv().unwrap(), S::MAX_SIGNED);
+    assert_eq!(S::from(10), S::TEN);
+
+    // Check the challenge mask
+    let mid_point_limbs: [u64; 4] = S::MAX_SIGNED.into();
+    let modulus_minus_one_limbs: [u64; 4] = (-S::ONE).into();
+    assert_eq!(S::CHALLENGE_MASK[0], u64::MAX);
+    assert_eq!(S::CHALLENGE_MASK[1], u64::MAX);
+    assert_eq!(S::CHALLENGE_MASK[2], u64::MAX);
+    assert_eq!(
+        S::CHALLENGE_MASK[3],
+        u64::MAX >> S::CHALLENGE_MASK[3].leading_zeros()
+    );
+    assert!(mid_point_limbs[3] < S::CHALLENGE_MASK[3]);
+    assert!(modulus_minus_one_limbs[3] > S::CHALLENGE_MASK[3]);
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -35,6 +35,24 @@ pub trait ScalarExt: Scalar {
 impl<S: Scalar> ScalarExt for S {}
 
 #[cfg(test)]
+pub(crate) fn test_scalar_constants<S: Scalar>() {
+    assert_eq!(S::from(0), S::ZERO);
+    assert_eq!(S::from(1), S::ONE);
+    assert_eq!(S::from(2), S::TWO);
+    // -1/2 == least upper bound
+    assert_eq!(-S::TWO.inv().unwrap(), S::MAX_SIGNED);
+    assert_eq!(S::from(10), S::TEN);
+
+    // Check the challenge mask
+    assert_eq!(
+        S::CHALLENGE_MASK,
+        U256::MAX >> S::CHALLENGE_MASK.leading_zeros()
+    );
+    assert!(S::MAX_SIGNED.into_u256_wrapping() < S::CHALLENGE_MASK);
+    assert!((-S::ONE).into_u256_wrapping() > S::CHALLENGE_MASK);
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::base::scalar::{test_scalar::TestScalar, Curve25519Scalar, MontScalar};

--- a/crates/proof-of-sql/src/base/scalar/test_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar.rs
@@ -1,20 +1,10 @@
-use super::{MontScalar, Scalar};
+use super::MontScalar;
 use ark_ff::{Fp, MontBackend, MontConfig};
 
 /// An implementation of `Scalar` intended for use in testing when a concrete implementation is required.
 ///
 /// Ultimately, a wrapper type around the field element `ark_curve25519::Fr` and should be used in place of `ark_curve25519::Fr`.
 pub type TestScalar = MontScalar<TestMontConfig>;
-
-impl Scalar for TestScalar {
-    const MAX_SIGNED: Self = Self(ark_ff::MontFp!(
-        "3618502788666131106986593281521497120428558179689953803000975469142727125494"
-    ));
-    const ZERO: Self = Self(ark_ff::MontFp!("0"));
-    const ONE: Self = Self(ark_ff::MontFp!("1"));
-    const TWO: Self = Self(ark_ff::MontFp!("2"));
-    const TEN: Self = Self(ark_ff::MontFp!("10"));
-}
 
 /// An implementation of `MontConfig` intended for use in testing when a concrete implementation is required.
 ///

--- a/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
@@ -1,8 +1,7 @@
 use super::ScalarExt;
-use crate::base::scalar::{test_scalar::TestScalar, Scalar};
+use crate::base::scalar::{scalar::test_scalar_constants, test_scalar::TestScalar, Scalar};
 use bnum::types::U256;
 use core::str::FromStr;
-use num_traits::Inv;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 const MAX_TEST_SCALAR_SIGNED_VALUE_AS_STRING: &str =
@@ -16,13 +15,8 @@ fn random_u256(seed: u64) -> U256 {
 }
 
 #[test]
-fn we_can_get_test_scalar_constants_from_z_p() {
-    assert_eq!(TestScalar::from(0), TestScalar::ZERO);
-    assert_eq!(TestScalar::from(1), TestScalar::ONE);
-    assert_eq!(TestScalar::from(2), TestScalar::TWO);
-    // -1/2 == least upper bound
-    assert_eq!(-TestScalar::TWO.inv().unwrap(), TestScalar::MAX_SIGNED);
-    assert_eq!(TestScalar::from(10), TestScalar::TEN);
+fn we_have_correct_constants_for_test_scalar() {
+    test_scalar_constants::<TestScalar>();
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/test_scalar_test.rs
@@ -1,5 +1,5 @@
 use super::ScalarExt;
-use crate::base::scalar::{scalar::test_scalar_constants, test_scalar::TestScalar, Scalar};
+use crate::base::scalar::{test_scalar::TestScalar, test_scalar_constants, Scalar};
 use bnum::types::U256;
 use core::str::FromStr;
 use rand::{rngs::StdRng, Rng, SeedableRng};

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -26,7 +26,7 @@ use super::{DoryProverPublicSetup, GT};
 use crate::base::{
     commitment::{Commitment, CommittableColumn},
     impl_serde_for_ark_serde_checked,
-    scalar::{MontScalar, Scalar},
+    scalar::MontScalar,
 };
 use alloc::vec::Vec;
 use ark_ec::pairing::PairingOutput;
@@ -37,16 +37,6 @@ use num_traits::One;
 
 /// The Dory scalar type. (alias for `MontScalar<ark_bls12_381::FrConfig>`)
 pub type DoryScalar = MontScalar<ark_bls12_381::FrConfig>;
-
-impl Scalar for DoryScalar {
-    const MAX_SIGNED: Self = Self(ark_ff::MontFp!(
-        "26217937587563095239723870254092982918845276250263818911301829349969290592256"
-    ));
-    const ZERO: Self = Self(ark_ff::MontFp!("0"));
-    const ONE: Self = Self(ark_ff::MontFp!("1"));
-    const TWO: Self = Self(ark_ff::MontFp!("2"));
-    const TEN: Self = Self(ark_ff::MontFp!("10"));
-}
 
 #[derive(
     Debug,
@@ -110,12 +100,18 @@ mod tests {
             commitment::{Commitment, NumColumnsMismatch, VecCommitmentExt},
             database::{Column, OwnedColumn},
             proof::{Keccak256Transcript, Transcript},
+            scalar::scalar::test_scalar_constants,
         },
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };
     use ark_ec::pairing::Pairing;
     use ark_ff::UniformRand;
     use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn we_have_correct_constants_for_dory_scalar() {
+        test_scalar_constants::<DoryScalar>();
+    }
 
     #[test]
     fn we_can_convert_from_columns() {

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -100,7 +100,7 @@ mod tests {
             commitment::{Commitment, NumColumnsMismatch, VecCommitmentExt},
             database::{Column, OwnedColumn},
             proof::{Keccak256Transcript, Transcript},
-            scalar::scalar::test_scalar_constants,
+            scalar::test_scalar_constants,
         },
         proof_primitive::dory::{rand_util::test_rng, ProverSetup, PublicParameters},
     };

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -92,16 +92,6 @@ impl Sub for HyperKZGCommitment {
     }
 }
 
-impl Scalar for BNScalar {
-    const MAX_SIGNED: Self = Self(ark_ff::MontFp!(
-        "10944121435919637611123202872628637544274182200208017171849102093287904247808"
-    ));
-    const ZERO: Self = Self(ark_ff::MontFp!("0"));
-    const ONE: Self = Self(ark_ff::MontFp!("1"));
-    const TWO: Self = Self(ark_ff::MontFp!("2"));
-    const TEN: Self = Self(ark_ff::MontFp!("10"));
-}
-
 fn compute_commitments_impl<T: Into<BNScalar> + Clone>(
     setup: &CommitmentKey<HyperKZGEngine>,
     offset: usize,
@@ -270,22 +260,19 @@ impl CommitmentEvaluationProof for HyperKZGCommitmentEvaluationProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base::commitment::commitment_evaluation_proof_test::{
-        test_commitment_evaluation_proof_with_length_1, test_random_commitment_evaluation_proof,
-        test_simple_commitment_evaluation_proof,
+    use crate::base::{
+        commitment::commitment_evaluation_proof_test::{
+            test_commitment_evaluation_proof_with_length_1,
+            test_random_commitment_evaluation_proof, test_simple_commitment_evaluation_proof,
+        },
+        scalar::scalar::test_scalar_constants,
     };
     use ark_std::UniformRand;
     use nova_snark::provider::hyperkzg::CommitmentEngine;
-    use num_traits::Inv;
 
     #[test]
-    fn we_can_get_bn_scalar_constants_from_z_p() {
-        assert_eq!(BNScalar::from(0), BNScalar::ZERO);
-        assert_eq!(BNScalar::from(1), BNScalar::ONE);
-        assert_eq!(BNScalar::from(2), BNScalar::TWO);
-        // -1/2 == least upper bound
-        assert_eq!(-BNScalar::TWO.inv().unwrap(), BNScalar::MAX_SIGNED);
-        assert_eq!(BNScalar::from(10), BNScalar::TEN);
+    fn we_have_correct_constants_for_bn_scalar() {
+        test_scalar_constants::<BNScalar>();
     }
 
     #[test]

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -265,7 +265,7 @@ mod tests {
             test_commitment_evaluation_proof_with_length_1,
             test_random_commitment_evaluation_proof, test_simple_commitment_evaluation_proof,
         },
-        scalar::scalar::test_scalar_constants,
+        scalar::test_scalar_constants,
     };
     use ark_std::UniformRand;
     use nova_snark::provider::hyperkzg::CommitmentEngine;


### PR DESCRIPTION
# Rationale for this change

The current mechanism for drawing a challenge is a bit opaque. This simplifies it.

# What changes are included in this PR?

When drawing a challenge from the transcript, it is 32 bytes long. Instead of using `[u64; 4]` to coerce it into a `Scalar`, it is more straightforward to simply drop the first few bits. This can be accomplished by masking the challenged by a `CHALLENGE_MASK` before converting to a `Scalar`.

Additionally, this PR updates the `Scalar` implementations so that we have a blanket implementation of `impl<T> Scalar for MontScalar<T>`. This removes the need to manually figure out the constants for each Scalar type.

# Are these changes tested?

Yes.