### PR TITLE
refactor: fix membership check

### DIFF
--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -9,7 +9,7 @@ use crate::base::{
     map::{IndexMap, IndexSet},
     scalar::Scalar,
 };
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::cmp::Ordering;
 use itertools::Itertools;
@@ -66,18 +66,19 @@ pub(crate) fn ordered_set_union<'a, S: Scalar>(
 pub(crate) fn get_multiplicities<'a, S: Scalar>(
     data: &[Column<'a, S>],
     unique: &[Column<'a, S>],
-) -> Vec<i128> {
+    alloc: &'a Bump,
+) -> &'a [i128] {
     // If unique is empty, the multiplicities vector is empty
     if unique.is_empty() {
-        return Vec::new();
+        return alloc.alloc_slice_fill_copy(0, 0_i128);
     }
     let num_unique_rows = unique[0].len();
     // If data is empty, all multiplicities are 0
     if data.is_empty() {
-        return vec![0; num_unique_rows];
+        return alloc.alloc_slice_fill_copy(num_unique_rows, 0_i128);
     }
     let num_rows = data[0].len();
-    (0..num_unique_rows)
+    let multiplicities = (0..num_unique_rows)
         .map(|unique_index| {
             (0..num_rows)
                 .filter(|&data_index| {
@@ -86,7 +87,8 @@ pub(crate) fn get_multiplicities<'a, S: Scalar>(
                 })
                 .count() as i128
         })
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+    alloc.alloc_slice_copy(multiplicities.as_slice())
 }
 
 /// Compute the CROSS JOIN / cartesian product of two tables.
@@ -845,11 +847,12 @@ mod tests {
     /// Get Multiplicities
     #[test]
     fn we_can_get_multiplicities_empty_scenarios() {
+        let alloc = Bump::new();
         let empty_data: Vec<Column<TestScalar>> = vec![];
         let empty_unique: Vec<Column<TestScalar>> = vec![];
 
         // 1) Both 'data' and 'unique' empty
-        let result = get_multiplicities(&empty_data, &empty_unique);
+        let result = get_multiplicities(&empty_data, &empty_unique, &alloc);
         assert!(
             result.is_empty(),
             "When both are empty, result should be empty"
@@ -857,7 +860,7 @@ mod tests {
 
         // 2) 'unique' empty, 'data' non-empty
         let nonempty_data = vec![Column::<TestScalar>::Boolean(&[true, false])];
-        let result = get_multiplicities(&nonempty_data, &empty_unique);
+        let result = get_multiplicities(&nonempty_data, &empty_unique, &alloc);
         assert!(
             result.is_empty(),
             "When 'unique' is empty, result must be empty"
@@ -865,16 +868,17 @@ mod tests {
 
         // 3) 'unique' non-empty, 'data' empty => all zeros
         let nonempty_unique = vec![Column::<TestScalar>::Boolean(&[true, true, false])];
-        let result = get_multiplicities(&empty_data, &nonempty_unique);
+        let result = get_multiplicities(&empty_data, &nonempty_unique, &alloc);
         assert_eq!(
             result,
-            vec![0_i128; 3],
+            &[0_i128, 0, 0],
             "If data is empty, multiplicities should be zeros"
         );
     }
 
     #[test]
     fn we_can_get_multiplicities() {
+        let alloc = Bump::new();
         let data = vec![
             Column::<TestScalar>::Boolean(&[true, false, true, true, true]),
             Column::<TestScalar>::Int(&[1, 2, 1, 1, 2]),
@@ -886,7 +890,7 @@ mod tests {
             Column::<TestScalar>::BigInt(&[2_i64, 4, 1, 1]),
         ];
 
-        let result = get_multiplicities(&data, &unique);
-        assert_eq!(result, vec![1, 0, 3, 1], "Expected multiplicities");
+        let result = get_multiplicities(&data, &unique, &alloc);
+        assert_eq!(result, &[1, 0, 3, 1], "Expected multiplicities");
     }
 }

--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -66,7 +66,7 @@ pub(crate) fn ordered_set_union<'a, S: Scalar>(
 pub(crate) fn get_multiplicities<'a, S: Scalar>(
     data: &[Column<'a, S>],
     unique: &[Column<'a, S>],
-) -> Vec<u64> {
+) -> Vec<i128> {
     // If unique is empty, the multiplicities vector is empty
     if unique.is_empty() {
         return Vec::new();
@@ -84,7 +84,7 @@ pub(crate) fn get_multiplicities<'a, S: Scalar>(
                     compare_single_row_of_tables(data, unique, data_index, unique_index)
                         == Ok(Ordering::Equal)
                 })
-                .count() as u64
+                .count() as i128
         })
         .collect::<Vec<_>>()
 }
@@ -868,7 +868,7 @@ mod tests {
         let result = get_multiplicities(&empty_data, &nonempty_unique);
         assert_eq!(
             result,
-            vec![0_u64; 3],
+            vec![0_i128; 3],
             "If data is empty, multiplicities should be zeros"
         );
     }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -32,6 +32,7 @@ pub trait Scalar:
     + for<'a> core::convert::From<&'a i64> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a i128> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a u8> // Required for `Column` to implement `MultilinearExtension`
+    + for<'a> core::convert::From<&'a u64> // Required for `Column` to implement `MultilinearExtension`
     + core::convert::TryInto <bool>
     + core::convert::TryInto<u8>
     + core::convert::TryInto <i8>

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -122,6 +122,8 @@ impl ProverEvaluate for MembershipCheckTestPlan {
             alloc,
             alpha,
             beta,
+            alloc.alloc_slice_fill_copy(source_table.num_rows(), true),
+            alloc.alloc_slice_fill_copy(candidate_table.num_rows(), true),
             &source_columns,
             &candidate_columns,
         );


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
We want to let membership check gadget take care of multiplicity computation to reduce the amount of duplicates in the sort merge join code.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.