### PR TITLE
feat(sol): add EC generator values and other EC operations

### DIFF
--- a/solidity/scripts/lint-and-test.sh
+++ b/solidity/scripts/lint-and-test.sh
@@ -5,7 +5,9 @@
 set -euo pipefail
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
+find . -type f -name "*.post.sol" -delete
 scripts/install_deps.sh
+scripts/pre_forge.sh clean
 scripts/pre_forge.sh test --summary
 scripts/check_coverage.sh
 solhint 'src/**/*.sol' 'test/**/*.sol' -w 0

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -44,6 +44,34 @@ uint256 constant INVALID_EC_PAIRING_INPUTS = 0x4385b511_00000000_00000000_000000
 /// @dev Error code for when the evaluation of a round in a sumcheck proof does not match the expected value.
 uint256 constant ROUND_EVALUATION_MISMATCH = 0x741f5c3f_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 
+/// @dev The X coordinate of the G1 generator point.
+uint256 constant G1_GEN_X = 1;
+/// @dev The Y coordinate of the G1 generator point.
+uint256 constant G1_GEN_Y = 2;
+
+/// @dev The G2 generator point's x-coordinate real component.
+uint256 constant G2_GEN_X_REAL = 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed;
+/// @dev The G2 generator point's x-coordinate imaginary component.
+uint256 constant G2_GEN_X_IMAG = 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2;
+/// @dev The G2 generator point's y-coordinate real component.
+uint256 constant G2_GEN_Y_REAL = 0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa;
+/// @dev The G2 generator point's y-coordinate imaginary component.
+uint256 constant G2_GEN_Y_IMAG = 0x090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b;
+
+/// @dev The X coordinate of the negated G1 generator point.
+uint256 constant G1_NEG_GEN_X = 1;
+/// @dev The Y coordinate of the negated G1 generator point.
+uint256 constant G1_NEG_GEN_Y = 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45;
+
+/// @dev The G2 negated generator point's x-coordinate real component.
+uint256 constant G2_NEG_GEN_X_REAL = 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed;
+/// @dev The G2 negated generator point's x-coordinate imaginary component.
+uint256 constant G2_NEG_GEN_X_IMAG = 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2;
+/// @dev The G2 negated generator point's y-coordinate real component.
+uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d;
+/// @dev The G2 negated generator point's y-coordinate imaginary component.
+uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
+
 /// @title Errors library
 /// @notice Library containing custom error definitions.
 library Errors {

--- a/solidity/src/base/ECPrecompiles.pre.sol
+++ b/solidity/src/base/ECPrecompiles.pre.sol
@@ -154,4 +154,63 @@ library ECPrecompiles {
         }
         __resultArgs = __args;
     }
+
+    /// @notice Convenience function for multiplying a constant point by a scalar and adding to another point in place.
+    /// @dev In effect, this function does the operation `a += c * scalar`, where c is a constant point.
+    /// The first point is in memory, and the constant point coordinates are provided as arguments.
+    /// The input memory is in the format [a_x, a_y, _, _, _].
+    /// The third, fourth, and fifth slots are used as scratch space.
+    /// @param __args The input memory containing the first point and scratch space.
+    /// @param __cx The x-coordinate of the constant point.
+    /// @param __cy The y-coordinate of the constant point.
+    /// @param __scalar The scalar to multiply the constant point by.
+    function __constantECMulAddAssign(uint256[5] memory __args, uint256 __cx, uint256 __cy, uint256 __scalar)
+        internal
+        view
+    {
+        assembly {
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_add(args_ptr) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_mul(args_ptr) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_mul_assign(args_ptr, scalar) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            function constant_ec_mul_add_assign(args_ptr, c_x, c_y, scalar) {
+                mstore(add(args_ptr, WORDX2_SIZE), c_x)
+                mstore(add(args_ptr, WORDX3_SIZE), c_y)
+                ec_mul_assign(add(args_ptr, WORDX2_SIZE), scalar)
+                ec_add(args_ptr)
+            }
+            constant_ec_mul_add_assign(__args, __cx, __cy, __scalar)
+        }
+    }
+
+    /// @notice Convenience function for adding a point from memory to another point.
+    /// @dev In effect, this function does the operation `a += c`, where both points are in memory.
+    /// The input memory is in the format [a_x, a_y, _, _]. The third and fourth slots are used as scratch space.
+    /// @param __args The input memory containing the first point and scratch space.
+    /// @param __c The memory pointer to the second point [c_x, c_y].
+    function __ecAddAssign(uint256[4] memory __args, uint256[2] memory __c) internal view {
+        assembly {
+            // IMPORT-YUL ECPrecompiles.pre.sol
+            function ec_add(args_ptr) {
+                pop(staticcall(0, 0, 0, 0, 0, 0))
+                revert(0, 0)
+            }
+            function ec_add_assign(args_ptr, c_ptr) {
+                mcopy(add(args_ptr, WORDX2_SIZE), c_ptr, WORDX2_SIZE)
+                ec_add(args_ptr)
+            }
+            ec_add_assign(__args, __c)
+        }
+    }
 }

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -5,37 +5,55 @@ pragma solidity ^0.8.28;
 import {Test} from "forge-std/Test.sol";
 import "../../src/base/Constants.sol";
 
-contract ConstantsTest is Test {
-    function testErrorFailedInvalidECAddInputs() public {
-        vm.expectRevert(Errors.InvalidECAddInputs.selector);
+library ErrorTest {
+    function causeInvalidECAddInputs() public pure {
         assembly {
             mstore(0, INVALID_EC_ADD_INPUTS)
             revert(0, 4)
         }
     }
 
-    function testErrorFailedInvalidECMulInputs() public {
-        vm.expectRevert(Errors.InvalidECMulInputs.selector);
+    function causeInvalidECMulInputs() public pure {
         assembly {
             mstore(0, INVALID_EC_MUL_INPUTS)
             revert(0, 4)
         }
     }
 
-    function testErrorFailedInvalidECPairingInputs() public {
-        vm.expectRevert(Errors.InvalidECPairingInputs.selector);
+    function causeInvalidECPairingInputs() public pure {
         assembly {
             mstore(0, INVALID_EC_PAIRING_INPUTS)
             revert(0, 4)
         }
     }
 
-    function testErrorFailedRoundEvaluationMismatch() public {
-        vm.expectRevert(Errors.RoundEvaluationMismatch.selector);
+    function causeRoundEvaluationMismatch() public pure {
         assembly {
             mstore(0, ROUND_EVALUATION_MISMATCH)
             revert(0, 4)
         }
+    }
+}
+
+contract ConstantsTest is Test {
+    function testErrorFailedInvalidECAddInputs() public {
+        vm.expectRevert(Errors.InvalidECAddInputs.selector);
+        ErrorTest.causeInvalidECAddInputs();
+    }
+
+    function testErrorFailedInvalidECMulInputs() public {
+        vm.expectRevert(Errors.InvalidECMulInputs.selector);
+        ErrorTest.causeInvalidECMulInputs();
+    }
+
+    function testErrorFailedInvalidECPairingInputs() public {
+        vm.expectRevert(Errors.InvalidECPairingInputs.selector);
+        ErrorTest.causeInvalidECPairingInputs();
+    }
+
+    function testErrorFailedRoundEvaluationMismatch() public {
+        vm.expectRevert(Errors.RoundEvaluationMismatch.selector);
+        ErrorTest.causeRoundEvaluationMismatch();
     }
 
     function testModulusMaskIsCorrect() public pure {
@@ -54,7 +72,7 @@ contract ConstantsTest is Test {
         assert(MODULUS_PLUS_ONE == MODULUS + 1);
     }
 
-    function testWordSizesAreCrrect() public pure {
+    function testWordSizesAreCorrect() public pure {
         assert(WORD_SIZE == 32);
         assert(WORDX2_SIZE == 2 * WORD_SIZE);
         assert(WORDX3_SIZE == 3 * WORD_SIZE);

--- a/solidity/test/base/ECPrecompiles.t.pre.sol
+++ b/solidity/test/base/ECPrecompiles.t.pre.sol
@@ -1,9 +1,36 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {ECPrecompiles} from "../../src/base/ECPrecompiles.pre.sol";
+import { Test } from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import { ECPrecompiles } from "../../src/base/ECPrecompiles.pre.sol";
 
-contract ECPrecompilesTest {
+library ECPrecompilesTestWrapper {
+    function ecAdd(uint256[4] calldata args) external view {
+        ECPrecompiles.__ecAdd(args);
+    }
+
+    function ecMul(uint256[3] calldata args) external view {
+        ECPrecompiles.__ecMul(args);
+    }
+
+    function ecPairingX2(uint256[12] calldata args) external view returns (uint256 success) {
+        success = ECPrecompiles.__ecPairingX2(args);
+    }
+}
+
+library ECPrecompilesTestHelper {
+    function ecBasePower(uint256 e) public view returns (uint256 x, uint256 y) {
+        uint256[3] memory scratch = [G1_GEN_X, G1_GEN_Y, e % MODULUS];
+        assembly {
+            pop(staticcall(ECMUL_GAS, ECMUL_ADDRESS, scratch, WORDX3_SIZE, scratch, WORDX2_SIZE))
+        }
+        x = scratch[0];
+        y = scratch[1];
+    }
+}
+
+contract ECPrecompilesTest is Test {
     function testECAdd() public view {
         uint256[4] memory argsPtr = [uint256(1), 2, 1, 2];
         ECPrecompiles.__ecAdd(argsPtr);
@@ -22,9 +49,45 @@ contract ECPrecompilesTest {
         assert(argsPtr[3] == 2);
     }
 
-    function testFailsECAddInvalidInput() public view {
-        uint256[4] memory argsPtr = [uint256(1), 2, 3, 4];
+    function testFuzzECAdd(uint256 a, uint256 b) public view {
+        uint256 c = addmod(a, b, MODULUS);
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 bx, uint256 by) = ECPrecompilesTestHelper.ecBasePower(b);
+        (uint256 cx, uint256 cy) = ECPrecompilesTestHelper.ecBasePower(c);
+        uint256[4] memory argsPtr = [ax, ay, bx, by];
         ECPrecompiles.__ecAdd(argsPtr);
+        assert(argsPtr[0] == cx);
+        assert(argsPtr[1] == cy);
+        // scratch space
+        assert(argsPtr[2] == bx);
+        assert(argsPtr[3] == by);
+    }
+
+    function testFuzzECAddInfinity(uint256 a) public view {
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        uint256[4] memory argsPtr = [ax, ay, 0, 0];
+        ECPrecompiles.__ecAdd(argsPtr);
+        assert(argsPtr[0] == ax);
+        assert(argsPtr[1] == ay);
+        // scratch space
+        assert(argsPtr[2] == 0);
+        assert(argsPtr[3] == 0);
+    }
+
+    function testAddGenToNegGen() public view {
+        uint256[4] memory argsPtr = [G1_GEN_X, G1_GEN_Y, G1_NEG_GEN_X, G1_NEG_GEN_Y];
+        ECPrecompiles.__ecAdd(argsPtr);
+        assert(argsPtr[0] == 0);
+        assert(argsPtr[1] == 0);
+        // scratch space
+        assert(argsPtr[2] == G1_NEG_GEN_X);
+        assert(argsPtr[3] == G1_NEG_GEN_Y);
+    }
+
+    function testRevertWhenECAddInvalidInput() public {
+        uint256[4] memory argsPtr = [uint256(1), 2, 3, 4];
+        vm.expectRevert(Errors.InvalidECAddInputs.selector);
+        ECPrecompilesTestWrapper.ecAdd(argsPtr);
     }
 
     function testECMul() public view {
@@ -43,9 +106,22 @@ contract ECPrecompilesTest {
         assert(argsPtr[2] == 1);
     }
 
-    function testFailsECMulInvalidInput() public view {
-        uint256[3] memory argsPtr = [uint256(2), 3, 4];
+    function testFuzzECMul(uint256 a, uint256 e) public view {
+        uint256 c = mulmod(a, e, MODULUS);
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 cx, uint256 cy) = ECPrecompilesTestHelper.ecBasePower(c);
+        uint256[3] memory argsPtr = [ax, ay, e];
         ECPrecompiles.__ecMul(argsPtr);
+        assert(argsPtr[0] == cx);
+        assert(argsPtr[1] == cy);
+        // scratch space
+        assert(argsPtr[2] == e);
+    }
+
+    function testRevertWhenECMulInvalidInput() public {
+        uint256[3] memory argsPtr = [uint256(2), 3, 4];
+        vm.expectRevert(Errors.InvalidECMulInputs.selector);
+        ECPrecompilesTestWrapper.ecMul(argsPtr);
     }
 
     function testECMulAssign() public view {
@@ -62,6 +138,18 @@ contract ECPrecompilesTest {
         assert(argsPtr[1] == 2);
         // scratch space
         assert(argsPtr[2] == 1);
+    }
+
+    function testFuzzECMulAssign(uint256 a, uint256 e) public view {
+        uint256 c = mulmod(a, e, MODULUS);
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 cx, uint256 cy) = ECPrecompilesTestHelper.ecBasePower(c);
+        uint256[3] memory argsPtr = [ax, ay, 0xDEAD];
+        ECPrecompiles.__ecMulAssign(argsPtr, e);
+        assert(argsPtr[0] == cx);
+        assert(argsPtr[1] == cy);
+        // scratch space
+        assert(argsPtr[2] == e);
     }
 
     function testECPairingX2() public view {
@@ -82,9 +170,110 @@ contract ECPrecompilesTest {
         assert(ECPrecompiles.__ecPairingX2(argsPtr) == 1);
     }
 
-    function testFailsECPairingX2WithInvalidInput() public view {
+    function testG1GenIsNontrivial() public view {
+        uint256[12] memory argsPtr = [
+            G1_GEN_X,
+            G1_GEN_Y,
+            G2_GEN_X_IMAG,
+            G2_GEN_X_REAL,
+            G2_GEN_Y_IMAG,
+            G2_GEN_Y_REAL,
+            G1_GEN_X,
+            G1_GEN_Y,
+            G2_GEN_X_IMAG,
+            G2_GEN_X_REAL,
+            G2_GEN_Y_IMAG,
+            G2_GEN_Y_REAL
+        ];
+        assert(ECPrecompiles.__ecPairingX2(argsPtr) == 0);
+    }
+
+    function testG1NegGenIsCorrect() public view {
+        uint256[12] memory argsPtr = [
+            G1_GEN_X,
+            G1_GEN_Y,
+            G2_GEN_X_IMAG,
+            G2_GEN_X_REAL,
+            G2_GEN_Y_IMAG,
+            G2_GEN_Y_REAL,
+            G1_GEN_X,
+            G1_GEN_Y,
+            G2_NEG_GEN_X_IMAG,
+            G2_NEG_GEN_X_REAL,
+            G2_NEG_GEN_Y_IMAG,
+            G2_NEG_GEN_Y_REAL
+        ];
+        assert(ECPrecompiles.__ecPairingX2(argsPtr) == 1);
+    }
+
+    function testFuzzECPairingX2WithValidInputsThatDoNotSumToZero(uint256 a, uint256 b) public view {
+        vm.assume(a != 0 || b != 0);
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 bx, uint256 by) = ECPrecompilesTestHelper.ecBasePower(b);
+        uint256[12] memory argsPtr = [
+            ax,
+            ay,
+            G2_GEN_X_IMAG,
+            G2_GEN_X_REAL,
+            G2_GEN_Y_IMAG,
+            G2_GEN_Y_REAL,
+            bx,
+            by,
+            G2_GEN_X_IMAG,
+            G2_GEN_X_REAL,
+            G2_GEN_Y_IMAG,
+            G2_GEN_Y_REAL
+        ];
+        assert(ECPrecompiles.__ecPairingX2(argsPtr) == 0);
+    }
+
+    function testFuzzECPairingX2WithValidInputsThatDoSumToZero(uint256 a) public view {
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 bx, uint256 by) = ECPrecompilesTestHelper.ecBasePower(MODULUS - (a % MODULUS));
+        uint256[12] memory argsPtr = [
+            ax,
+            ay,
+            G2_GEN_X_IMAG,
+            G2_GEN_X_REAL,
+            G2_GEN_Y_IMAG,
+            G2_GEN_Y_REAL,
+            bx,
+            by,
+            G2_GEN_X_IMAG,
+            G2_GEN_X_REAL,
+            G2_GEN_Y_IMAG,
+            G2_GEN_Y_REAL
+        ];
+        assert(ECPrecompiles.__ecPairingX2(argsPtr) == 1);
+        uint256[12] memory argsPtr2 = [
+            ax,
+            ay,
+            G2_GEN_X_IMAG,
+            G2_GEN_X_REAL,
+            G2_GEN_Y_IMAG,
+            G2_GEN_Y_REAL,
+            ax,
+            ay,
+            G2_NEG_GEN_X_IMAG,
+            G2_NEG_GEN_X_REAL,
+            G2_NEG_GEN_Y_IMAG,
+            G2_NEG_GEN_Y_REAL
+        ];
+        assert(ECPrecompiles.__ecPairingX2(argsPtr2) == 1);
+    }
+
+    function testFuzzECPairingX2RevertsWithInvalidInput(uint256[12] memory argsPtr) public {
+        for (uint256 i = 0; i < 12; ++i) {
+            vm.assume(argsPtr[i] != 0);
+        }
+        vm.expectRevert(Errors.InvalidECPairingInputs.selector);
+        ECPrecompilesTestWrapper.ecPairingX2(argsPtr);
+    }
+
+    function testRevertWhenECPairingX2WithSimpleInvalidInput() public {
         uint256[12] memory argsPtr = [uint256(1), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        ECPrecompiles.__ecPairingX2(argsPtr);
+        vm.expectRevert(Errors.InvalidECPairingInputs.selector);
+        ECPrecompilesTestWrapper.ecPairingX2(argsPtr);
     }
 
     function testCalldataECAddAssign() public view {
@@ -103,6 +292,20 @@ contract ECPrecompilesTest {
         // scratch space
         assert(argsPtr[2] == 1);
         assert(argsPtr[3] == 2);
+    }
+
+    function testFuzzCalldataECAddAssign(uint256 a, uint256 b) public view {
+        uint256 c = addmod(a, b, MODULUS);
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 bx, uint256 by) = ECPrecompilesTestHelper.ecBasePower(b);
+        (uint256 cx, uint256 cy) = ECPrecompilesTestHelper.ecBasePower(c);
+        uint256[4] memory argsPtr = [ax, ay, 0xDEAD, 0xDEAD];
+        argsPtr = ECPrecompiles.__calldataECAddAssign(argsPtr, [bx, by]);
+        assert(argsPtr[0] == cx);
+        assert(argsPtr[1] == cy);
+        // scratch space
+        assert(argsPtr[2] == bx);
+        assert(argsPtr[3] == by);
     }
 
     function testCalldataECMulAddAssign() public view {
@@ -132,5 +335,120 @@ contract ECPrecompilesTest {
         assert(argsPtr[2] == 1);
         assert(argsPtr[3] == 2);
         assert(argsPtr[4] == 1);
+    }
+
+    function testFuzzCalldataECMulAddAssign(uint256 a, uint256 b, uint256 e) public view {
+        uint256 be = mulmod(b, e, MODULUS);
+        uint256 c = addmod(a, be, MODULUS);
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 bx, uint256 by) = ECPrecompilesTestHelper.ecBasePower(b);
+        (uint256 cx, uint256 cy) = ECPrecompilesTestHelper.ecBasePower(c);
+        uint256[5] memory argsPtr = [ax, ay, 0xDEAD, 0xDEAD, 0xDEAD];
+        argsPtr = ECPrecompiles.__calldataECMulAddAssign(argsPtr, [bx, by], e);
+        assert(argsPtr[0] == cx);
+        assert(argsPtr[1] == cy);
+        // scratch space shows intermediate result of b * e
+        (uint256 bex, uint256 bey) = ECPrecompilesTestHelper.ecBasePower(be);
+        assert(argsPtr[2] == bex);
+        assert(argsPtr[3] == bey);
+        assert(argsPtr[4] == e);
+    }
+
+    function testConstantECMulAddAssign() public view {
+        uint256[5] memory argsPtr = [uint256(1), 2, 0xDEAD, 0xDEAD, 0xDEAD];
+        ECPrecompiles.__constantECMulAddAssign(argsPtr, 1, 2, 1);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+        assert(argsPtr[4] == 1);
+
+        argsPtr = [uint256(0), 0, 0xDEAD, 0xDEAD, 0xDEAD];
+        ECPrecompiles.__constantECMulAddAssign(argsPtr, 1, 2, 2);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[3] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        assert(argsPtr[4] == 2);
+
+        argsPtr = [uint256(0), 0, 0xDEAD, 0xDEAD, 0xDEAD];
+        ECPrecompiles.__constantECMulAddAssign(argsPtr, 1, 2, 1);
+        assert(argsPtr[0] == 1);
+        assert(argsPtr[1] == 2);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+        assert(argsPtr[4] == 1);
+    }
+
+    function testFuzzConstantECMulAddAssign(uint256 a, uint256 b, uint256 e) public view {
+        uint256 be = mulmod(b, e, MODULUS);
+        uint256 c = addmod(a, be, MODULUS);
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 bx, uint256 by) = ECPrecompilesTestHelper.ecBasePower(b);
+        (uint256 cx, uint256 cy) = ECPrecompilesTestHelper.ecBasePower(c);
+        uint256[5] memory argsPtr = [ax, ay, 0xDEAD, 0xDEAD, 0xDEAD];
+        ECPrecompiles.__constantECMulAddAssign(argsPtr, bx, by, e);
+        assert(argsPtr[0] == cx);
+        assert(argsPtr[1] == cy);
+        // scratch space shows intermediate result of b * e
+        (uint256 bex, uint256 bey) = ECPrecompilesTestHelper.ecBasePower(be);
+        assert(argsPtr[2] == bex);
+        assert(argsPtr[3] == bey);
+        assert(argsPtr[4] == e);
+    }
+
+    function testECAddAssign() public view {
+        uint256[4] memory argsPtr = [uint256(1), 2, 0xDEAD, 0xDEAD];
+        uint256[2] memory point = [uint256(1), 2];
+        ECPrecompiles.__ecAddAssign(argsPtr, point);
+        assert(argsPtr[0] == 0x030644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd3);
+        assert(argsPtr[1] == 0x15ed738c0e0a7c92e7845f96b2ae9c0a68a6a449e3538fc7ff3ebf7a5a18a2c4);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+
+        argsPtr = [uint256(0), 0, 0xDEAD, 0xDEAD];
+        ECPrecompiles.__ecAddAssign(argsPtr, point);
+        assert(argsPtr[0] == 1);
+        assert(argsPtr[1] == 2);
+        // scratch space
+        assert(argsPtr[2] == 1);
+        assert(argsPtr[3] == 2);
+    }
+
+    function testFuzzECAddAssign(uint256 a, uint256 b) public view {
+        uint256 c = addmod(a, b, MODULUS);
+        (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
+        (uint256 bx, uint256 by) = ECPrecompilesTestHelper.ecBasePower(b);
+        (uint256 cx, uint256 cy) = ECPrecompilesTestHelper.ecBasePower(c);
+        uint256[4] memory argsPtr = [ax, ay, 0xDEAD, 0xDEAD];
+        uint256[2] memory point = [bx, by];
+        ECPrecompiles.__ecAddAssign(argsPtr, point);
+        assert(argsPtr[0] == cx);
+        assert(argsPtr[1] == cy);
+        // scratch space
+        assert(argsPtr[2] == bx);
+        assert(argsPtr[3] == by);
+    }
+
+    function testGeneratorsAreGenerators() public view {
+        // Check that the generators are not the identity. i.e., that 2gen != gen.
+        uint256[4] memory argsPtr = [G1_GEN_X, G1_GEN_Y, G1_GEN_X, G1_GEN_Y];
+        ECPrecompiles.__ecAdd(argsPtr);
+        assert(argsPtr[0] != G1_GEN_X);
+        assert(argsPtr[1] != G1_GEN_Y);
+        // scratch space
+        assert(argsPtr[2] == G1_GEN_X);
+        assert(argsPtr[3] == G1_GEN_Y);
+        // Check that the generator has order that divides the modulus. i.e., that (modulus+1)*gen == gen.
+        uint256[3] memory argsPtr2 = [G1_GEN_X, G1_GEN_Y, MODULUS + 1];
+        ECPrecompiles.__ecMul(argsPtr2);
+        assert(argsPtr2[0] == G1_GEN_X);
+        assert(argsPtr2[1] == G1_GEN_Y);
+        // scratch space
+        assert(argsPtr2[2] == MODULUS + 1);
     }
 }


### PR DESCRIPTION
# Rationale for this change

We will need these EC operations in the next PR.

# What changes are included in this PR?

* The generators and negatives of the generators are added as constants.
* `constant_ec_mul_add_assign` and `ec_add_assign` are added
* Ci/tooling related is slightly updated.

# Are these changes tested?

Yes. Most of the PR is testing the above, as well as improving the overall EC tests.