### PR TITLE
feat: add `SortMergeJoinExec`

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -431,6 +431,7 @@ where
     const ONE: Self = Self(Fp::ONE);
     const TWO: Self = Self(Fp::new(ark_ff::BigInt([2, 0, 0, 0])));
     const TEN: Self = Self(Fp::new(ark_ff::BigInt([10, 0, 0, 0])));
+    const TWO_POW_64: Self = Self(Fp::new(ark_ff::BigInt([0, 1, 0, 0])));
     const CHALLENGE_MASK: U256 = {
         assert!(
             T::MODULUS.0[3].leading_zeros() < 64,

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -76,6 +76,8 @@ pub trait Scalar:
     const TWO: Self;
     /// 2 + 2 + 2 + 2 + 2
     const TEN: Self;
+    /// 2^64
+    const TWO_POW_64: Self;
     /// The value to mask the challenge with to ensure it is in the field.
     /// This one less than the largest power of 2 that is less than the field modulus.
     const CHALLENGE_MASK: U256;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -38,7 +38,6 @@ pub(crate) fn first_round_evaluate_membership_check<'a, S: Scalar>(
     );
     let multiplicities = get_multiplicities::<S>(candidate_subset, columns, alloc);
     builder.produce_intermediate_mle(multiplicities as &[_]);
-    builder.request_post_result_challenges(2);
     multiplicities
 }
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -67,6 +67,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
             &source_columns,
             &candidate_columns,
         );
+        builder.request_post_result_challenges(2);
         table([(Ident::new("multiplicities"), Column::Int128(multiplicities))])
     }
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -2,8 +2,7 @@
 mod membership_check;
 mod monotonic;
 mod shift;
-#[allow(unused_imports, dead_code)]
-use membership_check::{
+pub(crate) use membership_check::{
     final_round_evaluate_membership_check, first_round_evaluate_membership_check,
     verify_membership_check,
 };
@@ -21,7 +20,8 @@ mod range_check;
 mod range_check_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod sign_expr_test;
-#[allow(unused_imports, dead_code)]
-use monotonic::{final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic};
+pub(crate) use monotonic::{
+    final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic,
+};
 #[cfg(test)]
 mod monotonic_test;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -44,13 +44,17 @@ pub(crate) fn final_round_evaluate_monotonic<'a, S: Scalar, const STRICT: bool, 
     // 1. Prove that `shifted_column` is a shift of `column`
     final_round_evaluate_shift(builder, alloc, alpha, beta, column, shifted_column);
     // 2. Construct an indicator `diff = column - shifted_column`
-    let diff = alloc.alloc_slice_fill_with(num_rows + 1, |i| {
-        if i == num_rows {
-            -column[num_rows - 1]
-        } else {
-            column[i] - shifted_column[i]
-        }
-    });
+    let diff = if num_rows >= 1 {
+        alloc.alloc_slice_fill_with(num_rows + 1, |i| {
+            if i == num_rows {
+                -column[num_rows - 1]
+            } else {
+                column[i] - shifted_column[i]
+            }
+        })
+    } else {
+        alloc.alloc_slice_fill_copy(1, S::ZERO)
+    };
     // Since sign expr which we uses for the sign proof only distinguishes between nonnegative
     // and negative integers we need to transform the indicator to be either ind < 0 or ind >= 0
     //

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -1,4 +1,7 @@
-use super::{EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, TableExec, UnionExec};
+use super::{
+    EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, SortMergeJoinExec, TableExec,
+    UnionExec,
+};
 use crate::{
     base::{
         database::{ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableRef},
@@ -57,4 +60,10 @@ pub enum DynProofPlan {
     ///     <ProofPlan>
     /// ```
     Union(UnionExec),
+    /// `ProofPlan` for queries of the form
+    /// ```ignore
+    ///     <ProofPlan> INNER JOIN <ProofPlan>
+    ///     ON col1 = col2
+    /// ```
+    SortMergeJoin(SortMergeJoinExec),
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/mod.rs
@@ -45,6 +45,11 @@ pub(crate) use union_exec::UnionExec;
 #[cfg(all(test, feature = "blitzar"))]
 mod union_exec_test;
 
+mod sort_merge_join_exec;
+pub(crate) use sort_merge_join_exec::SortMergeJoinExec;
+#[cfg(all(test, feature = "blitzar"))]
+mod sort_merge_join_exec_test;
+
 mod dyn_proof_plan;
 pub use dyn_proof_plan::DynProofPlan;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -1,0 +1,592 @@
+use super::DynProofPlan;
+use crate::{
+    base::{
+        database::{
+            join_util::{
+                apply_sort_merge_join_indexes, get_columns_of_table, get_sort_merge_join_indexes,
+                ordered_set_union,
+            },
+            slice_operation::apply_slice_to_indexes,
+            ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+        },
+        map::{IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
+            SumcheckSubpolynomialType, VerificationBuilder,
+        },
+        proof_gadgets::{
+            final_round_evaluate_membership_check, final_round_evaluate_monotonic,
+            first_round_evaluate_membership_check, first_round_evaluate_monotonic,
+            verify_membership_check, verify_monotonic,
+        },
+    },
+};
+use alloc::{boxed::Box, vec, vec::Vec};
+use bumpalo::{
+    collections::{CollectIn, Vec as BumpVec},
+    Bump,
+};
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// `ProofPlan` for queries of the form
+/// ```ignore
+///     <ProofPlan> INNER JOIN <ProofPlan>
+///     ON col1 = col2
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SortMergeJoinExec {
+    pub(super) left: Box<DynProofPlan>,
+    pub(super) right: Box<DynProofPlan>,
+    pub(super) left_join_column_indexes: Vec<usize>,
+    pub(super) right_join_column_indexes: Vec<usize>,
+    pub(super) result_idents: Vec<Ident>,
+}
+
+impl SortMergeJoinExec {
+    /// Create a new `SortMergeJoinExec` with the given left and right plans
+    ///
+    /// # Panics
+    /// Panics if one of the following conditions is met:
+    /// - The join column index is out of bounds
+    /// - The number of join columns is different
+    /// - The number of result idents is different from the expected number of columns
+    pub fn new(
+        left: Box<DynProofPlan>,
+        right: Box<DynProofPlan>,
+        left_join_column_indexes: Vec<usize>,
+        right_join_column_indexes: Vec<usize>,
+        result_idents: Vec<Ident>,
+    ) -> Self {
+        let num_columns_left = left.get_column_result_fields().len();
+        let num_columns_right = right.get_column_result_fields().len();
+        let max_left_join_column_index = left_join_column_indexes.iter().max().unwrap_or(&0);
+        let max_right_join_column_index = right_join_column_indexes.iter().max().unwrap_or(&0);
+        if *max_left_join_column_index >= num_columns_left
+            || *max_right_join_column_index >= num_columns_right
+        {
+            panic!("Join column index out of bounds");
+        }
+        let num_join_columns = left_join_column_indexes.len();
+        assert!(
+            (num_join_columns == right_join_column_indexes.len()),
+            "Join columns should have the same number of columns"
+        );
+        assert!(
+            (result_idents.len() == num_columns_left + num_columns_right - num_join_columns),
+            "The amount of result idents should be the same as the expected number of columns"
+        );
+        Self {
+            left,
+            right,
+            left_join_column_indexes,
+            right_join_column_indexes,
+            result_idents,
+        }
+    }
+}
+
+impl ProofPlan for SortMergeJoinExec
+where
+    SortMergeJoinExec: ProverEvaluate,
+{
+    #[allow(clippy::too_many_lines, clippy::similar_names)]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        // 1. columns
+        // TODO: Make sure `GroupByExec` as self.input is supported
+        let left_eval = self
+            .left
+            .verifier_evaluate(builder, accessor, None, one_eval_map)?;
+        let right_eval = self
+            .right
+            .verifier_evaluate(builder, accessor, None, one_eval_map)?;
+        // 2. One evals and rho evals
+        let left_one_eval = left_eval.one_eval();
+        let right_one_eval = right_eval.one_eval();
+        let res_one_eval = builder.try_consume_one_evaluation()?;
+        let u_one_eval = builder.try_consume_one_evaluation()?;
+        let left_rho_eval = builder.try_consume_rho_evaluation()?;
+        let right_rho_eval = builder.try_consume_rho_evaluation()?;
+        // 3. alpha, beta
+        let alpha = builder.try_consume_post_result_challenge()?;
+        let beta = builder.try_consume_post_result_challenge()?;
+        // 4. column evals
+        let left_column_evals = left_eval.column_evals();
+        let right_column_evals = right_eval.column_evals();
+        let num_columns_left = left_column_evals.len();
+        let num_columns_right = right_column_evals.len();
+        let enhanced_left_column_evals = left_column_evals
+            .iter()
+            .chain(core::iter::once(&left_rho_eval))
+            .copied()
+            .collect::<Vec<_>>();
+        let enhanced_right_column_evals = right_column_evals
+            .iter()
+            .chain(core::iter::once(&right_rho_eval))
+            .copied()
+            .collect::<Vec<_>>();
+        let num_columns_u = self.left_join_column_indexes.len();
+        if num_columns_u != 1 {
+            return Err(ProofError::VerificationError {
+                error: "Join on multiple columns not supported yet",
+            });
+        }
+        let num_columns_enhanced_res = num_columns_left + num_columns_right - num_columns_u + 2;
+        let enhanced_res_column_evals =
+            builder.try_consume_final_round_mle_evaluations(num_columns_enhanced_res)?;
+        // 5. First round MLE evaluations: `i` and `u`
+        //TODO: Make it possible for `u` to have multiple columns
+        let rho_bar_left_eval = enhanced_res_column_evals[num_columns_left];
+        let rho_bar_right_eval = enhanced_res_column_evals[num_columns_enhanced_res - 1];
+        let i_eval: S = itertools::repeat_n(S::TWO, 64_usize).product::<S>() * rho_bar_left_eval
+            + rho_bar_right_eval;
+        let u_column_eval = builder.try_consume_first_round_mle_evaluation()?;
+        // 6. Membership checks
+        let hat_left_column_indexes = self
+            .left_join_column_indexes
+            .iter()
+            .copied()
+            .chain((0..=num_columns_left).filter(|i| !self.left_join_column_indexes.contains(i)))
+            .collect::<Vec<_>>();
+        let hat_right_column_indexes = self
+            .right_join_column_indexes
+            .iter()
+            .copied()
+            .chain((0..=num_columns_right).filter(|i| !self.right_join_column_indexes.contains(i)))
+            .collect::<Vec<_>>();
+        let hat_left_column_evals =
+            apply_slice_to_indexes(&enhanced_left_column_evals, &hat_left_column_indexes)
+                .expect("Indexes can not be out of bounds");
+        let hat_right_column_evals =
+            apply_slice_to_indexes(&enhanced_right_column_evals, &hat_right_column_indexes)
+                .expect("Indexes can not be out of bounds");
+        let tilde_left_column_indexes = (0..=num_columns_left).collect::<Vec<_>>();
+        let tilde_right_column_indexes = (0..num_columns_u)
+            .chain(num_columns_left + 1..num_columns_enhanced_res)
+            .collect::<Vec<_>>();
+        let tilde_left_column_evals =
+            apply_slice_to_indexes(&enhanced_res_column_evals, &tilde_left_column_indexes)
+                .expect("Indexes can not be out of bounds");
+        let tilde_right_column_evals =
+            apply_slice_to_indexes(&enhanced_res_column_evals, &tilde_right_column_indexes)
+                .expect("Indexes can not be out of bounds");
+        verify_membership_check(
+            builder,
+            alpha,
+            beta,
+            left_one_eval,
+            res_one_eval,
+            &hat_left_column_evals,
+            &tilde_left_column_evals,
+        )?;
+        verify_membership_check(
+            builder,
+            alpha,
+            beta,
+            right_one_eval,
+            res_one_eval,
+            &hat_right_column_evals,
+            &tilde_right_column_evals,
+        )?;
+        let left_join_column_evals =
+            apply_slice_to_indexes(&enhanced_left_column_evals, &self.left_join_column_indexes)
+                .expect("Indexes can not be out of bounds");
+        let right_join_column_evals = apply_slice_to_indexes(
+            &enhanced_right_column_evals,
+            &self.right_join_column_indexes,
+        )
+        .expect("Indexes can not be out of bounds");
+        //TODO: Relax to allow multiple columns
+        if left_join_column_evals.len() != 1 || right_join_column_evals.len() != 1 {
+            return Err(ProofError::VerificationError {
+                error: "Left and right join columns should have exactly one column",
+            });
+        }
+        let w_l_eval = verify_membership_check(
+            builder,
+            alpha,
+            beta,
+            u_one_eval,
+            left_one_eval,
+            &[u_column_eval],
+            &left_join_column_evals,
+        )?;
+        let w_r_eval = verify_membership_check(
+            builder,
+            alpha,
+            beta,
+            u_one_eval,
+            right_one_eval,
+            &[u_column_eval],
+            &right_join_column_evals,
+        )?;
+        // 7. Monotonicity checks
+        verify_monotonic::<S, true, true>(builder, alpha, beta, i_eval, res_one_eval)?;
+        verify_monotonic::<S, true, true>(builder, alpha, beta, u_column_eval, u_one_eval)?;
+        // 8. Prove that sum w_l * w_r = chi_m
+        // sum w_l * w_r - chi_m = 0
+        builder.try_produce_sumcheck_subpolynomial_evaluation(
+            SumcheckSubpolynomialType::ZeroSum,
+            w_l_eval * w_r_eval - res_one_eval,
+            2,
+        )?;
+        // 9. Return the result
+        // Drop the two rho columns
+        let res_column_indexes = (0..num_columns_left)
+            .chain(num_columns_left + 1..num_columns_left + 1 + num_columns_right - num_columns_u)
+            .collect::<Vec<_>>();
+        let res_column_evals =
+            apply_slice_to_indexes(&enhanced_res_column_evals, &res_column_indexes)
+                .expect("Indexes can not be out of bounds");
+        Ok(TableEvaluation::new(res_column_evals, res_one_eval))
+    }
+
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        let left_other_column_indexes = (0..self.left.get_column_result_fields().len())
+            .filter(|i| !self.left_join_column_indexes.contains(i))
+            .collect::<Vec<_>>();
+        let right_other_column_indexes = (0..self.right.get_column_result_fields().len())
+            .filter(|i| !self.right_join_column_indexes.contains(i))
+            .collect::<Vec<_>>();
+        let left_join_column_fields = apply_slice_to_indexes(
+            &self.left.get_column_result_fields(),
+            &self.left_join_column_indexes,
+        )
+        .expect("Indexes can not be out of bounds");
+        let left_other_column_fields = apply_slice_to_indexes(
+            &self.left.get_column_result_fields(),
+            &left_other_column_indexes,
+        )
+        .expect("Indexes can not be out of bounds");
+        let right_other_column_fields = apply_slice_to_indexes(
+            &self.right.get_column_result_fields(),
+            &right_other_column_indexes,
+        )
+        .expect("Indexes can not be out of bounds");
+        let column_types = left_join_column_fields
+            .iter()
+            .chain(left_other_column_fields.iter())
+            .chain(right_other_column_fields.iter())
+            .map(ColumnField::data_type)
+            .collect::<Vec<_>>();
+        self.result_idents
+            .iter()
+            .zip_eq(column_types)
+            .map(|(ident, column_type)| ColumnField::new(ident.clone(), column_type))
+            .collect()
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        self.left
+            .get_column_references()
+            .into_iter()
+            .chain(self.right.get_column_references())
+            .collect()
+    }
+
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        self.left
+            .get_table_references()
+            .into_iter()
+            .chain(self.right.get_table_references())
+            .collect()
+    }
+}
+
+impl ProverEvaluate for SortMergeJoinExec {
+    #[tracing::instrument(
+        name = "SortMergeJoinExec::first_round_evaluate",
+        level = "debug",
+        skip_all
+    )]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        let left = self.left.first_round_evaluate(builder, alloc, table_map);
+        let right = self.right.first_round_evaluate(builder, alloc, table_map);
+        let num_rows_left = left.num_rows();
+        let num_rows_right = right.num_rows();
+        let num_columns_left = left.num_columns();
+        let num_columns_right = right.num_columns();
+        let enhanced_left = left.add_rho_column(alloc);
+        let enhanced_right = right.add_rho_column(alloc);
+        let left_on = get_columns_of_table(&enhanced_left, &self.left_join_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        let right_on = get_columns_of_table(&enhanced_right, &self.right_join_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        // 1. Conduct the join
+        let (left_row_indexes, right_row_indexes): (Vec<usize>, Vec<usize>) =
+            get_sort_merge_join_indexes(&left_on, &right_on, num_rows_left, num_rows_right)
+                .iter()
+                .copied()
+                .unzip();
+        let enhanced_res = apply_sort_merge_join_indexes(
+            &enhanced_left,
+            &enhanced_right,
+            &self.left_join_column_indexes,
+            &self.right_join_column_indexes,
+            &left_row_indexes,
+            &right_row_indexes,
+            alloc,
+        )
+        .expect("Can not do sort merge join");
+        let num_rows_res = left_row_indexes.len();
+        // 2. Get and commit the strictly increasing column, `u`
+        // ordered set union `u`
+        let u = ordered_set_union(&left_on, &right_on, alloc).unwrap();
+        let num_columns_u = u.len();
+        assert!(
+            (num_columns_u == 1),
+            "Join on multiple columns not supported yet"
+        );
+        let u_0 = u[0].to_scalar_with_scaling(0);
+        let num_rows_u = u[0].len();
+        let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
+        builder.produce_intermediate_mle(alloc_u_0 as &[_]);
+        // 3. One eval and rho eval
+        builder.produce_one_evaluation_length(num_rows_res);
+        builder.produce_one_evaluation_length(num_rows_u);
+        builder.produce_rho_evaluation_length(num_rows_left);
+        builder.produce_rho_evaluation_length(num_rows_right);
+        // 4. Membership checks
+        let hat_left_column_indexes = self
+            .left_join_column_indexes
+            .iter()
+            .copied()
+            .chain((0..=num_columns_left).filter(|i| !self.left_join_column_indexes.contains(i)))
+            .collect::<Vec<_>>();
+        let hat_right_column_indexes = self
+            .right_join_column_indexes
+            .iter()
+            .copied()
+            .chain((0..=num_columns_right).filter(|i| !self.right_join_column_indexes.contains(i)))
+            .collect::<Vec<_>>();
+        let hat_left_columns = get_columns_of_table(&enhanced_left, &hat_left_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        let hat_right_columns = get_columns_of_table(&enhanced_right, &hat_right_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        let tilde_left_columns = enhanced_res[0..=num_columns_left].to_vec();
+        let tilde_right_columns: Vec<_> = enhanced_res[0..num_columns_u]
+            .iter()
+            .chain(&enhanced_res[num_columns_left + 1..])
+            .copied()
+            .collect();
+        first_round_evaluate_membership_check(
+            builder,
+            alloc,
+            &hat_left_columns,
+            &tilde_left_columns,
+        );
+        first_round_evaluate_membership_check(
+            builder,
+            alloc,
+            &hat_right_columns,
+            &tilde_right_columns,
+        );
+        first_round_evaluate_membership_check(builder, alloc, &u, &left_on);
+        first_round_evaluate_membership_check(builder, alloc, &u, &right_on);
+        // 5. Monotonicity checks
+        first_round_evaluate_monotonic(builder, num_rows_res);
+        first_round_evaluate_monotonic(builder, num_rows_u);
+        // 6. Request post-result challenges
+        builder.request_post_result_challenges(2);
+        // 7. Return join result
+        // Drop the two rho columns
+        let res_column_indexes = (0..num_columns_left)
+            .chain(num_columns_left + 1..num_columns_left + 1 + num_columns_right - num_columns_u)
+            .collect::<Vec<_>>();
+        let res_columns = apply_slice_to_indexes(&enhanced_res, &res_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        let tab = Table::try_from_iter_with_options(
+            self.result_idents.iter().cloned().zip_eq(res_columns),
+            TableOptions::new(Some(num_rows_res)),
+        )
+        .expect("Can not create table");
+        tab
+    }
+
+    #[tracing::instrument(
+        name = "SortMergeJoinExec::final_round_evaluate",
+        level = "debug",
+        skip_all
+    )]
+    #[allow(unused_variables)]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        let left = self.left.final_round_evaluate(builder, alloc, table_map);
+        let right = self.right.final_round_evaluate(builder, alloc, table_map);
+        let num_rows_left = left.num_rows();
+        let num_rows_right = right.num_rows();
+        let num_columns_left = left.num_columns();
+        let num_columns_right = right.num_columns();
+
+        let left_ones = alloc.alloc_slice_fill_copy(num_rows_left, true);
+        let right_ones = alloc.alloc_slice_fill_copy(num_rows_right, true);
+
+        let enhanced_left = left.add_rho_column(alloc);
+        let enhanced_right = right.add_rho_column(alloc);
+
+        let left_on = get_columns_of_table(&enhanced_left, &self.left_join_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        let right_on = get_columns_of_table(&enhanced_right, &self.right_join_column_indexes)
+            .expect("Indexes can not be out of bounds");
+
+        // 1. Conduct the join
+        let (left_row_indexes, right_row_indexes): (Vec<usize>, Vec<usize>) =
+            get_sort_merge_join_indexes(&left_on, &right_on, num_rows_left, num_rows_right)
+                .iter()
+                .copied()
+                .unzip();
+
+        // Instead of storing the join result in a local `Vec`, we copy it into bump-allocated memory
+        // so it will outlive this scope (matching the `'a` lifetime) and avoid borrow issues.
+        let raw_enhanced_res = apply_sort_merge_join_indexes(
+            &enhanced_left,
+            &enhanced_right,
+            &self.left_join_column_indexes,
+            &self.right_join_column_indexes,
+            &left_row_indexes,
+            &right_row_indexes,
+            alloc,
+        )
+        .expect("Can not do sort merge join");
+        // Store in bump
+        let enhanced_res = alloc.alloc_slice_copy(raw_enhanced_res.as_slice());
+
+        let num_rows_res = left_row_indexes.len();
+        let res_ones = alloc.alloc_slice_fill_copy(num_rows_res, true);
+
+        // 2. Get the strictly increasing columns, `i` and `u`
+        // i = left_row_index * 2^64 + right_row_index
+        // which is strictly increasing
+        let i = left_row_indexes
+            .iter()
+            .zip_eq(right_row_indexes.iter())
+            .map(|(l, r)| S::from((*l as i128) << 64 | (*r as i128)))
+            .collect::<Vec<_>>();
+        let alloc_i = alloc.alloc_slice_copy(i.as_slice());
+
+        // ordered set union `u`
+        let u = ordered_set_union(&left_on, &right_on, alloc).unwrap();
+        let num_columns_u = u.len();
+        assert!(
+            (num_columns_u == 1),
+            "Join on multiple columns not supported yet"
+        );
+        let u_0 = u[0].to_scalar_with_scaling(0);
+        let num_rows_u = u[0].len();
+        let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
+        let u_ones = alloc.alloc_slice_fill_copy(num_rows_u, true);
+        let alloc_u_0 = alloc.alloc_slice_copy(u_0.as_slice());
+
+        // 3. Get post-result challenges
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+
+        // 4. Produce MLEs for `res`
+        // We can reference `enhanced_res` safely because it's bump-allocated.
+        let alloc_enhanced_res = enhanced_res.iter().collect_in::<BumpVec<_>>(alloc);
+        for column in &alloc_enhanced_res {
+            builder.produce_intermediate_mle(*column);
+        }
+
+        // 5. Membership checks
+        let hat_left_column_indexes = self
+            .left_join_column_indexes
+            .iter()
+            .copied()
+            .chain((0..=num_columns_left).filter(|i| !self.left_join_column_indexes.contains(i)))
+            .collect::<Vec<_>>();
+        let hat_right_column_indexes = self
+            .right_join_column_indexes
+            .iter()
+            .copied()
+            .chain((0..=num_columns_right).filter(|i| !self.right_join_column_indexes.contains(i)))
+            .collect::<Vec<_>>();
+
+        let hat_left_columns = get_columns_of_table(&enhanced_left, &hat_left_column_indexes)
+            .expect("Indexes can not be out of bounds");
+        let hat_right_columns = get_columns_of_table(&enhanced_right, &hat_right_column_indexes)
+            .expect("Indexes can not be out of bounds");
+
+        let tilde_left_columns = enhanced_res[0..=num_columns_left].to_vec();
+        let tilde_right_columns: Vec<_> = enhanced_res[0..num_columns_u] // rho col is right after left columns
+            .iter()
+            .chain(&enhanced_res[num_columns_left + 1..])
+            .copied()
+            .collect();
+
+        final_round_evaluate_membership_check(
+            builder,
+            alloc,
+            alpha,
+            beta,
+            left_ones,
+            res_ones,
+            &hat_left_columns,
+            &tilde_left_columns,
+        );
+        final_round_evaluate_membership_check(
+            builder,
+            alloc,
+            alpha,
+            beta,
+            right_ones,
+            res_ones,
+            &hat_right_columns,
+            &tilde_right_columns,
+        );
+        let w_l = final_round_evaluate_membership_check(
+            builder, alloc, alpha, beta, u_ones, left_ones, &u, &left_on,
+        );
+        let w_r = final_round_evaluate_membership_check(
+            builder, alloc, alpha, beta, u_ones, right_ones, &u, &right_on,
+        );
+
+        // 6. Monotonicity checks
+        final_round_evaluate_monotonic::<S, true, true>(builder, alloc, alpha, beta, alloc_i);
+        final_round_evaluate_monotonic::<S, true, true>(builder, alloc, alpha, beta, alloc_u_0);
+
+        // 7. Prove that sum w_l * w_r = chi_m
+        // sum w_l * w_r - chi_m = 0
+        builder.produce_sumcheck_subpolynomial(
+            SumcheckSubpolynomialType::ZeroSum,
+            vec![
+                (S::one(), vec![Box::new(w_l as &[_]), Box::new(w_r as &[_])]),
+                (-S::one(), vec![Box::new(res_ones as &[_])]),
+            ],
+        );
+
+        // 8. Return join result
+        // Drop the two rho columns
+        let res_column_indexes = (0..num_columns_left)
+            .chain(num_columns_left + 1..num_columns_left + 1 + num_columns_right - num_columns_u)
+            .collect::<Vec<_>>();
+        let res_columns = apply_slice_to_indexes(enhanced_res, &res_column_indexes)
+            .expect("Indexes can not be out of bounds");
+
+        Table::try_from_iter_with_options(
+            self.result_idents.iter().cloned().zip_eq(res_columns),
+            TableOptions::new(Some(num_rows_res)),
+        )
+        .expect("Can not create table")
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -145,6 +145,7 @@ where
             });
         }
         let num_columns_res_hat = num_columns_left + num_columns_right - num_columns_u + 2;
+        // `\hat{J}` in the protocol
         let res_hat_column_evals =
             builder.try_consume_final_round_mle_evaluations(num_columns_res_hat)?;
         // 5. First round MLE evaluations: `i` and `U`

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -1,0 +1,258 @@
+use super::test_utility::*;
+use crate::{
+    base::database::{
+        owned_table_utility::*, table_utility::*, ColumnType, TableTestAccessor, TestAccessor,
+    },
+    sql::proof::{exercise_verification, VerifiableQueryResult},
+};
+use blitzar::proof::InnerProductProof;
+use bumpalo::Bump;
+use sqlparser::ast::Ident;
+
+#[test]
+fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let left = table([
+        borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
+        borrowed_varchar(
+            "name",
+            ["Chloe", "Margaret", "Prudence", "Lucy", "Pepper"],
+            &alloc,
+        ),
+    ]);
+    let table_left = "sxt.cats".parse().unwrap();
+    let right = table([
+        borrowed_bigint("id", [1_i64, 2, 98, 4, 1, 2, 7], &alloc),
+        borrowed_varchar(
+            "human",
+            ["Cassia", "Cassia", "Gretta", "Gretta", "Ian", "Ian", "Erik"],
+            &alloc,
+        ),
+    ]);
+    let table_right = "sxt.cat_details".parse().unwrap();
+    accessor.add_table(table_left, left, 0);
+    accessor.add_table(table_right, right, 0);
+    let ast = sort_merge_join(
+        table_exec(
+            table_left,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("name", ColumnType::VarChar),
+            ],
+        ),
+        table_exec(
+            table_right,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("human", ColumnType::VarChar),
+            ],
+        ),
+        vec![0],
+        vec![0],
+        vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, table_left);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("id", [1_i64, 1, 2, 2, 4]),
+        varchar("name", ["Chloe", "Chloe", "Margaret", "Margaret", "Lucy"]),
+        varchar("human", ["Cassia", "Ian", "Cassia", "Ian", "Gretta"]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let left = table([
+        borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
+        borrowed_varchar(
+            "name",
+            ["Chloe", "Margaret", "Prudence", "Lucy", "Pepper"],
+            &alloc,
+        ),
+    ]);
+    let table_left = "sxt.cats".parse().unwrap();
+    let right = table([
+        borrowed_bigint("id", [10_i64, 11, 12], &alloc),
+        borrowed_varchar("human", ["Rachel", "Rachel", "Megan"], &alloc),
+    ]);
+    let table_right = "sxt.cat_details".parse().unwrap();
+    accessor.add_table(table_left, left, 0);
+    accessor.add_table(table_right, right, 0);
+    let ast = sort_merge_join(
+        table_exec(
+            table_left,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("name", ColumnType::VarChar),
+            ],
+        ),
+        table_exec(
+            table_right,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("human", ColumnType::VarChar),
+            ],
+        ),
+        vec![0],
+        vec![0],
+        vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, table_left);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("id", [0_i64; 0]),
+        varchar("name", [""; 0]),
+        varchar("human", [""; 0]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[allow(clippy::too_many_lines)]
+#[test]
+fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_or_both_tables_have_no_rows(
+) {
+    // Left table has no rows but right table has rows
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let left = table([
+        borrowed_bigint("id", [0_i64; 0], &alloc),
+        borrowed_varchar("name", [""; 0], &alloc),
+    ]);
+    let table_left = "sxt.cats".parse().unwrap();
+    let right = table([
+        borrowed_bigint("id", [10_i64, 11, 12], &alloc),
+        borrowed_varchar("human", ["Rachel", "Rachel", "Megan"], &alloc),
+    ]);
+    let table_right = "sxt.cat_details".parse().unwrap();
+    accessor.add_table(table_left, left, 0);
+    accessor.add_table(table_right, right, 0);
+    let ast = sort_merge_join(
+        table_exec(
+            table_left,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("name", ColumnType::VarChar),
+            ],
+        ),
+        table_exec(
+            table_right,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("human", ColumnType::VarChar),
+            ],
+        ),
+        vec![0],
+        vec![0],
+        vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, table_right);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("id", [0_i64; 0]),
+        varchar("name", [""; 0]),
+        varchar("human", [""; 0]),
+    ]);
+    assert_eq!(res, expected_res);
+
+    // Right table has no rows but left table has rows
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let left = table([
+        borrowed_bigint("id", [1_i64, 2, 3, 4, 5], &alloc),
+        borrowed_varchar(
+            "name",
+            ["Chloe", "Margaret", "Prudence", "Lucy", "Pepper"],
+            &alloc,
+        ),
+    ]);
+    let table_left = "sxt.cats".parse().unwrap();
+    let right = table([
+        borrowed_bigint("id", [0_i64; 0], &alloc),
+        borrowed_varchar("human", [""; 0], &alloc),
+    ]);
+    let table_right = "sxt.cat_details".parse().unwrap();
+    accessor.add_table(table_left, left, 0);
+    accessor.add_table(table_right, right, 0);
+    let ast = sort_merge_join(
+        table_exec(
+            table_left,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("name", ColumnType::VarChar),
+            ],
+        ),
+        table_exec(
+            table_right,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("human", ColumnType::VarChar),
+            ],
+        ),
+        vec![0],
+        vec![0],
+        vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, table_left);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("id", [0_i64; 0]),
+        varchar("name", [""; 0]),
+        varchar("human", [""; 0]),
+    ]);
+    assert_eq!(res, expected_res);
+
+    // Both tables have no rows
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let left = table([
+        borrowed_bigint("id", [0_i64; 0], &alloc),
+        borrowed_varchar("name", [""; 0], &alloc),
+    ]);
+    let table_left = "sxt.cats".parse().unwrap();
+    let right = table([
+        borrowed_bigint("id", [0_i64; 0], &alloc),
+        borrowed_varchar("human", [""; 0], &alloc),
+    ]);
+    let table_right = "sxt.cat_details".parse().unwrap();
+    accessor.add_table(table_left, left, 0);
+    accessor.add_table(table_right, right, 0);
+    let ast = sort_merge_join(
+        table_exec(
+            table_left,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("name", ColumnType::VarChar),
+            ],
+        ),
+        table_exec(
+            table_right,
+            vec![
+                column_field("id", ColumnType::BigInt),
+                column_field("human", ColumnType::VarChar),
+            ],
+        ),
+        vec![0],
+        vec![0],
+        vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, table_left);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("id", [0_i64; 0]),
+        varchar("name", [""; 0]),
+        varchar("human", [""; 0]),
+    ]);
+    assert_eq!(res, expected_res);
+}

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -3,7 +3,10 @@ use crate::{
     base::database::{
         owned_table_utility::*, table_utility::*, ColumnType, TableTestAccessor, TestAccessor,
     },
-    sql::proof::{exercise_verification, VerifiableQueryResult},
+    sql::{
+        proof::{exercise_verification, VerifiableQueryResult},
+        proof_exprs::test_utility::*,
+    },
 };
 use blitzar::proof::InnerProductProof;
 use bumpalo::Bump;
@@ -60,6 +63,190 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
         bigint("id", [1_i64, 1, 2, 2, 4]),
         varchar("name", ["Chloe", "Chloe", "Margaret", "Margaret", "Lucy"]),
         varchar("human", ["Cassia", "Ian", "Cassia", "Ian", "Gretta"]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_merge_join() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let cats = table([
+        borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 29, 20, 21], &alloc),
+        borrowed_varchar(
+            "name",
+            [
+                "Chloe", "Margaret", "Prudence", "Lucy", "Pepper", "Rocky", "Whiskers", "Mittens",
+                "Felix",
+            ],
+            &alloc,
+        ),
+    ]);
+    let table_cats = "sxt.cats".parse().unwrap();
+    let cat_details = table([
+        borrowed_bigint("id", [1_i64, 2, 98, 4, 1, 2, 7, 5, 6], &alloc),
+        borrowed_varchar(
+            "human",
+            [
+                "Cassia", "Cassia", "Gretta", "Gretta", "Ian", "Ian", "Erik", "Gretta", "Gretta",
+            ],
+            &alloc,
+        ),
+    ]);
+    let table_cat_details = "sxt.cat_details".parse().unwrap();
+    accessor.add_table(table_cats, cats, 0);
+    accessor.add_table(table_cat_details, cat_details, 0);
+    let ast = slice_exec(
+        sort_merge_join(
+            filter(
+                cols_expr_plan(table_cats, &["id", "name"], &accessor),
+                tab(table_cats),
+                lte(column(table_cats, "id", &accessor), const_int128(20)),
+            ),
+            filter(
+                cols_expr_plan(table_cat_details, &["id", "human"], &accessor),
+                tab(table_cat_details),
+                not(equal(
+                    column(table_cat_details, "human", &accessor),
+                    const_varchar("Gretta"),
+                )),
+            ),
+            vec![0],
+            vec![0],
+            vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
+        ),
+        2,
+        Some(3),
+    );
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, table_cats);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("id", [2_i64, 2]),
+        varchar("name", ["Margaret", "Margaret"]),
+        varchar("human", ["Cassia", "Ian"]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_sort_merge_joins() {
+    let alloc = Bump::new();
+    let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
+    let cats = table([
+        borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 10, 29, 20, 21], &alloc),
+        borrowed_varchar(
+            "name",
+            [
+                "Chloe", "Margaret", "Prudence", "Lucy", "Pepper", "Rocky", "Nova", "Whiskers",
+                "Mittens", "Felix",
+            ],
+            &alloc,
+        ),
+    ]);
+    let table_cats = "sxt.cats".parse().unwrap();
+    let cat_human = table([
+        borrowed_bigint("id", [1_i64, 2, 98, 4, 10, 1, 2, 7, 5, 6], &alloc),
+        borrowed_varchar(
+            "human",
+            [
+                "Cassia", "Cassia", "Gretta", "Gretta", "Trevor", "Ian", "Ian", "Erik", "Gretta",
+                "Gretta",
+            ],
+            &alloc,
+        ),
+        borrowed_varchar(
+            "state",
+            ["TX", "TX", "NC", "NC", "CO", "NC", "NC", "ND", "NC", "NC"],
+            &alloc,
+        ),
+    ]);
+    let table_cat_human = "sxt.cat_human".parse().unwrap();
+    let cat_vet = table([
+        borrowed_bigint("id", [1_i64, 2, 3, 4, 5, 6, 9, 8, 10], &alloc),
+        borrowed_varchar(
+            "hospital",
+            [
+                "Mint Hill",
+                "Mint Hill",
+                "Brown Creek",
+                "Brown Creek",
+                "Brown Creek",
+                "Brown Creek",
+                "Clear Creek",
+                "Clear Creek",
+                "Rock Creek",
+            ],
+            &alloc,
+        ),
+    ]);
+    let table_cat_vet = "sxt.cat_vet".parse().unwrap();
+    accessor.add_table(table_cats, cats, 0);
+    accessor.add_table(table_cat_human, cat_human, 0);
+    accessor.add_table(table_cat_vet, cat_vet, 0);
+    let ast = sort_merge_join(
+        sort_merge_join(
+            filter(
+                cols_expr_plan(table_cats, &["id", "name"], &accessor),
+                tab(table_cats),
+                lte(column(table_cats, "id", &accessor), const_int128(20)),
+            ),
+            filter(
+                cols_expr_plan(table_cat_human, &["id", "human", "state"], &accessor),
+                tab(table_cat_human),
+                not(equal(
+                    column(table_cat_human, "human", &accessor),
+                    const_varchar("Gretta"),
+                )),
+            ),
+            vec![0],
+            vec![0],
+            vec![
+                Ident::new("id"),
+                Ident::new("name"),
+                Ident::new("human"),
+                Ident::new("state"),
+            ],
+        ),
+        filter(
+            cols_expr_plan(table_cat_vet, &["id", "hospital"], &accessor),
+            tab(table_cat_vet),
+            not(equal(
+                column(table_cat_vet, "hospital", &accessor),
+                const_varchar("Clear Creek"),
+            )),
+        ),
+        vec![0],
+        vec![0],
+        vec![
+            Ident::new("id"),
+            Ident::new("name"),
+            Ident::new("human"),
+            Ident::new("state"),
+            Ident::new("hospital"),
+        ],
+    );
+
+    let verifiable_res: VerifiableQueryResult<InnerProductProof> =
+        VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, table_cats);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        bigint("id", [1_i64, 1, 2, 2, 10]),
+        varchar("name", ["Chloe", "Chloe", "Margaret", "Margaret", "Nova"]),
+        varchar("human", ["Cassia", "Ian", "Cassia", "Ian", "Trevor"]),
+        varchar("state", ["TX", "NC", "TX", "NC", "CO"]),
+        varchar(
+            "hospital",
+            [
+                "Mint Hill",
+                "Mint Hill",
+                "Mint Hill",
+                "Mint Hill",
+                "Rock Creek",
+            ],
+        ),
     ]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -131,6 +131,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_sort_merge_joins() {
     let alloc = Bump::new();
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());

--- a/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/test_utility.rs
@@ -1,11 +1,12 @@
 use super::{
-    DynProofPlan, EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, TableExec,
-    UnionExec,
+    DynProofPlan, EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, SortMergeJoinExec,
+    TableExec, UnionExec,
 };
 use crate::{
     base::database::{ColumnField, ColumnType, TableRef},
     sql::proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
 };
+use sqlparser::ast::Ident;
 
 pub fn column_field(name: &str, column_type: ColumnType) -> ColumnField {
     ColumnField::new(name.into(), column_type)
@@ -56,4 +57,20 @@ pub fn slice_exec(input: DynProofPlan, skip: usize, fetch: Option<usize>) -> Dyn
 
 pub fn union_exec(inputs: Vec<DynProofPlan>, schema: Vec<ColumnField>) -> DynProofPlan {
     DynProofPlan::Union(UnionExec::new(inputs, schema))
+}
+
+pub fn sort_merge_join(
+    left: DynProofPlan,
+    right: DynProofPlan,
+    left_join_column_indexes: Vec<usize>,
+    right_join_column_indexes: Vec<usize>,
+    result_idents: Vec<Ident>,
+) -> DynProofPlan {
+    DynProofPlan::SortMergeJoin(SortMergeJoinExec::new(
+        Box::new(left),
+        Box::new(right),
+        left_join_column_indexes,
+        right_join_column_indexes,
+        result_idents,
+    ))
 }

--- a/docs/protocols/inner_join.tex
+++ b/docs/protocols/inner_join.tex
@@ -25,20 +25,30 @@
 \begin{document}
 \maketitle
 
-\noindent Let $L = (l_{ij})$, $R = (r_{ij})$. Let their index columns be $\rho_l$ and $\rho_r$ respectively. Let $\bar{L} = (L|\rho_l)$ and $\bar{R} = (R|\rho_r)$ be enhanced versions of $L$ and $R$ with the last column the index ones. Join $L$ and $R$ on the columns $L'$ and $R'$ which have column indexes $j_l = (l'_0,\cdots, l'_{k-1})$ and $j_r = (r'_0,\cdots, r'_{k-1})$ respectively. The remaining columns of $L$ and $R$ are $L''$ and $R''$ respectively. The inner join $J$ can be expressed as $J = (C|\breve{L}|\breve{R})$ where $C$ consists of the common join columns in the order of $j_l$, and $\breve{L}$ and $\breve{R}$ are the remaining columns of $J$ from $L$ and $R$ respectively.
-Let $\hat{L}$ be a column permutation of $(L|\rho_l)$ by having $C$ first and then other columns of the table, that is, $\hat{L} = (L'|L''|\rho_l)$. Similarly we have $\hat{R} = (R'|R''|\rho_r)$. Let $\bar{J}$ be the inner join of $\bar{L}$ and $\bar{R}$ on the columns $L'$ and $R'$. Hence $\bar{J}=(C|\breve{L}|\bar{\rho}_l|\breve{R}|\bar{\rho}_r)$. Let $\tilde{L}=(C|\breve{L}|\bar{\rho}_l)$ and $\tilde{R}=(C|\breve{R}|\bar{\rho}_r)$. To prove that $J$ is the inner join of $L$ and $R$ we need to prove the following:\\
+\noindent Let $L = (l_{ij})$, $R = (r_{ij})$ be two tables. Join $L$ and $R$ on the columns $C_\ell$ and $C_r$ which have column indexes $j_l = (l'_0,\cdots, l'_{k-1})$ and $j_r = (r'_0,\cdots, r'_{k-1})$ respectively. \\
+\noindent Let the prover-provided index columns of $L$ and $R$ be $i_\ell:=\rho_{[0, m_\ell)}$ and $i_r:=\rho_{[0, m_r)}$ respectively. Let $\hat{L} = (L|i_\ell)$ and $\hat{R} = (R|i_r)$ be versions of $L$ and $R$ with the last column the index ones.  The remaining columns of $L$ and $R$ are $A$ and $B$ respectively in their respective original ordering. The inner join $J$ can be expressed as $J = (\bar{C}|\bar{A}|\bar{B})$ where $\bar{C}$ consists of the common join columns in the order of $j_l$, and $\bar{A}$ and $\bar{B}$ are the remaining columns of $J$ from $L$ and $R$ respectively, that is, corresponding to columns of $A$ and $B$.\\
+\noindent Let $\tilde{L}$ be a column permutation of $\hat{L}$ by having $C$ first and then other columns of the table, that is, $\tilde{L} = (C_\ell|A|i_\ell)$. Similarly we have $\tilde{R} = (C_r|B|i_r)$. Let $\hat{J}$ be the inner join of $\hat{L}$ and $\hat{R}$ on the columns $C_\ell$ and $C_r$. Hence $\hat{J}=(\bar{C}|\bar{A}|\bar{i_\ell}|\bar{B}|\bar{i_r})$. Let $J_\ell=(\bar{C}|\bar{A}|\bar{i_l})$ and $J_r=(\bar{C}|\bar{B}|\bar{i_r})$. To prove that $J$ is the inner join of $L$ and $R$ we need to prove the following:\\
 
+\section{Summary}
+\begin{itemize}
+    \item Plan values: $j_\ell$, $j_r$ and number of columns in each of $L$ and $R$
+    \item Inputs: $L$, $R$, $w_\ell$, and $w_r$
+    \item Outputs: $J$ and $m$
+    \item Hints: $m_\ell$, $m_r$, $\bar{i_l}$, $\bar{i_r}$, $U$, $w_l$, $w_r$, and all the internal hints for the gadgets.
+\end{itemize}
+
+\section{Details}
 \textbf{1. Membership}
 \begin{enumerate}
-  \item[(a)] $\tilde{L}$ consists of copies of rows of $\hat{L}$ with multiplicity vector $v_l$.
-  \item[(b)] $\tilde{R}$ consists of copies of rows of $\hat{R}$ with multiplicity vector $v_r$.
+  \item[(a)] $J_\ell$ consists of copies of rows of $\tilde{L}$.
+  \item[(b)] $J_r$ consists of copies of rows of $\tilde{R}$.
 \end{enumerate}
 
 \noindent Note that with (a) and (b) the join conditions are validated. That is, every row of $J$ has to be a row in the inner join.\\
 
 \textbf{2. Uniqueness of rows of $J$}
 
-We can just focus on the row index columns $l_0$ and $r_0$ or, better yet, let $i = \bar{\rho}_l \cdot 2^{BITS} + \bar{\rho}_r$. We need to prove that $i$ is strictly increasing (or decreasing).\\
+We can just focus on the prover-provided index columns $i_\ell$ and $i_r$ or, better yet, let $i = \bar{i_\ell} \cdot 2^{BITS} + \bar{i_r}$. We need to prove that $i$ is strictly increasing (or decreasing).\\
 \noindent With (1) and (2), $J$ is a subset of the inner join. That is, if we can prove that the row count of $J$ matches that of the inner join, we will establish that it is exactly the inner join.\\
 
 \textbf{3. Row count}

--- a/docs/protocols/inner_join.tex
+++ b/docs/protocols/inner_join.tex
@@ -1,0 +1,57 @@
+\documentclass[11pt]{article}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage[margin=1in]{geometry}
+\usepackage{graphicx}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{hyperref}
+\usepackage{microtype}
+\usepackage{todonotes}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  citecolor=blue,
+  urlcolor=blue
+}
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt}
+
+\title{Inner Join}
+\author{Space and Time Inc}
+\date{January 2025}
+
+\begin{document}
+\maketitle
+
+\noindent Let $L = (l_{ij})$, $R = (r_{ij})$. Let their index columns be $\rho_l$ and $\rho_r$ respectively. Let $\bar{L} = (L|\rho_l)$ and $\bar{R} = (R|\rho_r)$ be enhanced versions of $L$ and $R$ with the last column the index ones. Join $L$ and $R$ on the columns $L'$ and $R'$ which have column indexes $j_l = (l'_0,\cdots, l'_{k-1})$ and $j_r = (r'_0,\cdots, r'_{k-1})$ respectively. The remaining columns of $L$ and $R$ are $L''$ and $R''$ respectively. The inner join $J$ can be expressed as $J = (C|\breve{L}|\breve{R})$ where $C$ consists of the common join columns in the order of $j_l$, and $\breve{L}$ and $\breve{R}$ are the remaining columns of $J$ from $L$ and $R$ respectively.
+Let $\hat{L}$ be a column permutation of $(L|\rho_l)$ by having $C$ first and then other columns of the table, that is, $\hat{L} = (L'|L''|\rho_l)$. Similarly we have $\hat{R} = (R'|R''|\rho_r)$. Let $\bar{J}$ be the inner join of $\bar{L}$ and $\bar{R}$ on the columns $L'$ and $R'$. Hence $\bar{J}=(C|\breve{L}|\bar{\rho}_l|\breve{R}|\bar{\rho}_r)$. Let $\tilde{L}=(C|\breve{L}|\bar{\rho}_l)$ and $\tilde{R}=(C|\breve{R}|\bar{\rho}_r)$. To prove that $J$ is the inner join of $L$ and $R$ we need to prove the following:\\
+
+\textbf{1. Membership}
+\begin{enumerate}
+  \item[(a)] $\tilde{L}$ consists of copies of rows of $\hat{L}$ with multiplicity vector $v_l$.
+  \item[(b)] $\tilde{R}$ consists of copies of rows of $\hat{R}$ with multiplicity vector $v_r$.
+\end{enumerate}
+
+\noindent Note that with (a) and (b) the join conditions are validated. That is, every row of $J$ has to be a row in the inner join.\\
+
+\textbf{2. Uniqueness of rows of $J$}
+
+We can just focus on the row index columns $l_0$ and $r_0$ or, better yet, let $i = \bar{\rho}_l \cdot 2^{BITS} + \bar{\rho}_r$. We need to prove that $i$ is strictly increasing (or decreasing).\\
+\noindent With (1) and (2), $J$ is a subset of the inner join. That is, if we can prove that the row count of $J$ matches that of the inner join, we will establish that it is exactly the inner join.\\
+
+\textbf{3. Row count}
+
+Let $U$ be the distinct set union of $L'$ and $R'$. We need to prove the following:\\
+\begin{enumerate}
+\item[(a)] $U$ is strictly increasing (or decreasing).
+\item[(b)] $L'$ consist of copies of rows of $U$ with multiplicity vector $w_l$.
+\item[(c)] $R'$ consist of copies of rows of $U$ with multiplicity vector $w_r$.
+\item[(d)] $w_l \cdot w_r \overset{\Sigma}{=} \chi_m$ with $m$ the number of rows the prover claims $J$ has.
+\end{enumerate}
+
+Thus, it is established that $J$ is the inner join of $L$ and $R$ on $L'$ and $R'$.\\
+
+\end{document}
+

--- a/docs/protocols/inner_join.tex
+++ b/docs/protocols/inner_join.tex
@@ -25,43 +25,42 @@
 \begin{document}
 \maketitle
 
-\noindent Let $L = (l_{ij})$, $R = (r_{ij})$ be two tables. Join $L$ and $R$ on the columns $C_\ell$ and $C_r$ which have column indexes $j_l = (l'_0,\cdots, l'_{k-1})$ and $j_r = (r'_0,\cdots, r'_{k-1})$ respectively. \\
-\noindent Let the prover-provided index columns of $L$ and $R$ be $i_\ell:=\rho_{[0, m_\ell)}$ and $i_r:=\rho_{[0, m_r)}$ respectively. Let $\hat{L} = (L|i_\ell)$ and $\hat{R} = (R|i_r)$ be versions of $L$ and $R$ with the last column the index ones.  The remaining columns of $L$ and $R$ are $A$ and $B$ respectively in their respective original ordering. The inner join $J$ can be expressed as $J = (\bar{C}|\bar{A}|\bar{B})$ where $\bar{C}$ consists of the common join columns in the order of $j_l$, and $\bar{A}$ and $\bar{B}$ are the remaining columns of $J$ from $L$ and $R$ respectively, that is, corresponding to columns of $A$ and $B$.\\
-\noindent Let $\tilde{L}$ be a column permutation of $\hat{L}$ by having $C$ first and then other columns of the table, that is, $\tilde{L} = (C_\ell|A|i_\ell)$. Similarly we have $\tilde{R} = (C_r|B|i_r)$. Let $\hat{J}$ be the inner join of $\hat{L}$ and $\hat{R}$ on the columns $C_\ell$ and $C_r$. Hence $\hat{J}=(\bar{C}|\bar{A}|\bar{i_\ell}|\bar{B}|\bar{i_r})$. Let $J_\ell=(\bar{C}|\bar{A}|\bar{i_l})$ and $J_r=(\bar{C}|\bar{B}|\bar{i_r})$. To prove that $J$ is the inner join of $L$ and $R$ we need to prove the following:\\
+\noindent Let $L = (\ell_{ij})$, $R = (r_{ij})$ be two tables. Join $L$ and $R$ on the columns $C_L$ and $C_R$ which have column indexes $j_L = (\ell'_0,\cdots, \ell'_{k-1})$ and $j_R = (r'_0,\cdots, r'_{k-1})$ respectively. \\
+\noindent Let the prover-provided index columns of $L$ and $R$ be $i_L:=\rho_{[0, m_L)}$ and $i_R:=\rho_{[0, m_R)}$ respectively. The remaining columns of $L$ and $R$ are $A$ and $B$ respectively in their respective original ordering. Let $\bar{C}$ consist of the common join columns in the order of $j_L$ (and $j_R$), and $\bar{A}$ and $\bar{B}$ be the remaining columns from $L$ and $R$ respectively, that is, corresponding to columns of $A$ and $B$.\\
+So, $L$ and $R$ are reorderings of $(C_L,A)$ and $(C_R,B)$.  To prove that $J = (\bar{C}|\bar{A}|\bar{B})$ is the inner join of $L$ and $R$ we need to prove the following:\\
 
 \section{Summary}
 \begin{itemize}
-    \item Plan values: $j_\ell$, $j_r$ and number of columns in each of $L$ and $R$
-    \item Inputs: $L$, $R$, $w_\ell$, and $w_r$
+    \item Plan values: $j_L$, $j_R$ and number of columns in each of $L$ and $R$
+    \item Inputs: $L$, $R$
     \item Outputs: $J$ and $m$
-    \item Hints: $m_\ell$, $m_r$, $\bar{i_l}$, $\bar{i_r}$, $U$, $w_l$, $w_r$, and all the internal hints for the gadgets.
+    \item Hints: $m_L$, $m_R$, $\bar{i}_L$, $\bar{i}_R$, $U$, $w_L$, $w_R$, and all the internal hints for the gadgets.
 \end{itemize}
 
 \section{Details}
 \textbf{1. Membership}
 \begin{enumerate}
-  \item[(a)] $J_\ell$ consists of copies of rows of $\tilde{L}$.
-  \item[(b)] $J_r$ consists of copies of rows of $\tilde{R}$.
+  \item[(a)] $(\bar{C}|\bar{A}|\bar{i}_L)$ consists of copies of rows of $(C_L|A|i_L)$.
+  \item[(b)] $(\bar{C}|\bar{B}|\bar{i}_R)$ consists of copies of rows of $(C_R|B|i_R)$.
 \end{enumerate}
 
 \noindent Note that with (a) and (b) the join conditions are validated. That is, every row of $J$ has to be a row in the inner join.\\
 
 \textbf{2. Uniqueness of rows of $J$}
 
-We can just focus on the prover-provided index columns $i_\ell$ and $i_r$ or, better yet, let $i = \bar{i_\ell} \cdot 2^{BITS} + \bar{i_r}$. We need to prove that $i$ is strictly increasing (or decreasing).\\
+We can just focus on the prover-provided index columns $\bar{i}_L$ and $\bar{i}_R$. We need to prove that $(\bar{i}_L, \bar{i}_R)$ is strictly increasing (or decreasing) to show that rows of $J$ are unique. Note that if $R$ can not have more than $2^{BITS}$ rows we can use $\bar{i} = \bar{i}_L \cdot 2^{BITS} + \bar{i}_R$ as a shortcut. That is, $(\bar{i}_L, \bar{i}_R)$ is strictly increasing (or decreasing) if and only if $\bar{i}$ is.\\
 \noindent With (1) and (2), $J$ is a subset of the inner join. That is, if we can prove that the row count of $J$ matches that of the inner join, we will establish that it is exactly the inner join.\\
 
 \textbf{3. Row count}
 
-Let $U$ be the distinct set union of $L'$ and $R'$. We need to prove the following:\\
+Let $U$ be the distinct set union of $C_L$ and $C_R$. We need to prove the following:\\
 \begin{enumerate}
 \item[(a)] $U$ is strictly increasing (or decreasing).
-\item[(b)] $L'$ consist of copies of rows of $U$ with multiplicity vector $w_l$.
-\item[(c)] $R'$ consist of copies of rows of $U$ with multiplicity vector $w_r$.
-\item[(d)] $w_l \cdot w_r \overset{\Sigma}{=} \chi_m$ with $m$ the number of rows the prover claims $J$ has.
+\item[(b)] $C_L$ consist of copies of rows of $U$ with multiplicity vector $w_L$.
+\item[(c)] $C_R$ consist of copies of rows of $U$ with multiplicity vector $w_R$.
+\item[(d)] $w_L \cdot w_R \overset{\Sigma}{=} \chi_{[0,m)}$ with $m$ the number of rows the prover claims $J$ has.
 \end{enumerate}
 
-Thus, it is established that $J$ is the inner join of $L$ and $R$ on $L'$ and $R'$.\\
+Thus, it is established that $J$ is the inner join of $L$ and $R$ on $C_L = C_R$.\\
 
 \end{document}
-


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.
Depends on the following PRs:
- [x] #430
- [x] #482 
- [x] #503
- [x] #506
- [x] #509 
- [x] #510

Closes #394.
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
We need to add sort merge inner joins.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `SortMergeJoinExec`
- add `Column::rho` and `Table::add_rho_column`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Will be.