### PR TITLE
feat: add Yul Transcript and MathUtil libraries

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -243,10 +243,12 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
+      - name: Install dependencies
+        run: solidity/scripts/install_deps.sh
       - name: Run tests
-        run: |
-          solidity/scripts/install_deps.sh
-          solidity/scripts/test.sh -vvv
+        run: solidity/scripts/pre_forge.sh test -vvv
+      - name: Check code coverage
+        run: solidity/scripts/check_coverage.sh
 
   solhint:
     name: solhint
@@ -256,7 +258,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install solhint
         run: npm install -g solhint
-      - name: Run tests
+      - name: Run lints
         run: |
           cd solidity/src
           solhint '**/*.sol' -w 0

--- a/solidity/scripts/check_coverage.sh
+++ b/solidity/scripts/check_coverage.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+solidity/scripts/pre_forge.sh coverage
+if [ $(solidity/scripts/pre_forge.sh coverage | grep -o "[0-9\.]*%" | uniq | tr -d '\n') != "%100.00%" ]; then
+    >&2 echo "missing test coverage!"
+    exit 1
+fi
+echo "100% test coverage!"

--- a/solidity/scripts/pre_forge.sh
+++ b/solidity/scripts/pre_forge.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 scripts/preprocess_yul_imports.sh src
-forge test "$@"
+forge "$@"

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+// This is the modulus of the bn254 scalar field.
+uint256 constant MODULUS = 0x30644e72_e131a029_b85045b6_8181585d_2833e848_79b97091_43e1f593_f0000001;
+// This is largest mask that can be applied to a 256-bit number in order to enforce that it is less than the modulus.
+uint256 constant MODULUS_MASK = 0x1FFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF;
+// This is the size of a word in bytes: 32.
+uint256 constant WORD_SIZE = 0x20;
+// This is the position of the free memory pointer in the context of the EVM memory.
+uint256 constant FREE_PTR = 0x40;

--- a/solidity/src/base/MathUtil.sol
+++ b/solidity/src/base/MathUtil.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+/// @title Math Utilities Library
+/// @notice Provides functions to perform various math operations
+library MathUtil {
+    /// @notice Computes `max(1,ceil(log_2(value)))`
+    /// @dev The smallest integer greater than or equal to the base 2 logarithm of a number.
+    /// If the number is less than 2, the result is 1.
+    /// @param value0 The input value for which to compute the logarithm
+    /// @return exponent0 The computed logarithm value
+    function log2Up(uint256 value0) internal pure returns (uint256 exponent0) {
+        assembly {
+            function log2_up(value) -> exponent {
+                if value { value := sub(value, 1) }
+                exponent := 1
+                for {} shr(exponent, value) {} { exponent := add(exponent, 1) }
+            }
+            exponent0 := log2_up(value0)
+        }
+    }
+}

--- a/solidity/src/base/Transcript.sol
+++ b/solidity/src/base/Transcript.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+// assembly only constants
+// solhint-disable-next-line no-unused-import
+import {FREE_PTR, MODULUS_MASK, WORD_SIZE} from "./Constants.sol";
+
+/// @title Transcript Library
+/// @notice Provides functions to manage a simple public coin transcript
+/// @dev The transcript is a sequence of messages and challenges, where each challenge is a scalar (less than MODULUS).
+library Transcript {
+    /// @notice Draw a challenge from the transcript, and update the state of the transcript.
+    /// @dev The result should be a scalar value (less than MODULUS).
+    /// The challenges is a masked version of the current state of the transcript.
+    /// The new state of the transcript is the hash of the current state.
+    /// @param transcript0 The current state of the transcript
+    /// @return result0 The drawn challenge
+    function drawChallenge(uint256[1] memory transcript0) internal pure returns (uint256 result0) {
+        assembly {
+            function draw_challenge(transcript_ptr) -> result {
+                result := and(mload(transcript_ptr), MODULUS_MASK)
+                mstore(transcript_ptr, keccak256(transcript_ptr, WORD_SIZE))
+            }
+            result0 := draw_challenge(transcript0)
+        }
+    }
+
+    /// @notice Draw multiple challenges from the transcript, and update the state of the transcript.
+    /// @dev This is equivalent to calling `drawChallenge` multiple times.
+    /// The returned value is a pointer to newly allocated memory containing the challenges.
+    /// The first entry is NOT the length of the results. That is count.
+    /// @param transcript0 The current state of the transcript
+    /// @param count0 The number of challenges to draw
+    /// @return resultPtr0 A pointer to the memory containing the drawn challenges
+    function drawChallenges(uint256[1] memory transcript0, uint256 count0) internal pure returns (uint256 resultPtr0) {
+        assembly {
+            function draw_challenges(transcript_ptr, count) -> result_ptr {
+                // allocate `count` words
+                let free_ptr := mload(FREE_PTR)
+                mstore(FREE_PTR, add(free_ptr, mul(count, WORD_SIZE)))
+                // result is the pointer to the first word
+                result_ptr := free_ptr
+                // first challenge is the current transcript state
+                let challenge := mload(transcript_ptr)
+                for {} count {} {
+                    mstore(transcript_ptr, challenge)
+
+                    // store challenge in next word
+                    mstore(free_ptr, and(challenge, MODULUS_MASK))
+                    // hash challenge to get next challenge
+                    challenge := keccak256(transcript_ptr, WORD_SIZE)
+                    // increment to next word
+                    free_ptr := add(free_ptr, WORD_SIZE)
+                    // decrement count
+                    count := sub(count, 1)
+                }
+                // The last (unused) challenge is the current state of the transcript
+                mstore(transcript_ptr, challenge)
+            }
+            resultPtr0 := draw_challenges(transcript0, count0)
+        }
+    }
+
+    /// @notice Append calldata to the transcript, and update the state of the transcript.
+    /// @dev This is achieved by hashing the current transcript state with the new calldata.
+    /// @param transcript0 The current state of the transcript
+    /// @param data0 The calldata to append
+    /// @return transcriptOut0 The updated state of the transcript
+    function appendCalldata( // solhint-disable-line gas-calldata-parameters
+    uint256[1] memory transcript0, bytes calldata data0)
+        external
+        pure
+        returns (uint256[1] memory transcriptOut0)
+    {
+        assembly {
+            function append_calldata(transcript_ptr, offset, size) {
+                let free_ptr := mload(FREE_PTR)
+                mstore(free_ptr, mload(transcript_ptr))
+                calldatacopy(add(free_ptr, WORD_SIZE), offset, size)
+                mstore(transcript_ptr, keccak256(free_ptr, add(size, WORD_SIZE)))
+            }
+            append_calldata(transcript0, data0.offset, data0.length)
+        }
+        transcriptOut0 = transcript0;
+    }
+}

--- a/solidity/test/base/MathUtil.t.sol
+++ b/solidity/test/base/MathUtil.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {MathUtil} from "../../src/base/MathUtil.sol";
+
+library MathUtilTest {
+    function testWeCanComputeLog2Up() public pure {
+        /* solhint-disable gas-strict-inequalities */
+        for (uint256 i = 0; i <= 2; ++i) {
+            assert(MathUtil.log2Up(i) == 1);
+        }
+        for (uint256 i = 3; i <= 4; ++i) {
+            assert(MathUtil.log2Up(i) == 2);
+        }
+        for (uint256 i = 5; i <= 8; ++i) {
+            assert(MathUtil.log2Up(i) == 3);
+        }
+        for (uint256 i = 9; i <= 16; ++i) {
+            assert(MathUtil.log2Up(i) == 4);
+        }
+        for (uint256 i = 17; i <= 32; ++i) {
+            assert(MathUtil.log2Up(i) == 5);
+        }
+        /* solhint-enable gas-strict-inequalities */
+    }
+
+    function testFuzzLog2Up(uint256 value) public pure {
+        uint256 exponent = MathUtil.log2Up(value);
+        if (value < 2) {
+            assert(exponent == 1);
+            return;
+        } else if (exponent < 256) {
+            assert((1 << exponent) >= value); // solhint-disable-line gas-strict-inequalities
+            assert((1 << (exponent - 1)) < value);
+        } else {
+            assert(exponent == 256);
+            assert((1 << 255) < value);
+        }
+    }
+}

--- a/solidity/test/base/Transcript.t.sol
+++ b/solidity/test/base/Transcript.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Transcript} from "../../src/base/Transcript.sol";
+import {MODULUS, WORD_SIZE, FREE_PTR} from "../../src/base/Constants.sol";
+
+library TranscriptTest {
+    function testWeCanDrawChallenge() public pure {
+        uint256[1] memory transcriptAPtr = [uint256(12345)];
+        uint256[1] memory transcriptBPtr = [uint256(6789)];
+        uint256 challengeA1 = Transcript.drawChallenge(transcriptAPtr);
+        uint256 challengeA2 = Transcript.drawChallenge(transcriptAPtr);
+        uint256 challengeB1 = Transcript.drawChallenge(transcriptBPtr);
+        uint256 challengeB2 = Transcript.drawChallenge(transcriptBPtr);
+        assert(challengeA1 == 12345);
+        assert(challengeA1 != challengeA2);
+        assert(challengeB1 == 6789);
+        assert(challengeB1 != challengeB2);
+        assert(challengeA1 != challengeB2);
+        assert(challengeB1 != challengeA2);
+        assert(challengeA2 != challengeB2);
+        assert(challengeA1 < MODULUS);
+        assert(challengeA2 < MODULUS);
+        assert(challengeB1 < MODULUS);
+        assert(challengeB2 < MODULUS);
+    }
+
+    function testWeCanDrawMultipleChallenges() public pure {
+        uint256[1] memory transcriptAPtr = [uint256(12345)];
+        uint256[1] memory transcriptBPtr = [uint256(12345)];
+        uint256 challengeA1 = Transcript.drawChallenge(transcriptAPtr);
+        uint256 challengeA2 = Transcript.drawChallenge(transcriptAPtr);
+        uint256 challengeA3 = Transcript.drawChallenge(transcriptAPtr);
+        uint256 challengeA4 = Transcript.drawChallenge(transcriptAPtr);
+
+        uint256 resultBPtr = Transcript.drawChallenges(transcriptBPtr, 4);
+        uint256[4] memory resultB;
+        assembly {
+            resultB := resultBPtr
+        }
+
+        assert(challengeA1 == resultB[0]);
+        assert(challengeA2 == resultB[1]);
+        assert(challengeA3 == resultB[2]);
+        assert(challengeA4 == resultB[3]);
+        assert(challengeA1 < MODULUS);
+        assert(challengeA2 < MODULUS);
+        assert(challengeA3 < MODULUS);
+        assert(challengeA4 < MODULUS);
+    }
+
+    function testFuzzTwoTranscriptsGiveDifferentChallengesUnlessTheyAreTheSame(
+        uint256[1] memory transcriptA,
+        uint256[1] memory transcriptB
+    ) public pure {
+        uint256 challengeA1 = Transcript.drawChallenge(transcriptA);
+        uint256 challengeB1 = Transcript.drawChallenge(transcriptB);
+        uint256 challengeA2 = Transcript.drawChallenge(transcriptA);
+        uint256 challengeB2 = Transcript.drawChallenge(transcriptB);
+        if (transcriptA[0] == transcriptB[0]) {
+            assert(challengeA1 == challengeB1);
+            assert(challengeA2 == challengeB2);
+        } else {
+            assert(challengeA1 != challengeB1);
+            assert(challengeA2 != challengeB2);
+        }
+        assert(challengeA1 != challengeA2);
+        assert(challengeA1 != challengeB2);
+        assert(challengeA2 != challengeB1);
+        assert(challengeB1 != challengeB2);
+        assert(challengeA1 < MODULUS);
+        assert(challengeA2 < MODULUS);
+        assert(challengeB1 < MODULUS);
+        assert(challengeB2 < MODULUS);
+    }
+
+    function testFuzzSameTranscriptsGiveSameChallenges(uint256 state) public pure {
+        testFuzzTwoTranscriptsGiveDifferentChallengesUnlessTheyAreTheSame([state], [state]);
+    }
+
+    function testFuzzDrawingMultipleChallengesGivesTheSameChallengesAsIndividually(uint256 state, uint8 count)
+        public
+        pure
+    {
+        uint256[1] memory transcriptA = [state];
+        uint256[1] memory transcriptB = [state];
+        uint256 freePtrBefore;
+        assembly {
+            freePtrBefore := mload(FREE_PTR)
+        }
+        uint256 challengePtr = Transcript.drawChallenges(transcriptA, count);
+        uint256 freePtrAfter;
+        assembly {
+            freePtrAfter := mload(FREE_PTR)
+        }
+        assert(freePtrBefore + count * WORD_SIZE == freePtrAfter);
+        for (uint256 i = 0; i < count; ++i) {
+            uint256 challenge = Transcript.drawChallenge(transcriptB);
+            uint256 result;
+            assembly {
+                result := mload(challengePtr)
+            }
+            challengePtr += WORD_SIZE;
+            assert(challenge == result);
+            assert(challenge < MODULUS);
+        }
+    }
+
+    function testAppendCalldata() public pure {
+        uint256[1] memory state = Transcript.appendCalldata(
+            [0x0123456789ABCDEF_0123456789ABCDEF_0123456789ABCDEF_0123456789ABCDEF], hex"C001C0DE"
+        );
+        uint256 expectedState = uint256(
+            keccak256(
+                hex"0123456789ABCDEF" hex"0123456789ABCDEF" hex"0123456789ABCDEF" hex"0123456789ABCDEF" hex"C001C0DE"
+            )
+        );
+        assert(state[0] == expectedState);
+    }
+
+    function testFuzzAppendCalldata(uint256 start, bytes calldata data) public pure {
+        uint256[1] memory state = Transcript.appendCalldata([start], data);
+        uint256 expectedState = uint256(keccak256(abi.encodePacked(start, data)));
+        assert(state[0] == expectedState);
+    }
+}


### PR DESCRIPTION
# Rationale for this change

This PR is the first of many breaking #508 into manageable pieces.

# What changes are included in this PR?

The following Yul functions are added, along with testing around them. They will be imported in future PRs.
* `log2_up`
* `draw_challenge`
* `draw_challenges`
* `append_calldata`


# Are these changes tested?
Yes