### PR TITLE
feat: add rho eval

### DIFF
--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
@@ -1,4 +1,9 @@
-use core::ops::{Add, Mul, Sub};
+use super::compute_evaluation_vector;
+use alloc::vec;
+use core::{
+    iter::Sum,
+    ops::{Add, Mul, MulAssign, Sub, SubAssign},
+};
 use num_traits::{One, Zero};
 
 /// Given the points a and b with length nu, we can evaluate the lagrange basis of length 2^nu at the two points.
@@ -103,4 +108,18 @@ where
                 }
             })
     }
+}
+
+pub fn compute_rho_eval<F>(length: usize, point: &[F]) -> F
+where
+    F: One + Sub<Output = F> + MulAssign + SubAssign + Mul<Output = F> + Send + Sync + Copy + Sum,
+    i128: Into<F>,
+{
+    let mut eval_vec = vec![F::one(); length];
+    compute_evaluation_vector(&mut eval_vec, point);
+    eval_vec
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| v * Into::<F>::into(i as i128))
+        .sum()
 }

--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation.rs
@@ -113,13 +113,13 @@ where
 pub fn compute_rho_eval<F>(length: usize, point: &[F]) -> F
 where
     F: One + Sub<Output = F> + MulAssign + SubAssign + Mul<Output = F> + Send + Sync + Copy + Sum,
-    i128: Into<F>,
+    u64: Into<F>,
 {
     let mut eval_vec = vec![F::one(); length];
     compute_evaluation_vector(&mut eval_vec, point);
     eval_vec
         .into_iter()
         .enumerate()
-        .map(|(i, v)| v * Into::<F>::into(i as i128))
+        .map(|(i, v)| v * Into::<F>::into(i as u64))
         .sum()
 }

--- a/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/lagrange_basis_evaluation_test.rs
@@ -1,7 +1,7 @@
 use crate::base::{
     polynomial::{
-        compute_evaluation_vector, compute_truncated_lagrange_basis_inner_product,
-        compute_truncated_lagrange_basis_sum,
+        compute_evaluation_vector, compute_rho_eval,
+        compute_truncated_lagrange_basis_inner_product, compute_truncated_lagrange_basis_sum,
     },
     scalar::test_scalar::TestScalar,
 };
@@ -22,6 +22,12 @@ fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_0_variables() 
     );
 }
 #[test]
+fn compute_rho_eval_gives_correct_values_with_0_variables() {
+    let point: Vec<TestScalar> = vec![];
+    assert_eq!(compute_rho_eval(1, &point), TestScalar::from(0u8));
+    assert_eq!(compute_rho_eval(0, &point), TestScalar::from(0u8));
+}
+#[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_1_variables() {
     let point: Vec<TestScalar> = vec![TestScalar::from(2u8)];
     assert_eq!(
@@ -36,6 +42,19 @@ fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_1_variables() 
         compute_truncated_lagrange_basis_sum(0, &point),
         TestScalar::from(0u8)
     );
+}
+#[test]
+fn compute_rho_eval_gives_correct_values_with_1_variables() {
+    let point: Vec<TestScalar> = vec![TestScalar::from(2u8)];
+    assert_eq!(
+        compute_rho_eval(2, &point),
+        TestScalar::from(2u8) // This is 0 * (1-2) + 1 * (2)
+    );
+    assert_eq!(
+        compute_rho_eval(1, &point),
+        -TestScalar::from(0u8) // This is 0 * (1-2)
+    );
+    assert_eq!(compute_rho_eval(0, &point), TestScalar::from(0u8));
 }
 #[test]
 fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_2_variables() {
@@ -60,6 +79,27 @@ fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_2_variables() 
         compute_truncated_lagrange_basis_sum(0, &point),
         TestScalar::from(0u8)
     );
+}
+#[test]
+fn compute_rho_eval_gives_correct_values_with_2_variables() {
+    let point = vec![TestScalar::from(2u8), TestScalar::from(5u8)];
+    assert_eq!(
+        compute_rho_eval(4, &point),
+        TestScalar::from(12u8) // This is 0 * (1-2)(1-5) + 1 * (2)(1-5) + 2 * (1-2)(5) + 3 * (2)(5)
+    );
+    assert_eq!(
+        compute_rho_eval(3, &point),
+        -TestScalar::from(18u8) // This is 0 * (1-2)(1-5) + 1 * (2)(1-5) + 2 * (1-2)(5)
+    );
+    assert_eq!(
+        compute_rho_eval(2, &point),
+        -TestScalar::from(8u8) // This is 0 * (1-2)(1-5) + 1 * (2)(1-5)
+    );
+    assert_eq!(
+        compute_rho_eval(1, &point),
+        TestScalar::from(0u8) // This is 0 * (1-2)(1-5)
+    );
+    assert_eq!(compute_rho_eval(0, &point), TestScalar::from(0u8));
 }
 
 #[test]
@@ -108,48 +148,21 @@ fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_3_variables() 
 }
 
 #[test]
-fn compute_truncated_lagrange_basis_sum_gives_correct_values_with_3_variables_using_dalek_scalar() {
+fn compute_rho_eval_gives_correct_values_with_3_variables() {
     let point = vec![
         TestScalar::from(2u8),
         TestScalar::from(5u8),
         TestScalar::from(7u8),
     ];
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(8, &point),
-        TestScalar::from(1u8)
-    );
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(7, &point),
-        -TestScalar::from(69u8)
-    );
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(6, &point),
-        -TestScalar::from(34u8)
-    );
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(5, &point),
-        TestScalar::from(22u8)
-    );
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(4, &point),
-        -TestScalar::from(6u8)
-    );
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(3, &point),
-        TestScalar::from(54u8)
-    );
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(2, &point),
-        TestScalar::from(24u8)
-    );
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(1, &point),
-        -TestScalar::from(24u8)
-    );
-    assert_eq!(
-        compute_truncated_lagrange_basis_sum(0, &point),
-        TestScalar::from(0u8)
-    );
+    assert_eq!(compute_rho_eval(8, &point), TestScalar::from(40u8));
+    assert_eq!(compute_rho_eval(7, &point), -TestScalar::from(450u16));
+    assert_eq!(compute_rho_eval(6, &point), -TestScalar::from(240u8));
+    assert_eq!(compute_rho_eval(5, &point), TestScalar::from(40u8));
+    assert_eq!(compute_rho_eval(4, &point), -TestScalar::from(72u8));
+    assert_eq!(compute_rho_eval(3, &point), TestScalar::from(108u8));
+    assert_eq!(compute_rho_eval(2, &point), TestScalar::from(48u8));
+    assert_eq!(compute_rho_eval(1, &point), TestScalar::from(0u8));
+    assert_eq!(compute_rho_eval(0, &point), TestScalar::from(0u8));
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/polynomial/mod.rs
+++ b/crates/proof-of-sql/src/base/polynomial/mod.rs
@@ -14,9 +14,12 @@ pub use evaluation_vector::compute_evaluation_vector;
 #[cfg(test)]
 mod evaluation_vector_test;
 
+#[allow(dead_code)]
 mod lagrange_basis_evaluation;
+#[allow(unused_imports)]
 pub use lagrange_basis_evaluation::{
-    compute_truncated_lagrange_basis_inner_product, compute_truncated_lagrange_basis_sum,
+    compute_rho_eval, compute_truncated_lagrange_basis_inner_product,
+    compute_truncated_lagrange_basis_sum,
 };
 #[cfg(test)]
 mod lagrange_basis_evaluation_test;

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -57,6 +57,7 @@ pub trait Scalar:
     + core::convert::From<i32>
     + core::convert::From<i16>
     + core::convert::From<i8>
+    + core::convert::From<u64>
     + core::convert::From<bool>
     + core::convert::Into<BigInt>
     + TryFrom<BigInt, Error = ScalarConversionError>


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
For joins it is necessary to have not only one evaluations but also evaluations of rho = (0, 1, 2, \cdots, n-1) vectors. Hence we need to add them to our proofs.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- an algorithm to compute rho evaluations
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.