### PR TITLE
refactor!: use only serde to extend transcript in QueryProof

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -600,8 +600,8 @@ fn verify_fails_if_an_intermediate_commitment_doesnt_match() {
         (),
     );
     let (mut proof, result) = QueryProof::<InnerProductProof>::new(&expr, &accessor, &());
-    proof.final_round_commitments[0] =
-        proof.final_round_commitments[0] * Curve25519Scalar::from(2u64);
+    proof.final_round_message.round_commitments[0] =
+        proof.final_round_message.round_commitments[0] * Curve25519Scalar::from(2u64);
     assert!(proof.verify(&expr, &accessor, result, &()).is_err());
 }
 

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -43,13 +43,14 @@ pub fn exercise_verification(
     assert!(res_p.verify(expr, accessor, &()).is_err());
 
     // try changing MLE evaluations
-    for i in 0..proof.final_round_pcs_proof_evaluations.len() {
+    for i in 0..proof.pcs_proof_evaluations.final_round.len() {
         let mut res_p = res.clone();
         res_p
             .proof
             .as_mut()
             .unwrap()
-            .final_round_pcs_proof_evaluations[i] += Curve25519Scalar::one();
+            .pcs_proof_evaluations
+            .final_round[i] += Curve25519Scalar::one();
         assert!(res_p.verify(expr, accessor, &()).is_err());
     }
 
@@ -63,9 +64,14 @@ pub fn exercise_verification(
         &(),
     )[0];
 
-    for i in 0..proof.final_round_commitments.len() {
+    for i in 0..proof.final_round_message.round_commitments.len() {
         let mut res_p = res.clone();
-        res_p.proof.as_mut().unwrap().final_round_commitments[i] = commit_p;
+        res_p
+            .proof
+            .as_mut()
+            .unwrap()
+            .final_round_message
+            .round_commitments[i] = commit_p;
         assert!(res_p.verify(expr, accessor, &()).is_err());
     }
 
@@ -76,7 +82,8 @@ pub fn exercise_verification(
     // vector; hence, changing the offset would have no effect.
     if accessor.get_length(table_ref) > 1
         || proof
-            .final_round_commitments
+            .final_round_message
+            .round_commitments
             .iter()
             .any(|&c| c != Identity::identity())
     {


### PR DESCRIPTION
# Rationale for this change

The QueryProof creation currently has a lot of custom transcript handling that differs from the QueryProof's serialization format. While the transcript handling aligns with EVM verification, it requires custom serialization. This PR makes it so that the two are identical.

# What changes are included in this PR?

* The QueryProof is broken up into smaller parts, each of which is put onto the transcript in aggregate. This simplifies the code.
* Each message uses serde to serialize the message and put it on the transcript. The underlying transcript dictates the actual serialization format.

# Are these changes tested?
They are tested by existing tests. Future PRs will have tests showing EVM compatibility.
