### PR TITLE
feat: replace RangeCheckWord with full Uint8 support

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -11,6 +11,7 @@ impl From<&ColumnType> for DataType {
     fn from(column_type: &ColumnType) -> Self {
         match column_type {
             ColumnType::Boolean => DataType::Boolean,
+            ColumnType::Uint8 => DataType::UInt8,
             ColumnType::TinyInt => DataType::Int8,
             ColumnType::SmallInt => DataType::Int16,
             ColumnType::Int => DataType::Int32,

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -24,7 +24,7 @@ use arrow::{
     array::{
         ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
         Int64Array, Int8Array, StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
-        TimestampNanosecondArray, TimestampSecondArray,
+        TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
@@ -84,6 +84,7 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
     fn from(value: OwnedColumn<S>) -> Self {
         match value {
             OwnedColumn::Boolean(col) => Arc::new(BooleanArray::from(col)),
+            OwnedColumn::Uint8(col) => Arc::new(UInt8Array::from(col)),
             OwnedColumn::TinyInt(col) => Arc::new(Int8Array::from(col)),
             OwnedColumn::SmallInt(col) => Arc::new(Int16Array::from(col)),
             OwnedColumn::Int(col) => Arc::new(Int32Array::from(col)),

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -204,6 +204,8 @@ pub enum ColumnBounds {
     /// Column does not have order.
     NoOrder,
     /// The bounds of a `TinyInt` column.
+    Uint8(Bounds<u8>),
+    /// The bounds of a `TinyInt` column.
     TinyInt(Bounds<i8>),
     /// The bounds of a `SmallInt` column.
     SmallInt(Bounds<i16>),
@@ -225,6 +227,7 @@ impl ColumnBounds {
     pub fn from_column(column: &CommittableColumn) -> ColumnBounds {
         match column {
             CommittableColumn::TinyInt(ints) => ColumnBounds::TinyInt(Bounds::from_iter(*ints)),
+            CommittableColumn::Uint8(ints) => ColumnBounds::Uint8(Bounds::from_iter(*ints)),
             CommittableColumn::SmallInt(ints) => ColumnBounds::SmallInt(Bounds::from_iter(*ints)),
             CommittableColumn::Int(ints) => ColumnBounds::Int(Bounds::from_iter(*ints)),
             CommittableColumn::BigInt(ints) => ColumnBounds::BigInt(Bounds::from_iter(*ints)),
@@ -235,8 +238,7 @@ impl ColumnBounds {
             CommittableColumn::Boolean(_)
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
-            | CommittableColumn::VarChar(_)
-            | CommittableColumn::RangeCheckWord(_) => ColumnBounds::NoOrder,
+            | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
         }
     }
 

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -203,7 +203,7 @@ pub struct ColumnBoundsMismatch {
 pub enum ColumnBounds {
     /// Column does not have order.
     NoOrder,
-    /// The bounds of a `TinyInt` column.
+    /// The bounds of a `Uint8` column.
     Uint8(Bounds<u8>),
     /// The bounds of a `TinyInt` column.
     TinyInt(Bounds<i8>),

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -122,6 +122,9 @@ impl Commitment for NaiveCommitment {
                     CommittableColumn::Boolean(bool_vec) => {
                         bool_vec.iter().map(core::convert::Into::into).collect()
                     }
+                    CommittableColumn::Uint8(u8_vec) => {
+                        u8_vec.iter().map(core::convert::Into::into).collect()
+                    }
                     CommittableColumn::TinyInt(tiny_int_vec) => {
                         tiny_int_vec.iter().map(core::convert::Into::into).collect()
                     }
@@ -150,10 +153,6 @@ impl Commitment for NaiveCommitment {
                     CommittableColumn::TimestampTZ(_, _, i64_vec) => {
                         i64_vec.iter().map(core::convert::Into::into).collect()
                     }
-                    CommittableColumn::RangeCheckWord(u8_scalar_vec) => u8_scalar_vec
-                        .iter()
-                        .map(core::convert::Into::into)
-                        .collect(),
                 };
                 vectors.append(&mut existing_scalars);
                 NaiveCommitment(vectors)

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -31,6 +31,13 @@ where
             )?;
             Ok(Column::TinyInt(alloc.alloc_slice_copy(&raw_values) as &[_]))
         }
+        ColumnType::Uint8 => {
+            let raw_values = apply_slice_to_indexes(
+                column.as_uint8().expect("Column types should match"),
+                indexes,
+            )?;
+            Ok(Column::Uint8(alloc.alloc_slice_copy(&raw_values) as &[_]))
+        }
         ColumnType::SmallInt => {
             let raw_values = apply_slice_to_indexes(
                 column.as_smallint().expect("Column types should match"),

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -23,6 +23,12 @@ pub trait RepetitionOp {
                     iter.next().expect("Iterator should have enough elements")
                 }) as &[_])
             }
+            ColumnType::Uint8 => {
+                let mut iter = Self::op(column.as_uint8().expect("Column types should match"), n);
+                Column::Uint8(alloc.alloc_slice_fill_with(len, |_| {
+                    iter.next().expect("Iterator should have enough elements")
+                }) as &[_])
+            }
             ColumnType::TinyInt => {
                 let mut iter = Self::op(column.as_tinyint().expect("Column types should match"), n);
                 Column::TinyInt(alloc.alloc_slice_fill_with(len, |_| {

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -43,6 +43,9 @@ pub fn filter_column_by_index<'a, S: Scalar>(
         Column::Boolean(col) => {
             Column::Boolean(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }
+        Column::Uint8(col) => {
+            Column::Uint8(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
+        }
         Column::TinyInt(col) => {
             Column::TinyInt(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -154,6 +154,7 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
     indexes: &[usize],
 ) -> &'a [S] {
     match column {
+        Column::Uint8(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::TinyInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
@@ -183,6 +184,8 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
 ) -> &'a [Option<S>] {
     match column {
         Column::Boolean(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Uint8(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+
         Column::TinyInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
@@ -215,6 +218,8 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
 ) -> &'a [Option<S>] {
     match column {
         Column::Boolean(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::Uint8(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+
         Column::TinyInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::SmallInt(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         Column::Int(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -18,6 +18,7 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
         .iter()
         .map(|col| match col {
             Column::Boolean(col) => col[i].cmp(&col[j]),
+            Column::Uint8(col) => col[i].cmp(&col[j]),
             Column::TinyInt(col) => col[i].cmp(&col[j]),
             Column::SmallInt(col) => col[i].cmp(&col[j]),
             Column::Int(col) => col[i].cmp(&col[j]),
@@ -129,6 +130,7 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
             let ordering = match col {
                 OwnedColumn::Boolean(col) => col[i].cmp(&col[j]),
                 OwnedColumn::TinyInt(col) => col[i].cmp(&col[j]),
+                OwnedColumn::Uint8(col) => col[i].cmp(&col[j]),
                 OwnedColumn::SmallInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::Int(col) => col[i].cmp(&col[j]),
                 OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -25,6 +25,8 @@ use serde::{Deserialize, Serialize};
 pub enum OwnedColumn<S: Scalar> {
     /// Boolean columns
     Boolean(Vec<bool>),
+    /// u8 columns
+    Uint8(Vec<u8>),
     /// i8 columns
     TinyInt(Vec<i8>),
     /// i16 columns
@@ -51,6 +53,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             OwnedColumn::Boolean(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::TinyInt(col) => inner_product_ref_cast(col, vec),
+            OwnedColumn::Uint8(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::SmallInt(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::Int(col) => inner_product_ref_cast(col, vec),
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {
@@ -70,6 +73,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             OwnedColumn::Boolean(col) => col.len(),
             OwnedColumn::TinyInt(col) => col.len(),
+            OwnedColumn::Uint8(col) => col.len(),
             OwnedColumn::SmallInt(col) => col.len(),
             OwnedColumn::Int(col) => col.len(),
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.len(),
@@ -84,6 +88,7 @@ impl<S: Scalar> OwnedColumn<S> {
         Ok(match self {
             OwnedColumn::Boolean(col) => OwnedColumn::Boolean(permutation.try_apply(col)?),
             OwnedColumn::TinyInt(col) => OwnedColumn::TinyInt(permutation.try_apply(col)?),
+            OwnedColumn::Uint8(col) => OwnedColumn::Uint8(permutation.try_apply(col)?),
             OwnedColumn::SmallInt(col) => OwnedColumn::SmallInt(permutation.try_apply(col)?),
             OwnedColumn::Int(col) => OwnedColumn::Int(permutation.try_apply(col)?),
             OwnedColumn::BigInt(col) => OwnedColumn::BigInt(permutation.try_apply(col)?),
@@ -105,6 +110,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             OwnedColumn::Boolean(col) => OwnedColumn::Boolean(col[start..end].to_vec()),
             OwnedColumn::TinyInt(col) => OwnedColumn::TinyInt(col[start..end].to_vec()),
+            OwnedColumn::Uint8(col) => OwnedColumn::Uint8(col[start..end].to_vec()),
             OwnedColumn::SmallInt(col) => OwnedColumn::SmallInt(col[start..end].to_vec()),
             OwnedColumn::Int(col) => OwnedColumn::Int(col[start..end].to_vec()),
             OwnedColumn::BigInt(col) => OwnedColumn::BigInt(col[start..end].to_vec()),
@@ -126,6 +132,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             OwnedColumn::Boolean(col) => col.is_empty(),
             OwnedColumn::TinyInt(col) => col.is_empty(),
+            OwnedColumn::Uint8(col) => col.is_empty(),
             OwnedColumn::SmallInt(col) => col.is_empty(),
             OwnedColumn::Int(col) => col.is_empty(),
             OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.is_empty(),
@@ -140,6 +147,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             OwnedColumn::Boolean(_) => ColumnType::Boolean,
             OwnedColumn::TinyInt(_) => ColumnType::TinyInt,
+            OwnedColumn::Uint8(_) => ColumnType::Uint8,
             OwnedColumn::SmallInt(_) => ColumnType::SmallInt,
             OwnedColumn::Int(_) => ColumnType::Int,
             OwnedColumn::BigInt(_) => ColumnType::BigInt,
@@ -160,6 +168,15 @@ impl<S: Scalar> OwnedColumn<S> {
                 scalars
                     .iter()
                     .map(|s| -> Result<bool, _> { TryInto::<bool>::try_into(*s) })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| OwnedColumnError::ScalarConversionError {
+                        error: "Overflow in scalar conversions".to_string(),
+                    })?,
+            )),
+            ColumnType::Uint8 => Ok(OwnedColumn::Uint8(
+                scalars
+                    .iter()
+                    .map(|s| -> Result<u8, _> { TryInto::<u8>::try_into(*s) })
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(|_| OwnedColumnError::ScalarConversionError {
                         error: "Overflow in scalar conversions".to_string(),
@@ -326,6 +343,7 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for OwnedColumn<S> {
         match col {
             Column::Boolean(col) => OwnedColumn::Boolean(col.to_vec()),
             Column::TinyInt(col) => OwnedColumn::TinyInt(col.to_vec()),
+            Column::Uint8(col) => OwnedColumn::Uint8(col.to_vec()),
             Column::SmallInt(col) => OwnedColumn::SmallInt(col.to_vec()),
             Column::Int(col) => OwnedColumn::Int(col.to_vec()),
             Column::BigInt(col) => OwnedColumn::BigInt(col.to_vec()),

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -92,6 +92,7 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
         {
             OwnedColumn::Boolean(col) => Column::Boolean(col),
             OwnedColumn::TinyInt(col) => Column::TinyInt(col),
+            OwnedColumn::Uint8(col) => Column::Uint8(col),
             OwnedColumn::SmallInt(col) => Column::SmallInt(col),
             OwnedColumn::Int(col) => Column::Int(col),
             OwnedColumn::BigInt(col) => Column::BigInt(col),

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -53,6 +53,16 @@ pub fn column_union<'a, S: Scalar>(
                 iter.next().expect("Iterator should have enough elements")
             }) as &[_])
         }
+        ColumnType::Uint8 => {
+            let mut iter = columns
+                .iter()
+                .flat_map(|col| col.as_uint8().expect("Column types should match"))
+                .copied();
+
+            Column::Uint8(alloc.alloc_slice_fill_with(len, |_| {
+                iter.next().expect("Iterator should have enough elements")
+            }) as &[_])
+        }
         ColumnType::TinyInt => {
             let mut iter = columns
                 .iter()

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -103,6 +103,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
                 c.inner_product(evaluation_vec)
             }
+            Column::Uint8(c) => c.inner_product(evaluation_vec),
             Column::TinyInt(c) => c.inner_product(evaluation_vec),
             Column::SmallInt(c) => c.inner_product(evaluation_vec),
             Column::Int(c) => c.inner_product(evaluation_vec),
@@ -117,6 +118,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
                 c.mul_add(res, multiplier);
             }
+            Column::Uint8(c) => c.mul_add(res, multiplier),
             Column::TinyInt(c) => c.mul_add(res, multiplier),
             Column::SmallInt(c) => c.mul_add(res, multiplier),
             Column::Int(c) => c.mul_add(res, multiplier),
@@ -131,6 +133,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
                 c.to_sumcheck_term(num_vars)
             }
+            Column::Uint8(c) => c.to_sumcheck_term(num_vars),
             Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
             Column::SmallInt(c) => c.to_sumcheck_term(num_vars),
             Column::Int(c) => c.to_sumcheck_term(num_vars),
@@ -145,6 +148,7 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
             Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
                 MultilinearExtension::<S>::id(c)
             }
+            Column::Uint8(c) => MultilinearExtension::<S>::id(c),
             Column::TinyInt(c) => MultilinearExtension::<S>::id(c),
             Column::SmallInt(c) => MultilinearExtension::<S>::id(c),
             Column::Int(c) => MultilinearExtension::<S>::id(c),

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -479,17 +479,27 @@ where
     MontScalar<T>: Scalar,
 {
     type Error = ScalarConversionError;
+
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
+        if value < MontScalar::<T>::ZERO {
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{value} is negative and cannot fit in a u8"),
+            });
+        }
+
         let abs: [u64; 4] = value.into();
+
         if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
             return Err(ScalarConversionError::Overflow {
                 error: format!("{value} is too large to fit in a u8"),
             });
         }
-        let val: u64 = abs[0];
-        val.try_into().map_err(|_| ScalarConversionError::Overflow {
-            error: format!("{value} is too large to fit in a u8"),
-        })
+
+        abs[0]
+            .try_into()
+            .map_err(|_| ScalarConversionError::Overflow {
+                error: format!("{value} is too large to fit in a u8"),
+            })
     }
 }
 

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -473,6 +473,26 @@ where
     }
 }
 
+impl<T> TryFrom<MontScalar<T>> for u8
+where
+    T: MontConfig<4>,
+    MontScalar<T>: Scalar,
+{
+    type Error = ScalarConversionError;
+    fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
+        let abs: [u64; 4] = value.into();
+        if abs[1] != 0 || abs[2] != 0 || abs[3] != 0 {
+            return Err(ScalarConversionError::Overflow {
+                error: format!("{value} is too large to fit in a u8"),
+            });
+        }
+        let val: u64 = abs[0];
+        val.try_into().map_err(|_| ScalarConversionError::Overflow {
+            error: format!("{value} is too large to fit in a u8"),
+        })
+    }
+}
+
 impl<T> TryFrom<MontScalar<T>> for i8
 where
     T: MontConfig<4>,

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -33,6 +33,7 @@ pub trait Scalar:
     + for<'a> core::convert::From<&'a i128> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a u8> // Required for `Column` to implement `MultilinearExtension`
     + core::convert::TryInto <bool>
+    + core::convert::TryInto<u8>
     + core::convert::TryInto <i8>
     + core::convert::TryInto <i16>
     + core::convert::TryInto <i32>
@@ -40,6 +41,7 @@ pub trait Scalar:
     + core::convert::TryInto <i128>
     + core::convert::Into<[u64; 4]>
     + core::convert::From<[u64; 4]>
+    + core::convert::From<u8>
     + core::cmp::Ord
     + core::ops::Neg<Output = Self>
     + num_traits::Zero

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -37,6 +37,7 @@ pub const fn min_as_f(column_type: ColumnType) -> F {
         ColumnType::BigInt | ColumnType::TimestampTZ(_, _) => MontFp!("-9223372036854775808"),
         ColumnType::Int128 => MontFp!("-170141183460469231731687303715884105728"),
         ColumnType::Decimal75(_, _)
+        | ColumnType::Uint8
         | ColumnType::Scalar
         | ColumnType::VarChar
         | ColumnType::Boolean => MontFp!("0"),
@@ -110,6 +111,9 @@ fn copy_column_data_to_slice(
         CommittableColumn::Boolean(column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
+        CommittableColumn::Uint8(column) => {
+            scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
+        }
         CommittableColumn::TinyInt(column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
@@ -130,7 +134,6 @@ fn copy_column_data_to_slice(
         | CommittableColumn::VarChar(column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
-        CommittableColumn::RangeCheckWord(_) => todo!(),
     }
 }
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -66,6 +66,7 @@ fn compute_dory_commitment(
 ) -> DoryCommitment {
     match committable_column {
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Uint8(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TinyInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::SmallInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),
@@ -77,9 +78,6 @@ fn compute_dory_commitment(
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TimestampTZ(_, _, column) => {
-            compute_dory_commitment_impl(column, offset, setup)
-        }
-        CommittableColumn::RangeCheckWord(column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -75,6 +75,7 @@ fn compute_dory_commitment(
 ) -> DynamicDoryCommitment {
     match committable_column {
         CommittableColumn::Scalar(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::Uint8(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TinyInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::SmallInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),
@@ -85,9 +86,6 @@ fn compute_dory_commitment(
         }
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TimestampTZ(_, _, column) => {
-            compute_dory_commitment_impl(column, offset, setup)
-        }
-        CommittableColumn::RangeCheckWord(column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -367,6 +367,17 @@ pub fn bit_table_and_scalars_for_packed_msm(
         .iter()
         .enumerate()
         .for_each(|(i, column)| match column {
+            CommittableColumn::Uint8(column) => {
+                pack_bit(
+                    column,
+                    &mut packed_scalars,
+                    cumulative_bit_sum_table[i],
+                    offset,
+                    committable_columns[i].column_type().byte_size(),
+                    bit_table_full_sum_in_bytes,
+                    num_matrix_commitment_columns,
+                );
+            }
             CommittableColumn::TinyInt(column) => {
                 pack_bit(
                     column,
@@ -436,17 +447,6 @@ pub fn bit_table_and_scalars_for_packed_msm(
             CommittableColumn::Decimal75(_, _, column)
             | CommittableColumn::Scalar(column)
             | CommittableColumn::VarChar(column) => {
-                pack_bit(
-                    column,
-                    &mut packed_scalars,
-                    cumulative_bit_sum_table[i],
-                    offset,
-                    committable_columns[i].column_type().byte_size(),
-                    bit_table_full_sum_in_bytes,
-                    num_matrix_commitment_columns,
-                );
-            }
-            CommittableColumn::RangeCheckWord(column) => {
                 pack_bit(
                     column,
                     &mut packed_scalars,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -123,6 +123,7 @@ impl Commitment for HyperKZGCommitment {
             .iter()
             .map(|column| match column {
                 CommittableColumn::Boolean(vals) => compute_commitments_impl(setup, offset, vals),
+                CommittableColumn::Uint8(vals) => compute_commitments_impl(setup, offset, vals),
                 CommittableColumn::TinyInt(vals) => compute_commitments_impl(setup, offset, vals),
                 CommittableColumn::SmallInt(vals) => compute_commitments_impl(setup, offset, vals),
                 CommittableColumn::Int(vals) => compute_commitments_impl(setup, offset, vals),
@@ -133,9 +134,6 @@ impl Commitment for HyperKZGCommitment {
                 CommittableColumn::Decimal75(_, _, vals)
                 | CommittableColumn::Scalar(vals)
                 | CommittableColumn::VarChar(vals) => compute_commitments_impl(setup, offset, vals),
-                CommittableColumn::RangeCheckWord(vals) => {
-                    compute_commitments_impl(setup, offset, vals)
-                }
             })
             .collect()
     }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -111,6 +111,7 @@ impl ProvableQueryResult {
             for entry in evaluation_vec.iter().take(output_length) {
                 let (x, sz) = match field.data_type() {
                     ColumnType::Boolean => decode_and_convert::<bool, S>(&self.data[offset..]),
+                    ColumnType::Uint8 => decode_and_convert::<u8, S>(&self.data[offset..]),
                     ColumnType::TinyInt => decode_and_convert::<i8, S>(&self.data[offset..]),
                     ColumnType::SmallInt => decode_and_convert::<i16, S>(&self.data[offset..]),
                     ColumnType::Int => decode_and_convert::<i32, S>(&self.data[offset..]),
@@ -163,6 +164,11 @@ impl ProvableQueryResult {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
                         Ok((field.name(), OwnedColumn::Boolean(col)))
+                    }
+                    ColumnType::Uint8 => {
+                        let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
+                        offset += num_read;
+                        Ok((field.name(), OwnedColumn::Uint8(col)))
                     }
                     ColumnType::TinyInt => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -32,6 +32,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
     fn num_bytes(&self, length: u64) -> usize {
         match self {
             Column::Boolean(col) => col.num_bytes(length),
+            Column::Uint8(col) => col.num_bytes(length),
             Column::TinyInt(col) => col.num_bytes(length),
             Column::SmallInt(col) => col.num_bytes(length),
             Column::Int(col) => col.num_bytes(length),
@@ -45,6 +46,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
     fn write(&self, out: &mut [u8], length: u64) -> usize {
         match self {
             Column::Boolean(col) => col.write(out, length),
+            Column::Uint8(col) => col.write(out, length),
             Column::TinyInt(col) => col.write(out, length),
             Column::SmallInt(col) => col.write(out, length),
             Column::Int(col) => col.write(out, length),

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -167,6 +167,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: &[ColumnField]) -> QueryRes
                     field.name(),
                     match field.data_type() {
                         ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
+                        ColumnType::Uint8 => OwnedColumn::Uint8(vec![]),
                         ColumnType::TinyInt => OwnedColumn::TinyInt(vec![]),
                         ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
                         ColumnType::Int => OwnedColumn::Int(vec![]),

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -118,6 +118,7 @@ fn append_single_row_to_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedColum
     let mut column = column.clone();
     match &mut column {
         OwnedColumn::Boolean(col) => col.push(false),
+        OwnedColumn::Uint8(col) => col.push(0),
         OwnedColumn::TinyInt(col) => col.push(0),
         OwnedColumn::SmallInt(col) => col.push(0),
         OwnedColumn::Int(col) => col.push(0),
@@ -151,6 +152,7 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
     let mut column = column.clone();
     match &mut column {
         OwnedColumn::Boolean(col) => col[0] ^= true,
+        OwnedColumn::Uint8(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::TinyInt(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::SmallInt(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::Int(col) => col[0] = col[0].wrapping_add(1),


### PR DESCRIPTION
# Rationale for this change

Currently, range proofs operate by breaking scalar-backed values into smaller words, with a size of 8 bits at the moment. These words are then committed to as part of the range proof, but because there currently exists no column type for u8, we commit to full size scalars instead. This causes a rather large overhead during proof times because we are committing to 256 bits instead of just 8.

#481 resolves this somewhat by refactoring the bit and bytesize methods used during the proof, but a cleaner solution is to just support the u8 as a column type. This PR introduces full posql support for the u8 column type and removes the ```RangeCheckWord``` type altogether.

# What changes are included in this PR?

- [x] Remove ```RangeCheckWord```
- [x] Support u8 column type (Column, OwnedColumn, CommittableColumn)

# Are these changes tested?
- [x] existing ```RangeCheckWord``` tests are simply updated to cover u8 instead.
- [x] crucially, existing range check tests pass, implying that the switch was successful and did not introduce any regressions.
