### PR TITLE
refactor: move examples out of check script, create scripts for testing and examples

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -146,7 +146,6 @@ jobs:
         - name: Run posql_db example (Without Blitzar)
           run: bash crates/proof-of-sql/examples/posql_db/run_example.sh --no-default-features --features="rayon"
 
-
   clippy:
     name: Clippy
     runs-on: large-8-core-32gb-22-04

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -120,22 +120,33 @@ jobs:
         run: |
             cargo test proof_primitive::dory::dory_compute_commitments_test --no-default-features --features="std" && \
             cargo test proof_primitive::dory::dynamic_dory_compute_commitments_test --no-default-features --features="std"
-      - name: Run hello_world example (With Blitzar)
-        run: cargo run --example hello_world --features="test"
-      - name: Run hello_world example (Without Blitzar and With Rayon)
-        run: cargo run --example hello_world --no-default-features --features="rayon test"
-      - name: Run hello_world example (Without Blitzar and Without Rayon)
-        run: cargo run --example hello_world --no-default-features --features="test"
-      - name: Run space example
-        run: cargo run --example space
-      - name: Run dog breeds example
-        run: cargo run --example dog_breeds
-      - name: Run wood types example
-        run: cargo run --example wood_types
-      - name: Run posql_db example (With Blitzar)
-        run: bash crates/proof-of-sql/examples/posql_db/run_example.sh
-      - name: Run posql_db example (Without Blitzar)
-        run: bash crates/proof-of-sql/examples/posql_db/run_example.sh --no-default-features --features="rayon"
+
+  examples:
+      name: Run Examples (Heavy)
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout sources
+          uses: actions/checkout@v3
+        - name: Install stable toolchain
+          run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+        - name: Run hello_world example (With Blitzar)
+          run: cargo run --example hello_world --features="test"
+        - name: Run hello_world example (Without Blitzar and With Rayon)
+          run: cargo run --example hello_world --no-default-features --features="rayon test"
+        - name: Run hello_world example (Without Blitzar and Without Rayon)
+          run: cargo run --example hello_world --no-default-features --features="test"
+        - name: Run space example
+          run: cargo run --example space
+        - name: Run dog breeds example
+          run: cargo run --example dog_breeds
+        - name: Run wood types example
+          run: cargo run --example wood_types
+        - name: Run posql_db example (With Blitzar)
+          run: bash crates/proof-of-sql/examples/posql_db/run_example.sh
+        - name: Run posql_db example (Without Blitzar)
+          run: bash crates/proof-of-sql/examples/posql_db/run_example.sh --no-default-features --features="rayon"
+
+
   clippy:
     name: Clippy
     runs-on: large-8-core-32gb-22-04

--- a/scripts/run_ci_checks.sh
+++ b/scripts/run_ci_checks.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status
-set -e
-
 # Display a help text
-[ "$1" = "-h" -o "$1" = "--help" ] && echo "Runs all CI checks (excluding tests, udeps, and the 'examples' job)." && exit
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  echo "Runs all CI checks (excluding tests, udeps, and the 'examples' job)."
+  echo "Does NOT run toolchain install/update commands."
+fi
 
 # The path to the YAML file that defines the CI workflows
 YAML_FILE=".github/workflows/lint-and-test.yml"
@@ -20,20 +20,18 @@ while [[ ! -f "$current_dir/sxt-proof-of-sql/.github/workflows/lint-and-test.yml
   # If we reach the root directory (i.e., /), stop to prevent an infinite loop
   if [[ "$current_dir" == "/" ]]; then
     echo "Could not find file."
-    exit 1
   fi
 done
 
 # Check if the YAML file exists
 if [ ! -f "$YAML_FILE" ]; then
     echo "YAML file $YAML_FILE does not exist."
-    exit 1
 fi
 
-# 1) Remove the entire `examples:` job section from the file
-# 2) Extract lines that contain 'cargo' commands
-# 3) Exclude lines with '--ignored', 'test', 'rustup', or 'udeps'
-# 4) Strip off the 'run:' prefix
+# 1) Remove the entire `examples:` job section from the file.
+# 2) Extract lines that contain 'cargo' commands.
+# 3) Exclude lines with '--ignored', 'test', 'rustup', or 'udeps'.
+# 4) Strip off the 'run:' prefix.
 cargo_commands=$(
   sed '/^\s*examples:/,/^[^[:space:]]/d' "$YAML_FILE" \
     | grep -E '^\s*run:.*cargo' \
@@ -46,11 +44,10 @@ cargo_commands=$(
 
 if [ -z "$cargo_commands" ]; then
     echo "No cargo commands found (other than tests, udeps, or in the 'examples' job)."
-    exit 1
 fi
 
 # Run each cargo command
-echo "Extracted cargo commands (excluding tests, udeps, and the 'examples' job):"
+echo "Extracted cargo commands (excluding tests, udeps, 'examples' job, and toolchain installs):"
 echo "$cargo_commands"
 echo "========================="
 

--- a/scripts/run_ci_checks.sh
+++ b/scripts/run_ci_checks.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Display a help text
-[ "$1" = "-h" -o "$1" = "--help" ] && echo "Runs all CI checks (excluding tests and udeps)." && exit
+[ "$1" = "-h" -o "$1" = "--help" ] && echo "Runs all CI checks (excluding tests, udeps, and the 'examples' job)." && exit
 
 # The path to the YAML file that defines the CI workflows
 YAML_FILE=".github/workflows/lint-and-test.yml"
@@ -30,21 +30,30 @@ if [ ! -f "$YAML_FILE" ]; then
     exit 1
 fi
 
-# Extract all lines that contain 'cargo' commands from the YAML file, 
-# excluding ones with '--ignored', 'test', 'rustup', or 'udeps'
-cargo_commands=$(grep -E '^\s*run:.*cargo' "$YAML_FILE" | grep -v -- '--ignored' | grep -v 'test' | grep -v 'rustup' | grep -v 'udeps' | sed -E 's/^\s*run:\s*//')
+# 1) Remove the entire `examples:` job section from the file
+# 2) Extract lines that contain 'cargo' commands
+# 3) Exclude lines with '--ignored', 'test', 'rustup', or 'udeps'
+# 4) Strip off the 'run:' prefix
+cargo_commands=$(
+  sed '/^\s*examples:/,/^[^[:space:]]/d' "$YAML_FILE" \
+    | grep -E '^\s*run:.*cargo' \
+    | grep -v -- '--ignored' \
+    | grep -v 'test' \
+    | grep -v 'rustup' \
+    | grep -v 'udeps' \
+    | sed -E 's/^\s*run:\s*//'
+)
 
 if [ -z "$cargo_commands" ]; then
-    echo "No cargo commands (other than tests) found in the YAML file."
+    echo "No cargo commands found (other than tests, udeps, or in the 'examples' job)."
     exit 1
 fi
 
-# Run each cargo command, ignoring tests which should be handled separately
-echo "Extracted cargo commands (excluding test commands, --ignored tests, and udeps):"
+# Run each cargo command
+echo "Extracted cargo commands (excluding tests, udeps, and the 'examples' job):"
 echo "$cargo_commands"
 echo "========================="
 
-# Execute the commands
 failed_tests=0
 while IFS= read -r cmd; do
     echo "Running command: $cmd"
@@ -57,7 +66,7 @@ done <<< "$cargo_commands"
 
 # Print the results
 if [ "$failed_tests" -gt 0 ]; then
-    echo "Error: $failed_tests CI checks (excluding tests and udeps) have FAILED."
+    echo "Error: $failed_tests CI checks have FAILED (excluding tests, udeps, and 'examples' job)."
 else
-    echo "All CI checks (excluding tests and udeps) have completed successfully."
+    echo "All CI checks (excluding tests, udeps, and 'examples' job) completed successfully."
 fi

--- a/scripts/run_ci_checks.sh
+++ b/scripts/run_ci_checks.sh
@@ -3,7 +3,6 @@
 # Display a help text
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
   echo "Runs all CI checks (excluding tests, udeps, and the 'examples' job)."
-  echo "Does NOT run toolchain install/update commands."
 fi
 
 # The path to the YAML file that defines the CI workflows

--- a/scripts/run_posql_examples.sh
+++ b/scripts/run_posql_examples.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Optional help text
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  echo "Runs only the cargo commands within the 'examples:' job in lint-and-test.yml,"
+  echo "without stopping the shell on errors. Prints a summary of any failures."
+
+fi
+
+# Location of GitHub Actions workflow file
+YAML_FILE=".github/workflows/lint-and-test.yml"
+
+# Ensure the file exists
+if [ ! -f "$YAML_FILE" ]; then
+  echo "Error: $YAML_FILE not found."
+  echo "Please run this script from the repository root or update YAML_FILE accordingly."
+  echo "Exiting with status 0, no commands executed."
+
+fi
+
+################################################################################
+# 1) Extract only the lines from 'examples:' up until the next top-level job
+#
+#    - We look for lines starting with exactly two spaces, then 'examples:',
+#      and capture everything until the next line that also starts with two
+#      spaces and ends with a colon (i.e., '  coverage:', '  clippy:', etc.).
+#
+# 2) Then find lines containing `cargo` commands and strip off 'run:'.
+################################################################################
+cargo_commands=$(
+  sed -n -E '/^  examples:/,/^  [A-Za-z0-9_]+:/p' "$YAML_FILE" \
+    | grep -E '^\s*run:.*cargo' \
+    | sed -E 's/^\s*run:\s*//'
+)
+
+# If we didn't find any commands, no big deal—just exit quietly.
+if [ -z "$cargo_commands" ]; then
+  echo "No cargo commands were found in the 'examples:' job block."
+  echo "Nothing to run."
+
+fi
+
+echo "Commands extracted from the 'examples:' job:"
+echo "--------------------------------------------"
+echo "$cargo_commands"
+echo "--------------------------------------------"
+echo
+
+################################################################################
+# 3) Run each command, but do NOT use exit codes. We'll collect failures
+#    and report at the end.
+################################################################################
+total=0
+failed=0
+
+while IFS= read -r cmd; do
+  total=$((total + 1))
+  echo "[$total] Running: $cmd"
+
+  if ! eval "$cmd"; then
+    echo "    -> Command FAILED (continuing)."
+    failed=$((failed + 1))
+  else
+    echo "    -> Command succeeded."
+  fi
+
+  echo
+done <<< "$cargo_commands"
+
+################################################################################
+# 4) Print a summary of how many commands failed. Always exit 0 to avoid
+#    crashing the shell or signaling an error code.
+################################################################################
+echo "Summary of examples job:"
+echo "  Total commands: $total"
+echo "  Failed commands: $failed"
+if [ "$failed" -gt 0 ]; then
+  echo "Some commands failed, but we are NOT exiting with a non-zero status."
+else
+  echo "All commands completed successfully!"
+fi

--- a/scripts/run_posql_examples.sh
+++ b/scripts/run_posql_examples.sh
@@ -2,9 +2,7 @@
 
 # Optional help text
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
-  echo "Runs only the cargo commands within the 'examples:' job in lint-and-test.yml,"
-  echo "without stopping the shell on errors. Prints a summary of any failures."
-
+  echo "Runs only the cargo commands within the 'examples:' job in lint-and-test.yml."
 fi
 
 # Location of GitHub Actions workflow file

--- a/scripts/run_test_jobs.sh
+++ b/scripts/run_test_jobs.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  echo "Runs only the 'test' job cargo commands from lint-and-test.yml, ignoring rustup lines."
+  echo "Does NOT exit non-zero on failures, just prints a summary."
+fi
+
+YAML_FILE=".github/workflows/lint-and-test.yml"
+
+# Ensure the YAML file exists
+if [ ! -f "$YAML_FILE" ]; then
+  echo "Error: '$YAML_FILE' does not exist."
+  echo "No commands to run. Exiting."
+fi
+
+###############################################################################
+# 1) Extract lines between:
+#      ^  test:         (2 spaces + 'test:')
+#   and
+#      ^  [A-Za-z0-9_]+:   (2 spaces + something else + ':')
+#   This ensures we only capture lines up to the next job at the same indentation.
+#
+# 2) Within that block, look for lines containing `run: cargo ...`.
+# 3) Exclude any with 'rustup'.
+# 4) Strip off 'run:' prefix.
+###############################################################################
+cargo_commands=$(
+  sed -n '/^  test:/,/^  [A-Za-z0-9_]\+:/p' "$YAML_FILE" \
+    | grep -E '^\s*run:.*cargo' \
+    | grep -v 'rustup' \
+    | sed -E 's/^\s*run:\s*//'
+)
+
+if [ -z "$cargo_commands" ]; then
+  echo "No cargo commands found in the 'test' job."
+  exit 0
+fi
+
+echo "Extracted cargo commands from the 'test:' job (skipping 'rustup'):"
+echo "------------------------------------------------------------------"
+echo "$cargo_commands"
+echo "------------------------------------------------------------------"
+echo
+
+###############################################################################
+# 2) Run each command, counting failures but NOT exiting on them.
+###############################################################################
+count=0
+failed=0
+
+while IFS= read -r cmd; do
+  count=$((count + 1))
+  echo "[$count] Running command: $cmd"
+  
+  if ! eval "$cmd"; then
+    echo "    -> Command FAILED (continuing)."
+    failed=$((failed + 1))
+  else
+    echo "    -> Command succeeded."
+  fi
+  echo
+done <<< "$cargo_commands"
+
+###############################################################################
+# 3) Print a summary. Always exit code 0 (no crash).
+###############################################################################
+echo "Summary of the 'test' job cargo commands:"
+echo "  Total commands: $count"
+echo "  Failed commands: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "Some commands failed, but we are NOT exiting with a non-zero code."
+else
+  echo "All commands in the 'test' job completed successfully!"
+fi
+
+

--- a/scripts/run_test_jobs.sh
+++ b/scripts/run_test_jobs.sh
@@ -2,7 +2,6 @@
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
   echo "Runs only the 'test' job cargo commands from lint-and-test.yml, ignoring rustup lines."
-  echo "Does NOT exit non-zero on failures, just prints a summary."
 fi
 
 YAML_FILE=".github/workflows/lint-and-test.yml"


### PR DESCRIPTION
# Rationale for this change

Currently, we have shell scripts to run the CI jobs locally before submitting commits to a PR, to ensure that remote CI jobs are successful with as few runs as possible. The current check job includes several computationally expensive examples that should not be included in in a check workflow. Making this refactor makes local CI simulation more reliable and reduces load of the remote CI runners.

# What changes are included in this PR?

- [x] moves examples into distinct block in lint-and-test yaml for CI jobs
- [x] creates testing and examples scripts for separating the local CI jobs

# Are these changes tested?
- [x] Test that check script correctly identifies all clippy lints in lint-and-release yaml
- [x] test that check script only runs checks
- [x] test that examples script only runs examples
- [x] test that test script only runs test 
