### PR TITLE
feat: add shift gadget

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -92,7 +92,7 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
             .get(index)
             .copied()
             .ok_or(ProofSizeMismatch::TooFewRhoLengths)?;
-        self.consumed_one_evaluations += 1;
+        self.consumed_rho_evaluations += 1;
         Ok(*self
             .mle_evaluations
             .rho_evaluations

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,5 +1,6 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
 mod membership_check;
+mod shift;
 #[allow(unused_imports, dead_code)]
 use membership_check::{
     final_round_evaluate_membership_check, first_round_evaluate_membership_check,
@@ -7,6 +8,10 @@ use membership_check::{
 };
 #[cfg(test)]
 mod membership_check_test;
+#[allow(unused_imports, dead_code)]
+use shift::{final_round_evaluate_shift, first_round_evaluate_shift, verify_shift};
+#[cfg(test)]
+mod shift_test;
 mod sign_expr;
 pub(crate) use sign_expr::{prover_evaluate_sign, result_evaluate_sign, verifier_evaluate_sign};
 #[allow(clippy::needless_range_loop)] // keep the loop for readability for now, refactor later

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -16,10 +16,10 @@ pub(crate) fn first_round_evaluate_shift<S: Scalar>(
     builder: &mut FirstRoundBuilder<'_, S>,
     num_rows: usize,
 ) {
+    // Note that we don't produce one eval lengths here
+    // since it needs to be done in uniqueness check which uses shifts.
     builder.produce_rho_evaluation_length(num_rows);
     builder.produce_rho_evaluation_length(num_rows + 1);
-    builder.produce_one_evaluation_length(num_rows);
-    builder.produce_one_evaluation_length(num_rows + 1);
 }
 
 /// Perform final round evaluation of downward shift.
@@ -105,11 +105,11 @@ pub(crate) fn verify_shift<S: Scalar>(
     beta: S,
     column_eval: S,
     shifted_column_eval: S,
+    chi_n_eval: S,
+    chi_n_plus_1_eval: S,
 ) -> Result<(), ProofError> {
     let rho_n_eval = builder.try_consume_rho_evaluation()?;
     let rho_n_plus_1_eval = builder.try_consume_rho_evaluation()?;
-    let chi_n_eval = builder.try_consume_one_evaluation()?;
-    let chi_n_plus_1_eval = builder.try_consume_one_evaluation()?;
     let c_fold_eval = alpha * fold_vals(beta, &[rho_n_eval + chi_n_eval, column_eval]);
     let d_fold_eval = alpha * fold_vals(beta, &[rho_n_plus_1_eval, shifted_column_eval]);
     let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -1,0 +1,140 @@
+use crate::{
+    base::{proof::ProofError, scalar::Scalar, slice_ops},
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder,
+        },
+        proof_plans::{fold_columns, fold_vals},
+    },
+};
+use alloc::{boxed::Box, vec};
+use bumpalo::Bump;
+use num_traits::{One, Zero};
+
+/// Perform first round evaluation of downward shift.
+pub(crate) fn first_round_evaluate_shift<S: Scalar>(
+    builder: &mut FirstRoundBuilder<'_, S>,
+    num_rows: usize,
+) {
+    builder.produce_rho_evaluation_length(num_rows);
+    builder.produce_rho_evaluation_length(num_rows + 1);
+    builder.produce_one_evaluation_length(num_rows);
+    builder.produce_one_evaluation_length(num_rows + 1);
+}
+
+/// Perform final round evaluation of downward shift.
+///
+/// # Panics
+/// Panics if `column.len() != shifted_column.len() - 1` which should always hold for shifts.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn final_round_evaluate_shift<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    column: &'a [S],
+    shifted_column: &'a [S],
+) {
+    let num_rows = column.len();
+    assert_eq!(
+        num_rows + 1,
+        shifted_column.len(),
+        "Shifted column length mismatch"
+    );
+    let rho_plus_chi_n =
+        alloc.alloc_slice_fill_with(num_rows, |i| S::from(i as u64 + 1_u64)) as &[_];
+    let rho_n_plus_1 = alloc.alloc_slice_fill_with(num_rows + 1, |i| S::from(i as u64)) as &[_];
+    let chi_n_plus_1 = alloc.alloc_slice_fill_copy(num_rows + 1, true);
+
+    let c_fold = alloc.alloc_slice_fill_copy(num_rows, Zero::zero());
+    fold_columns(c_fold, alpha, beta, &[rho_plus_chi_n, column]);
+    let c_fold_extended = alloc.alloc_slice_fill_copy(num_rows + 1, Zero::zero());
+    c_fold_extended[..num_rows].copy_from_slice(c_fold);
+    let c_star = alloc.alloc_slice_copy(c_fold_extended);
+    slice_ops::add_const::<S, S>(c_star, One::one());
+    slice_ops::batch_inversion(c_star);
+
+    let d_fold = alloc.alloc_slice_fill_copy(num_rows + 1, Zero::zero());
+    fold_columns(d_fold, alpha, beta, &[rho_n_plus_1, shifted_column]);
+    let d_star = alloc.alloc_slice_copy(d_fold);
+    slice_ops::add_const::<S, S>(d_star, One::one());
+    slice_ops::batch_inversion(d_star);
+
+    builder.produce_intermediate_mle(c_star as &[_]);
+    builder.produce_intermediate_mle(d_star as &[_]);
+
+    // sum c_star - d_star = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::ZeroSum,
+        vec![
+            (S::one(), vec![Box::new(c_star as &[_])]),
+            (-S::one(), vec![Box::new(d_star as &[_])]),
+        ],
+    );
+
+    // c_star + c_fold * c_star - chi_n_plus_1 = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(c_star as &[_])]),
+            (
+                S::one(),
+                vec![Box::new(c_fold_extended as &[_]), Box::new(c_star as &[_])],
+            ),
+            (-S::one(), vec![Box::new(chi_n_plus_1 as &[_])]),
+        ],
+    );
+
+    // d_star + d_fold * d_star - chi_n_plus_1 = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(d_star as &[_])]),
+            (
+                S::one(),
+                vec![Box::new(d_fold as &[_]), Box::new(d_star as &[_])],
+            ),
+            (-S::one(), vec![Box::new(chi_n_plus_1 as &[_])]),
+        ],
+    );
+}
+
+pub(crate) fn verify_shift<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    column_eval: S,
+    shifted_column_eval: S,
+) -> Result<(), ProofError> {
+    let rho_n_eval = builder.try_consume_rho_evaluation()?;
+    let rho_n_plus_1_eval = builder.try_consume_rho_evaluation()?;
+    let chi_n_eval = builder.try_consume_one_evaluation()?;
+    let chi_n_plus_1_eval = builder.try_consume_one_evaluation()?;
+    let c_fold_eval = alpha * fold_vals(beta, &[rho_n_eval + chi_n_eval, column_eval]);
+    let d_fold_eval = alpha * fold_vals(beta, &[rho_n_plus_1_eval, shifted_column_eval]);
+    let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+    let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+
+    //sum c_star - d_star = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::ZeroSum,
+        c_star_eval - d_star_eval,
+        1,
+    )?;
+
+    // c_star + c_fold * c_star - chi_n_plus_1 = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        c_star_eval + c_fold_eval * c_star_eval - chi_n_plus_1_eval,
+        2,
+    )?;
+
+    // d_star + d_fold * d_star - chi_n_plus_1 = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        d_star_eval + d_fold_eval * d_star_eval - chi_n_plus_1_eval,
+        2,
+    )?;
+
+    Ok(())
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
@@ -1,0 +1,309 @@
+//! This module contains the implementation of the `ShiftTestPlan` struct. This struct
+//! is used to check whether the membership check gadgets work correctly.
+use super::shift::{final_round_evaluate_shift, first_round_evaluate_shift, verify_shift};
+use crate::{
+    base::{
+        database::{
+            ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+        },
+        map::{indexset, IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    },
+};
+use bumpalo::Bump;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct ShiftTestPlan {
+    pub column: ColumnRef,
+    pub candidate_shifted_column: ColumnRef,
+    /// The length can be wrong in the test plan and that should error out
+    pub column_length: usize,
+}
+
+impl ProverEvaluate for ShiftTestPlan {
+    #[doc = "Evaluate the query, modify `FirstRoundBuilder` and return the result."]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        _alloc: &'a Bump,
+        _table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        builder.request_post_result_challenges(2);
+        // Evaluate the first round
+        first_round_evaluate_shift(builder, self.column_length);
+        // This is just a dummy table, the actual data is not used
+        Table::try_new_with_options(IndexMap::default(), TableOptions { row_count: Some(0) })
+            .unwrap()
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the table from the map using the table reference
+        let source_table: &Table<'a, S> = table_map
+            .get(&self.column.table_ref())
+            .expect("Table not found");
+        let source_column: Vec<S> = source_table
+            .inner_table()
+            .get(&self.column.column_id())
+            .expect("Column not found in table")
+            .to_scalar_with_scaling(0);
+        let alloc_source_column = alloc.alloc_slice_copy(&source_column);
+        builder.produce_intermediate_mle(alloc_source_column as &[_]);
+
+        let candidate_table = table_map
+            .get(&self.candidate_shifted_column.table_ref())
+            .expect("Table not found");
+        let candidate_column: Vec<S> = candidate_table
+            .inner_table()
+            .get(&self.candidate_shifted_column.column_id())
+            .expect("Column not found in table")
+            .to_scalar_with_scaling(0);
+        let alloc_candidate_column = alloc.alloc_slice_copy(&candidate_column);
+        builder.produce_intermediate_mle(alloc_candidate_column as &[_]);
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+        final_round_evaluate_shift(
+            builder,
+            alloc,
+            alpha,
+            beta,
+            alloc_source_column,
+            alloc_candidate_column,
+        );
+        // Return a dummy table
+        Table::try_new_with_options(IndexMap::default(), TableOptions { row_count: Some(0) })
+            .unwrap()
+    }
+}
+
+impl ProofPlan for ShiftTestPlan {
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        vec![]
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        indexset! {self.column.clone(), self.candidate_shifted_column.clone()}
+    }
+
+    #[doc = "Return all the tables referenced in the Query"]
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        indexset! {self.column.table_ref(), self.candidate_shifted_column.table_ref()}
+    }
+
+    #[doc = "Form components needed to verify and proof store into `VerificationBuilder`"]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        _one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        // Get the challenges from the builder
+        let alpha = builder.try_consume_post_result_challenge()?;
+        let beta = builder.try_consume_post_result_challenge()?;
+        // Get the columns
+        let column_eval = builder.try_consume_final_round_mle_evaluation()?;
+        let candidate_shift_eval = builder.try_consume_final_round_mle_evaluation()?;
+        // Evaluate the verifier
+        verify_shift(builder, alpha, beta, column_eval, candidate_shift_eval)?;
+        Ok(TableEvaluation::new(vec![], S::zero()))
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+        sql::proof::VerifiableQueryResult,
+    };
+    use blitzar::proof::InnerProductProof;
+
+    #[test]
+    fn we_can_do_shift() {
+        let alloc = Bump::new();
+        let source_table = table([
+            borrowed_bigint("a", [1, 2, 3], &alloc),
+            borrowed_varchar("b", ["Space", "and", "Time"], &alloc),
+            borrowed_boolean("c", [true, false, true], &alloc),
+        ]);
+        let candidate_table = table([
+            borrowed_bigint("c", [0, 1, 2, 3], &alloc),
+            borrowed_varchar("d", ["", "Space", "and", "Time"], &alloc),
+            borrowed_boolean("e", [false, true, false, true], &alloc),
+        ]);
+        let source_table_ref = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref,
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref, candidate_table, 0);
+
+        // BigInt column
+        let plan = ShiftTestPlan {
+            column: ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
+            candidate_shifted_column: ColumnRef::new(
+                candidate_table_ref,
+                "c".into(),
+                ColumnType::BigInt,
+            ),
+            column_length: 3,
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+
+        // Varchar column
+        let plan = ShiftTestPlan {
+            column: ColumnRef::new(source_table_ref, "b".into(), ColumnType::VarChar),
+            candidate_shifted_column: ColumnRef::new(
+                candidate_table_ref,
+                "d".into(),
+                ColumnType::VarChar,
+            ),
+            column_length: 3,
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+
+        // Boolean column
+        let plan = ShiftTestPlan {
+            column: ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+            candidate_shifted_column: ColumnRef::new(
+                candidate_table_ref,
+                "e".into(),
+                ColumnType::Boolean,
+            ),
+            column_length: 3,
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn we_cannot_do_shift_if_candidate_is_incorrect() {
+        let alloc = Bump::new();
+        let source_table = table([
+            borrowed_bigint("a", [1, 2, 3], &alloc),
+            borrowed_varchar("b", ["Space", "and", "Time"], &alloc),
+            borrowed_boolean("c", [true, false, true], &alloc),
+            borrowed_bigint("d", [5, 6, 7], &alloc),
+        ]);
+        let candidate_table = table([
+            borrowed_bigint("c", [2, 1, 2, 3], &alloc),
+            borrowed_varchar("d", ["The", "Space", "and", "Time"], &alloc),
+            borrowed_boolean("e", [true, true, false, true], &alloc),
+            borrowed_bigint("f", [0, 5, 6, 7], &alloc),
+        ]);
+        let source_table_ref = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref,
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref, candidate_table, 0);
+
+        // BigInt column
+        let plan = ShiftTestPlan {
+            column: ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
+            candidate_shifted_column: ColumnRef::new(
+                candidate_table_ref,
+                "c".into(),
+                ColumnType::BigInt,
+            ),
+            column_length: 3,
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        assert!(verifiable_res.verify(&plan, &accessor, &()).is_err());
+
+        // Varchar column
+        let plan = ShiftTestPlan {
+            column: ColumnRef::new(source_table_ref, "b".into(), ColumnType::VarChar),
+            candidate_shifted_column: ColumnRef::new(
+                candidate_table_ref,
+                "d".into(),
+                ColumnType::VarChar,
+            ),
+            column_length: 3,
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        assert!(verifiable_res.verify(&plan, &accessor, &()).is_err());
+
+        // Boolean column
+        let plan = ShiftTestPlan {
+            column: ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+            candidate_shifted_column: ColumnRef::new(
+                candidate_table_ref,
+                "e".into(),
+                ColumnType::Boolean,
+            ),
+            column_length: 3,
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        assert!(verifiable_res.verify(&plan, &accessor, &()).is_err());
+
+        // Success case: The last pair of columns is correct even though the others are not
+        let plan = ShiftTestPlan {
+            column: ColumnRef::new(source_table_ref, "d".into(), ColumnType::BigInt),
+            candidate_shifted_column: ColumnRef::new(
+                candidate_table_ref,
+                "f".into(),
+                ColumnType::BigInt,
+            ),
+            column_length: 3,
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+    }
+
+    #[should_panic(expected = "Shifted column length mismatch")]
+    #[test]
+    fn we_cannot_do_shift_if_column_length_is_wrong() {
+        let alloc = Bump::new();
+        let source_table = table([borrowed_bigint("a", [101, 102, 103, 104, 105, 106], &alloc)]);
+        let candidate_table = table([borrowed_bigint(
+            "a",
+            [102, 101, 102, 103, 104, 105, 106, -102],
+            &alloc,
+        )]);
+        let source_table_ref = "sxt.source_table".parse().unwrap();
+        let candidate_table_ref = "sxt.candidate_table".parse().unwrap();
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref,
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref, candidate_table, 0);
+
+        // BigInt column
+        let plan = ShiftTestPlan {
+            column: ColumnRef::new(source_table_ref, "a".into(), ColumnType::BigInt),
+            candidate_shifted_column: ColumnRef::new(
+                candidate_table_ref,
+                "a".into(),
+                ColumnType::BigInt,
+            ),
+            column_length: 7,
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
@@ -34,6 +34,8 @@ impl ProverEvaluate for ShiftTestPlan {
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
     ) -> Table<'a, S> {
         builder.request_post_result_challenges(2);
+        builder.produce_one_evaluation_length(self.column_length);
+        builder.produce_one_evaluation_length(self.column_length + 1);
         // Evaluate the first round
         first_round_evaluate_shift(builder, self.column_length);
         // This is just a dummy table, the actual data is not used
@@ -113,8 +115,18 @@ impl ProofPlan for ShiftTestPlan {
         // Get the columns
         let column_eval = builder.try_consume_final_round_mle_evaluation()?;
         let candidate_shift_eval = builder.try_consume_final_round_mle_evaluation()?;
+        let chi_n_eval = builder.try_consume_one_evaluation()?;
+        let chi_n_plus_1_eval = builder.try_consume_one_evaluation()?;
         // Evaluate the verifier
-        verify_shift(builder, alpha, beta, column_eval, candidate_shift_eval)?;
+        verify_shift(
+            builder,
+            alpha,
+            beta,
+            column_eval,
+            candidate_shift_eval,
+            chi_n_eval,
+            chi_n_plus_1_eval,
+        )?;
         Ok(TableEvaluation::new(vec![], S::zero()))
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

This PR depends on #462.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
Shifting is necessary for uniqueness which is necessary to prove inner joins.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add shift gadget
- fix a typo in `VerificationBuilder::try_consume_rho_evaluation`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.