### PR TITLE
docs: Fix typos

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -115,7 +115,7 @@ impl ColumnCommitmentMetadata {
         &self.bounds
     }
 
-    /// Contruct a [`ColumnCommitmentMetadata`] by analyzing a column.
+    /// Construct a [`ColumnCommitmentMetadata`] by analyzing a column.
     #[must_use]
     pub fn from_column(column: &CommittableColumn) -> ColumnCommitmentMetadata {
         ColumnCommitmentMetadata {

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -315,14 +315,14 @@ mod tests {
             Err(ColumnCommitmentsMismatch::NumColumns)
         ));
 
-        let emtpy_metadata = ColumnCommitmentMetadataMap::default();
+        let empty_metadata = ColumnCommitmentMetadataMap::default();
 
         assert!(matches!(
-            metadata_a.clone().try_union(emtpy_metadata.clone()),
+            metadata_a.clone().try_union(empty_metadata.clone()),
             Err(ColumnCommitmentsMismatch::NumColumns)
         ));
         assert!(matches!(
-            emtpy_metadata.try_union(metadata_a),
+            empty_metadata.try_union(metadata_a),
             Err(ColumnCommitmentsMismatch::NumColumns)
         ));
     }

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof.rs
@@ -28,7 +28,7 @@ pub trait CommitmentEvaluationProof {
     ///
     /// Note: `b_point` must have length `nu`, where `2^nu` is at least the length of `a`.
     /// `b_point` are the values for the variables that are being evaluated.
-    /// The resulting evaluation is the the inner product of `a` and `b`, where `b` is the expanded vector form of `b_point`.
+    /// The resulting evaluation is the inner product of `a` and `b`, where `b` is the expanded vector form of `b_point`.
     fn new(
         transcript: &mut impl Transcript,
         a: &[Self::Scalar],
@@ -40,7 +40,7 @@ pub trait CommitmentEvaluationProof {
     ///
     /// Note: `b_point` must have length `nu`, where `2^nu` is at least the length of `a`.
     /// `b_point` are the values for the variables that are being evaluated.
-    /// The resulting evaluation is the the inner product of `a` and `b`, where `b` is the expanded vector form of `b_point`.
+    /// The resulting evaluation is the inner product of `a` and `b`, where `b` is the expanded vector form of `b_point`.
     #[allow(clippy::too_many_arguments)]
     fn verify_proof(
         &self,

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -37,7 +37,7 @@ pub enum CommittableColumn<'a> {
     BigInt(&'a [i64]),
     /// Borrowed Int128 column, mapped to `i128`.
     Int128(&'a [i128]),
-    /// Borrowed Decimal75(precion, scale, column), mapped to 'i256'
+    /// Borrowed Decimal75(precision, scale, column), mapped to 'i256'
     Decimal75(Precision, i8, Vec<[u64; 4]>),
     /// Column of big ints for committing to, montgomery-reduced from a Scalar column.
     Scalar(Vec<[u64; 4]>),

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment.rs
@@ -54,7 +54,7 @@ pub type DoryScalar = MontScalar<ark_bls12_381::FrConfig>;
 /// The Dory commitment type.
 pub struct DoryCommitment(pub(super) GT);
 
-/// The default for GT is the the additive identity, but should be the multiplicative identity.
+/// The default for GT is the additive identity, but should be the multiplicative identity.
 impl Default for DoryCommitment {
     fn default() -> Self {
         Self(PairingOutput(One::one()))


### PR DESCRIPTION
I have corrected several typographical errors and improved the clarity of comments in the code. These changes include fixing spelling mistakes, removing redundant words, and ensuring variable names are accurate. This enhances the overall readability and accuracy of the documentation.
