### PR TITLE
fix: comments errors in codebase

### DIFF
--- a/crates/proof-of-sql/examples/posql_db/README.md
+++ b/crates/proof-of-sql/examples/posql_db/README.md
@@ -11,7 +11,7 @@ Run `cargo install --example posql_db --path crates/proof-of-sql` to install the
 > cargo install --example posql_db --path crates/proof-of-sql --no-default-features --features="cpu-perf"
 > ```
 
-## Quick Start Exmaple
+## Quick Start Example
 Run the following
 ```bash
 posql_db create -t sxt.table -c a,b -d BIGINT,VARCHAR

--- a/crates/proof-of-sql/src/base/proof/transcript_core.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript_core.rs
@@ -18,7 +18,7 @@ pub(super) trait TranscriptCore {
     fn raw_challenge(&mut self) -> [u8; 32];
 }
 
-/// private method to facilitate recieving challenges and reversing them. Undefined behavior if the size of `M` is not 32 bytes.
+/// private method to facilitate receiving challenges and reversing them. Undefined behavior if the size of `M` is not 32 bytes.
 ///
 /// # Panics
 /// - Panics if `M::read_from(&bytes)` fails to read the bytes into the type `M`.


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

Hope helps! 


 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

While reviewing the docs found errors in the comments to the code.
Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
