### PR TITLE
refactor!: evm verifier setup

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -36,8 +36,8 @@ impl Plan {
 #[derive(Serialize)]
 pub(super) struct FilterExec {
     table_number: usize,
-    results: Vec<Expr>,
     where_clause: Expr,
+    results: Vec<Expr>,
 }
 
 impl FilterExec {

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -64,17 +64,17 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
         .chain(&1_usize.to_be_bytes())
         .chain("a".as_bytes())
         .chain([])
-        .chain(&0_u32.to_be_bytes()) //   TableExec
+        .chain(&0_u32.to_be_bytes()) //   FilterExec
         .chain(&0_usize.to_be_bytes()) //   table_number
-        .chain(&1_usize.to_be_bytes()) //   results.len()
-        .chain(&0_u32.to_be_bytes()) //     results[0] - ColumnExpr
-        .chain(&0_usize.to_be_bytes()) //     column_number
         .chain(&1_u32.to_be_bytes()) //     where_clause - EqualsExpr
         .chain(&0_u32.to_be_bytes()) //       lhs - ColumnExpr
         .chain(&1_usize.to_be_bytes()) //       column_number
         .chain(&2_u32.to_be_bytes()) //       rhs - LiteralExpr
         .chain(&0_u32.to_be_bytes()) //         type
         .chain(&5_i64.to_be_bytes()) //         value
+        .chain(&1_usize.to_be_bytes()) //   results.len()
+        .chain(&0_u32.to_be_bytes()) //     results[0] - ColumnExpr
+        .chain(&0_usize.to_be_bytes()) //     column_number
         .copied()
         .collect();
     assert_eq!(bytes, expected_bytes);

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -143,6 +143,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         transcript.extend_serialize_as_le(expr);
         transcript.extend_serialize_as_le(&owned_table_result);
         transcript.extend_serialize_as_le(&min_row_num);
+        transcript.challenge_as_le();
 
         let first_round_message = FirstRoundMessage {
             range_length,
@@ -181,6 +182,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         };
 
         // add the commitments, bit distributions and one evaluation lengths to the proof
+        transcript.challenge_as_le();
         transcript.extend_serialize_as_le(&final_round_message);
 
         // construct the sumcheck polynomial
@@ -195,6 +197,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             num_sumcheck_variables,
             &SumcheckRandomScalars::new(&random_scalars, range_length, num_sumcheck_variables),
         );
+        transcript.challenge_as_le();
 
         // create the sumcheck proof -- this is the main part of proving a query
         let mut evaluation_point = vec![Zero::zero(); state.num_vars];
@@ -308,6 +311,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         transcript.extend_serialize_as_le(expr);
         transcript.extend_serialize_as_le(&result);
         transcript.extend_serialize_as_le(&min_row_num);
+        transcript.challenge_as_le();
 
         transcript.extend_serialize_as_le(&self.first_round_message);
 
@@ -322,6 +326,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
                 .collect();
 
         // add the commitments and bit distributions to the proof
+        transcript.challenge_as_le();
         transcript.extend_serialize_as_le(&self.final_round_message);
 
         // draw the random scalars for sumcheck
@@ -336,6 +341,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
             self.first_round_message.range_length,
             num_sumcheck_variables,
         );
+        transcript.challenge_as_le();
 
         // verify sumcheck up to the evaluation check
         let subclaim = self.sumcheck_proof.verify_without_evaluation(

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -129,10 +129,10 @@ pub fn prover_evaluate_equals_zero<'a, S: Scalar>(
 
     // selection_not
     let selection_not: &[_] = alloc.alloc_slice_fill_with(table_length, |i| lhs[i] != S::zero());
-    builder.produce_intermediate_mle(selection_not);
 
     // selection
     let selection: &[_] = alloc.alloc_slice_fill_with(table_length, |i| !selection_not[i]);
+    builder.produce_intermediate_mle(selection);
 
     // subpolynomial: selection * lhs
     builder.produce_sumcheck_subpolynomial(
@@ -162,8 +162,8 @@ pub fn verifier_evaluate_equals_zero<S: Scalar>(
 ) -> Result<S, ProofError> {
     // consume mle evaluations
     let lhs_pseudo_inv_eval = builder.try_consume_final_round_mle_evaluation()?;
-    let selection_not_eval = builder.try_consume_final_round_mle_evaluation()?;
-    let selection_eval = one_eval - selection_not_eval;
+    let selection_eval = builder.try_consume_final_round_mle_evaluation()?;
+    let selection_not_eval = one_eval - selection_eval;
 
     // subpolynomial: selection * lhs
     builder.try_produce_sumcheck_subpolynomial_evaluation(

--- a/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/fold_util_test.rs
@@ -6,16 +6,16 @@ use num_traits::Zero;
 #[test]
 fn we_can_fold_columns_with_scalars() {
     let expected = vec![
-        Curve25519Scalar::from(77 + 2061 * 33)
-            + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("1"),
-        Curve25519Scalar::from(77 + 3072 * 33)
-            + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("2"),
-        Curve25519Scalar::from(77 + 5083 * 33)
-            + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("3"),
-        Curve25519Scalar::from(77 + 7094 * 33)
-            + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("4"),
-        Curve25519Scalar::from(77 + 1005 * 33)
-            + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("5"),
+        Curve25519Scalar::from(77 + 1602 * 33)
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("1"),
+        Curve25519Scalar::from(77 + 2703 * 33)
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("2"),
+        Curve25519Scalar::from(77 + 3805 * 33)
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("3"),
+        Curve25519Scalar::from(77 + 4907 * 33)
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("4"),
+        Curve25519Scalar::from(77 + 5001 * 33)
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("5"),
     ];
 
     let str_scalars: [Curve25519Scalar; 5] =
@@ -47,14 +47,14 @@ fn we_can_fold_columns_with_scalars() {
 #[test]
 fn we_can_fold_columns_with_that_get_padded() {
     let expected = vec![
-        Curve25519Scalar::from(77 + 2061 * 33)
-            + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("1"),
-        Curve25519Scalar::from(77 + 3072 * 33)
-            + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("2"),
-        Curve25519Scalar::from(77 + 83 * 33)
-            + Curve25519Scalar::from(100 * 33) * Curve25519Scalar::from("3"),
-        Curve25519Scalar::from(77 + 94 * 33),
-        Curve25519Scalar::from(77 + 5 * 33),
+        Curve25519Scalar::from(77 + 1602 * 33)
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("1"),
+        Curve25519Scalar::from(77 + 2703 * 33)
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("2"),
+        Curve25519Scalar::from(77 + 3800 * 33)
+            + Curve25519Scalar::from(10 * 33) * Curve25519Scalar::from("3"),
+        Curve25519Scalar::from(77 + 4900 * 33),
+        Curve25519Scalar::from(77 + 5000 * 33),
         Curve25519Scalar::from(77),
         Curve25519Scalar::from(77),
         Curve25519Scalar::from(77),
@@ -116,6 +116,6 @@ fn we_can_fold_vals() {
                 5.into()
             ]
         ),
-        (54321).into()
+        (12345).into()
     );
 }


### PR DESCRIPTION
# Rationale for this change

This is the last bit of changes required in the Rust code in order to make the Rust prover/verifier compatible with the EVM verifier.

# What changes are included in this PR?

See commits

# Are these changes tested?
Existing tests cover these refactors.