### PR TITLE
feat(sol): add sumcheck verifier

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -41,6 +41,8 @@ uint256 constant INVALID_EC_ADD_INPUTS = 0x765bcba0_00000000_00000000_00000000_0
 uint256 constant INVALID_EC_MUL_INPUTS = 0xe32c7472_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 /// @dev Error code for when ECPAIRING inputs are invalid.
 uint256 constant INVALID_EC_PAIRING_INPUTS = 0x4385b511_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when the evaluation of a round in a sumcheck proof does not match the expected value.
+uint256 constant ROUND_EVALUATION_MISMATCH = 0x741f5c3f_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 
 /// @title Errors library
 /// @notice Library containing custom error definitions.
@@ -51,4 +53,6 @@ library Errors {
     error InvalidECMulInputs();
     /// @notice Error thrown when the inputs to the ECPAIRING precompile are invalid.
     error InvalidECPairingInputs();
+    /// @notice Error thrown when the evaluation of a round in a sumcheck proof does not match the expected value.
+    error RoundEvaluationMismatch();
 }

--- a/solidity/src/proof/Sumcheck.pre.sol
+++ b/solidity/src/proof/Sumcheck.pre.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+// assembly only constants
+// solhint-disable-next-line no-unused-import
+import {ROUND_EVALUATION_MISMATCH, FREE_PTR, WORD_SIZE, MODULUS, MODULUS_MASK} from "../base/Constants.sol";
+
+/// @title Sumcheck Protocol Verification Library
+/// @notice This library provides functions to verify sumcheck proofs in zero-knowledge protocols.
+library Sumcheck {
+    /// @notice Verifies a sumcheck proof
+    /// @dev NOTE: there are num_vars messages in the proof, which are polynomials of degree `degree`.
+    /// These coefficients are encoded with the leading coefficient first.
+    /// That is the coefficient of x^degree is first, and the constant term is last.
+    /// This is to facilitate using Horners method to evaluate the polynomial.
+    /// @param transcript0 The initial transcript state
+    /// @param proofPtr0 Pointer to the proof data in calldata
+    /// @param numVars0 Number of variables in the sumcheck protocol
+    /// @param degree0 Degree of the polynomial being checked
+    /// @return evaluationPointPtr0 Pointer to the evaluation points in memory
+    /// @return expectedEvaluation0 The expected evaluation result
+    function verifySumcheckProof(uint256[1] memory transcript0, uint256 proofPtr0, uint256 numVars0, uint256 degree0)
+        internal
+        pure
+        returns (uint256 evaluationPointPtr0, uint256 expectedEvaluation0)
+    {
+        assembly {
+            // IMPORT-YUL ../base/Transcript.sol
+            function append_calldata(transcript_ptr, offset, size) {
+                revert(0, 0)
+            }
+            function verify_sumcheck_proof(transcript_ptr, proof_ptr, num_vars, degree) ->
+                evaluation_point_ptr,
+                expected_evaluation
+            {
+                mstore(mload(FREE_PTR), mload(transcript_ptr))
+                mstore(add(mload(FREE_PTR), 0x20), or(shl(192, degree), shl(128, num_vars)))
+                mstore(transcript_ptr, keccak256(mload(FREE_PTR), 0x30))
+
+                expected_evaluation := 0
+                evaluation_point_ptr := mload(FREE_PTR)
+                mstore(FREE_PTR, add(evaluation_point_ptr, mul(WORD_SIZE, num_vars)))
+                let evaluation_ptr := evaluation_point_ptr
+                for {} num_vars { num_vars := sub(num_vars, 1) } {
+                    append_calldata(transcript_ptr, proof_ptr, mul(WORD_SIZE, add(degree, 1)))
+                    let challenge := and(mload(transcript_ptr), MODULUS_MASK)
+                    mstore(evaluation_ptr, challenge)
+                    evaluation_ptr := add(evaluation_ptr, WORD_SIZE)
+                    let coefficient := calldataload(proof_ptr)
+                    proof_ptr := add(proof_ptr, WORD_SIZE)
+                    let round_evaluation := coefficient
+                    let actual_sum := coefficient
+                    for { let d := degree } d { d := sub(d, 1) } {
+                        coefficient := calldataload(proof_ptr)
+                        proof_ptr := add(proof_ptr, WORD_SIZE)
+                        round_evaluation := mulmod(round_evaluation, challenge, MODULUS)
+                        round_evaluation := addmod(round_evaluation, coefficient, MODULUS)
+                        actual_sum := addmod(actual_sum, coefficient, MODULUS)
+                    }
+                    actual_sum := addmod(actual_sum, coefficient, MODULUS)
+                    if sub(expected_evaluation, actual_sum) {
+                        mstore(0, ROUND_EVALUATION_MISMATCH)
+                        revert(0, 4)
+                    }
+                    expected_evaluation := round_evaluation
+                }
+            }
+            evaluationPointPtr0, expectedEvaluation0 := verify_sumcheck_proof(transcript0, proofPtr0, numVars0, degree0)
+        }
+    }
+}

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 
+import {Errors} from "../../src/base/Constants.sol";
+/* solhint-disable no-unused-import */
 import {
     WORD_SIZE,
     WORDX2_SIZE,
@@ -13,14 +15,16 @@ import {
     MODULUS,
     MODULUS_PLUS_ONE,
     MODULUS_MASK,
-    Errors
+    INVALID_EC_ADD_INPUTS,
+    INVALID_EC_MUL_INPUTS,
+    INVALID_EC_PAIRING_INPUTS,
+    ROUND_EVALUATION_MISMATCH
 } from "../../src/base/Constants.sol";
-// solhint-disable-next-line no-unused-import
-import {INVALID_EC_ADD_INPUTS, INVALID_EC_MUL_INPUTS, INVALID_EC_PAIRING_INPUTS} from "../../src/base/Constants.sol";
+/* solhint-enable no-unused-import */
 
 contract ConstantsTest is Test {
     function testErrorFailedInvalidECAddInputs() public {
-        vm.expectPartialRevert(Errors.InvalidECAddInputs.selector);
+        vm.expectRevert(Errors.InvalidECAddInputs.selector);
         assembly {
             mstore(0, INVALID_EC_ADD_INPUTS)
             revert(0, 4)
@@ -28,7 +32,7 @@ contract ConstantsTest is Test {
     }
 
     function testErrorFailedInvalidECMulInputs() public {
-        vm.expectPartialRevert(Errors.InvalidECMulInputs.selector);
+        vm.expectRevert(Errors.InvalidECMulInputs.selector);
         assembly {
             mstore(0, INVALID_EC_MUL_INPUTS)
             revert(0, 4)
@@ -36,9 +40,17 @@ contract ConstantsTest is Test {
     }
 
     function testErrorFailedInvalidECPairingInputs() public {
-        vm.expectPartialRevert(Errors.InvalidECPairingInputs.selector);
+        vm.expectRevert(Errors.InvalidECPairingInputs.selector);
         assembly {
             mstore(0, INVALID_EC_PAIRING_INPUTS)
+            revert(0, 4)
+        }
+    }
+
+    function testErrorFailedRoundEvaluationMismatch() public {
+        vm.expectRevert(Errors.RoundEvaluationMismatch.selector);
+        assembly {
+            mstore(0, ROUND_EVALUATION_MISMATCH)
             revert(0, 4)
         }
     }

--- a/solidity/test/proof/Sumcheck.t.pre.sol
+++ b/solidity/test/proof/Sumcheck.t.pre.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Sumcheck} from "../../src/proof/Sumcheck.pre.sol";
+import {Errors, MODULUS, MODULUS_MASK, WORD_SIZE} from "../../src/base/Constants.sol";
+
+library SumcheckTestWrapper {
+    /// @notice Wrapper function to verify a sumcheck proof
+    /// @dev This function is used to get the return values instead of a pointer
+    /// @param transcript0 The initial transcript state
+    /// @param proof0 The proof data in calldata
+    /// @param numVars0 Number of variables in the sumcheck protocol
+    /// @param degree0 Degree of the polynomial being checked
+    /// @return evaluationPoint0 Array of evaluation points
+    /// @return expectedEvaluation0 The expected evaluation result
+    function verifySumcheckProof(
+        uint256[1] calldata transcript0,
+        bytes calldata proof0,
+        uint256 numVars0,
+        uint256 degree0
+    ) external pure returns (uint256[] memory evaluationPoint0, uint256 expectedEvaluation0) {
+        uint256 evaluationPointPtr0;
+        uint256 proofPtr0;
+        assembly {
+            proofPtr0 := proof0.offset
+        }
+        (evaluationPointPtr0, expectedEvaluation0) =
+            Sumcheck.verifySumcheckProof(transcript0, proofPtr0, numVars0, degree0);
+        evaluationPoint0 = new uint256[](numVars0);
+        for (uint256 i = 0; i < numVars0; ++i) {
+            uint256 position = evaluationPointPtr0 + i * WORD_SIZE;
+            uint256 value;
+            assembly {
+                value := mload(position)
+            }
+            evaluationPoint0[i] = value;
+        }
+    }
+}
+
+contract SumcheckTest is Test {
+    function testValidSumcheckProof() public pure {
+        SumcheckTestWrapper.verifySumcheckProof(
+            [0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF],
+            abi.encodePacked(
+                [
+                    202,
+                    21888242871839275222246405745257275088548364400416034343698204186575808494599,
+                    408,
+                    0,
+                    18915076809012878152013313149420939913818201595997650713446358010917568651211,
+                    4821950864711900890543716581523492116861394263754152560342078214775139490553,
+                    6328943293927711276825713532334998471262965289280119596396941649435012360810,
+                    2386198368190398642909095286002342871574765628704748036160073239584938195323,
+                    21405268855561213139254933443545185649703963970095593336009275275578128655038
+                ]
+            ),
+            3,
+            2
+        );
+    }
+
+    function testWeRevertWithInvalidSumcheckProof() public {
+        vm.expectRevert(Errors.RoundEvaluationMismatch.selector);
+        SumcheckTestWrapper.verifySumcheckProof(
+            [0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF],
+            abi.encodePacked(
+                [
+                    202,
+                    21888242871839275222246405745257275088548364400416034343698204186575808494599,
+                    408,
+                    1,
+                    18915076809012878152013313149420939913818201595997650713446358010917568651211,
+                    4821950864711900890543716581523492116861394263754152560342078214775139490553,
+                    6328943293927711276825713532334998471262965289280119596396941649435012360810,
+                    2386198368190398642909095286002342871574765628704748036160073239584938195323,
+                    21405268855561213139254933443545185649703963970095593336009275275578128655038
+                ]
+            ),
+            3,
+            2
+        );
+    }
+
+    function testFuzzWeRevertWhenSumcheckProofIsFullyRandom(
+        uint256[1] memory transcript,
+        uint256[] memory proof,
+        uint8 numVars,
+        uint8 degree
+    ) public {
+        // If numVars == 0, it is an empty proof and will always verify.
+        vm.assume(numVars > 0);
+        // The proof with entirely 0s will succeed and is not fully random, so we should not include it
+        bool allZeros = true;
+        uint256 proofLength = proof.length;
+        for (uint256 i = 0; i < proofLength; ++i) {
+            allZeros = allZeros && (proof[i] == 0);
+        }
+        vm.assume(!allZeros);
+
+        // any other proof will succeed with vanishingly low probability
+        vm.expectRevert(Errors.RoundEvaluationMismatch.selector);
+        SumcheckTestWrapper.verifySumcheckProof(transcript, abi.encodePacked(proof), numVars, degree);
+    }
+
+    /// With appropriate inputs, this test covers every possible valid proof
+    function testFuzzWeCanVerifyValidProofWithRandomDimensionsAndData(
+        uint256[1] memory transcript,
+        uint256[] memory rand,
+        uint8 numVars0,
+        uint8 degree0
+    ) public pure {
+        uint256 numVars = numVars0;
+        uint256 degree = degree0;
+        vm.assume(numVars * (degree + 1) < 1000);
+
+        uint256 transcriptP = uint256(keccak256(abi.encodePacked(transcript, uint64(degree), uint64(numVars))));
+        uint256[] memory validProof = new uint256[](numVars * (degree + 1));
+        uint256[] memory evalPoint = new uint256[](numVars);
+
+        uint256 nextSum = 0;
+        uint256 j = 0;
+        for (uint256 i = 0; i < numVars; ++i) {
+            uint256[] memory curRound = new uint256[](degree + 1);
+            uint256 curSum = 0;
+            for (uint256 d = 1; d < degree + 1; ++d) {
+                curRound[d] = j < rand.length ? rand[j] : 0;
+                curSum = addmod(curSum, curRound[d], MODULUS);
+                ++j;
+            }
+            curSum = addmod(curSum, curRound[degree], MODULUS);
+            curRound[0] = addmod(nextSum, (MODULUS - (curSum % MODULUS)), MODULUS);
+            transcriptP = uint256(keccak256(abi.encodePacked(transcriptP, curRound)));
+            uint256 challenge = transcriptP & MODULUS_MASK;
+            nextSum = 0;
+            for (uint256 d = 0; d < degree + 1; ++d) {
+                validProof[i * (degree + 1) + d] = curRound[d];
+                nextSum = addmod(mulmod(nextSum, challenge, MODULUS), curRound[d], MODULUS);
+            }
+            evalPoint[i] = challenge;
+        }
+
+        (uint256[] memory evaluationPoint, uint256 expectedEvaluation) =
+            SumcheckTestWrapper.verifySumcheckProof(transcript, abi.encodePacked(validProof), numVars, degree);
+
+        for (uint256 i = 0; i < numVars; ++i) {
+            assert(evaluationPoint[i] == evalPoint[i]);
+        }
+        assert(expectedEvaluation == nextSum);
+    }
+}


### PR DESCRIPTION
# Rationale for this change

This PR is the one of many breaking the EVM verifier into manageable pieces. In particular, this provides the sumcheck verifier.

# What changes are included in this PR?

The `verify_sumcheck_proof` Yul function is added and tested.


# Are these changes tested?
Yes