### PR TITLE
feat: add helper functions to `join_utils`

### DIFF
--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -41,7 +41,6 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
 /// Panics if `left` and `right` have different number of columns
 /// which should never happen since this function should only be called
 /// for joins.
-#[allow(dead_code)]
 pub(crate) fn compare_single_row_of_tables<S: Scalar>(
     left: &[Column<S>],
     right: &[Column<S>],

--- a/crates/proof-of-sql/src/base/database/table_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/table_operation_error.rs
@@ -17,6 +17,16 @@ pub enum TableOperationError {
         /// The schema of the table that caused the error
         actual_schema: Vec<ColumnField>,
     },
+    /// Errors related to joining tables with different numbers of columns.
+    #[snafu(display(
+        "Cannot join tables with different numbers of columns: {left_num_columns} and {right_num_columns}"
+    ))]
+    JoinWithDifferentNumberOfColumns {
+        /// The number of columns in the left-hand table
+        left_num_columns: usize,
+        /// The number of columns in the right-hand table
+        right_num_columns: usize,
+    },
     /// Errors related to joining tables on columns with incompatible types.
     #[snafu(display(
         "Cannot join tables on columns with incompatible types: {left_type:?} and {right_type:?}"


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
We need to add slice operations required for joins.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `ordered_set_union` and `get_multiplicities`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes