### PR TITLE
test: fix flaky sumcheck fuzz test

### DIFF
--- a/solidity/test/proof/Sumcheck.t.pre.sol
+++ b/solidity/test/proof/Sumcheck.t.pre.sol
@@ -93,10 +93,11 @@ contract SumcheckTest is Test {
     ) public {
         // If numVars == 0, it is an empty proof and will always verify.
         vm.assume(numVars > 0);
-        // The proof with entirely 0s will succeed and is not fully random, so we should not include it
+        // The proof with entirely 0s (expect for the last prover message) will succeed and is not fully random, so we should not include it
         bool allZeros = true;
-        uint256 proofLength = proof.length;
-        for (uint256 i = 0; i < proofLength; ++i) {
+        uint256 realProofLength = uint256(numVars - 1) * (uint256(degree) + 1);
+        uint256 nonZeroLength = proof.length > realProofLength ? realProofLength : proof.length;
+        for (uint256 i = 0; i < nonZeroLength; ++i) {
             allZeros = allZeros && (proof[i] == 0);
         }
         vm.assume(!allZeros);


### PR DESCRIPTION
# Rationale for this change

One of the sumcheck fuzz tests fails occasionally because a trivial proof is occasionally generated.

# What changes are included in this PR?

Trivial proof filtering is made more robust.

# Are these changes tested?

Yes, even when running the test 10000 times, there are no longer failures.