### PR TITLE
fix: add two error variants in `ProofSizeMismatch` and use them in `VerificationBuilder`

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -49,4 +49,10 @@ pub enum ProofSizeMismatch {
     /// This error occurs when the proof has too few sumcheck variables.
     #[snafu(display("Proof has too few sumcheck variables"))]
     TooFewSumcheckVariables,
+    /// This error occurs when a requested one length is not found.
+    #[snafu(display("Proof doesn't have requested one length"))]
+    OneLengthNotFound,
+    /// This error occurs when a requested rho length is not found.
+    #[snafu(display("Proof doesn't have requested rho length"))]
+    RhoLengthNotFound,
 }

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -78,7 +78,7 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
             .mle_evaluations
             .one_evaluations
             .get(&length)
-            .expect("One evaluation not found"))
+            .ok_or(ProofSizeMismatch::OneLengthNotFound)?)
     }
 
     /// Consume the evaluation of a rho evaluation
@@ -97,7 +97,7 @@ impl<'a, S: Scalar> VerificationBuilder<'a, S> {
             .mle_evaluations
             .rho_evaluations
             .get(&length)
-            .expect("Rho evaluation not found"))
+            .ok_or(ProofSizeMismatch::RhoLengthNotFound)?)
     }
 
     pub fn generator_offset(&self) -> usize {


### PR DESCRIPTION

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
These changes are beneficial since we shouldn't panic in `VerificationBuilder`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See title.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests do pass.