### PR TITLE
docs: Fix incorrect import path in "How it Works" section

### DIFF
--- a/solidity/scripts/README.md
+++ b/solidity/scripts/README.md
@@ -20,7 +20,7 @@ The script will recursively process all `*.pre.sol` files in the specified direc
    ```
 3. It also updates Solidity import paths from `.pre.sol` to `.post.sol`:
    ```solidity
-   import {SomeLibrary} from "./SomeLibrary.pre.sol";
+   import {SomeLibrary} from "./SomeLibrary.post.sol";
    ```
 
 4. When it finds an import directive:


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change  
The current documentation contains a typo in the **How it Works** section, specifically in point 3. The import statement incorrectly uses `.pre.sol` instead of `.post.sol`, which contradicts the described behavior of the script. This change ensures the documentation accurately reflects the intended functionality.

# What changes are included in this PR?  
- Updated the import statement in the **How it Works** section from:  
  ```solidity
  import {SomeLibrary} from "./SomeLibrary.pre.sol";
  ```  
  to:  
  ```solidity
  import {SomeLibrary} from "./SomeLibrary.post.sol";
  ```  

# Are these changes tested?  
This is a documentation fix, so no additional testing is required. The change aligns the example with the script's described behavior.
