### PR TITLE
feat(sol): add HyperKZG helpers

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -8,6 +8,8 @@ uint256 constant MODULUS = 0x30644e72_e131a029_b85045b6_8181585d_2833e848_79b970
 uint256 constant MODULUS_MASK = 0x1FFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF;
 /// @dev MODULUS + 1. Needs to be explicit for Yul usage.
 uint256 constant MODULUS_PLUS_ONE = 0x30644e72_e131a029_b85045b6_8181585d_2833e848_79b97091_43e1f593_f0000002;
+/// @dev MODULUS - 1. Needs to be explicit for Yul usage.
+uint256 constant MODULUS_MINUS_ONE = 0x30644e72_e131a029_b85045b6_8181585d_2833e848_79b97091_43e1f593_f0000000;
 /// @dev Size of a word in bytes: 32.
 uint256 constant WORD_SIZE = 0x20;
 /// @dev Size of two words in bytes.
@@ -16,6 +18,8 @@ uint256 constant WORDX2_SIZE = 0x20 * 2;
 uint256 constant WORDX3_SIZE = 0x20 * 3;
 /// @dev Size of four words in bytes.
 uint256 constant WORDX4_SIZE = 0x20 * 4;
+/// @dev Size of six words in bytes.
+uint256 constant WORDX6_SIZE = 0x20 * 6;
 /// @dev Size of twelve words in bytes.
 uint256 constant WORDX12_SIZE = 0x20 * 12;
 
@@ -53,6 +57,8 @@ uint256 constant TOO_FEW_FINAL_ROUND_MLES = 0xfb828ab5_00000000_00000000_0000000
 uint256 constant TOO_FEW_CHI_EVALUATIONS = 0x8ef4e6c9_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 /// @dev Error code for when too few rho evaluations are provided to the verification builder.
 uint256 constant TOO_FEW_RHO_EVALUATIONS = 0x3784ad97_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when the HyperKZG proof has an inconsistent v.
+uint256 constant HYPER_KZG_INCONSISTENT_V = 0x6a5ae827_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 
 /// @dev The X coordinate of the G1 generator point.
 uint256 constant G1_GEN_X = 1;
@@ -126,4 +132,6 @@ library Errors {
     error TooFewChiEvaluations();
     /// @notice Error thrown when too few rho evaluations are provided to the verification builder.
     error TooFewRhoEvaluations();
+    /// @notice Error thrown when the HyperKZG proof has an inconsistent v.
+    error HyperKZGInconsistentV();
 }

--- a/solidity/src/hyperkzg/HyperKZGHelpers.pre.sol
+++ b/solidity/src/hyperkzg/HyperKZGHelpers.pre.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+// assembly only constants
+/* solhint-disable no-unused-import */
+import {
+    FREE_PTR,
+    MODULUS,
+    MODULUS_MINUS_ONE,
+    MODULUS_MASK,
+    WORD_SIZE,
+    WORDX2_SIZE,
+    WORDX3_SIZE,
+    WORDX6_SIZE,
+    HYPER_KZG_INCONSISTENT_V
+} from "../base/Constants.sol";
+/* solhint-enable no-unused-import */
+
+/// @title HyperKZGHelpers
+/// @dev Library providing helper functions for the HyperKZG polynomial commitment verifier.
+library HyperKZGHelpers {
+    /// @notice Runs the Fiat-Shamir transcript to generate challenges for the HyperKZG proof
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// run_transcript(com_ptr, v_ptr, w_ptr, transcript_ptr, ell) -> r, q, d
+    /// ```
+    /// ##### Parameters
+    /// * `com_ptr` - the calldata pointer to the beginning of the data in `__com`
+    /// * `v_ptr` - the calldata pointer to the beginning of the data in `__v`
+    /// * `w_ptr` - the calldata pointer to the beginning of the data in `__w`
+    /// * `transcript_ptr` - the memory pointer to the transcript word
+    /// @dev Processes prover messages to generate random challenges
+    /// using a Fiat-Shamir transformation
+    /// @param __com The first prover message
+    /// @param __v The second prover message
+    /// @param __w The third prover message
+    /// @param __transcript Initial transcript value
+    /// @param __ell The size parameter for the proof
+    /// @return __r First challenge (r value)
+    /// @return __q Second challenge (q value)
+    /// @return __d Third challenge (d value)
+    function __runTranscript( // solhint-disable-line gas-calldata-parameters
+    bytes calldata __com, bytes calldata __v, bytes calldata __w, uint256[1] memory __transcript, uint256 __ell)
+        external
+        pure
+        returns (uint256 __r, uint256 __q, uint256 __d)
+    {
+        assembly {
+            // IMPORT-YUL ../base/Transcript.sol
+            function append_calldata(transcript_ptr, offset, size) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Transcript.sol
+            function draw_challenge(transcript_ptr) -> result {
+                revert(0, 0)
+            }
+            function run_transcript(com_ptr, v_ptr, w_ptr, transcript_ptr, ell) -> r, q, d {
+                append_calldata(transcript_ptr, com_ptr, mul(WORDX2_SIZE, sub(ell, 1)))
+                r := draw_challenge(transcript_ptr)
+
+                append_calldata(transcript_ptr, v_ptr, mul(WORDX3_SIZE, ell))
+                q := draw_challenge(transcript_ptr)
+
+                append_calldata(transcript_ptr, w_ptr, WORDX6_SIZE)
+                d := draw_challenge(transcript_ptr)
+            }
+            __r, __q, __d := run_transcript(__com.offset, __v.offset, __w.offset, __transcript, __ell)
+        }
+    }
+
+    /// @notice Calculate a bivariate polynomial evaluation for a given set of coefficients
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// bivariate_evaluation(v_ptr, q, d, ell) -> b
+    /// ```
+    /// ##### Parameters
+    /// * `v_ptr` - the calldata pointer to the beginning of the data in `__v`
+    /// @dev This function computes \\[\sum_{i=0}^{\ell-1} \sum_{j=0}^2 v_{i,j} \cdot d^jq^i. \\]
+    /// @dev The function is implemented using Horner's method in 2 dimensions,
+    /// so it only requires \\( 3\ell - 1 \\) multiplications and additions.
+    /// We do it in \\( 3\ell \\) for simplicity.
+    /// @param __v Array of coefficient triplets
+    /// @param __q First evaluation point
+    /// @param __d Second evaluation point
+    /// @return __b The evaluated polynomial value
+    function __bivariateEvaluation(uint256[3][] calldata __v, uint256 __q, uint256 __d)
+        external
+        pure
+        returns (uint256 __b)
+    {
+        assembly {
+            function bivariate_evaluation(v_ptr, q, d, ell) -> b {
+                let v_stack := add(v_ptr, mul(WORDX3_SIZE, ell))
+                for {} ell { ell := sub(ell, 1) } {
+                    // tmp = v2i
+                    v_stack := sub(v_stack, WORD_SIZE)
+                    let tmp := calldataload(v_stack)
+                    // tmp = v2i * d
+                    tmp := mulmod(tmp, d, MODULUS)
+                    // tmp += v1i
+                    v_stack := sub(v_stack, WORD_SIZE)
+                    tmp := addmod(tmp, calldataload(v_stack), MODULUS)
+                    // tmp *= d
+                    tmp := mulmod(tmp, d, MODULUS)
+                    // tmp += v0i
+                    v_stack := sub(v_stack, WORD_SIZE)
+                    tmp := addmod(tmp, calldataload(v_stack), MODULUS)
+
+                    // b *= q
+                    b := mulmod(b, q, MODULUS)
+                    // b += tmp
+                    b := addmod(b, tmp, MODULUS)
+                }
+            }
+            __b := bivariate_evaluation(__v.offset, __q, __d, __v.length)
+        }
+    }
+
+    /// @notice Check that the v array is consistent with the given r, x, and y values
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// check_v_consistency(v_ptr, r, x, y)
+    /// ```
+    /// ##### Parameters
+    /// * `v_ptr` - the calldata pointer to the beginning of the data in `__v`
+    /// * `x` - the memory pointer to `__x`. Note: this includes the length of the array as the first word
+    /// @dev This function checks that the following equation holds for all \\( i \in [0, \ell) \\):
+    /// \\[ r \cdot (2v_{i+1,2} + (x_i - 1) \cdot (v_{i,1} + v_{i,0})) + x_i \cdot (v_{i,1} - v_{i,0}) = 0 \\]
+    /// where \\( v_{\ell,i} = y \\).
+    /// @param __v Array being checked for consistency
+    /// @param __r Challenge value r
+    /// @param __x Array of x coordinates
+    /// @param __y y value
+    function __checkVConsistency( // solhint-disable-line gas-calldata-parameters
+    uint256[3][] calldata __v, uint256 __r, uint256[] memory __x, uint256 __y)
+        external
+        pure
+    {
+        assert(__x.length == __v.length);
+        assembly {
+            function check_v_consistency(v_ptr, r, x, y) {
+                let ell := mload(x)
+                let v_stack := add(v_ptr, mul(WORDX3_SIZE, ell))
+                x := add(x, mul(WORD_SIZE, add(ell, 1)))
+                let last_v2 := y
+                for {} ell { ell := sub(ell, 1) } {
+                    v_stack := sub(v_stack, WORD_SIZE)
+                    let v2i := calldataload(v_stack)
+                    v_stack := sub(v_stack, WORD_SIZE)
+                    let v1i := calldataload(v_stack)
+                    v_stack := sub(v_stack, WORD_SIZE)
+                    let v0i := calldataload(v_stack)
+                    x := sub(x, WORD_SIZE)
+                    let xi := mload(x)
+
+                    // r * (2 * y + (xi - 1) * (v1i + v0i)) + xi * (v1i - v0i)
+                    if addmod(
+                        mulmod(
+                            r,
+                            addmod(
+                                addmod(last_v2, last_v2, MODULUS),
+                                mulmod(addmod(xi, MODULUS_MINUS_ONE, MODULUS), addmod(v1i, v0i, MODULUS), MODULUS),
+                                MODULUS
+                            ),
+                            MODULUS
+                        ),
+                        mulmod(xi, addmod(v1i, sub(MODULUS, mod(v0i, MODULUS)), MODULUS), MODULUS),
+                        MODULUS
+                    ) {
+                        mstore(0, HYPER_KZG_INCONSISTENT_V)
+                        revert(0, 4)
+                    }
+
+                    last_v2 := v2i
+                }
+            }
+            check_v_consistency(__v.offset, __r, __x, __y)
+        }
+    }
+}

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -78,6 +78,14 @@ contract ConstantsTest is Test {
         }
     }
 
+    function testErrorFailedHyperKZGInconsistentV() public {
+        vm.expectRevert(Errors.HyperKZGInconsistentV.selector);
+        assembly {
+            mstore(0, HYPER_KZG_INCONSISTENT_V)
+            revert(0, 4)
+        }
+    }
+
     function testModulusMaskIsCorrect() public pure {
         assert(MODULUS > MODULUS_MASK);
         assert(MODULUS < (MODULUS_MASK << 1));
@@ -90,8 +98,9 @@ contract ConstantsTest is Test {
         assert(mask == 0);
     }
 
-    function testModulusPlusOneIsCorrect() public pure {
+    function testModulusPlusAndMinusOneAreCorrect() public pure {
         assert(MODULUS_PLUS_ONE == MODULUS + 1);
+        assert(MODULUS_MINUS_ONE == MODULUS - 1);
     }
 
     function testWordSizesAreCorrect() public pure {
@@ -99,6 +108,7 @@ contract ConstantsTest is Test {
         assert(WORDX2_SIZE == 2 * WORD_SIZE);
         assert(WORDX3_SIZE == 3 * WORD_SIZE);
         assert(WORDX4_SIZE == 4 * WORD_SIZE);
+        assert(WORDX6_SIZE == 6 * WORD_SIZE);
         assert(WORDX12_SIZE == 12 * WORD_SIZE);
     }
 

--- a/solidity/test/hyperkzg/HyperKZGHelpers.t.pre.sol
+++ b/solidity/test/hyperkzg/HyperKZGHelpers.t.pre.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {HyperKZGHelpers} from "../../src/hyperkzg/HyperKZGHelpers.pre.sol";
+
+contract HyperKZGHelpersTest is Test {
+    function testFuzzRunTranscriptWhenEllIs1(uint256[3] memory v, uint256[6] memory w, uint256[1] memory transcript)
+        public
+        pure
+    {
+        bytes32 expectedR = keccak256(abi.encodePacked(transcript, hex""));
+        bytes32 expectedQ = keccak256(abi.encodePacked(keccak256(abi.encodePacked(expectedR)), v));
+        bytes32 expectedD = keccak256(abi.encodePacked(keccak256(abi.encodePacked(expectedQ)), w));
+        (uint256 r, uint256 q, uint256 d) = HyperKZGHelpers.__runTranscript({
+            __com: hex"",
+            __v: abi.encodePacked(v),
+            __w: abi.encodePacked(w),
+            __transcript: transcript,
+            __ell: 1
+        });
+        assert(r == uint256(expectedR) & MODULUS_MASK);
+        assert(q == uint256(expectedQ) & MODULUS_MASK);
+        assert(d == uint256(expectedD) & MODULUS_MASK);
+    }
+
+    function testFuzzRunTranscriptWhenEllIs2(
+        uint256[2] memory com,
+        uint256[6] memory v,
+        uint256[6] memory w,
+        uint256[1] memory transcript
+    ) public pure {
+        bytes32 expectedR = keccak256(abi.encodePacked(transcript, com));
+        bytes32 expectedQ = keccak256(abi.encodePacked(keccak256(abi.encodePacked(expectedR)), v));
+        bytes32 expectedD = keccak256(abi.encodePacked(keccak256(abi.encodePacked(expectedQ)), w));
+        (uint256 r, uint256 q, uint256 d) = HyperKZGHelpers.__runTranscript({
+            __com: abi.encodePacked(com),
+            __v: abi.encodePacked(v),
+            __w: abi.encodePacked(w),
+            __transcript: transcript,
+            __ell: 2
+        });
+        assert(r == uint256(expectedR) & MODULUS_MASK);
+        assert(q == uint256(expectedQ) & MODULUS_MASK);
+        assert(d == uint256(expectedD) & MODULUS_MASK);
+    }
+
+    function testFuzzRunTranscriptWhenEllIs3(
+        uint256[4] memory com,
+        uint256[9] memory v,
+        uint256[6] memory w,
+        uint256[1] memory transcript
+    ) public pure {
+        bytes32 expectedR = keccak256(abi.encodePacked(transcript, com));
+        bytes32 expectedQ = keccak256(abi.encodePacked(keccak256(abi.encodePacked(expectedR)), v));
+        bytes32 expectedD = keccak256(abi.encodePacked(keccak256(abi.encodePacked(expectedQ)), w));
+        (uint256 r, uint256 q, uint256 d) = HyperKZGHelpers.__runTranscript({
+            __com: abi.encodePacked(com),
+            __v: abi.encodePacked(v),
+            __w: abi.encodePacked(w),
+            __transcript: transcript,
+            __ell: 3
+        });
+        assert(r == uint256(expectedR) & MODULUS_MASK);
+        assert(q == uint256(expectedQ) & MODULUS_MASK);
+        assert(d == uint256(expectedD) & MODULUS_MASK);
+    }
+
+    function testFuzzRunTranscriptRandom(uint256[] calldata proof, uint256[1] memory transcript) public pure {
+        vm.assume(proof.length > 8);
+        uint256 ell = (proof.length - 4) / (5);
+        bytes memory com = abi.encodePacked(proof[0:2 * (ell - 1)]);
+        bytes memory v = abi.encodePacked(proof[2 * ell - 2:5 * ell - 2]);
+        bytes memory w = abi.encodePacked(proof[5 * ell - 2:5 * ell + 4]);
+        bytes32 expectedR = keccak256(abi.encodePacked(transcript, com));
+        bytes32 expectedQ = keccak256(abi.encodePacked(keccak256(abi.encodePacked(expectedR)), v));
+        bytes32 expectedD = keccak256(abi.encodePacked(keccak256(abi.encodePacked(expectedQ)), w));
+
+        (uint256 r, uint256 q, uint256 d) =
+            HyperKZGHelpers.__runTranscript({__com: com, __v: v, __w: w, __transcript: transcript, __ell: ell});
+        assert(r == uint256(expectedR) & MODULUS_MASK);
+        assert(q == uint256(expectedQ) & MODULUS_MASK);
+        assert(d == uint256(expectedD) & MODULUS_MASK);
+    }
+
+    function testSmallBivariateEvaluation() public pure {
+        uint256[3][] memory v = new uint256[3][](2);
+        v[0] = [uint256(101), 102, 103];
+        v[1] = [uint256(104), 105, 106];
+
+        assert(
+            HyperKZGHelpers.__bivariateEvaluation(v, 5, 7)
+                == 101 * 1 + 102 * 7 + 103 * 49 + 104 * 5 + 105 * 35 + 106 * 245
+        );
+    }
+
+    function testEmpty() public pure {
+        uint256[3][] memory v = new uint256[3][](0);
+
+        assert(HyperKZGHelpers.__bivariateEvaluation(v, 5, 7) == 0);
+    }
+
+    function testFuzzBivariateEvaluation(uint256[3][] calldata v, uint256 q, uint256 d) public pure {
+        uint256 expectedSum = 0;
+        uint256 ell = v.length;
+        for (uint256 i = 0; i < ell; ++i) {
+            for (uint256 j = 0; j < 3; ++j) {
+                uint256 qdPow = 1;
+                for (uint256 k = 0; k < i; ++k) {
+                    qdPow = mulmod(qdPow, q, MODULUS);
+                }
+                for (uint256 k = 0; k < j; ++k) {
+                    qdPow = mulmod(qdPow, d, MODULUS);
+                }
+                expectedSum = addmod(expectedSum, mulmod(v[i][j], qdPow, MODULUS), MODULUS);
+            }
+        }
+        assert(HyperKZGHelpers.__bivariateEvaluation(v, q, d) == expectedSum);
+    }
+
+    function testEmptyCheckVConsistency() public pure {
+        uint256[3][] memory v = new uint256[3][](0);
+        uint256 r = 5;
+        uint256[] memory x = new uint256[](0);
+        uint256 y = 1234567890;
+        HyperKZGHelpers.__checkVConsistency(v, r, x, y);
+    }
+
+    function testSimpleCheckVConsistency() public pure {
+        uint256[3][] memory v = new uint256[3][](3);
+        v[0] = [uint256(0), 0, 1234567890];
+        v[1] = [uint256(1020), 1010, 0];
+        v[2] = [uint256(1020), 1010, 5 * (102 + 101)];
+        uint256 r = 5;
+        uint256[] memory x = new uint256[](3);
+        x[0] = 99999;
+        x[1] = 0;
+        x[2] = 1;
+        uint256 y = 102 - 101;
+        HyperKZGHelpers.__checkVConsistency(v, r, x, y);
+    }
+
+    function testFuzzCheckVConsistency(uint256[2][] memory vRand, uint256 r, uint256[] memory x, uint256 y)
+        public
+        pure
+    {
+        uint256 ell = x.length;
+        vm.assume(ell > 0);
+        vm.assume(vRand.length > ell);
+        uint256[3][] memory v = new uint256[3][](ell);
+        v[0][2] = vRand[ell][0];
+        for (uint256 i = 0; i < ell; ++i) {
+            // v_0 = 2r * vRand_0
+            // v_1 = 2r * vRand_1
+            v[i][0] = mulmod(mulmod(2, r, MODULUS), vRand[i][0], MODULUS);
+            v[i][1] = mulmod(mulmod(2, r, MODULUS), vRand[i][1], MODULUS);
+            // y =  r * (1 - x) * (vRand_0 + vRand_1) + x * (vRand_0 - vRand_1)
+            y = addmod(
+                mulmod(
+                    r,
+                    mulmod(
+                        1 + mulmod(MODULUS_MINUS_ONE, x[i], MODULUS), addmod(vRand[i][0], vRand[i][1], MODULUS), MODULUS
+                    ),
+                    MODULUS
+                ),
+                mulmod(x[i], addmod(vRand[i][0], mulmod(MODULUS_MINUS_ONE, vRand[i][1], MODULUS), MODULUS), MODULUS),
+                MODULUS
+            );
+            if (i < x.length - 1) {
+                v[i + 1][2] = y;
+            }
+        }
+        HyperKZGHelpers.__checkVConsistency(v, r, x, y);
+    }
+
+    /// forge-config: default.fuzz.max-test-rejects = 100000
+    function testFuzzRevertsVConsistency(uint256[3][] calldata v, uint256 r, uint256[] memory x, uint256 y) public {
+        vm.assume(x.length > 0);
+        vm.assume(v.length == x.length);
+        vm.expectRevert(Errors.HyperKZGInconsistentV.selector);
+        HyperKZGHelpers.__checkVConsistency(v, r, x, y);
+    }
+}


### PR DESCRIPTION
# Rationale for this change

The HyperKZG verifier can be broken down into smaller methods in order to facilitate more granular unit testing.

# What changes are included in this PR?

3 helper methods:
* `run_transcript`, which computes the challenges
* `bivariate_evaluation`, which computes the bivariate evaluation of the `v` vector in the HyperKZG proof.
* `check_v_consistency`, which checks the consistency of the `v` vector

# Are these changes tested?
Yes