### PR TITLE
docs: typo fix in README.md

### DIFF
--- a/crates/proof-of-sql/README.md
+++ b/crates/proof-of-sql/README.md
@@ -112,7 +112,7 @@ For detailed usage instructions and examples of how to create, append to, prove,
 Proof of SQL is optimized for speed and efficiency. Here's how it's so fast:
 
 1. We use **native, precomputed commitments** to the data. In other words, when adding data to the database, we compute a "digest" of the data, which effectively "locks in" the data. Instead of using a merkle tree based commitment, like those use in most blockchains, we use the commitment scheme that is inherent to Proof of SQL itself.
-2. SQL is conducive to a **natural arithmatization**, meaning that there is very little overhead compared with other proof systems that are designed around instructions/sequential compute. Instead, Proof of SQL is designed from the ground up with data processing and parallelism in mind.
+2. SQL is conducive to a **natural arithmetization**, meaning that there is very little overhead compared with other proof systems that are designed around instructions/sequential compute. Instead, Proof of SQL is designed from the ground up with data processing and parallelism in mind.
 3. We use **GPU acceleration** on the most expensive cryptography in the prover. We use [Blitzar](https://github.com/spaceandtimelabs/blitzar) as our acceleration framework.
 
 ### Setup


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

I’ve corrected the typo in the word "arithmatization" to the proper spelling, "**arithmetization**".

This update ensures consistency and accuracy in the codebase.