### PR TITLE
fix: type conversion in expression aggregation

### DIFF
--- a/crates/proof-of-sql-parser/src/utility.rs
+++ b/crates/proof-of-sql-parser/src/utility.rs
@@ -285,11 +285,10 @@ pub fn count_res(expr: Box<Expression>, alias: &str) -> SelectResultExpr {
 #[must_use]
 pub fn count_all_res(alias: &str) -> SelectResultExpr {
     SelectResultExpr::AliasedResultExpr(AliasedResultExpr {
-        expr: Expression::Aggregation {
+        expr: Box::new(Expression::Aggregation {
             op: AggregationOperator::Count,
             expr: Box::new(Expression::Wildcard),
-        }
-        .into(),
+        }),
         alias: alias.parse().unwrap(),
     })
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

The original code uses a .into() call after the Expression::Aggregation { ... }. However, the expr field type in AliasedResultExpr expects Box<Expression>, and the additional conversion via .into() may be redundant. The correct way is to directly create the Box<Expression> without using .into().
