### PR TITLE
Refactor/add bit check to sign expr

### DIFF
--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -444,6 +444,14 @@ where
             u64::MAX >> (T::MODULUS.0[3].leading_zeros() + 1),
         ])
     };
+    #[allow(clippy::cast_possible_truncation)]
+    const MAX_BITS: u8 = {
+        assert!(
+            T::MODULUS.0[3].leading_zeros() < 64,
+            "modulus expected to be larger than 1 << (64*3)"
+        );
+        255 - T::MODULUS.0[3].leading_zeros() as u8
+    };
 }
 
 impl<T> TryFrom<MontScalar<T>> for bool

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar_test.rs
@@ -1,11 +1,13 @@
 use crate::base::{
     map::IndexSet,
     scalar::{
-        test_scalar::TestScalar, test_scalar_constants, Curve25519Scalar, Scalar,
-        ScalarConversionError,
+        test_scalar::{TestMontConfig, TestScalar},
+        test_scalar_constants, Curve25519Scalar, Scalar, ScalarConversionError,
     },
 };
 use alloc::{format, string::ToString, vec::Vec};
+use ark_ff::MontConfig;
+use bnum::types::U256;
 use byte_slice_cast::AsByteSlice;
 use num_bigint::BigInt;
 use num_traits::{Inv, One, Zero};
@@ -503,4 +505,13 @@ fn test_bigint_to_scalar_overflow() {
         ),
         Err(ScalarConversionError::Overflow { .. })
     ));
+}
+
+#[test]
+fn we_can_bound_modulus_using_max_bits() {
+    let modulus_of_i_max_bits = U256::ONE << TestScalar::MAX_BITS;
+    let modulus_of_i_max_bits_plus_1 = U256::ONE << (TestScalar::MAX_BITS + 1);
+    let modulus_of_test_scalar = U256::from(TestMontConfig::MODULUS.0);
+    assert!(modulus_of_i_max_bits <= modulus_of_test_scalar);
+    assert!(modulus_of_i_max_bits_plus_1 > modulus_of_test_scalar);
 }

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -81,4 +81,6 @@ pub trait Scalar:
     /// The value to mask the challenge with to ensure it is in the field.
     /// This one less than the largest power of 2 that is less than the field modulus.
     const CHALLENGE_MASK: U256;
+    /// The largest n such that 2^n <=p
+    const MAX_BITS: u8;
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -111,7 +111,7 @@ impl ProofExpr for InequalityExpr {
         };
 
         // sign(diff) == -1
-        verifier_evaluate_sign(builder, diff_eval, chi_eval)
+        verifier_evaluate_sign(builder, diff_eval, chi_eval, 251)
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -111,7 +111,7 @@ impl ProofExpr for InequalityExpr {
         };
 
         // sign(diff) == -1
-        verifier_evaluate_sign(builder, diff_eval, chi_eval, 251)
+        verifier_evaluate_sign(builder, diff_eval, chi_eval, None)
     }
 
     fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -102,7 +102,7 @@ pub(crate) fn verify_monotonic<S: Scalar, const STRICT: bool, const ASC: bool>(
         (true, true) | (false, false) => shifted_column_eval - column_eval,
         _ => column_eval - shifted_column_eval,
     };
-    let sign_eval = verifier_evaluate_sign(builder, ind_eval, shifted_chi_eval, 251)?;
+    let sign_eval = verifier_evaluate_sign(builder, ind_eval, shifted_chi_eval, None)?;
     let singleton_chi_eval = builder.singleton_chi_evaluation();
     let allowed_evals = if STRICT {
         // sign(ind) == 1 for all but the first element and the last element

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -102,7 +102,7 @@ pub(crate) fn verify_monotonic<S: Scalar, const STRICT: bool, const ASC: bool>(
         (true, true) | (false, false) => shifted_column_eval - column_eval,
         _ => column_eval - shifted_column_eval,
     };
-    let sign_eval = verifier_evaluate_sign(builder, ind_eval, shifted_chi_eval)?;
+    let sign_eval = verifier_evaluate_sign(builder, ind_eval, shifted_chi_eval, 251)?;
     let singleton_chi_eval = builder.singleton_chi_evaluation();
     let allowed_evals = if STRICT {
         // sign(ind) == 1 for all but the first element and the last element

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -174,11 +174,26 @@ fn verify_bit_decomposition<S: ScalarExt>(
 mod tests {
     use crate::{
         base::{
-            bit::BitDistribution,
+            bit::{BitDistribution, BitDistrubutionError},
             scalar::{test_scalar::TestScalar, Scalar},
         },
         sql::proof_gadgets::sign_expr::verify_bit_decomposition,
     };
+
+    fn evaluate_matrix(matrix: &[&[i32]], terms: &[TestScalar]) -> Vec<TestScalar> {
+        matrix
+            .iter()
+            .map(|row| evaluate_terms(row, terms))
+            .collect()
+    }
+
+    fn evaluate_terms(coeffs: &[i32], terms: &[TestScalar]) -> TestScalar {
+        coeffs
+            .iter()
+            .zip(terms)
+            .map(|(&coef, &term)| TestScalar::from(coef) * term)
+            .sum()
+    }
 
     #[test]
     fn we_can_verify_bit_decomposition() {
@@ -195,13 +210,13 @@ mod tests {
     }
 
     #[test]
-    fn we_can_verify_bit_decomposition_constant_sign() {
+    fn we_can_verify_bit_decomposition_positive_sign() {
         let dist = BitDistribution {
             vary_mask: [629, 0, 0, 0],
             leading_bit_mask: [2, 0, 0, 9_223_372_036_854_775_808],
         };
-        let a = TestScalar::ONE;
-        let b = TestScalar::ONE;
+        let a = TestScalar::TEN;
+        let b = TestScalar::TWO;
         let expr_eval = TestScalar::from(118) * (TestScalar::ONE - a) * (TestScalar::ONE - b)
             + TestScalar::from(562) * a * (TestScalar::ONE - b)
             + TestScalar::from(3) * (TestScalar::ONE - a) * b;
@@ -231,5 +246,47 @@ mod tests {
         let sign_eval =
             verify_bit_decomposition(expr_eval, chi_eval, &bit_evals, &dist, 128).unwrap();
         assert_eq!(sign_eval, chi_eval);
+    }
+
+    #[test]
+    fn we_can_verify_bit_decomposition_i8_sign() {
+        let dist = BitDistribution {
+            vary_mask: [125, 0, 0, 9_223_372_036_854_775_808],
+            leading_bit_mask: [2, 0, 0, 9_223_372_036_854_775_808],
+        };
+        let a = TestScalar::TEN;
+        let b = TestScalar::TWO;
+        let one_minus_a = TestScalar::ONE - a;
+        let one_minus_b = TestScalar::ONE - b;
+
+        let s = [
+            one_minus_a * one_minus_b,
+            a * one_minus_b,
+            one_minus_a * b,
+            a * b,
+        ];
+
+        let expr_eval = evaluate_terms(&[106, 23, -60, -76], &s);
+        let one_eval = evaluate_terms(&[1, 1, 1, 1], &s);
+
+        let bit_matrix: &[&[i32]] = &[
+            &[0, 1, 0, 0],
+            &[0, 1, 1, 1],
+            &[1, 0, 0, 0],
+            &[0, 1, 0, 1],
+            &[1, 0, 0, 1],
+            &[1, 0, 1, 0],
+            &[1, 1, 0, 0],
+        ];
+
+        let bit_evals = evaluate_matrix(bit_matrix, &s);
+
+        let expected_eval = evaluate_terms(&[1, 1, 0, 0], &s);
+
+        let sign_eval =
+            verify_bit_decomposition(expr_eval, one_eval, &bit_evals, &dist, 8).unwrap();
+        assert_eq!(sign_eval, expected_eval);
+        let err = verify_bit_decomposition(expr_eval, one_eval, &bit_evals, &dist, 7).unwrap_err();
+        assert!(matches!(err, BitDistrubutionError::Verification));
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -162,9 +162,12 @@ fn verify_bit_decomposition<S: ScalarExt>(
             rhs += S::from_wrapping(mult) * bit_eval;
         }
     }
-    let bits_that_must_match_inverse_lead_bit = U256::MAX
-        .shl(num_bits_allowed.unwrap_or(S::MAX_BITS).min(S::MAX_BITS) - 1)
-        ^ U256::ONE.shl(255);
+    let num_bits_allowed = num_bits_allowed.unwrap_or(S::MAX_BITS);
+    if num_bits_allowed > S::MAX_BITS {
+        return Err(BitDistrubutionError::Verification);
+    }
+    let bits_that_must_match_inverse_lead_bit =
+        U256::MAX.shl(num_bits_allowed - 1) ^ U256::ONE.shl(255);
     let is_eval_too_many_bits = bits_that_must_match_inverse_lead_bit
         & dist.leading_bit_inverse_mask()
         == bits_that_must_match_inverse_lead_bit;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -270,7 +270,7 @@ mod tests {
         ];
 
         let expr_eval = evaluate_terms(&[106, 23, -60, -76], &s);
-        let one_eval = evaluate_terms(&[1, 1, 1, 1], &s);
+        let chi_eval = evaluate_terms(&[1, 1, 1, 1], &s);
 
         let bit_matrix: &[&[i32]] = &[
             &[0, 1, 0, 0],
@@ -287,10 +287,10 @@ mod tests {
         let expected_eval = evaluate_terms(&[1, 1, 0, 0], &s);
 
         let sign_eval =
-            verify_bit_decomposition(expr_eval, one_eval, &bit_evals, &dist, Some(8)).unwrap();
+            verify_bit_decomposition(expr_eval, chi_eval, &bit_evals, &dist, Some(8)).unwrap();
         assert_eq!(sign_eval, expected_eval);
         let err =
-            verify_bit_decomposition(expr_eval, one_eval, &bit_evals, &dist, Some(7)).unwrap_err();
+            verify_bit_decomposition(expr_eval, chi_eval, &bit_evals, &dist, Some(7)).unwrap_err();
         assert!(matches!(err, BitDistrubutionError::Verification));
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -66,7 +66,7 @@ fn we_can_verify_a_constant_decomposition() {
         3,
     );
     let data_eval = (&data).evaluate_at_point(&evaluation_point);
-    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval).unwrap();
+    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, 8).unwrap();
     assert_eq!(eval, Curve25519Scalar::ZERO);
 }
 
@@ -100,7 +100,7 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
         3,
     );
     let data_eval = Curve25519Scalar::from(2) * (&data).evaluate_at_point(&evaluation_point);
-    assert!(verifier_evaluate_sign(&mut builder, data_eval, *chi_eval).is_err());
+    assert!(verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, 128).is_err());
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -66,7 +66,7 @@ fn we_can_verify_a_constant_decomposition() {
         3,
     );
     let data_eval = (&data).evaluate_at_point(&evaluation_point);
-    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, 8).unwrap();
+    let eval = verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, Some(8)).unwrap();
     assert_eq!(eval, Curve25519Scalar::ZERO);
 }
 
@@ -100,7 +100,7 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
         3,
     );
     let data_eval = Curve25519Scalar::from(2) * (&data).evaluate_at_point(&evaluation_point);
-    assert!(verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, 128).is_err());
+    assert!(verifier_evaluate_sign(&mut builder, data_eval, *chi_eval, None).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

The code in sign_expr could verify that values use less than or equal to a given number of bits, but it does not currently. This PR adds that functionality.

# What changes are included in this PR?

Adding a parameter num_bits_allowed to verify_bit_decomposition and verfify_sign_expr, along with the corresponding functionality.

# Are these changes tested?
Yes.
