### PR TITLE
feat(sol): add VerificationBuilder library and initial queues

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -72,6 +72,9 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 /// @dev The G2 negated generator point's y-coordinate imaginary component.
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
+/// @dev Size of the verification builder in bytes.
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 0;
+
 /// @title Errors library
 /// @notice Library containing custom error definitions.
 library Errors {

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -45,6 +45,8 @@ uint256 constant INVALID_EC_PAIRING_INPUTS = 0x4385b511_00000000_00000000_000000
 uint256 constant ROUND_EVALUATION_MISMATCH = 0x741f5c3f_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 /// @dev Error code for when too few challenges are provided to the verification builder.
 uint256 constant TOO_FEW_CHALLENGES = 0x700caebe_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when too few final round mles are provided to the verification builder.
+uint256 constant TOO_FEW_FINAL_ROUND_MLES = 0xfb828ab5_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 
 /// @dev The X coordinate of the G1 generator point.
 uint256 constant G1_GEN_X = 1;
@@ -75,11 +77,15 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 2;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 4;
 /// @dev Offset of the pointer to the head of the challenge queue in the verification builder.
 uint256 constant CHALLENGE_HEAD_OFFSET = 0x20 * 0;
 /// @dev Offset of the pointer to the tail of the challenge queue in the verification builder.
 uint256 constant CHALLENGE_TAIL_OFFSET = 0x20 * 1;
+/// @dev Offset of the pointer to the head of the final round mles in the verification builder.
+uint256 constant FINAL_ROUND_MLE_HEAD_OFFSET = 0x20 * 2;
+/// @dev Offset of the pointer to the tail of the final round mles in the verification builder.
+uint256 constant FINAL_ROUND_MLE_TAIL_OFFSET = 0x20 * 3;
 
 /// @title Errors library
 /// @notice Library containing custom error definitions.
@@ -94,4 +100,6 @@ library Errors {
     error RoundEvaluationMismatch();
     /// @notice Error thrown when too few challenges are provided to the verification builder.
     error TooFewChallenges();
+    /// @notice Error thrown when too few final round mles are provided to the verification builder.
+    error TooFewFinalRoundMLEs();
 }

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -47,6 +47,8 @@ uint256 constant ROUND_EVALUATION_MISMATCH = 0x741f5c3f_00000000_00000000_000000
 uint256 constant TOO_FEW_CHALLENGES = 0x700caebe_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 /// @dev Error code for when too few final round mles are provided to the verification builder.
 uint256 constant TOO_FEW_FINAL_ROUND_MLES = 0xfb828ab5_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when too few chi evaluations are provided to the verification builder.
+uint256 constant TOO_FEW_CHI_EVALUATIONS = 0x8ef4e6c9_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 
 /// @dev The X coordinate of the G1 generator point.
 uint256 constant G1_GEN_X = 1;
@@ -77,7 +79,7 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 4;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 6;
 /// @dev Offset of the pointer to the head of the challenge queue in the verification builder.
 uint256 constant CHALLENGE_HEAD_OFFSET = 0x20 * 0;
 /// @dev Offset of the pointer to the tail of the challenge queue in the verification builder.
@@ -86,6 +88,10 @@ uint256 constant CHALLENGE_TAIL_OFFSET = 0x20 * 1;
 uint256 constant FINAL_ROUND_MLE_HEAD_OFFSET = 0x20 * 2;
 /// @dev Offset of the pointer to the tail of the final round mles in the verification builder.
 uint256 constant FINAL_ROUND_MLE_TAIL_OFFSET = 0x20 * 3;
+/// @dev Offset of the pointer to the head of the chi evaluations in the verification builder.
+uint256 constant CHI_EVALUATION_HEAD_OFFSET = 0x20 * 4;
+/// @dev Offset of the pointer to the tail of the chi evaluations in the verification builder.
+uint256 constant CHI_EVALUATION_TAIL_OFFSET = 0x20 * 5;
 
 /// @title Errors library
 /// @notice Library containing custom error definitions.
@@ -102,4 +108,6 @@ library Errors {
     error TooFewChallenges();
     /// @notice Error thrown when too few final round mles are provided to the verification builder.
     error TooFewFinalRoundMLEs();
+    /// @notice Error thrown when too few chi evaluations are provided to the verification builder.
+    error TooFewChiEvaluations();
 }

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -43,6 +43,8 @@ uint256 constant INVALID_EC_MUL_INPUTS = 0xe32c7472_00000000_00000000_00000000_0
 uint256 constant INVALID_EC_PAIRING_INPUTS = 0x4385b511_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 /// @dev Error code for when the evaluation of a round in a sumcheck proof does not match the expected value.
 uint256 constant ROUND_EVALUATION_MISMATCH = 0x741f5c3f_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when too few challenges are provided to the verification builder.
+uint256 constant TOO_FEW_CHALLENGES = 0x700caebe_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 
 /// @dev The X coordinate of the G1 generator point.
 uint256 constant G1_GEN_X = 1;
@@ -73,7 +75,11 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 0;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 2;
+/// @dev Offset of the pointer to the head of the challenge queue in the verification builder.
+uint256 constant CHALLENGE_HEAD_OFFSET = 0x20 * 0;
+/// @dev Offset of the pointer to the tail of the challenge queue in the verification builder.
+uint256 constant CHALLENGE_TAIL_OFFSET = 0x20 * 1;
 
 /// @title Errors library
 /// @notice Library containing custom error definitions.
@@ -86,4 +92,6 @@ library Errors {
     error InvalidECPairingInputs();
     /// @notice Error thrown when the evaluation of a round in a sumcheck proof does not match the expected value.
     error RoundEvaluationMismatch();
+    /// @notice Error thrown when too few challenges are provided to the verification builder.
+    error TooFewChallenges();
 }

--- a/solidity/src/proof/VerificationBuilder.sol
+++ b/solidity/src/proof/VerificationBuilder.sol
@@ -2,8 +2,7 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
-// solhint-disable-next-line no-unused-import
-import {FREE_PTR, VERIFICATION_BUILDER_SIZE} from "../base/Constants.sol";
+import "../base/Constants.sol"; // solhint-disable-line no-global-import
 
 library VerificationBuilder {
     /// @notice Allocates and reserves a block of memory for a verification builder.
@@ -15,6 +14,41 @@ library VerificationBuilder {
                 mstore(FREE_PTR, add(builder_ptr, VERIFICATION_BUILDER_SIZE))
             }
             __builderPtr := builder_allocate()
+        }
+    }
+
+    /// @notice Sets the challenges in the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @param __challengePtr The pointer to the challenges.
+    /// @param __challengeLength The number of challenges.
+    /// This is assumed to be "small", i.e. anything less than 2^64 will work.
+    function __setChallenges(uint256 __builderPtr, uint256 __challengePtr, uint256 __challengeLength) internal pure {
+        assembly {
+            function builder_set_challenges(builder_ptr, challenge_ptr, challenge_length) {
+                mstore(add(builder_ptr, CHALLENGE_HEAD_OFFSET), challenge_ptr)
+                mstore(add(builder_ptr, CHALLENGE_TAIL_OFFSET), add(challenge_ptr, mul(WORD_SIZE, challenge_length)))
+            }
+            builder_set_challenges(__builderPtr, __challengePtr, __challengeLength)
+        }
+    }
+
+    /// @notice Consumes a challenge from the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @return __challenge The consumed challenge.
+    /// @dev This function will revert if there are no challenges left to consume.
+    function __consumeChallenge(uint256 __builderPtr) internal pure returns (uint256 __challenge) {
+        assembly {
+            function builder_consume_challenge(builder_ptr) -> challenge {
+                let head_ptr := mload(add(builder_ptr, CHALLENGE_HEAD_OFFSET))
+                challenge := mload(head_ptr)
+                head_ptr := add(head_ptr, WORD_SIZE)
+                if gt(head_ptr, mload(add(builder_ptr, CHALLENGE_TAIL_OFFSET))) {
+                    mstore(0, TOO_FEW_CHALLENGES)
+                    revert(0, 4)
+                }
+                mstore(add(builder_ptr, CHALLENGE_HEAD_OFFSET), head_ptr)
+            }
+            __challenge := builder_consume_challenge(__builderPtr)
         }
     }
 }

--- a/solidity/src/proof/VerificationBuilder.sol
+++ b/solidity/src/proof/VerificationBuilder.sol
@@ -91,4 +91,44 @@ library VerificationBuilder {
             __evaluation := builder_consume_final_round_mle(__builderPtr)
         }
     }
+
+    /// @notice Sets the chi evaluations in the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @param __chiEvaluationPtr The pointer to the chi evaluations.
+    /// @param __chiEvaluationLength The number of chi evaluations.
+    function __setChiEvaluations(uint256 __builderPtr, uint256 __chiEvaluationPtr, uint256 __chiEvaluationLength)
+        internal
+        pure
+    {
+        assembly {
+            function builder_set_chi_evaluations(builder_ptr, chi_evaluation_ptr, chi_evaluation_length) {
+                mstore(add(builder_ptr, CHI_EVALUATION_HEAD_OFFSET), chi_evaluation_ptr)
+                mstore(
+                    add(builder_ptr, CHI_EVALUATION_TAIL_OFFSET),
+                    add(chi_evaluation_ptr, mul(WORD_SIZE, chi_evaluation_length))
+                )
+            }
+            builder_set_chi_evaluations(__builderPtr, __chiEvaluationPtr, __chiEvaluationLength)
+        }
+    }
+
+    /// @notice Consumes a chi evaluation from the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @return __evaluation The consumed chi evaluation.
+    /// @dev Reverts if there are no chi evaluations left.
+    function __consumeChiEvaluation(uint256 __builderPtr) internal pure returns (uint256 __evaluation) {
+        assembly {
+            function builder_consume_chi_evaluation(builder_ptr) -> evaluation {
+                let head_ptr := mload(add(builder_ptr, CHI_EVALUATION_HEAD_OFFSET))
+                evaluation := mload(head_ptr)
+                head_ptr := add(head_ptr, WORD_SIZE)
+                if gt(head_ptr, mload(add(builder_ptr, CHI_EVALUATION_TAIL_OFFSET))) {
+                    mstore(0, TOO_FEW_CHI_EVALUATIONS)
+                    revert(0, 4)
+                }
+                mstore(add(builder_ptr, CHI_EVALUATION_HEAD_OFFSET), head_ptr)
+            }
+            __evaluation := builder_consume_chi_evaluation(__builderPtr)
+        }
+    }
 }

--- a/solidity/src/proof/VerificationBuilder.sol
+++ b/solidity/src/proof/VerificationBuilder.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+// solhint-disable-next-line no-unused-import
+import {FREE_PTR, VERIFICATION_BUILDER_SIZE} from "../base/Constants.sol";
+
+library VerificationBuilder {
+    /// @notice Allocates and reserves a block of memory for a verification builder.
+    /// @return __builderPtr The pointer to the allocated builder region.
+    function __allocate() internal pure returns (uint256 __builderPtr) {
+        assembly {
+            function builder_allocate() -> builder_ptr {
+                builder_ptr := mload(FREE_PTR)
+                mstore(FREE_PTR, add(builder_ptr, VERIFICATION_BUILDER_SIZE))
+            }
+            __builderPtr := builder_allocate()
+        }
+    }
+}

--- a/solidity/src/proof/VerificationBuilder.sol
+++ b/solidity/src/proof/VerificationBuilder.sol
@@ -51,4 +51,44 @@ library VerificationBuilder {
             __challenge := builder_consume_challenge(__builderPtr)
         }
     }
+
+    /// @notice Sets the final round mles in the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @param __finalRoundMLEPtr The pointer to the final round mles.
+    /// @param __finalRoundMLELength The number of final round mles.
+    function __setFinalRoundMLEs(uint256 __builderPtr, uint256 __finalRoundMLEPtr, uint256 __finalRoundMLELength)
+        internal
+        pure
+    {
+        assembly {
+            function builder_set_final_round_mles(builder_ptr, final_round_mle_ptr, final_round_mle_length) {
+                mstore(add(builder_ptr, FINAL_ROUND_MLE_HEAD_OFFSET), final_round_mle_ptr)
+                mstore(
+                    add(builder_ptr, FINAL_ROUND_MLE_TAIL_OFFSET),
+                    add(final_round_mle_ptr, mul(WORD_SIZE, final_round_mle_length))
+                )
+            }
+            builder_set_final_round_mles(__builderPtr, __finalRoundMLEPtr, __finalRoundMLELength)
+        }
+    }
+
+    /// @notice Consumes a final round mle from the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @return __evaluation The consumed final round mle.
+    /// @dev Reverts if there are no final round mles left.
+    function __consumeFinalRoundMLE(uint256 __builderPtr) internal pure returns (uint256 __evaluation) {
+        assembly {
+            function builder_consume_final_round_mle(builder_ptr) -> evaluation {
+                let head_ptr := mload(add(builder_ptr, FINAL_ROUND_MLE_HEAD_OFFSET))
+                evaluation := mload(head_ptr)
+                head_ptr := add(head_ptr, WORD_SIZE)
+                if gt(head_ptr, mload(add(builder_ptr, FINAL_ROUND_MLE_TAIL_OFFSET))) {
+                    mstore(0, TOO_FEW_FINAL_ROUND_MLES)
+                    revert(0, 4)
+                }
+                mstore(add(builder_ptr, FINAL_ROUND_MLE_HEAD_OFFSET), head_ptr)
+            }
+            __evaluation := builder_consume_final_round_mle(__builderPtr)
+        }
+    }
 }

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -33,6 +33,13 @@ library ErrorTest {
             revert(0, 4)
         }
     }
+
+    function causeTooFewChallenges() public pure {
+        assembly {
+            mstore(0, TOO_FEW_CHALLENGES)
+            revert(0, 4)
+        }
+    }
 }
 
 contract ConstantsTest is Test {
@@ -54,6 +61,11 @@ contract ConstantsTest is Test {
     function testErrorFailedRoundEvaluationMismatch() public {
         vm.expectRevert(Errors.RoundEvaluationMismatch.selector);
         ErrorTest.causeRoundEvaluationMismatch();
+    }
+
+    function testErrorFailedTooFewChallenges() public {
+        vm.expectRevert(Errors.TooFewChallenges.selector);
+        ErrorTest.causeTooFewChallenges();
     }
 
     function testModulusMaskIsCorrect() public pure {
@@ -78,5 +90,18 @@ contract ConstantsTest is Test {
         assert(WORDX3_SIZE == 3 * WORD_SIZE);
         assert(WORDX4_SIZE == 4 * WORD_SIZE);
         assert(WORDX12_SIZE == 12 * WORD_SIZE);
+    }
+
+    function testVerificationBuilderOffsetsAreValid() public pure {
+        uint256[2] memory offsets = [CHALLENGE_HEAD_OFFSET, CHALLENGE_TAIL_OFFSET];
+        uint256 offsetsLength = offsets.length;
+        assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);
+        for (uint256 i = 0; i < offsetsLength; ++i) {
+            assert(offsets[i] % WORD_SIZE == 0); // Offsets must be word-aligned
+            assert(offsets[i] < VERIFICATION_BUILDER_SIZE); // Offsets must be within the builder
+            for (uint256 j = i + 1; j < offsetsLength; ++j) {
+                assert(offsets[i] != offsets[j]); // Offsets must be unique
+            }
+        }
     }
 }

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -40,6 +40,13 @@ library ErrorTest {
             revert(0, 4)
         }
     }
+
+    function causeTooFewFinalRoundMLEs() public pure {
+        assembly {
+            mstore(0, TOO_FEW_FINAL_ROUND_MLES)
+            revert(0, 4)
+        }
+    }
 }
 
 contract ConstantsTest is Test {
@@ -68,6 +75,11 @@ contract ConstantsTest is Test {
         ErrorTest.causeTooFewChallenges();
     }
 
+    function testErrorFailedTooFewFinalRoundMLEs() public {
+        vm.expectRevert(Errors.TooFewFinalRoundMLEs.selector);
+        ErrorTest.causeTooFewFinalRoundMLEs();
+    }
+
     function testModulusMaskIsCorrect() public pure {
         assert(MODULUS > MODULUS_MASK);
         assert(MODULUS < (MODULUS_MASK << 1));
@@ -93,7 +105,8 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[2] memory offsets = [CHALLENGE_HEAD_OFFSET, CHALLENGE_TAIL_OFFSET];
+        uint256[4] memory offsets =
+            [CHALLENGE_HEAD_OFFSET, CHALLENGE_TAIL_OFFSET, FINAL_ROUND_MLE_HEAD_OFFSET, FINAL_ROUND_MLE_TAIL_OFFSET];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);
         for (uint256 i = 0; i < offsetsLength; ++i) {

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -47,6 +47,13 @@ library ErrorTest {
             revert(0, 4)
         }
     }
+
+    function causeTooFewChiEvaluations() public pure {
+        assembly {
+            mstore(0, TOO_FEW_CHI_EVALUATIONS)
+            revert(0, 4)
+        }
+    }
 }
 
 contract ConstantsTest is Test {
@@ -80,6 +87,11 @@ contract ConstantsTest is Test {
         ErrorTest.causeTooFewFinalRoundMLEs();
     }
 
+    function testErrorFailedTooFewChiEvaluations() public {
+        vm.expectRevert(Errors.TooFewChiEvaluations.selector);
+        ErrorTest.causeTooFewChiEvaluations();
+    }
+
     function testModulusMaskIsCorrect() public pure {
         assert(MODULUS > MODULUS_MASK);
         assert(MODULUS < (MODULUS_MASK << 1));
@@ -105,8 +117,14 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[4] memory offsets =
-            [CHALLENGE_HEAD_OFFSET, CHALLENGE_TAIL_OFFSET, FINAL_ROUND_MLE_HEAD_OFFSET, FINAL_ROUND_MLE_TAIL_OFFSET];
+        uint256[6] memory offsets = [
+            CHALLENGE_HEAD_OFFSET,
+            CHALLENGE_TAIL_OFFSET,
+            FINAL_ROUND_MLE_HEAD_OFFSET,
+            FINAL_ROUND_MLE_TAIL_OFFSET,
+            CHI_EVALUATION_HEAD_OFFSET,
+            CHI_EVALUATION_TAIL_OFFSET
+        ];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);
         for (uint256 i = 0; i < offsetsLength; ++i) {

--- a/solidity/test/base/ECPrecompiles.t.pre.sol
+++ b/solidity/test/base/ECPrecompiles.t.pre.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import { Test } from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import "../../src/base/Constants.sol";
-import { ECPrecompiles } from "../../src/base/ECPrecompiles.pre.sol";
+import {ECPrecompiles} from "../../src/base/ECPrecompiles.pre.sol";
 
 library ECPrecompilesTestWrapper {
     function ecAdd(uint256[4] calldata args) external view {

--- a/solidity/test/proof/VerificationBuilder.t.sol
+++ b/solidity/test/proof/VerificationBuilder.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/proof/VerificationBuilder.sol";
+
+library VerificationBuilderTest {
+    function testFuzzAllocateBuilder(uint256[] memory) public pure {
+        // Note: the extra parameter is simply to make the free pointer location unpredictable.
+        uint256 expectedBuilder;
+        assembly {
+            expectedBuilder := mload(FREE_PTR)
+        }
+        assert(VerificationBuilder.__allocate() == expectedBuilder);
+        uint256 freePtr;
+        assembly {
+            freePtr := mload(FREE_PTR)
+        }
+        assert(freePtr == expectedBuilder + VERIFICATION_BUILDER_SIZE);
+    }
+}

--- a/solidity/test/proof/VerificationBuilder.t.sol
+++ b/solidity/test/proof/VerificationBuilder.t.sol
@@ -14,6 +14,14 @@ library VerificationBuilderTestHelper {
         }
         VerificationBuilder.__setChallenges(builderPtr, challengePtr, challenges.length);
     }
+
+    function setFinalRoundMLEs(uint256 builderPtr, uint256[] memory finalRoundMLEs) internal pure {
+        uint256 finalRoundMLEsPtr;
+        assembly {
+            finalRoundMLEsPtr := add(finalRoundMLEs, WORD_SIZE)
+        }
+        VerificationBuilder.__setFinalRoundMLEs(builderPtr, finalRoundMLEsPtr, finalRoundMLEs.length);
+    }
 }
 
 contract VerificationBuilderTest is Test {
@@ -100,5 +108,79 @@ contract VerificationBuilderTest is Test {
         }
         vm.expectRevert(Errors.TooFewChallenges.selector);
         VerificationBuilder.__consumeChallenge(builderPtr);
+    }
+
+    function testSetFinalRoundMLEs() public pure {
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilder.__setFinalRoundMLEs(builderPtr, 0xABCD, 0x1234);
+        uint256 head;
+        uint256 tail;
+        assembly {
+            head := mload(add(builderPtr, FINAL_ROUND_MLE_HEAD_OFFSET))
+            tail := mload(add(builderPtr, FINAL_ROUND_MLE_TAIL_OFFSET))
+        }
+        assert(head == 0xABCD);
+        assert(tail == 0xABCD + WORD_SIZE * 0x1234);
+    }
+
+    function testFuzzSetFinalRoundMLEs(uint256[] memory, uint256 finalRoundMLEPtr, uint64 finalRoundMLELength)
+        public
+        pure
+    {
+        vm.assume(finalRoundMLEPtr < 2 ** 64);
+        vm.assume(finalRoundMLELength < 2 ** 64);
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilder.__setFinalRoundMLEs(builderPtr, finalRoundMLEPtr, finalRoundMLELength);
+        uint256 head;
+        uint256 tail;
+        assembly {
+            head := mload(add(builderPtr, FINAL_ROUND_MLE_HEAD_OFFSET))
+            tail := mload(add(builderPtr, FINAL_ROUND_MLE_TAIL_OFFSET))
+        }
+        assert(head == finalRoundMLEPtr);
+        assert(tail == finalRoundMLEPtr + WORD_SIZE * finalRoundMLELength);
+    }
+
+    function testSetAndConsumeZeroFinalRoundMLEs() public {
+        uint256[] memory finalRoundMLEs = new uint256[](0);
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilderTestHelper.setFinalRoundMLEs(builderPtr, finalRoundMLEs);
+        vm.expectRevert(Errors.TooFewFinalRoundMLEs.selector);
+        VerificationBuilder.__consumeFinalRoundMLE(builderPtr);
+    }
+
+    function testSetAndConsumeOneFinalRoundMLE() public {
+        uint256[] memory finalRoundMLEs = new uint256[](1);
+        finalRoundMLEs[0] = 0x12345678;
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilderTestHelper.setFinalRoundMLEs(builderPtr, finalRoundMLEs);
+        assert(VerificationBuilder.__consumeFinalRoundMLE(builderPtr) == 0x12345678);
+        vm.expectRevert(Errors.TooFewFinalRoundMLEs.selector);
+        VerificationBuilder.__consumeFinalRoundMLE(builderPtr);
+    }
+
+    function testSetAndConsumeFinalRoundMLEs() public {
+        uint256[] memory finalRoundMLEs = new uint256[](3);
+        finalRoundMLEs[0] = 0x12345678;
+        finalRoundMLEs[1] = 0x23456789;
+        finalRoundMLEs[2] = 0x3456789A;
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilderTestHelper.setFinalRoundMLEs(builderPtr, finalRoundMLEs);
+        assert(VerificationBuilder.__consumeFinalRoundMLE(builderPtr) == 0x12345678);
+        assert(VerificationBuilder.__consumeFinalRoundMLE(builderPtr) == 0x23456789);
+        assert(VerificationBuilder.__consumeFinalRoundMLE(builderPtr) == 0x3456789A);
+        vm.expectRevert(Errors.TooFewFinalRoundMLEs.selector);
+        VerificationBuilder.__consumeFinalRoundMLE(builderPtr);
+    }
+
+    function testFuzzSetAndConsumeFinalRoundMLEs(uint256[] memory, uint256[] memory finalRoundMLEs) public {
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilderTestHelper.setFinalRoundMLEs(builderPtr, finalRoundMLEs);
+        uint256 finalRoundMLEsLength = finalRoundMLEs.length;
+        for (uint256 i = 0; i < finalRoundMLEsLength; ++i) {
+            assert(VerificationBuilder.__consumeFinalRoundMLE(builderPtr) == finalRoundMLEs[i]);
+        }
+        vm.expectRevert(Errors.TooFewFinalRoundMLEs.selector);
+        VerificationBuilder.__consumeFinalRoundMLE(builderPtr);
     }
 }

--- a/solidity/test/proof/VerificationBuilder.t.sol
+++ b/solidity/test/proof/VerificationBuilder.t.sol
@@ -2,10 +2,21 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
+import {Test} from "forge-std/Test.sol";
 import "../../src/base/Constants.sol";
 import {VerificationBuilder} from "../../src/proof/VerificationBuilder.sol";
 
-library VerificationBuilderTest {
+library VerificationBuilderTestHelper {
+    function setChallenges(uint256 builderPtr, uint256[] memory challenges) internal pure {
+        uint256 challengePtr;
+        assembly {
+            challengePtr := add(challenges, WORD_SIZE)
+        }
+        VerificationBuilder.__setChallenges(builderPtr, challengePtr, challenges.length);
+    }
+}
+
+contract VerificationBuilderTest is Test {
     function testFuzzAllocateBuilder(uint256[] memory) public pure {
         // Note: the extra parameter is simply to make the free pointer location unpredictable.
         uint256 expectedBuilder;
@@ -18,5 +29,76 @@ library VerificationBuilderTest {
             freePtr := mload(FREE_PTR)
         }
         assert(freePtr == expectedBuilder + VERIFICATION_BUILDER_SIZE);
+    }
+
+    function testSetChallenges() public pure {
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilder.__setChallenges(builderPtr, 0xABCD, 0x1234);
+        uint256 head;
+        uint256 tail;
+        assembly {
+            head := mload(add(builderPtr, CHALLENGE_HEAD_OFFSET))
+            tail := mload(add(builderPtr, CHALLENGE_TAIL_OFFSET))
+        }
+        assert(head == 0xABCD);
+        assert(tail == 0xABCD + WORD_SIZE * 0x1234);
+    }
+
+    function testFuzzSetChallenges(uint256[] memory, uint256 challengePtr, uint64 challengeLength) public pure {
+        vm.assume(challengePtr < 2 ** 64);
+        vm.assume(challengeLength < 2 ** 64);
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilder.__setChallenges(builderPtr, challengePtr, challengeLength);
+        uint256 head;
+        uint256 tail;
+        assembly {
+            head := mload(add(builderPtr, CHALLENGE_HEAD_OFFSET))
+            tail := mload(add(builderPtr, CHALLENGE_TAIL_OFFSET))
+        }
+        assert(head == challengePtr);
+        assert(tail == challengePtr + WORD_SIZE * challengeLength);
+    }
+
+    function testSetAndConsumeZeroChallenges() public {
+        uint256[] memory challenges = new uint256[](0);
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilderTestHelper.setChallenges(builderPtr, challenges);
+        vm.expectRevert(Errors.TooFewChallenges.selector);
+        VerificationBuilder.__consumeChallenge(builderPtr);
+    }
+
+    function testSetAndConsumeOneChallenge() public {
+        uint256[] memory challenges = new uint256[](1);
+        challenges[0] = 0x12345678;
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilderTestHelper.setChallenges(builderPtr, challenges);
+        assert(VerificationBuilder.__consumeChallenge(builderPtr) == 0x12345678);
+        vm.expectRevert(Errors.TooFewChallenges.selector);
+        VerificationBuilder.__consumeChallenge(builderPtr);
+    }
+
+    function testSetAndConsumeChallenges() public {
+        uint256[] memory challenges = new uint256[](3);
+        challenges[0] = 0x12345678;
+        challenges[1] = 0x23456789;
+        challenges[2] = 0x3456789A;
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilderTestHelper.setChallenges(builderPtr, challenges);
+        assert(VerificationBuilder.__consumeChallenge(builderPtr) == 0x12345678);
+        assert(VerificationBuilder.__consumeChallenge(builderPtr) == 0x23456789);
+        assert(VerificationBuilder.__consumeChallenge(builderPtr) == 0x3456789A);
+        vm.expectRevert(Errors.TooFewChallenges.selector);
+        VerificationBuilder.__consumeChallenge(builderPtr);
+    }
+
+    function testFuzzSetAndConsumeChallenges(uint256[] memory, uint256[] memory challenges) public {
+        uint256 builderPtr = VerificationBuilder.__allocate();
+        VerificationBuilderTestHelper.setChallenges(builderPtr, challenges);
+        uint256 challengesLength = challenges.length;
+        for (uint256 i = 0; i < challengesLength; ++i) {
+            assert(VerificationBuilder.__consumeChallenge(builderPtr) == challenges[i]);
+        }
+        vm.expectRevert(Errors.TooFewChallenges.selector);
+        VerificationBuilder.__consumeChallenge(builderPtr);
     }
 }


### PR DESCRIPTION
# Rationale for this change

The verifier needs to retain/build state while traversing the proof plan. This PR mirrors the `VerificationBuilder` in the rust code.

# What changes are included in this PR?

* The base VerificationBuilder library is added.
* The `challenges`, `final_round_mle`, and `chi_evaluation` queues are added.

# Are these changes tested?

Yes