### PR TITLE
fix: code comments errors 

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar_ext.rs
@@ -2,8 +2,8 @@ use super::Scalar;
 use bnum::types::U256;
 use core::cmp::Ordering;
 
-/// Extention trait for blanket implementations for `Scalar` types.
-/// This trait is primarily to avoid cluttering the core `Scalar` implementation with default implemenentations
+/// Extension trait for blanket implementations for `Scalar` types.
+/// This trait is primarily to avoid cluttering the core `Scalar` implementation with default implementations
 /// and provides helper methods for `Scalar`.
 pub trait ScalarExt: Scalar {
     /// Compute 10^exponent for the Scalar. Note that we do not check for overflow.

--- a/crates/proof-of-sql/src/evm_compatibility/primitive_serialize_ext.rs
+++ b/crates/proof-of-sql/src/evm_compatibility/primitive_serialize_ext.rs
@@ -27,7 +27,7 @@ pub trait PrimitiveSerializeExt<S: Scalar>: Sized {
         self.serialize_slice(&[value])
     }
 
-    /// Serializes a scalar value. The scalar is serialized as a 256-bit, bytwise-big-endian integer.
+    /// Serializes a scalar value. The scalar is serialized as a 256-bit, bytewise-big-endian integer.
     /// This is the format used by the EVM for representing integers.
     ///
     /// # Arguments


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.


 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
