### PR TITLE
feat: add permutation gadget

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
 mod membership_check;
 mod monotonic;
+mod permutation_check;
 mod shift;
 pub(crate) use membership_check::{
     final_round_evaluate_membership_check, first_round_evaluate_membership_check,
@@ -8,6 +9,10 @@ pub(crate) use membership_check::{
 };
 #[cfg(test)]
 mod membership_check_test;
+#[allow(unused_imports, dead_code)]
+use permutation_check::{final_round_evaluate_permutation_check, verify_permutation_check};
+#[cfg(test)]
+mod permutation_check_test;
 use shift::{final_round_evaluate_shift, first_round_evaluate_shift, verify_shift};
 #[cfg(test)]
 mod shift_test;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
@@ -1,0 +1,132 @@
+use crate::{
+    base::{database::Column, proof::ProofError, scalar::Scalar, slice_ops},
+    sql::{
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        proof_plans::{fold_columns, fold_vals},
+    },
+};
+use alloc::{boxed::Box, vec};
+use bumpalo::Bump;
+use num_traits::{One, Zero};
+
+/// Perform final round evaluation of the permutation check.
+///
+/// # Panics
+/// Panics if the number of source and candidate columns are not equal
+/// or if the number of columns is zero.
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn final_round_evaluate_permutation_check<'a, S: Scalar>(
+    builder: &mut FinalRoundBuilder<'a, S>,
+    alloc: &'a Bump,
+    alpha: S,
+    beta: S,
+    chi: &'a [bool],
+    columns: &[Column<'a, S>],
+    candidate_subset: &[Column<'a, S>],
+) {
+    assert_eq!(
+        columns.len(),
+        candidate_subset.len(),
+        "The number of source and candidate columns should be equal"
+    );
+    assert!(
+        !columns.is_empty(),
+        "The number of source columns should be greater than 0"
+    );
+    // Fold the columns
+    let c_fold = alloc.alloc_slice_fill_copy(chi.len(), Zero::zero());
+    fold_columns(c_fold, alpha, beta, columns);
+    let d_fold = alloc.alloc_slice_fill_copy(chi.len(), Zero::zero());
+    fold_columns(d_fold, alpha, beta, candidate_subset);
+
+    let c_star = alloc.alloc_slice_copy(c_fold);
+    slice_ops::add_const::<S, S>(c_star, One::one());
+    slice_ops::batch_inversion(c_star);
+
+    let d_star = alloc.alloc_slice_copy(d_fold);
+    slice_ops::add_const::<S, S>(d_star, One::one());
+    slice_ops::batch_inversion(d_star);
+
+    builder.produce_intermediate_mle(c_star as &[_]);
+    builder.produce_intermediate_mle(d_star as &[_]);
+
+    // sum c_star - d_star = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::ZeroSum,
+        vec![
+            (S::one(), vec![Box::new(c_star as &[_])]),
+            (-S::one(), vec![Box::new(d_star as &[_])]),
+        ],
+    );
+
+    // c_star + c_fold * c_star - chi = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(c_star as &[_])]),
+            (
+                S::one(),
+                vec![Box::new(c_star as &[_]), Box::new(c_fold as &[_])],
+            ),
+            (-S::one(), vec![Box::new(chi as &[_])]),
+        ],
+    );
+
+    // d_star + d_fold * d_star - chi = 0
+    builder.produce_sumcheck_subpolynomial(
+        SumcheckSubpolynomialType::Identity,
+        vec![
+            (S::one(), vec![Box::new(d_star as &[_])]),
+            (
+                S::one(),
+                vec![Box::new(d_star as &[_]), Box::new(d_fold as &[_])],
+            ),
+            (-S::one(), vec![Box::new(chi as &[_])]),
+        ],
+    );
+}
+
+#[allow(dead_code)]
+pub(crate) fn verify_permutation_check<S: Scalar>(
+    builder: &mut VerificationBuilder<S>,
+    alpha: S,
+    beta: S,
+    chi_eval: S,
+    column_evals: &[S],
+    candidate_evals: &[S],
+) -> Result<(), ProofError> {
+    // Check that the source and candidate columns have the same amount of columns
+    if column_evals.len() != candidate_evals.len() {
+        return Err(ProofError::VerificationError {
+            error: "The number of source and candidate columns should be equal",
+        });
+    }
+    let c_fold_eval = fold_vals(beta, column_evals);
+    let d_fold_eval = fold_vals(beta, candidate_evals);
+    let c_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+    let d_star_eval = builder.try_consume_final_round_mle_evaluation()?;
+
+    // sum c_star - d_star = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::ZeroSum,
+        c_star_eval - d_star_eval,
+        1,
+    )?;
+
+    // c_star + c_fold * c_star - chi = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        (S::ONE + alpha * c_fold_eval) * c_star_eval - chi_eval,
+        2,
+    )?;
+
+    // d_star + d_fold * d_star - chi = 0
+    builder.try_produce_sumcheck_subpolynomial_evaluation(
+        SumcheckSubpolynomialType::Identity,
+        (S::ONE + alpha * d_fold_eval) * d_star_eval - chi_eval,
+        2,
+    )?;
+
+    Ok(())
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -1,0 +1,448 @@
+//! This module contains the implementation of the `PermutationCheckTestPlan` struct. This struct
+//! is used to check whether the permutation check gadgets work correctly.
+use super::permutation_check::{final_round_evaluate_permutation_check, verify_permutation_check};
+use crate::{
+    base::{
+        database::{
+            table_utility::table_with_row_count, ColumnField, ColumnRef, OwnedTable, Table,
+            TableEvaluation, TableOptions, TableRef,
+        },
+        map::{indexset, IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    },
+};
+use bumpalo::{
+    collections::{vec::Vec as BumpVec, CollectIn},
+    Bump,
+};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct PermutationCheckTestPlan {
+    pub source_table: TableRef,
+    pub candidate_table: TableRef,
+    pub source_columns: Vec<ColumnRef>,
+    pub candidate_columns: Vec<ColumnRef>,
+}
+
+impl ProverEvaluate for PermutationCheckTestPlan {
+    #[doc = "Evaluate the query, modify `FirstRoundBuilder` and return the result."]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FirstRoundBuilder<'a, S>,
+        _alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Get the tables from the map using the table reference
+        let source_table: &Table<'a, S> =
+            table_map.get(&self.source_table).expect("Table not found");
+        // Produce one evaluation length
+        builder.produce_one_evaluation_length(source_table.num_rows());
+        builder.request_post_result_challenges(2);
+        table_with_row_count([], 0)
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table_map: &IndexMap<TableRef, Table<'a, S>>,
+    ) -> Table<'a, S> {
+        // Check that the source columns belong to the source table
+        for col_ref in &self.source_columns {
+            assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");
+        }
+        // Check that the candidate columns belong to the candidate table
+        for col_ref in &self.candidate_columns {
+            assert_eq!(self.candidate_table, col_ref.table_ref(), "Table not found");
+        }
+        // Get the table from the map using the table reference
+        let source_table: &Table<'a, S> =
+            table_map.get(&self.source_table).expect("Table not found");
+        let source_columns = self
+            .source_columns
+            .iter()
+            .map(|col_ref| {
+                let col = *(source_table
+                    .inner_table()
+                    .get(&col_ref.column_id())
+                    .expect("Column not found in table"));
+                builder.produce_intermediate_mle(col);
+                col
+            })
+            .collect_in::<BumpVec<_>>(alloc);
+        let candidate_table = table_map
+            .get(&self.candidate_table)
+            .expect("Table not found");
+        let candidate_columns = self
+            .candidate_columns
+            .iter()
+            .map(|col_ref| {
+                let col = *(candidate_table
+                    .inner_table()
+                    .get(&col_ref.column_id())
+                    .expect("Column not found in table"));
+                builder.produce_intermediate_mle(col);
+                col
+            })
+            .collect_in::<BumpVec<_>>(alloc);
+        let alpha = builder.consume_post_result_challenge();
+        let beta = builder.consume_post_result_challenge();
+        // Perform final permutation check
+        final_round_evaluate_permutation_check(
+            builder,
+            alloc,
+            alpha,
+            beta,
+            alloc.alloc_slice_fill_copy(source_table.num_rows(), true),
+            &source_columns,
+            &candidate_columns,
+        );
+        table_with_row_count([], 0)
+    }
+}
+
+impl ProofPlan for PermutationCheckTestPlan {
+    fn get_column_result_fields(&self) -> Vec<ColumnField> {
+        Vec::<ColumnField>::new()
+    }
+
+    fn get_column_references(&self) -> IndexSet<ColumnRef> {
+        self.source_columns
+            .iter()
+            .chain(self.candidate_columns.iter())
+            .cloned()
+            .collect()
+    }
+
+    #[doc = "Return all the tables referenced in the Query"]
+    fn get_table_references(&self) -> IndexSet<TableRef> {
+        indexset! {self.source_table.clone(), self.candidate_table.clone()}
+    }
+
+    #[doc = "Form components needed to verify and proof store into `VerificationBuilder`"]
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        _result: Option<&OwnedTable<S>>,
+        _one_eval_map: &IndexMap<TableRef, S>,
+    ) -> Result<TableEvaluation<S>, ProofError> {
+        // Get the challenges from the builder
+        let alpha = builder.try_consume_post_result_challenge()?;
+        let beta = builder.try_consume_post_result_challenge()?;
+        let num_columns = self.source_columns.len();
+        // Get the columns
+        let column_evals = builder.try_consume_final_round_mle_evaluations(num_columns)?;
+        // Get the target columns
+        let candidate_subset_evals =
+            builder.try_consume_final_round_mle_evaluations(num_columns)?;
+        // Get the one evaluations
+        let chi_eval = builder.try_consume_one_evaluation()?;
+        // Evaluate the verifier
+        verify_permutation_check(
+            builder,
+            alpha,
+            beta,
+            chi_eval,
+            &column_evals,
+            &candidate_subset_evals,
+        )?;
+        Ok(TableEvaluation::new(vec![], S::ZERO))
+    }
+}
+
+#[cfg(all(test, feature = "blitzar"))]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{table_utility::*, ColumnType, TableTestAccessor, TestAccessor},
+            scalar::Curve25519Scalar,
+        },
+        sql::proof::VerifiableQueryResult,
+    };
+    use blitzar::proof::InnerProductProof;
+
+    #[test]
+    fn we_can_do_minimal_permutation_check() {
+        let alloc = Bump::new();
+        let source_table = table([borrowed_bigint("a", [1, 2, 3], &alloc)]);
+        let candidate_table = table([borrowed_bigint("c", [2, 3, 1], &alloc)]);
+        let source_table_ref = TableRef::new("sxt", "source_table");
+        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref.clone(),
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
+        let plan = PermutationCheckTestPlan {
+            source_table: source_table_ref.clone(),
+            candidate_table: candidate_table_ref.clone(),
+            source_columns: vec![ColumnRef::new(
+                source_table_ref,
+                "a".into(),
+                ColumnType::BigInt,
+            )],
+            candidate_columns: vec![ColumnRef::new(
+                candidate_table_ref,
+                "c".into(),
+                ColumnType::BigInt,
+            )],
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+    }
+
+    #[test]
+    fn we_can_do_permutation_check() {
+        let alloc = Bump::new();
+        let source_table = table([
+            borrowed_bigint("a", [1, 2, 3], &alloc),
+            borrowed_varchar("b", ["Space", "and", "Time"], &alloc),
+            borrowed_boolean("c", [true, false, true], &alloc),
+            borrowed_bigint("d", [5, 6, 7], &alloc),
+        ]);
+        let candidate_table = table([
+            borrowed_bigint("c", [2, 3, 1], &alloc),
+            borrowed_varchar("d", ["and", "Time", "Space"], &alloc),
+            borrowed_boolean("e", [false, true, true], &alloc),
+            borrowed_bigint("f", [5, 6, 7], &alloc),
+        ]);
+        let source_table_ref = TableRef::new("sxt", "source_table");
+        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref.clone(),
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
+        let plan = PermutationCheckTestPlan {
+            source_table: source_table_ref.clone(),
+            candidate_table: candidate_table_ref.clone(),
+            source_columns: vec![
+                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
+                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+            ],
+            candidate_columns: vec![
+                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
+                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
+                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+            ],
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+    }
+
+    #[test]
+    fn we_can_do_permutation_check_when_tables_have_no_rows() {
+        let alloc = Bump::new();
+        let source_table = table([
+            borrowed_bigint("a", [0_i64; 0], &alloc),
+            borrowed_varchar("b", [""; 0], &alloc),
+            borrowed_boolean("c", [true; 0], &alloc),
+            borrowed_bigint("d", [0_i64; 0], &alloc),
+        ]);
+        let candidate_table = table([
+            borrowed_bigint("c", [0_i64; 0], &alloc),
+            borrowed_varchar("d", [""; 0], &alloc),
+            borrowed_boolean("e", [true; 0], &alloc),
+            borrowed_bigint("f", [0_i64; 0], &alloc),
+        ]);
+        let source_table_ref = TableRef::new("sxt", "source_table");
+        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref.clone(),
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
+        let plan = PermutationCheckTestPlan {
+            source_table: source_table_ref.clone(),
+            candidate_table: candidate_table_ref.clone(),
+            source_columns: vec![
+                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                ColumnRef::new(source_table_ref.clone(), "b".into(), ColumnType::VarChar),
+                ColumnRef::new(source_table_ref, "c".into(), ColumnType::Boolean),
+            ],
+            candidate_columns: vec![
+                ColumnRef::new(candidate_table_ref.clone(), "c".into(), ColumnType::BigInt),
+                ColumnRef::new(candidate_table_ref.clone(), "d".into(), ColumnType::VarChar),
+                ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
+            ],
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+    }
+
+    #[test]
+    #[should_panic(expected = "The number of source and candidate columns should be equal")]
+    fn we_cannot_do_permutation_check_if_source_and_candidate_have_different_number_of_columns() {
+        let alloc = Bump::new();
+        let source_table = table([
+            borrowed_bigint("a", [1, 2], &alloc),
+            borrowed_bigint("b", [3, 4], &alloc),
+        ]);
+        let candidate_table = table([borrowed_bigint("a", [1, 2], &alloc)]);
+        let source_table_ref = TableRef::new("sxt", "source_table");
+        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref.clone(),
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
+        let plan = PermutationCheckTestPlan {
+            source_table: source_table_ref.clone(),
+            candidate_table: candidate_table_ref.clone(),
+            source_columns: vec![
+                ColumnRef::new(source_table_ref.clone(), "a".into(), ColumnType::BigInt),
+                ColumnRef::new(source_table_ref, "b".into(), ColumnType::BigInt),
+            ],
+            candidate_columns: vec![ColumnRef::new(
+                candidate_table_ref,
+                "a".into(),
+                ColumnType::BigInt,
+            )],
+        };
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+    }
+
+    #[test]
+    #[should_panic(expected = "The number of source columns should be greater than 0")]
+    fn we_can_do_permutation_check_if_there_are_no_columns_in_the_tables() {
+        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions { row_count: Some(5) },
+        )
+        .unwrap();
+        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions { row_count: Some(4) },
+        )
+        .unwrap();
+        let source_table_ref = TableRef::new("sxt", "source_table");
+        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref.clone(),
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
+        let plan = PermutationCheckTestPlan {
+            source_table: source_table_ref,
+            candidate_table: candidate_table_ref,
+            source_columns: vec![],
+            candidate_columns: vec![],
+        };
+        let _verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+    }
+
+    #[test]
+    #[should_panic(expected = "The number of source columns should be greater than 0")]
+    fn we_cannot_do_permutation_check_if_there_are_no_columns_in_the_tables_and_candidate_has_no_rows_either(
+    ) {
+        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions { row_count: Some(5) },
+        )
+        .unwrap();
+        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions { row_count: Some(0) },
+        )
+        .unwrap();
+        let source_table_ref = TableRef::new("sxt", "source_table");
+        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref.clone(),
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
+        let plan = PermutationCheckTestPlan {
+            source_table: source_table_ref,
+            candidate_table: candidate_table_ref,
+            source_columns: vec![],
+            candidate_columns: vec![],
+        };
+        let _verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+    }
+
+    // This one doesn't panic since it is an empty query
+    #[test]
+    fn we_can_do_permutation_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
+        let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions { row_count: Some(0) },
+        )
+        .unwrap();
+        let candidate_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
+            IndexMap::default(),
+            TableOptions { row_count: Some(0) },
+        )
+        .unwrap();
+        let source_table_ref = TableRef::new("sxt", "source_table");
+        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref.clone(),
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
+        let plan = PermutationCheckTestPlan {
+            source_table: source_table_ref,
+            candidate_table: candidate_table_ref,
+            source_columns: vec![],
+            candidate_columns: vec![],
+        };
+        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+    }
+
+    #[test]
+    #[should_panic(expected = "The number of source columns should be greater than 0")]
+    fn we_cannot_do_permutation_check_if_no_column_is_selected() {
+        let alloc = Bump::new();
+        let source_table = table([
+            borrowed_bigint("a", [1, 2], &alloc),
+            borrowed_bigint("b", [3, 4], &alloc),
+        ]);
+        let candidate_table = table([
+            borrowed_bigint("a", [1, 2], &alloc),
+            borrowed_bigint("b", [3, 4], &alloc),
+        ]);
+        let source_table_ref = TableRef::new("sxt", "source_table");
+        let candidate_table_ref = TableRef::new("sxt", "candidate_table");
+        let mut accessor = TableTestAccessor::<InnerProductProof>::new_from_table(
+            source_table_ref.clone(),
+            source_table,
+            0,
+            (),
+        );
+        accessor.add_table(candidate_table_ref.clone(), candidate_table, 0);
+        let plan = PermutationCheckTestPlan {
+            source_table: source_table_ref,
+            candidate_table: candidate_table_ref,
+            source_columns: vec![],
+            candidate_columns: vec![],
+        };
+        let _verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+    }
+}

--- a/docs/protocols/permutation.tex
+++ b/docs/protocols/permutation.tex
@@ -1,0 +1,52 @@
+\documentclass[11pt]{article}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage[margin=1in]{geometry}
+\usepackage{graphicx}
+\usepackage{amsmath,amssymb}
+\usepackage{booktabs}
+\usepackage{hyperref}
+\usepackage{microtype}
+\usepackage{todonotes}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  citecolor=blue,
+  urlcolor=blue
+}
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt}
+
+\title{Permutation}
+\author{Space and Time Inc}
+\date{February 2025}
+
+\begin{document}
+\maketitle
+
+\noindent Let $A=(a_{ij})$ be a table. We need to prove that $R=(r_{ij})$ is a permuted version of $A$. \\
+
+\section{Summary}
+\begin{itemize}
+    \item Plan values: $i$ and number of columns in $A$
+    \item Inputs: $A$
+    \item Outputs: $R$
+    \item Hints: $c$, $d$, $c^\ast$, $d^\ast$.
+\end{itemize}
+
+\section{Details}
+We set 
+
+\begin{align*}
+    \hat{c} &\equiv \sum_j a_j \beta^j &\hat{d} &\equiv \sum_j r_ j \beta^j
+\end{align*}
+
+The $3$ constraints are:
+
+\begin{align*}
+    c^\ast \cdot (\alpha + \hat{c}) &\equiv \chi_{[0,n)}\\
+    d^\ast \cdot (\alpha + \hat{d}) &\equiv \chi_{[0,n)}\\
+    c^\ast &\overset{\sum}{=} d^\ast
+\end{align*}
+\end{document}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to define `OrderByExec` we need to have permutation.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
The permutation gadget
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.