### PR TITLE
fix: Fix return_one() to Return 1 Instead of Reverting

### DIFF
--- a/solidity/src/Placeholder.pre.sol
+++ b/solidity/src/Placeholder.pre.sol
@@ -16,10 +16,10 @@ library TestScript {
         assembly {
             // IMPORT-YUL Placeholder.pre.sol
             function return_one() -> result {
-                revert(0, 0)
+                result := 1  // Returning 1 instead of revert
             }
             a := return_one()
         }
-        assert(a == 1);
+        assert(a == 1);  // Verifying that the result is 1
     }
 }


### PR DESCRIPTION
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change:
I noticed an issue where the `return_one()` function was using `revert(0, 0)` instead of returning a value. This caused the transaction to revert unexpectedly. To address this, the function was updated to return the value `1` as intended.

# What changes are included in this PR?
1. **Updated `return_one()` function**: Replaced `revert(0, 0)` with `result := 1`, as the intention seemed to be returning `1`.
2. **Fixed test behavior**: Ensured the test properly checks for the result value `1` instead of encountering a revert.

# Are these changes tested?
The test now runs correctly and verifies that the result is equal to `1` without reverting the transaction.