### PR TITLE
feat: support for variable length binary

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -21,6 +21,7 @@ impl From<&ColumnType> for DataType {
                 DataType::Decimal256(precision.value(), *scale)
             }
             ColumnType::VarChar => DataType::Utf8,
+            ColumnType::VarBinary => DataType::Binary,
             ColumnType::Scalar => unimplemented!("Cannot convert Scalar type to arrow type"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 let arrow_timezone = Some(Arc::from(timezone.to_string()));

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -22,9 +22,9 @@ use crate::base::{
 use alloc::sync::Arc;
 use arrow::{
     array::{
-        ArrayRef, BooleanArray, Decimal128Array, Decimal256Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, StringArray, TimestampMicrosecondArray, TimestampMillisecondArray,
-        TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+        ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Decimal256Array, Int16Array,
+        Int32Array, Int64Array, Int8Array, StringArray, TimestampMicrosecondArray,
+        TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
     },
     datatypes::{i256, DataType, Schema, SchemaRef, TimeUnit as ArrowTimeUnit},
     error::ArrowError,
@@ -105,6 +105,9 @@ impl<S: Scalar> From<OwnedColumn<S>> for ArrayRef {
             }
             OwnedColumn::Scalar(_) => unimplemented!("Cannot convert Scalar type to arrow type"),
             OwnedColumn::VarChar(col) => Arc::new(StringArray::from(col)),
+            OwnedColumn::VarBinary(col) => {
+                Arc::new(BinaryArray::from_iter_values(col.iter().map(Vec::as_slice)))
+            }
             OwnedColumn::TimestampTZ(time_unit, _, col) => match time_unit {
                 PoSQLTimeUnit::Second => Arc::new(TimestampSecondArray::from(col)),
                 PoSQLTimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(col)),
@@ -234,6 +237,15 @@ impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
                     .unwrap()
                     .iter()
                     .map(|s| s.unwrap().to_string())
+                    .collect(),
+            )),
+            DataType::Binary => Ok(Self::VarBinary(
+                value
+                    .as_any()
+                    .downcast_ref::<BinaryArray>()
+                    .unwrap()
+                    .iter()
+                    .map(|s| s.map(<[u8]>::to_vec).unwrap())
                     .collect(),
             )),
             DataType::Timestamp(time_unit, timezone) => match time_unit {

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -9,7 +9,9 @@ use crate::{
 };
 use alloc::sync::Arc;
 use arrow::{
-    array::{ArrayRef, BooleanArray, Decimal128Array, Float32Array, Int64Array, StringArray},
+    array::{
+        ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Float32Array, Int64Array, StringArray,
+    },
     datatypes::Schema,
     record_batch::RecordBatch,
 };
@@ -24,6 +26,17 @@ fn we_can_convert_between_owned_column_and_array_ref_impl(
     assert!(ic_to_ar == array_ref);
     assert_eq!(*owned_column, ar_to_ic);
 }
+
+fn we_can_convert_between_varbinary_owned_column_and_array_ref_impl(data: &[Vec<u8>]) {
+    let owned_col = OwnedColumn::<TestScalar>::VarBinary(data.to_owned());
+    let arrow_col = Arc::new(BinaryArray::from(
+        data.iter()
+            .map(std::vec::Vec::as_slice)
+            .collect::<Vec<&[u8]>>(),
+    ));
+    we_can_convert_between_owned_column_and_array_ref_impl(&owned_col, arrow_col);
+}
+
 fn we_can_convert_between_boolean_owned_column_and_array_ref_impl(data: Vec<bool>) {
     we_can_convert_between_owned_column_and_array_ref_impl(
         &OwnedColumn::<TestScalar>::Boolean(data.clone()),
@@ -68,6 +81,15 @@ fn we_can_convert_between_owned_column_and_array_ref() {
     we_can_convert_between_varchar_owned_column_and_array_ref_impl(
         data.into_iter().map(String::from).collect(),
     );
+
+    let varbin_data = vec![
+        b"foo".to_vec(),
+        b"bar".to_vec(),
+        b"baz".to_vec(),
+        vec![],
+        b"some bytes".to_vec(),
+    ];
+    we_can_convert_between_varbinary_owned_column_and_array_ref_impl(&varbin_data);
 }
 
 #[test]

--- a/crates/proof-of-sql/src/base/commitment/column_bounds.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_bounds.rs
@@ -238,6 +238,7 @@ impl ColumnBounds {
             CommittableColumn::Boolean(_)
             | CommittableColumn::Decimal75(_, _, _)
             | CommittableColumn::Scalar(_)
+            | CommittableColumn::VarBinary(_)
             | CommittableColumn::VarChar(_) => ColumnBounds::NoOrder,
         }
     }

--- a/crates/proof-of-sql/src/base/commitment/committable_column.rs
+++ b/crates/proof-of-sql/src/base/commitment/committable_column.rs
@@ -2,7 +2,7 @@ use crate::base::{
     database::{Column, ColumnType, OwnedColumn},
     math::decimal::Precision,
     ref_into::RefInto,
-    scalar::Scalar,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::vec::Vec;
 #[cfg(feature = "blitzar")]
@@ -43,6 +43,8 @@ pub enum CommittableColumn<'a> {
     Scalar(Vec<[u64; 4]>),
     /// Column of limbs for committing to scalars, hashed from a `VarChar` column.
     VarChar(Vec<[u64; 4]>),
+    /// Column of limbs for committing to scalars, hashed from a `Binary` column.
+    VarBinary(Vec<[u64; 4]>),
     /// Borrowed Timestamp column with Timezone, mapped to `i64`.
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, &'a [i64]),
 }
@@ -60,7 +62,8 @@ impl CommittableColumn<'_> {
             CommittableColumn::Int128(col) => col.len(),
             CommittableColumn::Decimal75(_, _, col)
             | CommittableColumn::Scalar(col)
-            | CommittableColumn::VarChar(col) => col.len(),
+            | CommittableColumn::VarChar(col)
+            | CommittableColumn::VarBinary(col) => col.len(),
             CommittableColumn::Boolean(col) => col.len(),
         }
     }
@@ -92,6 +95,7 @@ impl<'a> From<&CommittableColumn<'a>> for ColumnType {
             }
             CommittableColumn::Scalar(_) => ColumnType::Scalar,
             CommittableColumn::VarChar(_) => ColumnType::VarChar,
+            CommittableColumn::VarBinary(_) => ColumnType::VarBinary,
             CommittableColumn::Boolean(_) => ColumnType::Boolean,
             CommittableColumn::TimestampTZ(tu, tz, _) => ColumnType::TimestampTZ(*tu, *tz),
         }
@@ -116,6 +120,10 @@ impl<'a, S: Scalar> From<&Column<'a, S>> for CommittableColumn<'a> {
             Column::VarChar((_, scalars)) => {
                 let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
                 CommittableColumn::VarChar(as_limbs)
+            }
+            Column::VarBinary((_, scalars)) => {
+                let as_limbs: Vec<_> = scalars.iter().map(RefInto::<[u64; 4]>::ref_into).collect();
+                CommittableColumn::VarBinary(as_limbs)
             }
             Column::TimestampTZ(tu, tz, times) => CommittableColumn::TimestampTZ(*tu, *tz, times),
         }
@@ -152,6 +160,13 @@ impl<'a, S: Scalar> From<&'a OwnedColumn<S>> for CommittableColumn<'a> {
                 strings
                     .iter()
                     .map(Into::<S>::into)
+                    .map(Into::<[u64; 4]>::into)
+                    .collect(),
+            ),
+            OwnedColumn::VarBinary(bytes) => CommittableColumn::VarBinary(
+                bytes
+                    .iter()
+                    .map(|b| S::from_byte_slice_via_hash(b))
                     .map(Into::<[u64; 4]>::into)
                     .collect(),
             ),
@@ -217,7 +232,8 @@ impl<'a, 'b> From<&'a CommittableColumn<'b>> for Sequence<'a> {
             CommittableColumn::Int128(ints) => Sequence::from(*ints),
             CommittableColumn::Decimal75(_, _, limbs)
             | CommittableColumn::Scalar(limbs)
-            | CommittableColumn::VarChar(limbs) => Sequence::from(limbs),
+            | CommittableColumn::VarChar(limbs)
+            | CommittableColumn::VarBinary(limbs) => Sequence::from(limbs),
             CommittableColumn::Boolean(bools) => Sequence::from(*bools),
             CommittableColumn::TimestampTZ(_, _, times) => Sequence::from(*times),
         }
@@ -230,6 +246,68 @@ mod tests {
     use crate::{base::scalar::test_scalar::TestScalar, proof_primitive::dory::DoryScalar};
     use blitzar::compute::compute_curve25519_commitments;
     use curve25519_dalek::ristretto::CompressedRistretto;
+
+    #[test]
+    fn we_can_get_type_and_length_of_varbinary_column() {
+        // empty case
+        let varbinary_committable_column = CommittableColumn::VarBinary(Vec::new());
+        assert_eq!(varbinary_committable_column.len(), 0);
+        assert!(varbinary_committable_column.is_empty());
+        assert_eq!(
+            varbinary_committable_column.column_type(),
+            ColumnType::VarBinary
+        );
+
+        let limbs = vec![[1, 2, 3, 4], [5, 6, 7, 8]];
+        let varbinary_committable_column = CommittableColumn::VarBinary(limbs.clone());
+        assert_eq!(varbinary_committable_column.len(), 2);
+        assert!(!varbinary_committable_column.is_empty());
+        assert_eq!(
+            varbinary_committable_column.column_type(),
+            ColumnType::VarBinary
+        );
+    }
+
+    #[test]
+    fn we_can_convert_from_owned_varbinary_column() {
+        // empty case
+        let owned_column = OwnedColumn::<TestScalar>::VarBinary(Vec::new());
+        let from_owned_column = CommittableColumn::from(&owned_column);
+        assert_eq!(from_owned_column, CommittableColumn::VarBinary(vec![]));
+
+        let byte_data = vec![b"foo".to_vec(), b"bar".to_vec()];
+        let owned_column = OwnedColumn::<TestScalar>::VarBinary(byte_data.clone());
+        let from_owned_column = CommittableColumn::from(&owned_column);
+
+        match from_owned_column {
+            CommittableColumn::VarBinary(limbs) => {
+                assert_eq!(limbs.len(), byte_data.len());
+            }
+            _ => panic!("Expected VarBinary"),
+        }
+    }
+
+    #[test]
+    fn we_can_commit_to_varbinary_column_through_committable_column() {
+        let committable_column = CommittableColumn::VarBinary(vec![]);
+        let sequence = Sequence::from(&committable_column);
+        let mut commitment_buffer = [CompressedRistretto::default()];
+        compute_curve25519_commitments(&mut commitment_buffer, &[sequence], 0);
+        assert_eq!(commitment_buffer[0], CompressedRistretto::default());
+
+        let hashed_limbs = vec![[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]];
+        let committable_column = CommittableColumn::VarBinary(hashed_limbs.clone());
+
+        let sequence_actual = Sequence::from(&committable_column);
+        let sequence_expected = Sequence::from(hashed_limbs.as_slice());
+        let mut commitment_buffer = [CompressedRistretto::default(); 2];
+        compute_curve25519_commitments(
+            &mut commitment_buffer,
+            &[sequence_actual, sequence_expected],
+            0,
+        );
+        assert_eq!(commitment_buffer[0], commitment_buffer[1]);
+    }
 
     #[test]
     fn we_can_convert_from_owned_decimal75_column_to_committable_column() {

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -147,7 +147,8 @@ impl Commitment for NaiveCommitment {
                     CommittableColumn::Scalar(scalar_vec) => {
                         scalar_vec.iter().map(core::convert::Into::into).collect()
                     }
-                    CommittableColumn::VarChar(varchar_vec) => {
+                    CommittableColumn::VarChar(varchar_vec)
+                    | CommittableColumn::VarBinary(varchar_vec) => {
                         varchar_vec.iter().map(core::convert::Into::into).collect()
                     }
                     CommittableColumn::TimestampTZ(_, _, i64_vec) => {
@@ -199,6 +200,27 @@ fn we_can_compute_commitments_from_commitable_columns_with_offset() {
     let committable_columns: &[CommittableColumn] = &[commitable_column_a];
     let commitments = NaiveCommitment::compute_commitments(committable_columns, 1, &());
     assert_eq!(commitments[0].0, column_a_scalars);
+}
+
+#[test]
+fn we_can_compute_commitments_from_commitable_varbinary_column() {
+    let varbinary_data = vec![[1u64, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]];
+    let varbinary_scalars: Vec<TestScalar> = varbinary_data.iter().map(Into::into).collect();
+    let commitable_column_varbinary = CommittableColumn::VarBinary(varbinary_data);
+    let commitments = NaiveCommitment::compute_commitments(&[commitable_column_varbinary], 0, &());
+    assert_eq!(commitments[0].0, varbinary_scalars);
+}
+
+#[test]
+fn we_can_compute_commitments_from_commitable_varbinary_column_with_offset() {
+    let raw_limb_data = [[100u64, 101, 102, 103], [1, 2, 3, 4], [5, 6, 7, 8]];
+    let trimmed_data = &raw_limb_data[1..];
+    let commitable_column = CommittableColumn::VarBinary(trimmed_data.to_vec());
+    let commitments = NaiveCommitment::compute_commitments(&[commitable_column], 1, &());
+    let expected: Vec<TestScalar> = core::iter::once(TestScalar::ZERO)
+        .chain(trimmed_data.iter().map(Into::into))
+        .collect();
+    assert_eq!(commitments[0].0, expected);
 }
 
 #[cfg(test)]

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -52,6 +52,8 @@ pub enum Column<'a, S: Scalar> {
     /// - the second element maps to a timezone
     /// - the third element maps to columns of timeunits since unix epoch
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, &'a [i64]),
+    /// Variable length binary columns
+    VarBinary((&'a [&'a [u8]], &'a [S])),
 }
 
 impl<'a, S: Scalar> Column<'a, S> {
@@ -72,6 +74,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::TimestampTZ(time_unit, timezone, _) => {
                 ColumnType::TimestampTZ(*time_unit, *timezone)
             }
+            Self::VarBinary(..) => ColumnType::VarBinary,
         }
     }
     /// Returns the length of the column.
@@ -87,6 +90,10 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::Int(col) => col.len(),
             Self::BigInt(col) | Self::TimestampTZ(_, _, col) => col.len(),
             Self::VarChar((col, scals)) => {
+                assert_eq!(col.len(), scals.len());
+                col.len()
+            }
+            Self::VarBinary((col, scals)) => {
                 assert_eq!(col.len(), scals.len());
                 col.len()
             }
@@ -176,6 +183,17 @@ impl<'a, S: Scalar> Column<'a, S> {
                     alloc.alloc_slice_copy(scalars.as_slice()),
                 ))
             }
+            OwnedColumn::VarBinary(col) => {
+                let scalars = col
+                    .iter()
+                    .map(|b| S::from_byte_slice_via_hash(b))
+                    .collect::<Vec<_>>();
+                let bytes = col.iter().map(|s| s as &'a [u8]).collect::<Vec<_>>();
+                Column::VarBinary((
+                    alloc.alloc_slice_clone(&bytes),
+                    alloc.alloc_slice_copy(scalars.as_slice()),
+                ))
+            }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col.as_slice()),
         }
     }
@@ -260,6 +278,14 @@ impl<'a, S: Scalar> Column<'a, S> {
         }
     }
 
+    /// Returns the column as a slice of strings and a slice of scalars if it is a varchar column. Otherwise, returns None.
+    pub(crate) fn as_varbinary(&self) -> Option<(&'a [&'a [u8]], &'a [S])> {
+        match self {
+            Self::VarBinary((col, scals)) => Some((col, scals)),
+            _ => None,
+        }
+    }
+
     /// Returns the column as a slice of i64 if it is a timestamp column. Otherwise, returns None.
     pub(crate) fn as_timestamptz(&self) -> Option<&'a [i64]> {
         match self {
@@ -281,7 +307,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::BigInt(col) | Self::TimestampTZ(_, _, col) => S::from(col[index]),
             Self::Int128(col) => S::from(col[index]),
             Self::Scalar(col) | Self::Decimal75(_, _, col) => col[index],
-            Self::VarChar((_, scals)) => scals[index],
+            Self::VarChar((_, scals)) | Self::VarBinary((_, scals)) => scals[index],
         })
     }
 
@@ -293,6 +319,7 @@ impl<'a, S: Scalar> Column<'a, S> {
             Self::Boolean(col) => slice_cast_with(col, |b| S::from(b) * scale_factor),
             Self::Decimal75(_, _, col) => slice_cast_with(col, |s| *s * scale_factor),
             Self::VarChar((_, values)) => slice_cast_with(values, |s| *s * scale_factor),
+            Self::VarBinary((_, values)) => slice_cast_with(values, |s| *s * scale_factor),
             Self::Uint8(col) => slice_cast_with(col, |i| S::from(i) * scale_factor),
             Self::TinyInt(col) => slice_cast_with(col, |i| S::from(i) * scale_factor),
             Self::SmallInt(col) => slice_cast_with(col, |i| S::from(i) * scale_factor),
@@ -345,6 +372,9 @@ pub enum ColumnType {
     /// Mapped to `S`
     #[serde(alias = "SCALAR", alias = "scalar")]
     Scalar,
+    /// Mapped to [u8]
+    #[serde(alias = "BINARY", alias = "BINARY")]
+    VarBinary,
 }
 
 impl ColumnType {
@@ -459,7 +489,7 @@ impl ColumnType {
             // Scalars are not in database & are only used for typeless comparisons for testing so we return 0
             // so that they do not cause errors when used in comparisons.
             Self::Scalar => Some(0_u8),
-            Self::Boolean | Self::VarChar => None,
+            Self::Boolean | Self::VarChar | Self::VarBinary => None,
         }
     }
     /// Returns scale of a [`ColumnType`] if it is convertible to a decimal wrapped in `Some()`. Otherwise return None.
@@ -474,7 +504,7 @@ impl ColumnType {
             | Self::BigInt
             | Self::Int128
             | Self::Scalar => Some(0),
-            Self::Boolean | Self::VarChar => None,
+            Self::Boolean | Self::VarBinary | Self::VarChar => None,
             Self::TimestampTZ(tu, _) => match tu {
                 PoSQLTimeUnit::Second => Some(0),
                 PoSQLTimeUnit::Millisecond => Some(3),
@@ -495,7 +525,9 @@ impl ColumnType {
             Self::Int => size_of::<i32>(),
             Self::BigInt | Self::TimestampTZ(_, _) => size_of::<i64>(),
             Self::Int128 => size_of::<i128>(),
-            Self::Scalar | Self::Decimal75(_, _) | Self::VarChar => size_of::<[u64; 4]>(),
+            Self::Scalar | Self::Decimal75(_, _) | Self::VarBinary | Self::VarChar => {
+                size_of::<[u64; 4]>()
+            }
         }
     }
 
@@ -516,9 +548,12 @@ impl ColumnType {
             | Self::BigInt
             | Self::Int128
             | Self::TimestampTZ(_, _) => true,
-            Self::Decimal75(_, _) | Self::Scalar | Self::VarChar | Self::Boolean | Self::Uint8 => {
-                false
-            }
+            Self::Decimal75(_, _)
+            | Self::Scalar
+            | Self::VarBinary
+            | Self::VarChar
+            | Self::Boolean
+            | Self::Uint8 => false,
         }
     }
 }
@@ -542,6 +577,7 @@ impl Display for ColumnType {
                 )
             }
             ColumnType::VarChar => write!(f, "VARCHAR"),
+            ColumnType::VarBinary => write!(f, "BINARY"),
             ColumnType::Scalar => write!(f, "SCALAR"),
             ColumnType::TimestampTZ(timeunit, timezone) => {
                 write!(f, "TIMESTAMP(TIMEUNIT: {timeunit}, TIMEZONE: {timezone})")
@@ -1128,5 +1164,41 @@ mod tests {
             Column::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc(), &[1, 2, 3]);
         assert_eq!(column.column_type().byte_size(), 8);
         assert_eq!(column.column_type().bit_size(), 64);
+    }
+
+    #[test]
+    fn we_can_get_length_of_varbinary_column() {
+        let raw_bytes: &[&[u8]] = &[b"foo", b"bar", b""];
+        let scalars: Vec<TestScalar> = raw_bytes
+            .iter()
+            .map(|b| TestScalar::from_le_bytes_mod_order(b))
+            .collect();
+
+        let column = Column::VarBinary((raw_bytes, &scalars));
+        assert_eq!(column.len(), 3);
+        assert!(!column.is_empty());
+        assert_eq!(column.column_type(), ColumnType::VarBinary);
+    }
+
+    #[test]
+    fn we_can_convert_varbinary_owned_column_to_column_and_back() {
+        use bumpalo::Bump;
+        let alloc = Bump::new();
+
+        let owned_varbinary = OwnedColumn::VarBinary(vec![b"abc".to_vec(), b"xyz".to_vec()]);
+
+        let column = Column::<TestScalar>::from_owned_column(&owned_varbinary, &alloc);
+        match column {
+            Column::VarBinary((bytes, scalars)) => {
+                assert_eq!(bytes.len(), 2);
+                assert_eq!(scalars.len(), 2);
+                assert_eq!(bytes[0], b"abc");
+                assert_eq!(bytes[1], b"xyz");
+            }
+            _ => panic!("Expected VarBinary column"),
+        }
+
+        let round_trip_owned: OwnedColumn<TestScalar> = (&column).into();
+        assert_eq!(owned_varbinary, round_trip_owned);
     }
 }

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -93,6 +93,17 @@ where
                 alloc.alloc_slice_copy(&scalars) as &[_],
             )))
         }
+
+        ColumnType::VarBinary => {
+            let (raw_values, raw_scalars) =
+                column.as_varbinary().expect("Column types should match");
+            let raw_values = apply_slice_to_indexes(raw_values, indexes)?;
+            let scalars = apply_slice_to_indexes(raw_scalars, indexes)?;
+            Ok(Column::VarBinary((
+                alloc.alloc_slice_clone(&raw_values) as &[_],
+                alloc.alloc_slice_copy(&scalars) as &[_],
+            )))
+        }
         ColumnType::TimestampTZ(tu, tz) => {
             let raw_values = apply_slice_to_indexes(
                 column.as_timestamptz().expect("Column types should match"),
@@ -153,5 +164,30 @@ mod tests {
             result,
             Err(ColumnOperationError::IndexOutOfBounds { .. })
         ));
+    }
+
+    #[test]
+    fn test_apply_index_op_varbinary() {
+        let bump = Bump::new();
+
+        let raw_bytes: Vec<&[u8]> = vec![b"foo".as_ref(), b"bar".as_ref(), b"baz".as_ref()];
+        let scalars: Vec<TestScalar> = raw_bytes
+            .iter()
+            .map(|b| TestScalar::from_le_bytes_mod_order(b))
+            .collect();
+
+        let column = Column::VarBinary((raw_bytes.as_slice(), scalars.as_slice()));
+
+        let indexes = [2, 0];
+
+        let result = apply_column_to_indexes(&column, &bump, &indexes).unwrap();
+        let expected_bytes = vec![b"baz".as_ref(), b"foo".as_ref()];
+        let expected_scalars: Vec<TestScalar> = expected_bytes
+            .iter()
+            .map(|b| TestScalar::from_le_bytes_mod_order(b))
+            .collect();
+        let expected = Column::VarBinary((expected_bytes.as_slice(), expected_scalars.as_slice()));
+
+        assert_eq!(result, expected);
     }
 }

--- a/crates/proof-of-sql/src/base/database/filter_util.rs
+++ b/crates/proof-of-sql/src/base/database/filter_util.rs
@@ -65,6 +65,10 @@ pub fn filter_column_by_index<'a, S: Scalar>(
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
             alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
         )),
+        Column::VarBinary((col, scals)) => Column::VarBinary((
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])),
+            alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| scals[i])),
+        )),
         Column::Scalar(col) => {
             Column::Scalar(alloc.alloc_slice_fill_iter(indexes.iter().map(|&i| col[i])))
         }

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -165,7 +165,10 @@ pub(crate) fn sum_aggregate_column_by_index_counts<'a, S: Scalar>(
         }
         Column::Scalar(col) => sum_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         // The following should never be reached because the `SUM` function can only be applied to numeric types.
-        Column::VarChar(_) | Column::TimestampTZ(_, _, _) | Column::Boolean(_) => {
+        Column::VarChar(_)
+        | Column::TimestampTZ(_, _, _)
+        | Column::Boolean(_)
+        | Column::VarBinary(_) => {
             unreachable!("SUM can not be applied to non-numeric types")
         }
     }
@@ -199,7 +202,7 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
         }
         Column::Scalar(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
         // The following should never be reached because the `MAX` function can't be applied to varchar.
-        Column::VarChar(_) => {
+        Column::VarChar(_) | Column::VarBinary(_) => {
             unreachable!("MAX can not be applied to varchar")
         }
     }
@@ -232,6 +235,7 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
             min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::VarBinary(_) => unreachable!("MIN can not be applied to varchar"),
         // The following should never be reached because the `MIN` function can't be applied to varchar.
         Column::VarChar(_) => {
             unreachable!("MIN can not be applied to varchar")

--- a/crates/proof-of-sql/src/base/database/order_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util.rs
@@ -27,6 +27,7 @@ pub(crate) fn compare_indexes_by_columns<S: Scalar>(
             Column::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
             Column::Scalar(col) => col[i].cmp(&col[j]),
             Column::VarChar((col, _)) => col[i].cmp(col[j]),
+            Column::VarBinary((col, _)) => col[i].cmp(col[j]),
         })
         .find(|&ord| ord != Ordering::Equal)
         .unwrap_or(Ordering::Equal)
@@ -142,6 +143,7 @@ pub(crate) fn compare_indexes_by_owned_columns_with_direction<S: Scalar>(
                 OwnedColumn::Decimal75(_, _, col) => col[i].signed_cmp(&col[j]),
                 OwnedColumn::Scalar(col) => col[i].cmp(&col[j]),
                 OwnedColumn::VarChar(col) => col[i].cmp(&col[j]),
+                OwnedColumn::VarBinary(col) => col[i].cmp(&col[j]),
             };
             match direction {
                 OrderByDirection::Asc => ordering,

--- a/crates/proof-of-sql/src/base/database/order_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/order_by_util_test.rs
@@ -292,3 +292,26 @@ fn we_can_compare_columns_with_direction() {
         Ordering::Less
     );
 }
+
+#[test]
+fn we_can_compare_indexes_by_columns_for_varbinary_columns() {
+    let raw_bytes = [
+        b"foo".as_ref(),
+        b"bar".as_ref(),
+        b"baz".as_ref(),
+        b"baz".as_ref(),
+        b"bar".as_ref(),
+    ];
+    let scalars: Vec<TestScalar> = raw_bytes
+        .iter()
+        .map(|b| TestScalar::from_le_bytes_mod_order(b))
+        .collect();
+    let col_varbinary = Column::VarBinary((raw_bytes.as_slice(), scalars.as_slice()));
+    let columns = &[col_varbinary];
+
+    assert_eq!(compare_indexes_by_columns(columns, 0, 1), Ordering::Greater); // "foo" vs "bar"
+    assert_eq!(compare_indexes_by_columns(columns, 1, 2), Ordering::Less); // "bar" vs "baz"
+    assert_eq!(compare_indexes_by_columns(columns, 2, 3), Ordering::Equal); // "baz" vs "baz"
+    assert_eq!(compare_indexes_by_columns(columns, 3, 4), Ordering::Greater); // "baz" vs "bar"
+    assert_eq!(compare_indexes_by_columns(columns, 1, 4), Ordering::Equal); // "bar" vs "bar"
+}

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
     map::IndexMap,
+    scalar::ScalarExt,
 };
 use alloc::{string::String, vec::Vec};
 use bumpalo::Bump;
@@ -109,6 +110,21 @@ impl<CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for OwnedTableTestA
                     .alloc
                     .alloc_slice_fill_iter(col.iter().map(|s| (*s).into()));
                 Column::VarChar((col, scals))
+            }
+            OwnedColumn::VarBinary(col) => {
+                // Convert each `Vec<u8>` to `&[u8]` for the `Column::VarBinary` "string-like" part.
+                let col_as_slices: &mut [&[u8]] = self
+                    .alloc
+                    .alloc_slice_fill_iter(col.iter().map(Vec::as_slice));
+
+                // Convert each `Vec<u8>` to a scalar by calling `from_le_bytes_mod_order`.
+                // That is the crucial step, because there's no direct `From<&[u8]>`.
+                let scals: &mut [CP::Scalar] = self.alloc.alloc_slice_fill_iter(
+                    col.iter()
+                        .map(|b| CP::Scalar::from_byte_slice_via_hash(b.as_slice())),
+                );
+
+                Column::VarBinary((col_as_slices, scals))
             }
             OwnedColumn::TimestampTZ(tu, tz, col) => Column::TimestampTZ(*tu, *tz, col),
         }

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -15,7 +15,7 @@
 //! ```
 use super::{OwnedColumn, OwnedTable};
 use crate::base::scalar::Scalar;
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use sqlparser::ast::Ident;
 
@@ -214,6 +214,25 @@ pub fn varchar<S: Scalar>(
     (
         name.into(),
         OwnedColumn::VarChar(data.into_iter().map(Into::into).collect()),
+    )
+}
+
+/// Creates a `(Ident, OwnedColumn)` pair for a varbinary column.
+/// This is primarily intended for use in conjunction with [`owned_table`].
+/// # Example
+/// ```
+/// use proof_of_sql::base::{database::owned_table_utility::*, scalar::Curve25519Scalar};
+/// let result = owned_table::<Curve25519Scalar>([
+///    varbinary("a", [[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+/// ]);
+/// ```
+pub fn varbinary<S: Scalar>(
+    name: impl Into<Ident>,
+    data: impl IntoIterator<Item = impl Into<Vec<u8>>>,
+) -> (Ident, OwnedColumn<S>) {
+    (
+        name.into(),
+        OwnedColumn::VarBinary(data.into_iter().map(Into::into).collect()),
     )
 }
 

--- a/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
+++ b/crates/proof-of-sql/src/base/polynomial/multilinear_extension.rs
@@ -99,9 +99,10 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
     fn inner_product(&self, evaluation_vec: &[S]) -> S {
         match self {
             Column::Boolean(c) => c.inner_product(evaluation_vec),
-            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
-                c.inner_product(evaluation_vec)
-            }
+            Column::Scalar(c)
+            | Column::VarChar((_, c))
+            | Column::VarBinary((_, c))
+            | Column::Decimal75(_, _, c) => c.inner_product(evaluation_vec),
             Column::Uint8(c) => c.inner_product(evaluation_vec),
             Column::TinyInt(c) => c.inner_product(evaluation_vec),
             Column::SmallInt(c) => c.inner_product(evaluation_vec),
@@ -114,7 +115,10 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
     fn mul_add(&self, res: &mut [S], multiplier: &S) {
         match self {
             Column::Boolean(c) => c.mul_add(res, multiplier),
-            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
+            Column::Scalar(c)
+            | Column::VarChar((_, c))
+            | Column::VarBinary((_, c))
+            | Column::Decimal75(_, _, c) => {
                 c.mul_add(res, multiplier);
             }
             Column::Uint8(c) => c.mul_add(res, multiplier),
@@ -129,9 +133,10 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
     fn to_sumcheck_term(&self, num_vars: usize) -> Vec<S> {
         match self {
             Column::Boolean(c) => c.to_sumcheck_term(num_vars),
-            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
-                c.to_sumcheck_term(num_vars)
-            }
+            Column::Scalar(c)
+            | Column::VarChar((_, c))
+            | Column::VarBinary((_, c))
+            | Column::Decimal75(_, _, c) => c.to_sumcheck_term(num_vars),
             Column::Uint8(c) => c.to_sumcheck_term(num_vars),
             Column::TinyInt(c) => c.to_sumcheck_term(num_vars),
             Column::SmallInt(c) => c.to_sumcheck_term(num_vars),
@@ -144,9 +149,10 @@ impl<S: Scalar> MultilinearExtension<S> for &Column<'_, S> {
     fn id(&self) -> (*const c_void, usize) {
         match self {
             Column::Boolean(c) => MultilinearExtension::<S>::id(c),
-            Column::Scalar(c) | Column::VarChar((_, c)) | Column::Decimal75(_, _, c) => {
-                MultilinearExtension::<S>::id(c)
-            }
+            Column::Scalar(c)
+            | Column::VarChar((_, c))
+            | Column::VarBinary((_, c))
+            | Column::Decimal75(_, _, c) => MultilinearExtension::<S>::id(c),
             Column::Uint8(c) => MultilinearExtension::<S>::id(c),
             Column::TinyInt(c) => MultilinearExtension::<S>::id(c),
             Column::SmallInt(c) => MultilinearExtension::<S>::id(c),

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product.rs
@@ -1,4 +1,8 @@
-use crate::base::if_rayon;
+use crate::base::{
+    if_rayon,
+    scalar::{Scalar, ScalarExt},
+};
+use alloc::vec::Vec;
 use core::{iter::Sum, ops::Mul};
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -24,5 +28,13 @@ where
     if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
         .zip(b)
         .map(|(a, b)| a.into() * *b)
+        .sum()
+}
+
+/// Cannot use blanket impls for `Vec<u8>` because bytes might have different embeddings as scalars
+pub fn inner_product_with_bytes<S: Scalar>(a: &[Vec<u8>], b: &[S]) -> S {
+    if_rayon!(a.par_iter().with_min_len(super::MIN_RAYON_LEN), a.iter())
+        .zip(b)
+        .map(|(lhs_bytes, &rhs)| S::from_byte_slice_via_hash(lhs_bytes) * rhs)
         .sum()
 }

--- a/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/inner_product_test.rs
@@ -1,5 +1,112 @@
 use super::*;
-use crate::base::scalar::test_scalar::TestScalar;
+use crate::base::scalar::{test_scalar::TestScalar, ScalarExt};
+
+#[test]
+fn test_inner_product_with_bytes_basic() {
+    // Suppose we have 3 rows of varbinary data
+    let lhs = vec![b"abc".to_vec(), b"xyz".to_vec(), b"foo".to_vec()];
+    // We'll multiply by [10, 20, 30]
+    let rhs = vec![
+        TestScalar::from(10),
+        TestScalar::from(20),
+        TestScalar::from(30),
+    ];
+    // The “actual” product
+    let product = inner_product_with_bytes(&lhs, &rhs);
+
+    // Build the “manual” approach: for each lhs row, do the keccak-based hash → scalar, sum
+    let expected = lhs
+        .iter()
+        .zip(rhs.iter())
+        .map(|(bytes, &sc)| TestScalar::from_byte_slice_via_hash(bytes) * sc)
+        .sum::<TestScalar>();
+
+    assert_eq!(product, expected);
+}
+
+#[test]
+fn test_inner_product_with_bytes_uneven() {
+    // LHS has 2 entries, RHS has 3
+    let lhs = vec![b"foo".to_vec(), b"bar".to_vec()];
+    let rhs = vec![
+        TestScalar::from(5),
+        TestScalar::from(6),
+        TestScalar::from(7),
+    ];
+    // Actual
+    let product = inner_product_with_bytes(&lhs, &rhs);
+    // Manual
+    let expected = lhs
+        .iter()
+        .zip(rhs.iter()) // stops at the shorter length (2)
+        .map(|(bytes, &sc)| TestScalar::from_byte_slice_via_hash(bytes) * sc)
+        .sum::<TestScalar>();
+    assert_eq!(product, expected);
+}
+
+#[test]
+fn test_inner_product_with_bytes_empty_lhs() {
+    // Both empty
+    let lhs: Vec<Vec<u8>> = vec![];
+    let rhs: Vec<TestScalar> = vec![];
+    assert_eq!(TestScalar::from(0), inner_product_with_bytes(&lhs, &rhs));
+}
+
+#[test]
+fn test_inner_product_with_bytes_partial_fits() {
+    // LHS has 2, RHS has 1
+    // Only 1 pair used
+    let lhs = vec![b"abc".to_vec(), b"xyz".to_vec()];
+    let rhs = vec![TestScalar::from(100)];
+    let product = inner_product_with_bytes(&lhs, &rhs);
+    // Manual
+    let expected = TestScalar::from_byte_slice_via_hash(b"abc") * TestScalar::from(100);
+    assert_eq!(product, expected);
+}
+
+#[test]
+fn test_inner_product_with_bytes_longest_rhs() {
+    // LHS has 3, RHS has 5
+    let lhs = vec![b"abc".to_vec(), b"xyz".to_vec(), b"foo".to_vec()];
+    let rhs = vec![
+        TestScalar::from(10),
+        TestScalar::from(20),
+        TestScalar::from(30),
+        TestScalar::from(40),
+        TestScalar::from(50),
+    ];
+    // Only first 3 pairs are used
+    let product = inner_product_with_bytes(&lhs, &rhs);
+    let expected = [(b"abc", 10), (b"xyz", 20), (b"foo", 30)]
+        .iter()
+        .map(|(bytes, sc)| {
+            TestScalar::from_byte_slice_via_hash(bytes.as_ref()) * TestScalar::from(*sc)
+        })
+        .sum::<TestScalar>();
+    assert_eq!(product, expected);
+}
+
+#[test]
+fn test_inner_product_with_bytes_some_edge_cases() {
+    // test small + large + empty strings
+    let lhs = vec![
+        b"".to_vec(),
+        b"\x00".to_vec(),
+        b"some big data in here ...".repeat(4).clone(), // repeated -> bigger
+    ];
+    let rhs = vec![
+        TestScalar::from(5),
+        TestScalar::from(10),
+        TestScalar::from(15),
+    ];
+    let product = inner_product_with_bytes(&lhs, &rhs);
+    let expected = lhs
+        .iter()
+        .zip(rhs.iter())
+        .map(|(bts, &sc)| TestScalar::from_byte_slice_via_hash(bts) * sc)
+        .sum::<TestScalar>();
+    assert_eq!(product, expected);
+}
 
 #[test]
 fn test_inner_product() {

--- a/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/blitzar_metadata_table.rs
@@ -40,6 +40,7 @@ pub const fn min_as_f(column_type: ColumnType) -> F {
         | ColumnType::Uint8
         | ColumnType::Scalar
         | ColumnType::VarChar
+        | ColumnType::VarBinary
         | ColumnType::Boolean => MontFp!("0"),
     }
 }
@@ -131,7 +132,8 @@ fn copy_column_data_to_slice(
         }
         CommittableColumn::Scalar(column)
         | CommittableColumn::Decimal75(_, _, column)
-        | CommittableColumn::VarChar(column) => {
+        | CommittableColumn::VarChar(column)
+        | CommittableColumn::VarBinary(column) => {
             scalar_row_slice[start..end].copy_from_slice(&column[index].offset_to_bytes());
         }
     }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_commitment_helper_cpu.rs
@@ -76,6 +76,7 @@ fn compute_dory_commitment(
             compute_dory_commitment_impl(column, offset, setup)
         }
         CommittableColumn::VarChar(column) => compute_dory_commitment_impl(column, offset, setup),
+        CommittableColumn::VarBinary(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::TimestampTZ(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_compute_commitments_test.rs
@@ -10,6 +10,26 @@ use num_traits::Zero;
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
 #[test]
+fn we_can_compute_a_dory_commitment_with_varbinary_values() {
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let setup = DoryProverPublicSetup::new(&prover_setup, 2);
+
+    let data = [[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]];
+    let col = CommittableColumn::VarBinary(data.to_vec());
+
+    let res = compute_dory_commitments(&[col], 0, &setup);
+
+    let Gamma_1 = public_parameters.Gamma_1;
+    let Gamma_2 = public_parameters.Gamma_2;
+    let expected: GT = Pairing::pairing(Gamma_1[0], Gamma_2[0]) * F::from(1u64)
+        + Pairing::pairing(Gamma_1[1], Gamma_2[0]) * F::from(2u64)
+        + Pairing::pairing(Gamma_1[2], Gamma_2[0]) * F::from(3u64);
+
+    assert_eq!(res[0].0, expected);
+}
+
+#[test]
 fn we_can_compute_a_dory_commitment_with_int128_values() {
     let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
     let prover_setup = ProverSetup::from(&public_parameters);

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -81,7 +81,9 @@ fn compute_dory_commitment(
         CommittableColumn::Int(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::BigInt(column) => compute_dory_commitment_impl(column, offset, setup),
         CommittableColumn::Int128(column) => compute_dory_commitment_impl(column, offset, setup),
-        CommittableColumn::VarChar(column) | CommittableColumn::Decimal75(_, _, column) => {
+        CommittableColumn::VarChar(column)
+        | CommittableColumn::VarBinary(column)
+        | CommittableColumn::Decimal75(_, _, column) => {
             compute_dory_commitment_impl(column, offset, setup)
         }
         CommittableColumn::Boolean(column) => compute_dory_commitment_impl(column, offset, setup),

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -446,7 +446,8 @@ pub fn bit_table_and_scalars_for_packed_msm(
             }
             CommittableColumn::Decimal75(_, _, column)
             | CommittableColumn::Scalar(column)
-            | CommittableColumn::VarChar(column) => {
+            | CommittableColumn::VarChar(column)
+            | CommittableColumn::VarBinary(column) => {
                 pack_bit(
                     column,
                     &mut packed_scalars,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -133,7 +133,10 @@ impl Commitment for HyperKZGCommitment {
                 CommittableColumn::Int128(vals) => compute_commitments_impl(setup, offset, vals),
                 CommittableColumn::Decimal75(_, _, vals)
                 | CommittableColumn::Scalar(vals)
-                | CommittableColumn::VarChar(vals) => compute_commitments_impl(setup, offset, vals),
+                | CommittableColumn::VarChar(vals)
+                | CommittableColumn::VarBinary(vals) => {
+                    compute_commitments_impl(setup, offset, vals)
+                }
             })
             .collect()
     }

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -2,7 +2,7 @@ use super::{decode_and_convert, decode_multiple_elements, ProvableResultColumn, 
 use crate::base::{
     database::{Column, ColumnField, ColumnType, OwnedColumn, OwnedTable, Table},
     polynomial::compute_evaluation_vector,
-    scalar::Scalar,
+    scalar::{Scalar, ScalarExt},
 };
 use alloc::{vec, vec::Vec};
 use num_traits::Zero;
@@ -122,6 +122,12 @@ impl ProvableQueryResult {
                     }
 
                     ColumnType::VarChar => decode_and_convert::<&str, S>(&self.data[offset..]),
+                    ColumnType::VarBinary => {
+                        let (raw_bytes, used) =
+                            decode_and_convert::<&[u8], &[u8]>(&self.data[offset..])?;
+                        let x = S::from_byte_slice_via_hash(raw_bytes);
+                        Ok((x, used))
+                    }
                     ColumnType::TimestampTZ(_, _) => {
                         decode_and_convert::<i64, S>(&self.data[offset..])
                     }
@@ -199,6 +205,17 @@ impl ProvableQueryResult {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;
                         offset += num_read;
                         Ok((field.name(), OwnedColumn::VarChar(col)))
+                    }
+                    ColumnType::VarBinary => {
+                        // Manually specify the item type: `&[u8]`
+                        let (decoded_slices, num_read) =
+                            decode_multiple_elements::<&[u8]>(&self.data[offset..], n)?;
+                        offset += num_read;
+
+                        // Convert those slices to owned `Vec<u8>`
+                        let col_vec = decoded_slices.into_iter().map(<[u8]>::to_vec).collect();
+
+                        Ok((field.name(), OwnedColumn::VarBinary(col_vec)))
                     }
                     ColumnType::Scalar => {
                         let (col, num_read) = decode_multiple_elements(&self.data[offset..], n)?;

--- a/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_result_column.rs
@@ -40,6 +40,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Int128(col) => col.num_bytes(length),
             Column::Decimal75(_, _, col) | Column::Scalar(col) => col.num_bytes(length),
             Column::VarChar((col, _)) => col.num_bytes(length),
+            Column::VarBinary((col, _)) => col.num_bytes(length),
         }
     }
 
@@ -54,6 +55,7 @@ impl<S: Scalar> ProvableResultColumn for Column<'_, S> {
             Column::Int128(col) => col.write(out, length),
             Column::Decimal75(_, _, col) | Column::Scalar(col) => col.write(out, length),
             Column::VarChar((col, _)) => col.write(out, length),
+            Column::VarBinary((col, _)) => col.write(out, length),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -178,6 +178,7 @@ fn make_empty_query_result<S: Scalar>(result_fields: &[ColumnField]) -> QueryRes
                         }
                         ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
                         ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
+                        ColumnType::VarBinary => OwnedColumn::VarBinary(vec![]),
                         ColumnType::TimestampTZ(tu, tz) => OwnedColumn::TimestampTZ(tu, tz, vec![]),
                     },
                 )

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -124,6 +124,7 @@ fn append_single_row_to_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedColum
         OwnedColumn::Int(col) => col.push(0),
         OwnedColumn::BigInt(col) | OwnedColumn::TimestampTZ(_, _, col) => col.push(0),
         OwnedColumn::VarChar(col) => col.push(String::new()),
+        OwnedColumn::VarBinary(col) => col.push(vec![0u8]),
         OwnedColumn::Int128(col) => col.push(0),
         OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col.push(S::ZERO),
     }
@@ -160,6 +161,7 @@ pub fn tamper_first_row_of_column<S: Scalar>(column: &OwnedColumn<S>) -> OwnedCo
             col[0] = col[0].wrapping_add(1);
         }
         OwnedColumn::VarChar(col) => col[0].push('1'),
+        OwnedColumn::VarBinary(col) => col[0].push(1u8),
         OwnedColumn::Int128(col) => col[0] = col[0].wrapping_add(1),
         OwnedColumn::Decimal75(_, _, col) | OwnedColumn::Scalar(col) => col[0] += S::ONE,
     }


### PR DESCRIPTION
# Rationale for this change

Introduces support for arbitrary length binary columns. This first pass introduces initial support for the type as per standard procedure for adding new PoSQL data types.

# What changes are included in this PR?

- [x] initial pass for var length binary

# Are these changes tested?
- [x] commitment tests
- [x] tests first pass functionality
- [x] tests arrow conversions
