### PR TITLE
feat: full Uint8 support

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -4,7 +4,7 @@ use arrow::{
     array::{
         Array, ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
         Int64Array, Int8Array, StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
-        TimestampNanosecondArray, TimestampSecondArray,
+        TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, TimeUnit as ArrowTimeUnit},
 };
@@ -128,6 +128,15 @@ impl ArrayRefExt for ArrayRef {
                         .ok_or(ArrowArrayToColumnConversionError::ArrayContainsNulls)?;
                     let values = alloc.alloc_slice_fill_with(range.len(), |i| boolean_slice[i]);
                     Ok(Column::Boolean(values))
+                } else {
+                    Err(ArrowArrayToColumnConversionError::UnsupportedType {
+                        datatype: self.data_type().clone(),
+                    })
+                }
+            }
+            DataType::UInt8 => {
+                if let Some(array) = self.as_any().downcast_ref::<UInt8Array>() {
+                    Ok(Column::Uint8(&array.values()[range.start..range.end]))
                 } else {
                     Err(ArrowArrayToColumnConversionError::UnsupportedType {
                         datatype: self.data_type().clone(),

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -43,6 +43,7 @@ impl TryFrom<DataType> for ColumnType {
     fn try_from(data_type: DataType) -> Result<Self, Self::Error> {
         match data_type {
             DataType::Boolean => Ok(ColumnType::Boolean),
+            DataType::UInt8 => Ok(ColumnType::Uint8),
             DataType::Int8 => Ok(ColumnType::TinyInt),
             DataType::Int16 => Ok(ColumnType::SmallInt),
             DataType::Int32 => Ok(ColumnType::Int),

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -166,6 +166,14 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .collect::<Option<Vec<bool>>>()
                     .ok_or(OwnedArrowConversionError::NullNotSupportedYet)?,
             )),
+            DataType::UInt8 => Ok(Self::Uint8(
+                value
+                    .as_any()
+                    .downcast_ref::<UInt8Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec(),
+            )),
             DataType::Int8 => Ok(Self::TinyInt(
                 value
                     .as_any()

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -248,6 +248,9 @@ impl ColumnBounds {
     pub fn try_union(self, other: Self) -> Result<Self, ColumnBoundsMismatch> {
         match (self, other) {
             (ColumnBounds::NoOrder, ColumnBounds::NoOrder) => Ok(ColumnBounds::NoOrder),
+            (ColumnBounds::Uint8(bounds_a), ColumnBounds::Uint8(bounds_b)) => {
+                Ok(ColumnBounds::Uint8(bounds_a.union(bounds_b)))
+            }
             (ColumnBounds::TinyInt(bounds_a), ColumnBounds::TinyInt(bounds_b)) => {
                 Ok(ColumnBounds::TinyInt(bounds_a.union(bounds_b)))
             }
@@ -280,6 +283,9 @@ impl ColumnBounds {
     pub fn try_difference(self, other: Self) -> Result<Self, ColumnBoundsMismatch> {
         match (self, other) {
             (ColumnBounds::NoOrder, ColumnBounds::NoOrder) => Ok(self),
+            (ColumnBounds::Uint8(bounds_a), ColumnBounds::Uint8(bounds_b)) => {
+                Ok(ColumnBounds::Uint8(bounds_a.difference(bounds_b)))
+            }
             (ColumnBounds::TinyInt(bounds_a), ColumnBounds::TinyInt(bounds_b)) => {
                 Ok(ColumnBounds::TinyInt(bounds_a.difference(bounds_b)))
             }

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -44,7 +44,8 @@ impl ColumnCommitmentMetadata {
         bounds: ColumnBounds,
     ) -> Result<ColumnCommitmentMetadata, InvalidColumnCommitmentMetadata> {
         match (column_type, bounds) {
-            (ColumnType::TinyInt, ColumnBounds::TinyInt(_))
+            (ColumnType::Uint8, ColumnBounds::Uint8(_))
+            | (ColumnType::TinyInt, ColumnBounds::TinyInt(_))
             | (ColumnType::SmallInt, ColumnBounds::SmallInt(_))
             | (ColumnType::Int, ColumnBounds::Int(_))
             | (ColumnType::BigInt, ColumnBounds::BigInt(_))

--- a/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
@@ -46,9 +46,9 @@ pub trait ArithmeticOp {
             });
         }
         match (&lhs, &rhs) {
-            // We can upcast a u8 into any of the signed types without incident. However, we cannot upcast
+            // We can cast a u8 into any of the signed types without incident. However, we cannot cast
             // a signed type into a u8 without potentially losing data. Therefore, we need a way to check
-            // that a signed type is greater than zero before we can upcast it into a u8.
+            // that a signed type is greater than zero before we can cast it into a u8.
             (OwnedColumn::Uint8(_), OwnedColumn::TinyInt(_)) => {
                 Err(ColumnOperationError::SignedCastingError {
                     left_type: ColumnType::Uint8,

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -56,6 +56,41 @@ pub trait ComparisonOp {
             });
         }
         let result = match (&lhs, &rhs) {
+            (OwnedColumn::Uint8(_), OwnedColumn::TinyInt(_)) => {
+                Err(ColumnOperationError::SignedCastingError {
+                    left_type: ColumnType::Uint8,
+                    right_type: ColumnType::TinyInt,
+                })
+            }
+            (OwnedColumn::Uint8(lhs), OwnedColumn::Uint8(rhs)) => {
+                Ok(slice_binary_op(lhs, rhs, Self::op))
+            }
+            (OwnedColumn::Uint8(lhs), OwnedColumn::SmallInt(rhs)) => {
+                Ok(slice_binary_op_left_upcast(lhs, rhs, Self::op))
+            }
+            (OwnedColumn::Uint8(lhs), OwnedColumn::Int(rhs)) => {
+                Ok(slice_binary_op_left_upcast(lhs, rhs, Self::op))
+            }
+            (OwnedColumn::Uint8(lhs), OwnedColumn::BigInt(rhs)) => {
+                Ok(slice_binary_op_left_upcast(lhs, rhs, Self::op))
+            }
+            (OwnedColumn::Uint8(lhs), OwnedColumn::Int128(rhs)) => {
+                Ok(slice_binary_op_left_upcast(lhs, rhs, Self::op))
+            }
+            (OwnedColumn::Uint8(lhs_values), OwnedColumn::Decimal75(_, _, rhs_values)) => {
+                Ok(Self::decimal_op_left_upcast(
+                    lhs_values,
+                    rhs_values,
+                    lhs.column_type(),
+                    rhs.column_type(),
+                ))
+            }
+            (OwnedColumn::TinyInt(_), OwnedColumn::Uint8(_)) => {
+                return Err(ColumnOperationError::SignedCastingError {
+                    left_type: ColumnType::TinyInt,
+                    right_type: ColumnType::Uint8,
+                })
+            }
             (OwnedColumn::TinyInt(lhs), OwnedColumn::TinyInt(rhs)) => {
                 Ok(slice_binary_op(lhs, rhs, Self::op))
             }

--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -72,6 +72,20 @@ pub enum ColumnOperationError {
         /// The length of the column
         len: usize,
     },
+
+    /// Errors related to casting between signed and unsigned types. This error can be
+    /// used as a signal that a casting operation is currently unsupported.
+    /// For example, an i8 can fit inside of a u8 iff it is greater than zero. The library
+    /// needs to have a way to check *and* prove that this condition is true. If the library
+    /// does not have a proving mechanism in place for this check, then this error is
+    /// then used to indicate that the operation is not supported.
+    #[snafu(display("Cannot fit {left_type} into {right_type} without losing data"))]
+    SignedCastingError {
+        /// `ColumnType` of left operand
+        left_type: ColumnType,
+        /// `ColumnType` of right operand
+        right_type: ColumnType,
+    },
 }
 
 /// Result type for column operations

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -18,6 +18,8 @@ pub enum LiteralValue {
     /// Boolean literals
     Boolean(bool),
     /// i8 literals
+    Uint8(u8),
+    /// i8 literals
     TinyInt(i8),
     /// i16 literals
     SmallInt(i16),
@@ -48,6 +50,7 @@ impl LiteralValue {
     pub fn column_type(&self) -> ColumnType {
         match self {
             Self::Boolean(_) => ColumnType::Boolean,
+            Self::Uint8(_) => ColumnType::Uint8,
             Self::TinyInt(_) => ColumnType::TinyInt,
             Self::SmallInt(_) => ColumnType::SmallInt,
             Self::Int(_) => ColumnType::Int,
@@ -64,6 +67,7 @@ impl LiteralValue {
     pub(crate) fn to_scalar<S: Scalar>(&self) -> S {
         match self {
             Self::Boolean(b) => b.into(),
+            Self::Uint8(i) => i.into(),
             Self::TinyInt(i) => i.into(),
             Self::SmallInt(i) => i.into(),
             Self::Int(i) => i.into(),

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -68,6 +68,9 @@ pub(crate) fn compare_single_row_of_tables<S: Scalar>(
             (Column::Boolean(left_col), Column::Boolean(right_col)) => {
                 left_col[left_row_index].cmp(&right_col[right_row_index])
             }
+            (Column::Uint8(left_col), Column::Uint8(right_col)) => {
+                left_col[left_row_index].cmp(&right_col[right_row_index])
+            }
             (Column::TinyInt(left_col), Column::TinyInt(right_col)) => {
                 left_col[left_row_index].cmp(&right_col[right_row_index])
             }
@@ -129,8 +132,8 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
         .map(|(col, direction)| {
             let ordering = match col {
                 OwnedColumn::Boolean(col) => col[i].cmp(&col[j]),
-                OwnedColumn::TinyInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::Uint8(col) => col[i].cmp(&col[j]),
+                OwnedColumn::TinyInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::SmallInt(col) => col[i].cmp(&col[j]),
                 OwnedColumn::Int(col) => col[i].cmp(&col[j]),
                 OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => {

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -45,6 +45,25 @@ pub fn owned_table<S: Scalar>(
     OwnedTable::try_from_iter(iter).unwrap()
 }
 
+/// Creates a (Ident, `OwnedColumn`) pair for a uint8 column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///     uint8("a", [1_u8, 2, 3]),
+/// ]);
+///```
+pub fn uint8<S: Scalar>(
+    name: impl Into<Ident>,
+    data: impl IntoIterator<Item = impl Into<u8>>,
+) -> (Ident, OwnedColumn<S>) {
+    (
+        name.into(),
+        OwnedColumn::Uint8(data.into_iter().map(Into::into).collect()),
+    )
+}
+
 /// Creates a (Ident, `OwnedColumn`) pair for a tinyint column.
 /// This is primarily intended for use in conjunction with [`owned_table`].
 /// # Example

--- a/crates/proof-of-sql/src/base/database/table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/table_utility.rs
@@ -64,6 +64,27 @@ pub fn table_with_row_count<'a, S: Scalar>(
     Table::try_from_iter_with_options(iter, TableOptions::new(Some(row_count))).unwrap()
 }
 
+/// Creates a (Ident, `Column`) pair for a uint8 column.
+/// This is primarily intended for use in conjunction with [`table`].
+/// # Example
+/// ```
+/// use bumpalo::Bump;
+/// use proof_of_sql::base::{database::table_utility::*, scalar::Curve25519Scalar};
+/// let alloc = Bump::new();
+/// let result = table::<Curve25519Scalar>([
+///     borrowed_uint8("a", [1_u8, 2, 3], &alloc),
+/// ]);
+///```
+pub fn borrowed_uint8<S: Scalar>(
+    name: impl Into<Ident>,
+    data: impl IntoIterator<Item = impl Into<u8>>,
+    alloc: &Bump,
+) -> (Ident, Column<'_, S>) {
+    let transformed_data: Vec<u8> = data.into_iter().map(Into::into).collect();
+    let alloc_data = alloc.alloc_slice_copy(&transformed_data);
+    (name.into(), Column::Uint8(alloc_data))
+}
+
 /// Creates a (Ident, `Column`) pair for a tinyint column.
 /// This is primarily intended for use in conjunction with [`table`].
 /// # Example

--- a/docs/SQLSyntaxSpecification.md
+++ b/docs/SQLSyntaxSpecification.md
@@ -15,6 +15,7 @@ FROM table
 * DataTypes
     - Bool / Boolean
     - Numeric Types
+        * Uint8 (8 bits)
         * TinyInt (8 bits)
         * SmallInt (16 bits)
         * Int / Integer (32 bits)


### PR DESCRIPTION
# Rationale for this change

#498 introduced minimal support for unsigned bytes as a PoSQL datatype. This was enough for commitments and other basic functionality. This PR introduces full-fledged support for Uint8 in anticipation of an upgrade to the PoSQL internal service (ProofsService).

# What changes are included in this PR?

- [x] Find every usage of verified fully functional types (i.e. do a grep for TinyInt) and make sure Uint8 accompanies the given functionality.

# Are these changes tested?
Covered in existing tests
