### PR TITLE
feat: add increasing gadget

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/increasing.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/increasing.rs
@@ -1,0 +1,109 @@
+//! Prove that a column is non-strictly increasing.
+use super::{
+    final_round_evaluate_shift, first_round_evaluate_shift, prover_evaluate_sign,
+    verifier_evaluate_sign, verify_shift,
+};
+use crate::{
+    base::{proof::ProofError, scalar::Scalar},
+    sql::proof::{FinalRoundBuilder, FirstRoundBuilder, VerificationBuilder},
+};
+use bumpalo::Bump;
+
+/// Perform first round evaluation of increasing.
+pub(crate) fn first_round_evaluate_increasing<S: Scalar>(
+    builder: &mut FirstRoundBuilder<'_, S>,
+    num_rows: usize,
+) {
+    builder.produce_one_evaluation_length(num_rows + 1);
+    first_round_evaluate_shift(builder, num_rows);
+}
+
+/// Perform final round evaluation of increasing.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn final_round_evaluate_increasing<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    column: &'a [S],
+) {
+    let num_rows = column.len();
+    let shifted_column =
+        alloc.alloc_slice_fill_with(
+            num_rows + 1,
+            |i| {
+                if i == 0 {
+                    S::ZERO
+                } else {
+                    column[i - 1]
+                }
+            },
+        );
+    builder.produce_intermediate_mle(shifted_column as &[_]);
+    // 1. Prove that `shifted_column` is a shift of `column`
+    final_round_evaluate_shift(builder, alloc, alpha, beta, column, shifted_column);
+    // 2. Construct an indicator `diff` such that if `diff` is all nonnegative except for the first and last elements,
+    // then `column` is non-strictly increasing
+    let diff = alloc.alloc_slice_fill_with(num_rows + 1, |i| {
+        if i == num_rows {
+            -column[num_rows - 1]
+        } else {
+            column[i] - shifted_column[i]
+        }
+    });
+
+    // 3. Prove that `diff` is all nonnegative with the possible exception of the first and last elements
+    // sign(diff) == 0 for all but the first element and the last element
+    // The first and last elements can only fit into three patterns
+    // 1. negative and non-negative
+    // 2. non-negative and negative
+    // 3. negative and negative
+    // Hence the evaluation of sign has to be in one of three cases
+    // 1. singleton_one_eval
+    // 2. shifted_one_eval - one_eval
+    // 3. singleton_one_eval + shifted_one_eval - one_eval
+    prover_evaluate_sign(builder, alloc, diff);
+}
+
+pub(crate) fn verify_increasing<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    column_eval: S,
+    one_eval: S,
+) -> Result<(), ProofError> {
+    // 1. Verify that `shifted_column` is a shift of `column`
+    let shifted_column_eval = builder.try_consume_final_round_mle_evaluation()?;
+    let shifted_one_eval = builder.try_consume_one_evaluation()?;
+    verify_shift(
+        builder,
+        alpha,
+        beta,
+        column_eval,
+        shifted_column_eval,
+        one_eval,
+        shifted_one_eval,
+    )?;
+    // 2. Verify that `sign_eval` is correct, that is, `column` is strictly increasing.
+    // The first and last elements of `diff` can only fit into three patterns
+    // 1. negative and non-negative
+    // 2. non-negative and negative
+    // 3. negative and negative
+    // Hence the evaluation of sign has to be in one of three cases
+    // 1. singleton_one_eval
+    // 2. shifted_one_eval - one_eval
+    // 3. singleton_one_eval + shifted_one_eval - one_eval
+    let sign_eval =
+        verifier_evaluate_sign(builder, column_eval - shifted_column_eval, shifted_one_eval)?;
+    let singleton_one_eval = builder.mle_evaluations.singleton_one_evaluation;
+    let last_element_eval = shifted_one_eval - one_eval;
+    if sign_eval != singleton_one_eval
+        && sign_eval != last_element_eval
+        && sign_eval != singleton_one_eval + last_element_eval
+    {
+        return Err(ProofError::VerificationError {
+            error: "column is not non-strictly increasing",
+        });
+    }
+    Ok(())
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/increasing_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/increasing_test.rs
@@ -1,0 +1,228 @@
+//! This module contains the implementation of the `IncreasingTestPlan` struct. This struct
+//! is used to check whether the increasing gadget works correctly.
+use super::increasing::{
+    final_round_evaluate_increasing, first_round_evaluate_increasing, verify_increasing,
+};
+use crate::{
+    base::{
+        database::{
+            ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+        },
+        map::{indexset, IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    },
+};
+use bumpalo::Bump;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct IncreasingTestPlan {
+    pub column: ColumnRef,
+}
+
+impl ProverEvaluate for IncreasingTestPlan {
+    #[doc = "Evaluate the query, modify `FirstRoundBuilder` and return the result."]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        _alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the tables from the map using the table reference
+        let table: &Table<'a, S> = table_map
+            .get(&self.column.table_ref())
+            .expect("Table not found");
+        let num_rows = table.num_rows();
+        builder.request_post_result_challenges(2);
+        builder.produce_one_evaluation_length(num_rows);
+        // Evaluate the first round
+        first_round_evaluate_increasing(builder, num_rows);
+        // This is just a dummy table, the actual data is not used
+        Table::try_new_with_options(IndexMap::default(), TableOptions { row_count: Some(0) })
+            .unwrap()
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the table from the map using the table reference
+        let table: &Table<'a, S> = table_map
+            .get(&self.column.table_ref())
+            .expect("Table not found");
+        let raw_column: Vec<S> = table
+            .inner_table()
+            .get(&self.column.column_id())
+            .expect("Column not found in table")
+            .to_scalar_with_scaling(0);
+        let alloc_column = alloc.alloc_slice_copy(&raw_column);
+        builder.produce_intermediate_mle(alloc_column as &[_]);
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+        final_round_evaluate_increasing(builder, alloc, alpha, beta, alloc_column);
+        // Return a dummy table
+        Table::try_new_with_options(IndexMap::default(), TableOptions { row_count: Some(0) })
+            .unwrap()
+    }
+}
+
+impl ProofPlan for IncreasingTestPlan {
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        vec![]
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        indexset! {self.column.clone()}
+    }
+
+    #[doc = "Return all the tables referenced in the Query"]
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        indexset! {self.column.table_ref()}
+    }
+
+    #[doc = "Form components needed to verify and proof store into `VerificationBuilder`"]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        _one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        // Get the challenges from the builder
+        let alpha = builder.try_consume_post_result_challenge()?;
+        let beta = builder.try_consume_post_result_challenge()?;
+        // Get evaluations
+        let column_eval = builder.try_consume_final_round_mle_evaluation()?;
+        let one_eval = builder.try_consume_one_evaluation()?;
+        // Evaluate the verifier
+        verify_increasing(builder, alpha, beta, column_eval, one_eval)?;
+        Ok(TableEvaluation::new(vec![], S::zero()))
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{table_utility::*, ColumnType, TableTestAccessor},
+            math::decimal::Precision,
+        },
+        sql::proof::VerifiableQueryResult,
+    };
+    use blitzar::proof::InnerProductProof;
+    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+
+    #[test]
+    fn we_can_figure_out_that_increasing_columns_are_increasing() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_bigint("bigint", [1, 2, 3, 3], &alloc),
+            borrowed_boolean("boolean", [false, false, true, true], &alloc),
+            borrowed_int128("const", [1_i128; 4], &alloc),
+            borrowed_smallint("strict", [1_i16, 2, 3, 4], &alloc),
+            borrowed_decimal75("decimal", 12, 1, [1, 2, 2, 2], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![1_625_072_400, 1_625_076_000, 1_625_076_000, 1_625_078_000],
+                &alloc,
+            ),
+        ]);
+        let table_ref = "sxt.table".parse().unwrap();
+        let accessor =
+            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref, table, 0, ());
+
+        // BigInt column
+        let plan = IncreasingTestPlan {
+            column: ColumnRef::new(table_ref, "bigint".into(), ColumnType::BigInt),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+
+        // Boolean column
+        let plan = IncreasingTestPlan {
+            column: ColumnRef::new(table_ref, "boolean".into(), ColumnType::Boolean),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+
+        // Constant int128 column
+        let plan = IncreasingTestPlan {
+            column: ColumnRef::new(table_ref, "const".into(), ColumnType::Int128),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+
+        // Smallint column
+        let plan = IncreasingTestPlan {
+            column: ColumnRef::new(table_ref, "strict".into(), ColumnType::SmallInt),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+
+        // Decimal75 column
+        let precision = Precision::new(12).unwrap();
+        let plan = IncreasingTestPlan {
+            column: ColumnRef::new(
+                table_ref,
+                "decimal".into(),
+                ColumnType::Decimal75(precision, 1),
+            ),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+
+        // Timestamptz column
+        let plan = IncreasingTestPlan {
+            column: ColumnRef::new(
+                table_ref,
+                "timestamp".into(),
+                ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            ),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn we_cannot_pass_increasing_check_if_column_is_not_increasing() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_bigint("a", [1, 2, 1], &alloc),
+            borrowed_boolean("c", [true, false, true], &alloc),
+        ]);
+        let table_ref = "sxt.table".parse().unwrap();
+        let accessor =
+            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref, table, 0, ());
+
+        // BigInt column
+        let plan = IncreasingTestPlan {
+            column: ColumnRef::new(table_ref, "a".into(), ColumnType::BigInt),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_err());
+
+        // Boolean column
+        let plan = IncreasingTestPlan {
+            column: ColumnRef::new(table_ref, "c".into(), ColumnType::Boolean),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_err());
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
 mod membership_check;
 mod shift;
+mod uniqueness;
 #[allow(unused_imports, dead_code)]
 use membership_check::{
     final_round_evaluate_membership_check, first_round_evaluate_membership_check,
@@ -8,7 +9,6 @@ use membership_check::{
 };
 #[cfg(test)]
 mod membership_check_test;
-#[allow(unused_imports, dead_code)]
 use shift::{final_round_evaluate_shift, first_round_evaluate_shift, verify_shift};
 #[cfg(test)]
 mod shift_test;
@@ -20,3 +20,9 @@ pub(crate) mod range_check;
 mod range_check_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod sign_expr_test;
+#[allow(unused_imports, dead_code)]
+use uniqueness::{
+    final_round_evaluate_uniqueness, first_round_evaluate_uniqueness, verify_uniqueness,
+};
+#[cfg(test)]
+mod uniqueness_test;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,4 +1,5 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
+mod increasing;
 mod membership_check;
 mod shift;
 mod uniqueness;
@@ -20,6 +21,12 @@ pub(crate) mod range_check;
 mod range_check_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod sign_expr_test;
+#[allow(unused_imports, dead_code)]
+use increasing::{
+    final_round_evaluate_increasing, first_round_evaluate_increasing, verify_increasing,
+};
+#[cfg(test)]
+mod increasing_test;
 #[allow(unused_imports, dead_code)]
 use uniqueness::{
     final_round_evaluate_uniqueness, first_round_evaluate_uniqueness, verify_uniqueness,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/uniqueness.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/uniqueness.rs
@@ -1,0 +1,107 @@
+use super::{
+    final_round_evaluate_shift, first_round_evaluate_shift, prover_evaluate_sign,
+    verifier_evaluate_sign, verify_shift,
+};
+use crate::{
+    base::{proof::ProofError, scalar::Scalar},
+    sql::proof::{FinalRoundBuilder, FirstRoundBuilder, VerificationBuilder},
+};
+use bumpalo::Bump;
+
+/// Perform first round evaluation of uniqueness.
+pub(crate) fn first_round_evaluate_uniqueness<S: Scalar>(
+    builder: &mut FirstRoundBuilder<'_, S>,
+    num_rows: usize,
+) {
+    builder.produce_one_evaluation_length(num_rows + 1);
+    first_round_evaluate_shift(builder, num_rows);
+}
+
+/// Perform final round evaluation of uniqueness.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn final_round_evaluate_uniqueness<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    column: &'a [S],
+) {
+    let num_rows = column.len();
+    let shifted_column =
+        alloc.alloc_slice_fill_with(
+            num_rows + 1,
+            |i| {
+                if i == 0 {
+                    S::ZERO
+                } else {
+                    column[i - 1]
+                }
+            },
+        );
+    builder.produce_intermediate_mle(shifted_column as &[_]);
+    // 1. Prove that `shifted_column` is a shift of `column`
+    final_round_evaluate_shift(builder, alloc, alpha, beta, column, shifted_column);
+    // 2. Construct an indicator `diff` such that if `diff` is all negative except for the first and last elements,
+    // then `column` is strictly increasing
+    let diff = alloc.alloc_slice_fill_with(num_rows + 1, |i| {
+        if i == num_rows {
+            column[num_rows - 1]
+        } else {
+            shifted_column[i] - column[i]
+        }
+    });
+
+    // 3. Prove that `diff` is all negative with the possible exception of the first and last elements
+    // sign(diff) == 1 for all but the first element and the last element
+    // The first and last elements can only fit into three patterns
+    // 1. negative and non-negative
+    // 2. non-negative and negative
+    // 3. non-negative and non-negative
+    // Hence the evaluation of sign has to be in one of three cases
+    // 1. one_eval
+    // 2. shifted_one_eval - singleton_one_eval
+    // 3. one_eval - singleton_one_eval
+    prover_evaluate_sign(builder, alloc, diff);
+}
+
+pub(crate) fn verify_uniqueness<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    column_eval: S,
+    one_eval: S,
+) -> Result<(), ProofError> {
+    // 1. Verify that `shifted_column` is a shift of `column`
+    let shifted_column_eval = builder.try_consume_final_round_mle_evaluation()?;
+    let shifted_one_eval = builder.try_consume_one_evaluation()?;
+    verify_shift(
+        builder,
+        alpha,
+        beta,
+        column_eval,
+        shifted_column_eval,
+        one_eval,
+        shifted_one_eval,
+    )?;
+    // 2. Verify that `sign_eval` is correct, that is, `column` is strictly increasing.
+    // The first and last elements of `diff` can only fit into three patterns
+    // 1. negative and non-negative
+    // 2. non-negative and negative
+    // 3. non-negative and non-negative
+    // Hence the evaluation of sign has to be in one of three cases
+    // 1. one_eval
+    // 2. shifted_one_eval - singleton_one_eval
+    // 3. one_eval - singleton_one_eval
+    let sign_eval =
+        verifier_evaluate_sign(builder, shifted_column_eval - column_eval, shifted_one_eval)?;
+    let singleton_one_eval = builder.mle_evaluations.singleton_one_evaluation;
+    if sign_eval != one_eval
+        && sign_eval != one_eval - singleton_one_eval
+        && sign_eval != shifted_one_eval - singleton_one_eval
+    {
+        return Err(ProofError::VerificationError {
+            error: "column is not strictly increasing",
+        });
+    }
+    Ok(())
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/uniqueness_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/uniqueness_test.rs
@@ -1,0 +1,183 @@
+//! This module contains the implementation of the `UniquenessTestPlan` struct. This struct
+//! is used to check whether the uniqueness gadget works correctly.
+use super::uniqueness::{
+    final_round_evaluate_uniqueness, first_round_evaluate_uniqueness, verify_uniqueness,
+};
+use crate::{
+    base::{
+        database::{
+            ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+        },
+        map::{indexset, IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    },
+};
+use bumpalo::Bump;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct UniquenessTestPlan {
+    pub column: ColumnRef,
+}
+
+impl ProverEvaluate for UniquenessTestPlan {
+    #[doc = "Evaluate the query, modify `FirstRoundBuilder` and return the result."]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        _alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the tables from the map using the table reference
+        let table: &Table<'a, S> = table_map
+            .get(&self.column.table_ref())
+            .expect("Table not found");
+        let num_rows = table.num_rows();
+        builder.request_post_result_challenges(2);
+        builder.produce_one_evaluation_length(num_rows);
+        // Evaluate the first round
+        first_round_evaluate_uniqueness(builder, num_rows);
+        // This is just a dummy table, the actual data is not used
+        Table::try_new_with_options(IndexMap::default(), TableOptions { row_count: Some(0) })
+            .unwrap()
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the table from the map using the table reference
+        let table: &Table<'a, S> = table_map
+            .get(&self.column.table_ref())
+            .expect("Table not found");
+        let raw_column: Vec<S> = table
+            .inner_table()
+            .get(&self.column.column_id())
+            .expect("Column not found in table")
+            .to_scalar_with_scaling(0);
+        let alloc_column = alloc.alloc_slice_copy(&raw_column);
+        builder.produce_intermediate_mle(alloc_column as &[_]);
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+        final_round_evaluate_uniqueness(builder, alloc, alpha, beta, alloc_column);
+        // Return a dummy table
+        Table::try_new_with_options(IndexMap::default(), TableOptions { row_count: Some(0) })
+            .unwrap()
+    }
+}
+
+impl ProofPlan for UniquenessTestPlan {
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        vec![]
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        indexset! {self.column.clone()}
+    }
+
+    #[doc = "Return all the tables referenced in the Query"]
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        indexset! {self.column.table_ref()}
+    }
+
+    #[doc = "Form components needed to verify and proof store into `VerificationBuilder`"]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        _one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        // Get the challenges from the builder
+        let alpha = builder.try_consume_post_result_challenge()?;
+        let beta = builder.try_consume_post_result_challenge()?;
+        // Get evaluations
+        let column_eval = builder.try_consume_final_round_mle_evaluation()?;
+        let one_eval = builder.try_consume_one_evaluation()?;
+        // Evaluate the verifier
+        verify_uniqueness(builder, alpha, beta, column_eval, one_eval)?;
+        Ok(TableEvaluation::new(vec![], S::zero()))
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod tests {
+    use super::*;
+    use crate::{
+        base::database::{table_utility::*, ColumnType, TableTestAccessor},
+        sql::proof::VerifiableQueryResult,
+    };
+    use blitzar::proof::InnerProductProof;
+
+    #[test]
+    fn we_can_figure_out_that_unique_increasing_columns_are_unique() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_bigint("a", [1, 2], &alloc),
+            borrowed_boolean("c", [false, true], &alloc),
+        ]);
+        let table_ref = "sxt.table".parse().unwrap();
+        let accessor =
+            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref, table, 0, ());
+
+        // BigInt column
+        let plan = UniquenessTestPlan {
+            column: ColumnRef::new(table_ref, "a".into(), ColumnType::BigInt),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+
+        // Boolean column
+        let plan = UniquenessTestPlan {
+            column: ColumnRef::new(table_ref, "c".into(), ColumnType::Boolean),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn we_cannot_pass_uniqueness_check_if_column_is_not_unique() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_bigint("a", [1, 1, 2], &alloc),
+            borrowed_varchar("b", ["Space"; 3], &alloc),
+            borrowed_boolean("c", [true, false, true], &alloc),
+        ]);
+        let table_ref = "sxt.table".parse().unwrap();
+        let accessor =
+            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref, table, 0, ());
+
+        // BigInt column
+        let plan = UniquenessTestPlan {
+            column: ColumnRef::new(table_ref, "a".into(), ColumnType::BigInt),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_err());
+
+        // Varchar column
+        let plan = UniquenessTestPlan {
+            column: ColumnRef::new(table_ref, "b".into(), ColumnType::VarChar),
+        };
+
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_err());
+
+        // Boolean column
+        let plan = UniquenessTestPlan {
+            column: ColumnRef::new(table_ref, "c".into(), ColumnType::Boolean),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let res = verifiable_res.verify(&plan, &accessor, &());
+        assert!(res.is_err());
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

Depends on #487

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This is a very simple gadget that is a variant of the uniqueness one (please merge that first) which can be used for ordering.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add increasing gadget.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.