### PR TITLE
chore: improve solhint linting

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -267,5 +267,7 @@ jobs:
         run: npm install -g solhint
       - name: Run lints
         run: |
-          cd solidity/src
+          cd solidity
+          scripts/preprocess_yul_imports.sh src
+          scripts/preprocess_yul_imports.sh test
           solhint '**/*.sol' -w 0

--- a/solidity/.solhint.json
+++ b/solidity/.solhint.json
@@ -1,16 +1,11 @@
 {
-    "extends": "solhint:recommended",
+    "extends": "solhint:all",
     "rules": {
-        "gas-calldata-parameters": "warn",
-        "gas-increment-by-one": "warn",
-        "gas-indexed-events": "warn",
-        "gas-length-in-loops": "warn",
-        "gas-multitoken1155": "warn",
-        "gas-named-return-values": "warn",
-        "gas-small-strings": "warn",
-        "gas-strict-inequalities": "warn",
-        "gas-struct-packing": "warn",
+        "comprehensive-interface": "off",
+        "foundry-test-functions": "off",
+        "no-global-import": "off",
         "no-inline-assembly": "off",
-        "one-contract-per-file": "off"
+        "one-contract-per-file": "off",
+        "ordering": "off"
     }
 }

--- a/solidity/.solhintignore
+++ b/solidity/.solhintignore
@@ -1,0 +1,1 @@
+dependencies/

--- a/solidity/scripts/preprocess_yul_imports.sh
+++ b/solidity/scripts/preprocess_yul_imports.sh
@@ -83,7 +83,7 @@ while IFS= read -r -d '' file; do
     # Handle Solidity imports
     /^import/ {
         import_line = $0
-        while (import_line !~ /;[[:space:]]*$/) {
+        while (import_line !~ /;/) {
             getline
             import_line = import_line "\n" $0
         }

--- a/solidity/src/base/ECPrecompiles.pre.sol
+++ b/solidity/src/base/ECPrecompiles.pre.sol
@@ -1,25 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-// assembly only constants
-/* solhint-disable no-unused-import */
-import {
-    ECADD_ADDRESS,
-    ECADD_GAS,
-    ECMUL_ADDRESS,
-    ECMUL_GAS,
-    ECPAIRING_ADDRESS,
-    ECPAIRINGX2_GAS,
-    INVALID_EC_ADD_INPUTS,
-    INVALID_EC_MUL_INPUTS,
-    INVALID_EC_PAIRING_INPUTS,
-    WORD_SIZE,
-    WORDX2_SIZE,
-    WORDX3_SIZE,
-    WORDX4_SIZE,
-    WORDX12_SIZE
-} from "./Constants.sol";
-/* solhint-enable no-unused-import */
+import "./Constants.sol";
 
 /// @title ECPrecompiles Library
 /// @notice A library holding Yul wrappers for the precompiled contracts.
@@ -43,7 +25,8 @@ library ECPrecompiles {
     }
 
     /// @notice Wrapper around the ECMUL precompile.
-    /// @dev The words are in the format [a_x, a_y, scalar], where the point a = (a_x, a_y) and scalar is the scalar to multiply by.
+    /// @dev The words are in the format [a_x, a_y, scalar], where the point
+    /// a = (a_x, a_y) and scalar is the scalar to multiply by.
     /// This function does an in-place multiplication of the point a by the scalar. In other words, it sets a *= scalar.
     /// The result is stored in the first two words of the input. If c = a * scalar, then the input memory is
     /// modified to be [c_x, c_y, scalar].
@@ -61,7 +44,8 @@ library ECPrecompiles {
     }
 
     /// @notice Wrapper around the ECPAIRING precompile.
-    /// @dev The words are in the format [a_x, a_y, g_x_imag, g_x_real, g_y_imag, g_y_real, b_x, b_y, h_x_imag, h_x_real, h_y_imag, h_y_real].
+    /// @dev The words are in the format
+    /// [a_x, a_y, g_x_imag, g_x_real, g_y_imag, g_y_real, b_x, b_y, h_x_imag, h_x_real, h_y_imag, h_y_real].
     /// Where the point a = (a_x, a_y) and the points g = (g_x_real + g_x_imag * i, g_y_real + g_y_imag * i),
     /// b = (b_x, b_y), and h = (h_x_real + h_x_imag * i, h_y_real + h_y_imag * i).
     /// This function computes the pairing check e(a, b) + e(g, h) == 0.

--- a/solidity/src/base/LagrangeBasisEvaluation.sol
+++ b/solidity/src/base/LagrangeBasisEvaluation.sol
@@ -2,15 +2,14 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
-// assembly only constants
-// solhint-disable-next-line no-unused-import
-import {MODULUS, MODULUS_PLUS_ONE, WORD_SIZE} from "./Constants.sol";
+import "./Constants.sol";
 
 /// @title Lagrange Basis Evaluation Library
 /// @notice A library for efficiently computing sums over Lagrange basis polynomials evaluated at points.
 library LagrangeBasisEvaluation {
     /// @notice Computes the sum of the Lagrange basis polynomials evaluated at a given point.
-    /// @notice This is a wrapper around the `compute_truncated_lagrange_basis_sum` Yul function. This wrapper is only intended to be used for testing.
+    /// @notice This is a wrapper around the `compute_truncated_lagrange_basis_sum` Yul function.
+    /// This wrapper is only intended to be used for testing.
     /// @param __length The length of the sum.
     /// @param __x The point at which to evaluate the Lagrange basis.
     /// @return __result The sum of the Lagrange basis polynomials evaluated at the given point.
@@ -51,14 +50,18 @@ library LagrangeBasisEvaluation {
 
     /// @notice Computes the inner product of the Lagrange basis polynomials evaluated at two given points.
     /// @notice Reverts if `__x` and `__y` have different lengths.
-    /// @notice This is a wrapper around the `compute_truncated_lagrange_basis_inner_product` Yul function. This wrapper is only intended to be used for testing.
+    /// @notice This is a wrapper around the `compute_truncated_lagrange_basis_inner_product` Yul function.
+    /// This wrapper is only intended to be used for testing.
     /// @param __length The length of the sum.
     /// @param __x The first point at which to evaluate the Lagrange basis.
     /// @param __y The second point at which to evaluate the Lagrange basis.
     /// @return __result The inner product of the Lagrange basis polynomials evaluated at the two points.
-    /// @dev Let \\(\chi_i(x)\\) be the \\(i\\)th Lagrange basis polynomial as described in [__computeTruncatedLagrangeBasisSum](#__computetruncatedlagrangebasissum).
-    /// @dev This function computes \\[ \sum_{i=0}^{\ell-1}\chi_i(x_0,\ldots,x_{\nu-1},0,\ldots)\chi_i(y_0,\ldots,y_{\nu-1},0,\ldots),\\]
-    /// where \\(\ell = \texttt{length}\\) and \\(\nu = \texttt{num_vars} = \texttt{__x.length} = \texttt{__y.length}\\).
+    /// @dev Let \\(\chi_i(x)\\) be the \\(i\\)th Lagrange basis polynomial as described in
+    /// [__computeTruncatedLagrangeBasisSum](#__computetruncatedlagrangebasissum).
+    /// @dev This function computes
+    /// \\[ \sum_{i=0}^{\ell-1}\chi_i(x_0,\ldots,x_{\nu-1},0,\ldots)\chi_i(y_0,\ldots,y_{\nu-1},0,\ldots),\\]
+    /// where \\(\ell = \texttt{length}\\) and
+    /// \\(\nu = \texttt{num_vars} = \texttt{__x.length} = \texttt{__y.length}\\).
     function __computeTruncatedLagrangeBasisInnerProduct(uint256 __length, uint256[] memory __x, uint256[] memory __y)
         internal
         pure

--- a/solidity/src/base/Transcript.sol
+++ b/solidity/src/base/Transcript.sol
@@ -2,9 +2,7 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
-// assembly only constants
-// solhint-disable-next-line no-unused-import
-import {FREE_PTR, MODULUS_MASK, WORD_SIZE} from "./Constants.sol";
+import "./Constants.sol";
 
 /// @title Transcript Library
 /// @notice Provides functions to manage a simple public coin transcript

--- a/solidity/src/proof/Sumcheck.pre.sol
+++ b/solidity/src/proof/Sumcheck.pre.sol
@@ -2,9 +2,7 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
-// assembly only constants
-// solhint-disable-next-line no-unused-import
-import {ROUND_EVALUATION_MISMATCH, FREE_PTR, WORD_SIZE, MODULUS, MODULUS_MASK} from "../base/Constants.sol";
+import "../base/Constants.sol";
 
 /// @title Sumcheck Protocol Verification Library
 /// @notice This library provides functions to verify sumcheck proofs in zero-knowledge protocols.
@@ -20,7 +18,8 @@ library Sumcheck {
     /// @param degree0 Degree of the polynomial being checked
     /// @return evaluationPointPtr0 Pointer to the evaluation points in memory
     /// @return expectedEvaluation0 The expected evaluation result
-    function verifySumcheckProof(uint256[1] memory transcript0, uint256 proofPtr0, uint256 numVars0, uint256 degree0)
+    function verifySumcheckProof( // solhint-disable-line function-max-lines
+    uint256[1] memory transcript0, uint256 proofPtr0, uint256 numVars0, uint256 degree0)
         internal
         pure
         returns (uint256 evaluationPointPtr0, uint256 expectedEvaluation0)

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -3,24 +3,7 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
-
-import {Errors} from "../../src/base/Constants.sol";
-/* solhint-disable no-unused-import */
-import {
-    WORD_SIZE,
-    WORDX2_SIZE,
-    WORDX3_SIZE,
-    WORDX4_SIZE,
-    WORDX12_SIZE,
-    MODULUS,
-    MODULUS_PLUS_ONE,
-    MODULUS_MASK,
-    INVALID_EC_ADD_INPUTS,
-    INVALID_EC_MUL_INPUTS,
-    INVALID_EC_PAIRING_INPUTS,
-    ROUND_EVALUATION_MISMATCH
-} from "../../src/base/Constants.sol";
-/* solhint-enable no-unused-import */
+import "../../src/base/Constants.sol";
 
 contract ConstantsTest is Test {
     function testErrorFailedInvalidECAddInputs() public {

--- a/solidity/test/base/LagrangeBasisEvaluation.t.sol
+++ b/solidity/test/base/LagrangeBasisEvaluation.t.sol
@@ -2,7 +2,7 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
-import {MODULUS} from "../../src/base/Constants.sol";
+import "../../src/base/Constants.sol";
 import {LagrangeBasisEvaluation} from "../../src/base/LagrangeBasisEvaluation.sol";
 
 /// A library for efficiently computing sums over Lagrange basis polynomials evaluated at points.

--- a/solidity/test/base/Transcript.t.sol
+++ b/solidity/test/base/Transcript.t.sol
@@ -2,11 +2,8 @@
 // This is licensed under the Cryptographic Open Software License 1.0
 pragma solidity ^0.8.28;
 
+import "../../src/base/Constants.sol";
 import {Transcript} from "../../src/base/Transcript.sol";
-import {MODULUS, WORD_SIZE} from "../../src/base/Constants.sol";
-// assembly only constants
-// solhint-disable-next-line no-unused-import
-import {FREE_PTR} from "../../src/base/Constants.sol";
 
 library TranscriptTest {
     function testWeCanDrawChallenge() public pure {

--- a/solidity/test/proof/Sumcheck.t.pre.sol
+++ b/solidity/test/proof/Sumcheck.t.pre.sol
@@ -3,9 +3,8 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
-
+import "../../src/base/Constants.sol";
 import {Sumcheck} from "../../src/proof/Sumcheck.pre.sol";
-import {Errors, MODULUS, MODULUS_MASK, WORD_SIZE} from "../../src/base/Constants.sol";
 
 library SumcheckTestWrapper {
     /// @notice Wrapper function to verify a sumcheck proof
@@ -93,7 +92,8 @@ contract SumcheckTest is Test {
     ) public {
         // If numVars == 0, it is an empty proof and will always verify.
         vm.assume(numVars > 0);
-        // The proof with entirely 0s (expect for the last prover message) will succeed and is not fully random, so we should not include it
+        // The proof with entirely 0s (expect for the last prover message) will succeed and is not fully random,
+        // so we should not include it
         bool allZeros = true;
         uint256 realProofLength = uint256(numVars - 1) * (uint256(degree) + 1);
         uint256 nonZeroLength = proof.length > realProofLength ? realProofLength : proof.length;


### PR DESCRIPTION
# Rationale for this change

This PR improves the solhint linting.

# What changes are included in this PR?

* Using `solhint:all` instead of `solhint:recommended`
* Using `.solhintignore` file.
* Cover everything in `solidity` rather than just `src`.

# Are these changes tested?
Yes