### PR TITLE
bench: add Jaeger benchmarks for HyperKZG commitment

### DIFF
--- a/crates/proof-of-sql/benches/README.md
+++ b/crates/proof-of-sql/benches/README.md
@@ -13,6 +13,7 @@ To run benchmarks with Jaeger, you need to do the following
     cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof
     cargo bench -p proof-of-sql --bench jaeger_benches Dory
     cargo bench -p proof-of-sql --bench jaeger_benches DynamicDory
+    cargo bench -p proof-of-sql --bench jaeger_benches HyperKZG
     ```
 3. Navigate to http://localhost:16686/ to see the results.
 4. To end the Jaeger service, run


### PR DESCRIPTION
# Rationale for this change
Add Jaeger benchmarks for the HyperKZG commitment scheme.

# What changes are included in this PR?
- Jaeger benchmarks are added to the HyperKZG commitment scheme.

# Are these changes tested?
Yes