### PR TITLE
feat: add `Row`, add `literal_at()` to `Column` and `OwnedColumn` && add `row()` to `Table` and `OwnedTable`

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -7,6 +7,9 @@ pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAcc
 mod column;
 pub use column::{Column, ColumnField, ColumnRef, ColumnType};
 
+mod row;
+pub use row::Row;
+
 #[allow(dead_code)]
 mod slice_operation;
 

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -1,4 +1,4 @@
-use super::{ColumnField, OwnedColumn, Table};
+use super::{ColumnField, OwnedColumn, Row, Table};
 use crate::base::{
     database::ColumnCoercionError, map::IndexMap, polynomial::compute_evaluation_vector,
     scalar::Scalar,
@@ -129,6 +129,25 @@ impl<S: Scalar> OwnedTable<S> {
     /// Returns the columns of this table as an Iterator
     pub fn column_names(&self) -> impl Iterator<Item = &Ident> {
         self.table.keys()
+    }
+
+    /// Returns the ith row of the table.
+    ///
+    /// If index is out of bounds, this function returns `None`.
+    #[must_use]
+    pub fn row(&self, index: usize) -> Option<Row> {
+        (index < self.num_rows()).then(|| {
+            Row::new(
+                self.table
+                    .values()
+                    .map(|column| {
+                        column
+                            .literal_at(index)
+                            .expect("Index is guaranteed to be within bounds")
+                    })
+                    .collect(),
+            )
+        })
     }
 
     pub(crate) fn mle_evaluations(&self, evaluation_point: &[S]) -> Vec<S> {

--- a/crates/proof-of-sql/src/base/database/row.rs
+++ b/crates/proof-of-sql/src/base/database/row.rs
@@ -1,0 +1,32 @@
+use super::LiteralValue;
+use alloc::vec::Vec;
+
+/// A single row of data, holding a list of literal values.
+pub struct Row {
+    values: Vec<LiteralValue>,
+}
+
+impl Row {
+    /// Create a new `Row` from a vector of values.
+    pub fn new(values: Vec<LiteralValue>) -> Self {
+        Row { values }
+    }
+
+    /// Get the values of the row.
+    #[must_use]
+    pub fn values(&self) -> &[LiteralValue] {
+        &self.values
+    }
+
+    /// Get the length of the row.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Is the row empty?
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}

--- a/crates/proof-of-sql/src/base/database/table.rs
+++ b/crates/proof-of-sql/src/base/database/table.rs
@@ -1,4 +1,4 @@
-use super::{Column, ColumnField};
+use super::{Column, ColumnField, Row};
 use crate::base::{map::IndexMap, scalar::Scalar};
 use alloc::vec::Vec;
 use snafu::Snafu;
@@ -137,6 +137,24 @@ impl<'a, S: Scalar> Table<'a, S> {
     #[must_use]
     pub fn column(&self, index: usize) -> Option<&Column<'a, S>> {
         self.table.values().nth(index)
+    }
+    /// Returns the ith row of the table.
+    ///
+    /// If index is out of bounds, this function returns `None`.
+    #[must_use]
+    pub fn row(&self, index: usize) -> Option<Row> {
+        (index < self.row_count).then(|| {
+            Row::new(
+                self.table
+                    .values()
+                    .map(|column| {
+                        column
+                            .literal_at(index)
+                            .expect("index guaranteed to be within bounds")
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
     }
 }
 

--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -8,6 +8,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Copy)]
 pub struct I256([u64; 4]);
 impl I256 {
+    /// Creates a new `I256` from a `[u64; 4]`.
+    #[must_use]
+    pub fn new(value: [u64; 4]) -> Self {
+        Self(value)
+    }
     /// Computes the wrapping negative of the value. This could perhaps be more efficient.
     fn neg(self) -> Self {
         let mut res = ark_ff::BigInt([0; 4]);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

Depends on #504.
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In preparation for expansion of inner joins to multiple join columns we need to define rows so that we can run `ordered_set_union` and `get_multiplicities) (defined in #506) on them.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `I256::new`
- add `Row`
- add `literal_at` for `Column` and `OwnedColumn`
- add `row` to `Table` and `OwnedTable`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Will be.