### PR TITLE
feat: add ECPrecompiles Yul library

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -247,6 +247,8 @@ jobs:
         run: solidity/scripts/install_deps.sh
       - name: Run tests
         run: solidity/scripts/pre_forge.sh test -vvv
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
       - name: Check code coverage
         run: solidity/scripts/check_coverage.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ output/
 *.post.sol
 
 **/dependencies
+
+solidity/lcov.info
+solidity/coverage-report

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -4,6 +4,7 @@ out = "out"
 solc = "0.8.28"
 libs = ["dependencies"]
 no-match-path = "**/*.pre.sol"
+no-match-coverage = "pre.sol"
 
 [dependencies]
 forge-std = "1.9.5"

--- a/solidity/scripts/README.md
+++ b/solidity/scripts/README.md
@@ -1,6 +1,6 @@
-# Yul Import Preprocessor
+# Yul and Solidity Import Preprocessor
 
-This script processes Solidity files containing special Yul import directives and replaces function declarations with the actual imported Yul code.
+This script processes Solidity files containing special Yul import directives and replaces function declarations with the actual imported Yul code. It also updates Solidity import paths from `.pre.sol` to `.post.sol`.
 
 ## Usage
 
@@ -18,8 +18,12 @@ The script will recursively process all `*.pre.sol` files in the specified direc
    // IMPORT-YUL path/to/file.sol
    function someFunction() { ... }
    ```
+3. It also updates Solidity import paths from `.pre.sol` to `.post.sol`:
+   ```solidity
+   import {SomeLibrary} from "./SomeLibrary.pre.sol";
+   ```
 
-3. When it finds an import directive:
+4. When it finds an import directive:
    - Resolves the import path relative to the source file.
    - Locates the specified function in the imported file.
    - Replaces the original function with the imported implementation.
@@ -59,6 +63,8 @@ contract YulUtils {
 
 Main contract (`Contract.pre.sol`):
 ```solidity
+import {YulUtils} from "../libs/YulUtils.pre.sol";
+
 contract MyContract {
     function processData(uint256 value) public pure returns (bytes32) {
         assembly {
@@ -79,6 +85,8 @@ contract MyContract {
 
 After processing (`Contract.post.sol`):
 ```solidity
+import {YulUtils} from "../libs/YulUtils.post.sol";
+
 contract MyContract {
     function processData(uint256 value) public pure returns (bytes32) {
         assembly {

--- a/solidity/scripts/check_coverage.sh
+++ b/solidity/scripts/check_coverage.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-solidity/scripts/pre_forge.sh coverage
-if [ $(solidity/scripts/pre_forge.sh coverage | grep -o "[0-9\.]*%" | uniq | tr -d '\n') != "%100.00%" ]; then
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+scripts/pre_forge.sh coverage -q --report lcov
+gawk -i inplace '
+    BEGIN { e=0; p="" }
+    $0 ~ /exclude_coverage_start/ { e=1; p=""; next }
+    $0 ~ /exclude_coverage_stop/ { e=0; next }
+    e==0 { if(p) print p; p=$0 }
+    END { if(p) print p }
+    ' lcov.info
+percentage=$(genhtml lcov.info -o coverage-report --branch-coverage | grep -o "[0-9\.]*%" | uniq | tr -d '\n')
+if [ $percentage != "100.0%" ]; then
     >&2 echo "missing test coverage!"
     exit 1
 fi

--- a/solidity/scripts/install_deps.sh
+++ b/solidity/scripts/install_deps.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 forge soldeer install

--- a/solidity/scripts/lint-and-test.sh
+++ b/solidity/scripts/lint-and-test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# This script is used to lint and test the Solidity codebase.
+# It is not used in the CI pipeline, but shold be identical to the CI pipeline's test job.
+# The CI pipeline is explicitly written out to make the pipeline more readable.
+set -euo pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+scripts/install_deps.sh
+scripts/pre_forge.sh test --summary
+scripts/check_coverage.sh
+solhint 'src/**/*.sol' 'test/**/*.sol' -w 0

--- a/solidity/scripts/pre_forge.sh
+++ b/solidity/scripts/pre_forge.sh
@@ -3,4 +3,5 @@ set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 scripts/preprocess_yul_imports.sh src
+scripts/preprocess_yul_imports.sh test
 forge "$@"

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -2,11 +2,51 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
-// This is the modulus of the bn254 scalar field.
+/// @dev The modulus of the bn254 scalar field.
 uint256 constant MODULUS = 0x30644e72_e131a029_b85045b6_8181585d_2833e848_79b97091_43e1f593_f0000001;
-// This is largest mask that can be applied to a 256-bit number in order to enforce that it is less than the modulus.
+/// @dev The largest mask that can be applied to a 256-bit number in order to enforce that it is less than the modulus.
 uint256 constant MODULUS_MASK = 0x1FFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF;
-// This is the size of a word in bytes: 32.
+/// @dev Size of a word in bytes: 32.
 uint256 constant WORD_SIZE = 0x20;
-// This is the position of the free memory pointer in the context of the EVM memory.
+/// @dev Size of two words in bytes.
+uint256 constant WORDX2_SIZE = 0x20 * 2;
+/// @dev Size of three words in bytes.
+uint256 constant WORDX3_SIZE = 0x20 * 3;
+/// @dev Size of four words in bytes.
+uint256 constant WORDX4_SIZE = 0x20 * 4;
+/// @dev Size of twelve words in bytes.
+uint256 constant WORDX12_SIZE = 0x20 * 12;
+
+/// @dev Position of the free memory pointer in the context of the EVM memory.
 uint256 constant FREE_PTR = 0x40;
+
+/// @dev Address of the ECADD precompile.
+uint256 constant ECADD_ADDRESS = 0x06;
+/// @dev Address of the ECMUL precompile.
+uint256 constant ECMUL_ADDRESS = 0x07;
+/// @dev Address of the ECPAIRING precompile.
+uint256 constant ECPAIRING_ADDRESS = 0x08;
+/// @dev Gas cost for the ECADD precompile.
+uint256 constant ECADD_GAS = 150;
+/// @dev Gas cost for the ECMUL precompile.
+uint256 constant ECMUL_GAS = 6000;
+/// @dev Gas cost for the ECPAIRING precompile with two pairings.
+uint256 constant ECPAIRINGX2_GAS = 45000 + 2 * 34000;
+
+/// @dev Error code for when ECADD inputs are invalid.
+uint256 constant INVALID_EC_ADD_INPUTS = 0x765bcba0_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when ECMUL inputs are invalid.
+uint256 constant INVALID_EC_MUL_INPUTS = 0xe32c7472_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when ECPAIRING inputs are invalid.
+uint256 constant INVALID_EC_PAIRING_INPUTS = 0x4385b511_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+
+/// @title Errors library
+/// @notice Library containing custom error definitions.
+library Errors {
+    /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
+    error InvalidECAddInputs();
+    /// @notice Error thrown when the inputs to the ECMUL precompile are invalid.
+    error InvalidECMulInputs();
+    /// @notice Error thrown when the inputs to the ECPAIRING precompile are invalid.
+    error InvalidECPairingInputs();
+}

--- a/solidity/src/base/ECPrecompiles.pre.sol
+++ b/solidity/src/base/ECPrecompiles.pre.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+// assembly only constants
+/* solhint-disable no-unused-import */
+import {
+    ECADD_ADDRESS,
+    ECADD_GAS,
+    ECMUL_ADDRESS,
+    ECMUL_GAS,
+    ECPAIRING_ADDRESS,
+    ECPAIRINGX2_GAS,
+    INVALID_EC_ADD_INPUTS,
+    INVALID_EC_MUL_INPUTS,
+    INVALID_EC_PAIRING_INPUTS,
+    WORD_SIZE,
+    WORDX2_SIZE,
+    WORDX3_SIZE,
+    WORDX4_SIZE,
+    WORDX12_SIZE
+} from "./Constants.sol";
+/* solhint-enable no-unused-import */
+
+/// @title ECPrecompiles Library
+/// @notice A library holding Yul wrappers for the precompiled contracts.
+library ECPrecompiles {
+    /// @notice Wrapper around the ECADD precompile.
+    /// @dev The words are in the format [a_x, a_y, b_x, b_y], where the point a = (a_x, a_y) and b = (b_x, b_y).
+    /// This function does an in-place addition of the points a and b. In other words, it sets a += b.
+    /// The result is stored in the first two words of the input. If c = a + b, then the input memory is
+    /// modified to be [c_x, c_y, b_x, b_y].
+    /// @param argsPtr0 The input memory containing the points to be added.
+    function ecAdd(uint256[4] memory argsPtr0) internal view {
+        assembly {
+            function ec_add(args_ptr) {
+                if iszero(staticcall(ECADD_GAS, ECADD_ADDRESS, args_ptr, WORDX4_SIZE, args_ptr, WORDX2_SIZE)) {
+                    mstore(0, INVALID_EC_ADD_INPUTS)
+                    revert(0, 4)
+                }
+            }
+            ec_add(argsPtr0)
+        }
+    }
+
+    /// @notice Wrapper around the ECMUL precompile.
+    /// @dev The words are in the format [a_x, a_y, scalar], where the point a = (a_x, a_y) and scalar is the scalar to multiply by.
+    /// This function does an in-place multiplication of the point a by the scalar. In other words, it sets a *= scalar.
+    /// The result is stored in the first two words of the input. If c = a * scalar, then the input memory is
+    /// modified to be [c_x, c_y, scalar].
+    /// @param argsPtr0 The input memory containing the point and scalar to be multiplied.
+    function ecMul(uint256[3] memory argsPtr0) internal view {
+        assembly {
+            function ec_mul(args_ptr) {
+                if iszero(staticcall(ECMUL_GAS, ECMUL_ADDRESS, args_ptr, WORDX3_SIZE, args_ptr, WORDX2_SIZE)) {
+                    mstore(0, INVALID_EC_MUL_INPUTS)
+                    revert(0, 4)
+                }
+            }
+            ec_mul(argsPtr0)
+        }
+    }
+
+    /// @notice Wrapper around the ECPAIRING precompile.
+    /// @dev The words are in the format [a_x, a_y, g_x_imag, g_x_real, g_y_imag, g_y_real, b_x, b_y, h_x_imag, h_x_real, h_y_imag, h_y_real].
+    /// Where the point a = (a_x, a_y) and the points g = (g_x_real + g_x_imag * i, g_y_real + g_y_imag * i),
+    /// b = (b_x, b_y), and h = (h_x_real + h_x_imag * i, h_y_real + h_y_imag * i).
+    /// This function computes the pairing check e(a, b) + e(g, h) == 0.
+    /// If the pairing check is successful, the function returns 1. Otherwise, it returns 0.
+    /// The input memory will have the first slot replaced by the returned value.
+    /// @param argsPtr0 The input memory containing the points for the pairing check.
+    /// @return success0 The result of the pairing check.
+    function ecPairingX2(uint256[12] memory argsPtr0) internal view returns (uint256 success0) {
+        assembly {
+            function ec_pairing_x2(args_ptr) -> success {
+                if iszero(staticcall(ECPAIRINGX2_GAS, ECPAIRING_ADDRESS, args_ptr, WORDX12_SIZE, args_ptr, WORD_SIZE)) {
+                    mstore(0, INVALID_EC_PAIRING_INPUTS)
+                    revert(0, 4)
+                }
+                success := mload(args_ptr)
+            }
+            success0 := ec_pairing_x2(argsPtr0)
+        }
+    }
+
+    /// @notice Convenience function for multiplying a point by a scalar in place.
+    /// @dev This is a thin wrapper around `ecMul` that sets the scalar in the input memory.
+    /// In effect, this function does the operation `a *= scalar`.
+    /// The input memory is in the format [a_x, a_y, _]. The third slot is used as scratch space to store the scalar.
+    /// @param argsPtr0 The input memory containing the point to be multiplied.
+    /// @param scalar0 The scalar to multiply the point by.
+    function ecMulAssign(uint256[3] memory argsPtr0, uint256 scalar0) internal view {
+        assembly {
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_mul(args_ptr) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            function ec_mul_assign(args_ptr, scalar) {
+                mstore(add(args_ptr, WORDX2_SIZE), scalar)
+                ec_mul(args_ptr)
+            }
+            ec_mul_assign(argsPtr0, scalar0)
+        }
+    }
+
+    /// @notice Wrapper around the ECADD precompile that takes the second point as calldata.
+    /// @dev The first point is in memory, and the second point is in calldata.
+    /// In effect, this function does the operation `a += c`, where c is in calldata and a is in memory.
+    /// The input memory is in the format [a_x, a_y, _, _]. The third and fourth slots are used as scratch space.
+    /// @param argsPtr0 The input memory containing the first point.
+    /// @param cPtr0 The calldata containing the second point.
+    /// @return argsPtrOut0 The result of the addition.
+    function calldataECAddAssign( // solhint-disable-line gas-calldata-parameters
+    uint256[4] memory argsPtr0, uint256[2] calldata cPtr0)
+        external
+        view
+        returns (uint256[4] memory argsPtrOut0)
+    {
+        assembly {
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_add(args_ptr) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            function calldata_ec_add_assign(args_ptr, c_ptr) {
+                calldatacopy(add(args_ptr, WORDX2_SIZE), c_ptr, WORDX2_SIZE)
+                ec_add(args_ptr)
+            }
+            calldata_ec_add_assign(argsPtr0, cPtr0)
+        }
+        argsPtrOut0 = argsPtr0;
+    }
+
+    /// @notice Convenience function for multiplying a point by a scalar and adding another point in place.
+    /// @dev In effect, this function does the operation `a += c * scalar`.
+    /// The first point is in memory, the second point is in calldata, and the scalar is in the stack.
+    /// The input memory is in the format [a_x, a_y, _, _, _]. The third and fourth slots are used as scratch space.
+    /// @param argsPtr0 The input memory containing the first point.
+    /// @param cPtr0 The calldata containing the second point.
+    /// @param scalar0 The scalar to multiply the second point by.
+    /// @return argsPtrOut0 The result of the operation.
+    function calldataECMulAddAssign( // solhint-disable-line gas-calldata-parameters
+    uint256[5] memory argsPtr0, uint256[2] calldata cPtr0, uint256 scalar0)
+        external
+        view
+        returns (uint256[5] memory argsPtrOut0)
+    {
+        assembly {
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_add(args_ptr) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_mul(args_ptr) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_mul_assign(args_ptr, scalar) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            function calldata_ec_mul_add_assign(args_ptr, c_ptr, scalar) {
+                calldatacopy(add(args_ptr, WORDX2_SIZE), c_ptr, WORDX2_SIZE)
+                ec_mul_assign(add(args_ptr, WORDX2_SIZE), scalar)
+                ec_add(args_ptr)
+            }
+            calldata_ec_mul_add_assign(argsPtr0, cPtr0, scalar0)
+        }
+        argsPtrOut0 = argsPtr0;
+    }
+}

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Errors} from "../../src/base/Constants.sol";
+// solhint-disable-next-line no-unused-import
+import {INVALID_EC_ADD_INPUTS, INVALID_EC_MUL_INPUTS, INVALID_EC_PAIRING_INPUTS} from "../../src/base/Constants.sol";
+
+contract ConstantsTest is Test {
+    function testErrorFailedInvalidECAddInputs() public {
+        vm.expectPartialRevert(Errors.InvalidECAddInputs.selector);
+        assembly {
+            mstore(0, INVALID_EC_ADD_INPUTS)
+            revert(0, 4)
+        }
+    }
+
+    function testErrorFailedInvalidECMulInputs() public {
+        vm.expectPartialRevert(Errors.InvalidECMulInputs.selector);
+        assembly {
+            mstore(0, INVALID_EC_MUL_INPUTS)
+            revert(0, 4)
+        }
+    }
+
+    function testErrorFailedInvalidECPairingInputs() public {
+        vm.expectPartialRevert(Errors.InvalidECPairingInputs.selector);
+        assembly {
+            mstore(0, INVALID_EC_PAIRING_INPUTS)
+            revert(0, 4)
+        }
+    }
+}

--- a/solidity/test/base/ECPrecompiles.t.pre.sol
+++ b/solidity/test/base/ECPrecompiles.t.pre.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {ECPrecompiles} from "../../src/base/ECPrecompiles.pre.sol";
+
+contract ECPrecompilesTest {
+    function testECAdd() public view {
+        uint256[4] memory argsPtr = [uint256(1), 2, 1, 2];
+        ECPrecompiles.ecAdd(argsPtr);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+
+        argsPtr = [uint256(0), 0, 1, 2];
+        ECPrecompiles.ecAdd(argsPtr);
+        assert(argsPtr[0] == 1);
+        assert(argsPtr[1] == 2);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+    }
+
+    function testFailsECAddInvalidInput() public view {
+        uint256[4] memory argsPtr = [uint256(1), 2, 3, 4];
+        ECPrecompiles.ecAdd(argsPtr);
+    }
+
+    function testECMul() public view {
+        uint256[3] memory argsPtr = [uint256(1), 2, 2];
+        ECPrecompiles.ecMul(argsPtr);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 2);
+
+        argsPtr = [uint256(1), 2, 1];
+        ECPrecompiles.ecMul(argsPtr);
+        assert(argsPtr[0] == 1);
+        assert(argsPtr[1] == 2);
+        // scratch space
+        assert(argsPtr[2] == 1);
+    }
+
+    function testFailsECMulInvalidInput() public view {
+        uint256[3] memory argsPtr = [uint256(2), 3, 4];
+        ECPrecompiles.ecMul(argsPtr);
+    }
+
+    function testECMulAssign() public view {
+        uint256[3] memory argsPtr = [uint256(1), 2, 0xDEAD];
+        ECPrecompiles.ecMulAssign(argsPtr, 2);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 2);
+
+        argsPtr = [uint256(1), 2, 0xDEAD];
+        ECPrecompiles.ecMulAssign(argsPtr, 1);
+        assert(argsPtr[0] == 1);
+        assert(argsPtr[1] == 2);
+        // scratch space
+        assert(argsPtr[2] == 1);
+    }
+
+    function testECPairingX2() public view {
+        uint256[12] memory argsPtr = [
+            0x2cf44499d5d27bb186308b7af7af02ac5bc9eeb6a3d147c186b21fb1b76e18da,
+            0x2c0f001f52110ccfe69108924926e45f0b0c868df0e7bde1fe16d3242dc715f6,
+            0x1fb19bb476f6b9e44e2a32234da8212f61cd63919354bc06aef31e3cfaff3ebc,
+            0x22606845ff186793914e03e21df544c34ffe2f2f3504de8a79d9159eca2d98d9,
+            0x2bd368e28381e8eccb5fa81fc26cf3f048eea9abfdd85d7ed3ab3698d63e4f90,
+            0x2fe02e47887507adf0ff1743cbac6ba291e66f59be6bd763950bb16041a0a85e,
+            0x0000000000000000000000000000000000000000000000000000000000000001,
+            0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45,
+            0x1971ff0471b09fa93caaf13cbf443c1aede09cc4328f5a62aad45f40ec133eb4,
+            0x091058a3141822985733cbdddfed0fd8d6c104e9e9eff40bf5abfef9ab163bc7,
+            0x2a23af9a5ce2ba2796c1f4e453a370eb0af8c212d9dc9acd8fc02c2e907baea2,
+            0x23a8eb0b0996252cb548a4487da97b02422ebc0e834613f954de6c7e0afdc1fc
+        ];
+        assert(ECPrecompiles.ecPairingX2(argsPtr) == 1);
+    }
+
+    function testFailsECPairingX2WithInvalidInput() public view {
+        uint256[12] memory argsPtr = [uint256(1), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        ECPrecompiles.ecPairingX2(argsPtr);
+    }
+
+    function testCalldataECAddAssign() public view {
+        uint256[4] memory argsPtr = [uint256(1), 2, 0x5C, 0xDEAD];
+        argsPtr = ECPrecompiles.calldataECAddAssign(argsPtr, [uint256(1), 2]);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+
+        argsPtr = [uint256(0), 0, 0xDEAD, 0xDEAD];
+        argsPtr = ECPrecompiles.calldataECAddAssign(argsPtr, [uint256(1), 2]);
+        assert(argsPtr[0] == 1);
+        assert(argsPtr[1] == 2);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+    }
+
+    function testCalldataECMulAddAssign() public view {
+        uint256[5] memory argsPtr = [uint256(1), 2, 0xDEAD, 0xDEAD, 0xDEAD];
+        argsPtr = ECPrecompiles.calldataECMulAddAssign(argsPtr, [uint256(1), 2], 1);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+        assert(argsPtr[4] == 1);
+
+        argsPtr = [uint256(0), 0, 0xDEAD, 0xDEAD, 0xDEAD];
+        argsPtr = ECPrecompiles.calldataECMulAddAssign(argsPtr, [uint256(1), 2], 2);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[3] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        assert(argsPtr[4] == 2);
+
+        argsPtr = [uint256(0), 0, 0xDEAD, 0xDEAD, 0xDEAD];
+        argsPtr = ECPrecompiles.calldataECMulAddAssign(argsPtr, [uint256(1), 2], 1);
+        assert(argsPtr[0] == 1);
+        assert(argsPtr[1] == 2);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+        assert(argsPtr[4] == 1);
+    }
+}

--- a/solidity/test/base/Transcript.t.sol
+++ b/solidity/test/base/Transcript.t.sol
@@ -3,7 +3,10 @@
 pragma solidity ^0.8.28;
 
 import {Transcript} from "../../src/base/Transcript.sol";
-import {MODULUS, WORD_SIZE, FREE_PTR} from "../../src/base/Constants.sol";
+import {MODULUS, WORD_SIZE} from "../../src/base/Constants.sol";
+// assembly only constants
+// solhint-disable-next-line no-unused-import
+import {FREE_PTR} from "../../src/base/Constants.sol";
 
 library TranscriptTest {
     function testWeCanDrawChallenge() public pure {


### PR DESCRIPTION
# Rationale for this change

This PR is the one of many breaking #508 into manageable pieces. In particular, this provides methods for elliptic curve operations.

# What changes are included in this PR?

The following Yul functions are added, along with some tests around them. They will be imported in future PRs.
* `ec_add`
* `ec_mul`
* `ec_pairing_x2`
* `ec_mul_assign`
* `calldata_ec_add_assign`
* `calldata_ec_mul_add_assign`

In addition to these methods, there is a lot of work done to preprocessing and CI to enable code coverage and tests to work properly.


# Are these changes tested?
Somewhat. It is difficult do any kind of thorough testing because the only mechanism that solidity has of computing ec operations is the precompiles.