### PR TITLE
chore!: give MontScalar and Keccak256Transcript EVM friendly serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ ark-std = { version = "0.5.0", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
 arrow = { version = "51.0.0" }
 arrow-csv = { version = "51.0.0" }
+bincode = { version = "1.3.3" }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3", default-features = false }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -24,6 +24,7 @@ ark-poly = { workspace = true }
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 arrow = { workspace = true, optional = true }
+bincode = { workspace = true }
 bit-iter = { workspace = true }
 bigdecimal = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -1,5 +1,6 @@
 use crate::base::scalar::Scalar;
 use alloc::vec::Vec;
+use bincode::Options;
 use zerocopy::{AsBytes, FromBytes};
 
 /// A public-coin transcript.
@@ -42,7 +43,12 @@ pub trait Transcript {
     /// # Panics
     /// - Panics if `postcard::to_allocvec(message)` fails to serialize the message.
     fn extend_serialize_as_le(&mut self, message: &(impl serde::Serialize + ?Sized)) {
-        self.extend_as_le_from_refs([postcard::to_allocvec(message).unwrap().as_slice()]);
+        self.extend_as_le_from_refs([bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .with_big_endian()
+            .serialize(message)
+            .unwrap()
+            .as_slice()]);
     }
     /// Appends a type that implements [`ark_serialize::CanonicalSerialize`] by appending the raw bytes (i.e. assuming the message is littleendian)
     ///

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -309,18 +309,16 @@ impl<T: MontConfig<4>> num_traits::Inv for MontScalar<T> {
 }
 impl<T: MontConfig<4>> Serialize for MontScalar<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut bytes = Vec::with_capacity(self.0.compressed_size());
-        self.0
-            .serialize_compressed(&mut bytes)
-            .map_err(serde::ser::Error::custom)?;
-        bytes.serialize(serializer)
+        let mut limbs: [u64; 4] = self.into();
+        limbs.reverse();
+        limbs.serialize(serializer)
     }
 }
 impl<'de, T: MontConfig<4>> Deserialize<'de> for MontScalar<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        CanonicalDeserialize::deserialize_compressed(Vec::deserialize(deserializer)?.as_slice())
-            .map_err(serde::de::Error::custom)
-            .map(Self)
+        let mut limbs: [u64; 4] = Deserialize::deserialize(deserializer)?;
+        limbs.reverse();
+        Ok(limbs.into())
     }
 }
 


### PR DESCRIPTION
# Rationale for this change

The EVM requires big-endian serialization. This PR aligns with this, while keeping this transparent for the Rust code.

# What changes are included in this PR?

* MontScalar limbs are reversed before serialization. This ensures that the Scalar is encoded in big endian form when using an appropriate serializer (Other Scalar implementations do not need to do this.)
* `bincode` (with big-endian, fixint) is used instead of postcard in the `Keccak256Transcript`.

# Are these changes tested?
By existing test. Other PRs will eventually demonstrate EVM compatibility.
