### PR TITLE
feat: add monotonic gadget

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,5 +1,6 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
 mod membership_check;
+mod monotonic;
 mod shift;
 #[allow(unused_imports, dead_code)]
 use membership_check::{
@@ -8,7 +9,6 @@ use membership_check::{
 };
 #[cfg(test)]
 mod membership_check_test;
-#[allow(unused_imports, dead_code)]
 use shift::{final_round_evaluate_shift, first_round_evaluate_shift, verify_shift};
 #[cfg(test)]
 mod shift_test;
@@ -20,3 +20,7 @@ pub(crate) mod range_check;
 mod range_check_test;
 #[cfg(all(test, feature = "blitzar"))]
 mod sign_expr_test;
+#[allow(unused_imports, dead_code)]
+use monotonic::{final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic};
+#[cfg(test)]
+mod monotonic_test;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -1,0 +1,143 @@
+//! Prove that a column is increasing or decreasing, strictly or non-strictly.
+use super::{
+    final_round_evaluate_shift, first_round_evaluate_shift, prover_evaluate_sign,
+    verifier_evaluate_sign, verify_shift,
+};
+use crate::{
+    base::{proof::ProofError, scalar::Scalar},
+    sql::proof::{FinalRoundBuilder, FirstRoundBuilder, VerificationBuilder},
+};
+use alloc::vec;
+use bumpalo::Bump;
+
+/// Perform first round evaluation of monotonicity.
+pub(crate) fn first_round_evaluate_monotonic<S: Scalar>(
+    builder: &mut FirstRoundBuilder<'_, S>,
+    num_rows: usize,
+) {
+    builder.produce_one_evaluation_length(num_rows + 1);
+    first_round_evaluate_shift(builder, num_rows);
+}
+
+/// Perform final round evaluation of monotonicity.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn final_round_evaluate_monotonic<'a, S: Scalar, const STRICT: bool, const ASC: bool>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    column: &'a [S],
+) {
+    let num_rows = column.len();
+    let shifted_column =
+        alloc.alloc_slice_fill_with(
+            num_rows + 1,
+            |i| {
+                if i == 0 {
+                    S::ZERO
+                } else {
+                    column[i - 1]
+                }
+            },
+        );
+    builder.produce_intermediate_mle(shifted_column as &[_]);
+    // 1. Prove that `shifted_column` is a shift of `column`
+    final_round_evaluate_shift(builder, alloc, alpha, beta, column, shifted_column);
+    // 2. Construct an indicator `diff = column - shifted_column`
+    let diff = alloc.alloc_slice_fill_with(num_rows + 1, |i| {
+        if i == num_rows {
+            -column[num_rows - 1]
+        } else {
+            column[i] - shifted_column[i]
+        }
+    });
+    // Since sign expr which we uses for the sign proof only distinguishes between nonnegative
+    // and negative integers we need to transform the indicator to be either ind < 0 or ind >= 0
+    //
+    // Due to the fact that column is monotonic either column - shifted_column
+    // or shifted_column - column will be all nonnegative or all negative
+    // everywhere with the possible exception of the first and last element
+    //
+    // Hence we need to do the following transformation
+    // column > shifted_column => shifted_column - column < 0
+    // column >= shifted_column => column - shifted_column >= 0
+    // column < shifted_column => column - shifted_column < 0
+    // column <= shifted_column => shifted_column - column >= 0
+    //
+    // This is why ind is constructed as below
+    let ind = match (STRICT, ASC) {
+        (true, true) | (false, false) => alloc.alloc_slice_fill_with(num_rows + 1, |i| -diff[i]),
+        _ => diff as &[_],
+    };
+
+    // 3. Prove the sign of `ind`
+    prover_evaluate_sign(builder, alloc, ind);
+}
+
+pub(crate) fn verify_monotonic<S: Scalar, const STRICT: bool, const ASC: bool>(
+    builder: &mut VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    column_eval: S,
+    one_eval: S,
+) -> Result<(), ProofError> {
+    // 1. Verify that `shifted_column` is a shift of `column`
+    let shifted_column_eval = builder.try_consume_final_round_mle_evaluation()?;
+    let shifted_one_eval = builder.try_consume_one_evaluation()?;
+    verify_shift(
+        builder,
+        alpha,
+        beta,
+        column_eval,
+        shifted_column_eval,
+        one_eval,
+        shifted_one_eval,
+    )?;
+    // 2. Verify that `ind_eval` is correct. See above for the explanation.
+    let ind_eval = match (STRICT, ASC) {
+        (true, true) | (false, false) => shifted_column_eval - column_eval,
+        _ => column_eval - shifted_column_eval,
+    };
+    let sign_eval = verifier_evaluate_sign(builder, ind_eval, shifted_one_eval)?;
+    let singleton_one_eval = builder.mle_evaluations.singleton_one_evaluation;
+    let allowed_evals = if STRICT {
+        // sign(ind) == 1 for all but the first element and the last element
+        // The first and last elements can only fit into three patterns
+        // 1. negative and non-negative
+        // 2. non-negative and negative
+        // 3. non-negative and non-negative
+        // Hence the evaluation of sign has to be in one of three cases
+        // 1. one_eval
+        // 2. shifted_one_eval - singleton_one_eval
+        // 3. one_eval - singleton_one_eval
+        vec![
+            one_eval,
+            shifted_one_eval - singleton_one_eval,
+            one_eval - singleton_one_eval,
+        ]
+    } else {
+        // sign(ind) == 0 for all but the first element and the last element
+        // The first and last elements can only fit into four patterns
+        // 1. negative and non-negative
+        // 2. non-negative and negative
+        // 3. negative and negative
+        // 4. non-negative and non-negative (only the all zero case)
+        // Hence the evaluation of sign has to be in one of four cases
+        // 1. singleton_one_eval
+        // 2. shifted_one_eval - one_eval
+        // 3. singleton_one_eval + shifted_one_eval - one_eval
+        // 4. 0
+        vec![
+            singleton_one_eval,
+            shifted_one_eval - one_eval,
+            singleton_one_eval + shifted_one_eval - one_eval,
+            S::ZERO,
+        ]
+    };
+    if !allowed_evals.contains(&sign_eval) {
+        return Err(ProofError::VerificationError {
+            error: "monotonicty check failed",
+        });
+    }
+    Ok(())
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -1,0 +1,441 @@
+//! This module contains the implementation of the `MonotonicTestPlan` struct. This struct
+//! is used to check whether the monotonic gadget works correctly.
+use super::monotonic::{
+    final_round_evaluate_monotonic, first_round_evaluate_monotonic, verify_monotonic,
+};
+use crate::{
+    base::{
+        database::{
+            ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+        },
+        map::{indexset, IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    },
+};
+use bumpalo::Bump;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct MonotonicTestPlan<const STRICT: bool, const ASC: bool> {
+    pub column: ColumnRef,
+}
+
+impl<const STRICT: bool, const ASC: bool> ProverEvaluate for MonotonicTestPlan<STRICT, ASC> {
+    #[doc = "Evaluate the query, modify `FirstRoundBuilder` and return the result."]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        _alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the tables from the map using the table reference
+        let table: &Table<'a, S> = table_map
+            .get(&self.column.table_ref())
+            .expect("Table not found");
+        let num_rows = table.num_rows();
+        builder.request_post_result_challenges(2);
+        builder.produce_one_evaluation_length(num_rows);
+        // Evaluate the first round
+        first_round_evaluate_monotonic(builder, num_rows);
+        // This is just a dummy table, the actual data is not used
+        Table::try_new_with_options(IndexMap::default(), TableOptions { row_count: Some(0) })
+            .unwrap()
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the table from the map using the table reference
+        let table: &Table<'a, S> = table_map
+            .get(&self.column.table_ref())
+            .expect("Table not found");
+        let raw_column: Vec<S> = table
+            .inner_table()
+            .get(&self.column.column_id())
+            .expect("Column not found in table")
+            .to_scalar_with_scaling(0);
+        let alloc_column = alloc.alloc_slice_copy(&raw_column);
+        builder.produce_intermediate_mle(alloc_column as &[_]);
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+        final_round_evaluate_monotonic::<S, STRICT, ASC>(builder, alloc, alpha, beta, alloc_column);
+        // Return a dummy table
+        Table::try_new_with_options(IndexMap::default(), TableOptions { row_count: Some(0) })
+            .unwrap()
+    }
+}
+
+impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT, ASC> {
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        vec![]
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        indexset! {self.column.clone()}
+    }
+
+    #[doc = "Return all the tables referenced in the Query"]
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        indexset! {self.column.table_ref()}
+    }
+
+    #[doc = "Form components needed to verify and proof store into `VerificationBuilder`"]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        _one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        // Get the challenges from the builder
+        let alpha = builder.try_consume_post_result_challenge()?;
+        let beta = builder.try_consume_post_result_challenge()?;
+        // Get evaluations
+        let column_eval = builder.try_consume_final_round_mle_evaluation()?;
+        let one_eval = builder.try_consume_one_evaluation()?;
+        // Evaluate the verifier
+        verify_monotonic::<S, STRICT, ASC>(builder, alpha, beta, column_eval, one_eval)?;
+        Ok(TableEvaluation::new(vec![], S::zero()))
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{table_utility::*, ColumnType, TableTestAccessor},
+            math::decimal::Precision,
+            scalar::Curve25519Scalar,
+        },
+        sql::proof::{QueryError, VerifiableQueryResult},
+    };
+    use blitzar::proof::InnerProductProof;
+    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
+
+    fn check_monotonic<const STRICT: bool, const ASC: bool>(
+        table_ref: TableRef,
+        accessor: &TableTestAccessor<InnerProductProof>,
+        column_name: &str,
+        column_type: ColumnType,
+        shall_error: bool,
+    ) {
+        let plan = MonotonicTestPlan::<STRICT, ASC> {
+            column: ColumnRef::new(table_ref, column_name.into(), column_type),
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, accessor, &());
+        let res = verifiable_res.verify(&plan, accessor, &());
+        if shall_error {
+            assert!(matches!(
+                res,
+                Err(QueryError::ProofError {
+                    source: ProofError::VerificationError { .. }
+                })
+            ));
+        } else {
+            assert!(res.is_ok());
+        }
+    }
+
+    /// Monotonicity of a column
+    enum Monotonicity {
+        /// The column is constant e.g. [1, 1, 1, 1]
+        Constant,
+        /// The column is strictly increasing e.g. [1, 2, 3, 4]
+        StrictlyIncreasing,
+        /// The column is increasing but not strictly so and not constant e.g. [1, 1, 2, 3]
+        NonStrictlyIncreasing,
+        /// The column is strictly decreasing e.g. [4, 3, 2, 1]
+        StrictlyDecreasing,
+        /// The column is decreasing but not strictly so and not constant e.g. [3, 2, 2, 1]
+        NonStrictlyDecreasing,
+        /// The column is non-monotonic e.g. [1, 2, 1, 2]
+        NonMonotonic,
+        /// The column is empty, making all checks vacuously true
+        Vacuous,
+    }
+
+    impl Monotonicity {
+        fn is_strict_asc(&self) -> bool {
+            matches!(
+                self,
+                Monotonicity::StrictlyIncreasing | Monotonicity::Vacuous
+            )
+        }
+
+        fn is_asc(&self) -> bool {
+            matches!(
+                self,
+                Monotonicity::StrictlyIncreasing
+                    | Monotonicity::NonStrictlyIncreasing
+                    | Monotonicity::Constant
+                    | Monotonicity::Vacuous
+            )
+        }
+
+        fn is_strict_desc(&self) -> bool {
+            matches!(
+                self,
+                Monotonicity::StrictlyDecreasing | Monotonicity::Vacuous
+            )
+        }
+
+        fn is_desc(&self) -> bool {
+            matches!(
+                self,
+                Monotonicity::StrictlyDecreasing
+                    | Monotonicity::NonStrictlyDecreasing
+                    | Monotonicity::Constant
+                    | Monotonicity::Vacuous
+            )
+        }
+    }
+
+    /// Run `check_monotonic` for all columns in a table with known data types
+    ///
+    /// Note that all columns in the table should have the same monotonicity
+    /// e.g. constant, strictly increasing, strictly decreasing,
+    /// increasing but not strictly increasing, decreasing but non strictly decreasing,
+    /// non-monotonic
+    fn check_monotonic_for_table<const STRICT: bool, const ASC: bool>(
+        table_ref: TableRef,
+        accessor: &TableTestAccessor<InnerProductProof>,
+        shall_error: bool,
+    ) {
+        let precision = Precision::new(50).unwrap();
+        check_monotonic::<STRICT, ASC>(
+            table_ref,
+            accessor,
+            "smallint",
+            ColumnType::SmallInt,
+            shall_error,
+        );
+        check_monotonic::<STRICT, ASC>(table_ref, accessor, "int", ColumnType::Int, shall_error);
+        check_monotonic::<STRICT, ASC>(
+            table_ref,
+            accessor,
+            "bigint",
+            ColumnType::BigInt,
+            shall_error,
+        );
+        check_monotonic::<STRICT, ASC>(
+            table_ref,
+            accessor,
+            "boolean",
+            ColumnType::Boolean,
+            shall_error,
+        );
+        check_monotonic::<STRICT, ASC>(
+            table_ref,
+            accessor,
+            "decimal",
+            ColumnType::Decimal75(precision, 1),
+            shall_error,
+        );
+        check_monotonic::<STRICT, ASC>(
+            table_ref,
+            accessor,
+            "timestamp",
+            ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
+            shall_error,
+        );
+    }
+
+    /// Run `check_monotonic_for_table` for all possible forms of monotonicity
+    fn check_all_monotonic_for_table(
+        table: Table<Curve25519Scalar>,
+        expected_monotonicity: &Monotonicity,
+    ) {
+        let table_ref = "sxt.table".parse().unwrap();
+        let accessor =
+            TableTestAccessor::<InnerProductProof>::new_from_table(table_ref, table, 0, ());
+        check_monotonic_for_table::<true, true>(
+            table_ref,
+            &accessor,
+            !expected_monotonicity.is_strict_asc(),
+        );
+        check_monotonic_for_table::<false, true>(
+            table_ref,
+            &accessor,
+            !expected_monotonicity.is_asc(),
+        );
+        check_monotonic_for_table::<true, false>(
+            table_ref,
+            &accessor,
+            !expected_monotonicity.is_strict_desc(),
+        );
+        check_monotonic_for_table::<false, false>(
+            table_ref,
+            &accessor,
+            !expected_monotonicity.is_desc(),
+        );
+    }
+
+    #[test]
+    fn we_can_check_monotonicity_for_empty_columns() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_smallint("smallint", [0_i16; 0], &alloc),
+            borrowed_int("int", [0; 0], &alloc),
+            borrowed_bigint("bigint", [0_i64; 0], &alloc),
+            borrowed_boolean("boolean", [false; 0], &alloc),
+            borrowed_decimal75("decimal", 50, 1, [0; 0], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![0; 0],
+                &alloc,
+            ),
+        ]);
+        // Vacuously true
+        check_all_monotonic_for_table(table, &Monotonicity::Vacuous);
+    }
+
+    #[test]
+    fn we_can_check_monotonicity_for_zero_columns() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_smallint("smallint", [0_i16; 3], &alloc),
+            borrowed_int("int", [0; 3], &alloc),
+            borrowed_bigint("bigint", [0_i64; 3], &alloc),
+            borrowed_boolean("boolean", [false; 3], &alloc),
+            borrowed_decimal75("decimal", 50, 1, [0; 3], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![0; 3],
+                &alloc,
+            ),
+        ]);
+        check_all_monotonic_for_table(table, &Monotonicity::Constant);
+    }
+
+    #[test]
+    fn we_can_check_monotonicity_for_const_columns() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_smallint("smallint", [1_i16; 3], &alloc),
+            borrowed_int("int", [1; 3], &alloc),
+            borrowed_bigint("bigint", [-1_i64; 3], &alloc),
+            borrowed_boolean("boolean", [true; 3], &alloc),
+            borrowed_decimal75("decimal", 50, 1, [1; 3], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![1_625_072_400; 3],
+                &alloc,
+            ),
+        ]);
+        check_all_monotonic_for_table(table, &Monotonicity::Constant);
+    }
+
+    #[test]
+    fn we_can_check_monotonicity_for_strictly_increasing_columns() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_smallint("smallint", [i16::MIN, i16::MAX], &alloc),
+            borrowed_int("int", [-2, -1], &alloc),
+            borrowed_bigint("bigint", [1, 2], &alloc),
+            borrowed_boolean("boolean", [false, true], &alloc),
+            borrowed_decimal75("decimal", 50, 1, [-1, 1], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![1_625_072_400, 1_625_076_000],
+                &alloc,
+            ),
+        ]);
+        check_all_monotonic_for_table(table, &Monotonicity::StrictlyIncreasing);
+    }
+
+    #[test]
+    fn we_can_check_monotonicity_for_increasing_columns() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_smallint("smallint", [1_i16, 2, 2], &alloc),
+            borrowed_int("int", [-2, -2, 0], &alloc),
+            borrowed_bigint("bigint", [-1, 0, 0], &alloc),
+            borrowed_boolean("boolean", [false, false, true], &alloc),
+            borrowed_decimal75("decimal", 50, 1, [-1, 1, 1], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![1_625_072_400, 1_625_076_000, 1_625_076_000],
+                &alloc,
+            ),
+        ]);
+        check_all_monotonic_for_table(table, &Monotonicity::NonStrictlyIncreasing);
+    }
+
+    #[test]
+    fn we_can_check_monotonicity_for_strictly_decreasing_columns() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_smallint("smallint", [i16::MAX, i16::MIN], &alloc),
+            borrowed_int("int", [-1, -2], &alloc),
+            borrowed_bigint("bigint", [2, 1], &alloc),
+            borrowed_boolean("boolean", [true, false], &alloc),
+            borrowed_decimal75("decimal", 50, 1, [1, -1], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![1_625_076_000, 1_625_072_400],
+                &alloc,
+            ),
+        ]);
+        check_all_monotonic_for_table(table, &Monotonicity::StrictlyDecreasing);
+    }
+
+    #[test]
+    fn we_can_check_monotonicity_for_decreasing_columns() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_smallint("smallint", [2_i16, 2, 1], &alloc),
+            borrowed_int("int", [0, -2, -2], &alloc),
+            borrowed_bigint("bigint", [0, 0, -1], &alloc),
+            borrowed_boolean("boolean", [true, false, false], &alloc),
+            borrowed_decimal75("decimal", 50, 1, [1, 1, -1], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![1_625_076_000, 1_625_076_000, 1_625_072_400],
+                &alloc,
+            ),
+        ]);
+        check_all_monotonic_for_table(table, &Monotonicity::NonStrictlyDecreasing);
+    }
+
+    #[test]
+    fn we_can_check_monotonicity_for_non_monotonic_columns() {
+        let alloc = Bump::new();
+        let table = table([
+            borrowed_smallint("smallint", [1_i16, 2, 1], &alloc),
+            borrowed_int("int", [-2, -1, -2], &alloc),
+            borrowed_bigint("bigint", [1, 0, 1], &alloc),
+            borrowed_boolean("boolean", [false, true, false], &alloc),
+            borrowed_decimal75("decimal", 50, 1, [-1, 1, -1], &alloc),
+            borrowed_timestamptz(
+                "timestamp",
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                vec![1_625_072_400, 1_625_076_000, 1_625_072_400],
+                &alloc,
+            ),
+        ]);
+        check_all_monotonic_for_table(table, &Monotonicity::NonMonotonic);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.
Replaces #487 and #502

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to do inner joins and ordering we need to be able to prove that a single column is increasing, strictly or not.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add monotonic gadget.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.