### PR TITLE
feat: mock verification builder

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -24,7 +24,7 @@ pub struct MockVerificationBuilder<S: Scalar> {
 
 impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
     fn try_consume_chi_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
-        Ok(S::ONE)
+        unimplemented!("No tests currently use this function")
     }
 
     fn try_produce_sumcheck_subpolynomial_evaluation(
@@ -228,4 +228,151 @@ pub fn run_verify_for_each_row<
         verification_builder.increment_row_index();
     }
     verification_builder
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MockVerificationBuilder;
+    use crate::{
+        base::{
+            bit::BitDistribution,
+            proof::ProofSizeMismatch,
+            scalar::{test_scalar::TestScalar, Scalar},
+        },
+        sql::proof::{SumcheckSubpolynomialType, VerificationBuilder},
+    };
+
+    #[should_panic(expected = "No tests currently use this function")]
+    #[test]
+    fn we_can_get_unimplemented_error_for_try_consume_rho_evaluation() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        verification_builder.try_consume_rho_evaluation().unwrap();
+    }
+
+    #[should_panic(expected = "No tests currently use this function")]
+    #[test]
+    fn we_can_get_unimplemented_error_for_try_consume_first_round_mle_evaluation() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        verification_builder
+            .try_consume_first_round_mle_evaluation()
+            .unwrap();
+    }
+
+    #[should_panic(expected = "No tests currently use this function")]
+    #[test]
+    fn we_can_get_unimplemented_error_for_singleton_chi_evaluation() {
+        let verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        verification_builder.singleton_chi_evaluation();
+    }
+
+    #[should_panic(expected = "No tests currently use this function")]
+    #[test]
+    fn we_can_get_unimplemented_error_for_try_consume_chi_evaluation() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        verification_builder.try_consume_chi_evaluation().unwrap();
+    }
+
+    #[should_panic(expected = "No tests currently use this function")]
+    #[test]
+    fn we_can_get_unimplemented_error_for_rho_256_evaluation() {
+        let verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        verification_builder.rho_256_evaluation().unwrap();
+    }
+
+    #[should_panic(expected = "No tests currently use this function")]
+    #[test]
+    fn we_can_get_unimplemented_error_for_try_consume_post_result_challenge() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        verification_builder
+            .try_consume_post_result_challenge()
+            .unwrap();
+    }
+
+    #[test]
+    fn we_can_get_sumcheck_proof_too_small_for_identity() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        let error = verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::Identity,
+                TestScalar::ONE,
+                2,
+            )
+            .unwrap_err();
+        assert!(matches!(error, ProofSizeMismatch::SumcheckProofTooSmall));
+    }
+
+    #[test]
+    fn we_can_get_sumcheck_proof_too_small_for_zero_sum() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        let error = verification_builder
+            .try_produce_sumcheck_subpolynomial_evaluation(
+                SumcheckSubpolynomialType::ZeroSum,
+                TestScalar::ONE,
+                3,
+            )
+            .unwrap_err();
+        assert!(matches!(error, ProofSizeMismatch::SumcheckProofTooSmall));
+    }
+
+    #[test]
+    fn we_can_get_final_round_mle_evaluations() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(
+                Vec::new(),
+                2,
+                vec![
+                    vec![TestScalar::ONE, TestScalar::TWO],
+                    vec![-TestScalar::ONE, -TestScalar::TWO],
+                ],
+            );
+        let result = verification_builder
+            .try_consume_final_round_mle_evaluations(2)
+            .unwrap();
+        assert_eq!(result, vec![TestScalar::ONE, TestScalar::TWO]);
+    }
+
+    #[test]
+    fn we_can_get_error_when_not_enough_evaluations() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        let error = verification_builder
+            .try_consume_final_round_mle_evaluations(2)
+            .unwrap_err();
+        assert!(matches!(error, ProofSizeMismatch::TooFewMLEEvaluations));
+    }
+
+    #[test]
+    fn we_can_try_consume_bit_distribution() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(
+                vec![BitDistribution::new::<TestScalar, TestScalar>(&[
+                    TestScalar::ONE,
+                ])],
+                2,
+                Vec::new(),
+            );
+        let result = verification_builder.try_consume_bit_distribution().unwrap();
+        assert_eq!(
+            result,
+            BitDistribution::new::<TestScalar, TestScalar>(&[TestScalar::ONE])
+        );
+    }
+
+    #[test]
+    fn we_can_get_error_when_not_enough_bit_distributions() {
+        let mut verification_builder: MockVerificationBuilder<TestScalar> =
+            MockVerificationBuilder::new(Vec::new(), 2, Vec::new());
+        let error = verification_builder
+            .try_consume_bit_distribution()
+            .unwrap_err();
+        assert!(matches!(error, ProofSizeMismatch::TooFewBitDistributions));
+    }
 }

--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -1,0 +1,147 @@
+use super::{SumcheckSubpolynomialType, VerificationBuilder};
+use crate::base::{bit::BitDistribution, proof::ProofSizeMismatch, scalar::Scalar};
+use alloc::vec::Vec;
+use core::iter;
+
+/// Track components used to verify a query's proof
+pub struct MockVerificationBuilder<S: Scalar> {
+    bit_distributions: Vec<BitDistribution>,
+    bit_distribution_offset: usize,
+    consumed_final_round_pcs_proof_mles: usize,
+    subpolynomial_max_multiplicands: usize,
+
+    evaluation_row_index: usize,
+    final_round_mles: Vec<Vec<S>>,
+    pub(crate) identity_subpolynomial_evaluations: Vec<Vec<S>>,
+    pub(crate) zerosum_subpolynomial_evaluations: Vec<Vec<S>>,
+}
+
+impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
+    /// Consume the evaluation of a one evaluation
+    ///
+    /// # Panics
+    /// It should never panic, as the length of the one evaluation is guaranteed to be present
+    fn try_consume_chi_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        unimplemented!()
+    }
+
+    fn try_produce_sumcheck_subpolynomial_evaluation(
+        &mut self,
+        subpolynomial_type: SumcheckSubpolynomialType,
+        eval: S,
+        degree: usize,
+    ) -> Result<(), ProofSizeMismatch> {
+        match subpolynomial_type {
+            SumcheckSubpolynomialType::Identity => {
+                if self.identity_subpolynomial_evaluations.len() <= self.evaluation_row_index {
+                    self.identity_subpolynomial_evaluations
+                        .extend(iter::repeat(Vec::new()).take(
+                            self.evaluation_row_index
+                                - self.identity_subpolynomial_evaluations.len()
+                                + 1,
+                        ));
+                }
+                if degree + 1 > self.subpolynomial_max_multiplicands {
+                    Err(ProofSizeMismatch::SumcheckProofTooSmall)?;
+                }
+                self.identity_subpolynomial_evaluations[self.evaluation_row_index].push(eval);
+            }
+            SumcheckSubpolynomialType::ZeroSum => {
+                if self.zerosum_subpolynomial_evaluations.len() <= self.evaluation_row_index {
+                    self.zerosum_subpolynomial_evaluations
+                        .extend(iter::repeat(Vec::new()).take(
+                            self.evaluation_row_index
+                                - self.zerosum_subpolynomial_evaluations.len()
+                                + 1,
+                        ));
+                }
+                if degree > self.subpolynomial_max_multiplicands {
+                    Err(ProofSizeMismatch::SumcheckProofTooSmall)?;
+                }
+                self.zerosum_subpolynomial_evaluations[self.evaluation_row_index].push(eval);
+            }
+        }
+        Ok(())
+    }
+
+    fn try_consume_bit_distribution(&mut self) -> Result<BitDistribution, ProofSizeMismatch> {
+        let res = self
+            .bit_distributions
+            .get(self.bit_distribution_offset)
+            .cloned()
+            .ok_or(ProofSizeMismatch::TooFewBitDistributions)?;
+        self.bit_distribution_offset += 1;
+        Ok(res)
+    }
+
+    fn try_consume_rho_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        unimplemented!()
+    }
+
+    fn try_consume_first_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        unimplemented!()
+    }
+
+    fn try_consume_final_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
+        let index = self.consumed_final_round_pcs_proof_mles;
+        self.consumed_final_round_pcs_proof_mles += 1;
+        Ok(*self
+            .final_round_mles
+            .get(self.evaluation_row_index)
+            .cloned()
+            .ok_or(ProofSizeMismatch::TooFewMLEEvaluations)?
+            .get(index)
+            .unwrap_or(&S::ZERO))
+    }
+
+    fn singleton_chi_evaluation(&self) -> S {
+        unimplemented!()
+    }
+
+    fn rho_256_evaluation(&self) -> Option<S> {
+        unimplemented!()
+    }
+
+    fn try_consume_post_result_challenge(&mut self) -> Result<S, ProofSizeMismatch> {
+        unimplemented!()
+    }
+
+    fn try_consume_final_round_mle_evaluations(
+        &mut self,
+        count: usize,
+    ) -> Result<Vec<S>, ProofSizeMismatch> {
+        iter::repeat_with(|| self.try_consume_final_round_mle_evaluation())
+            .take(count)
+            .collect()
+    }
+}
+
+impl<S: Scalar> MockVerificationBuilder<S> {
+    #[allow(
+        clippy::missing_panics_doc,
+        reason = "The only possible panic is from the assertion comparing lengths, which is clear from context."
+    )]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        bit_distributions: Vec<BitDistribution>,
+        subpolynomial_max_multiplicands: usize,
+        final_round_mles: Vec<Vec<S>>,
+    ) -> Self {
+        Self {
+            bit_distributions,
+            bit_distribution_offset: 0,
+            consumed_final_round_pcs_proof_mles: 0,
+            subpolynomial_max_multiplicands,
+            evaluation_row_index: 0,
+            final_round_mles,
+            identity_subpolynomial_evaluations: Vec::new(),
+            zerosum_subpolynomial_evaluations: Vec::new(),
+        }
+    }
+
+    pub fn increment_row_index(&mut self) {
+        self.bit_distribution_offset = 0;
+        self.consumed_final_round_pcs_proof_mles = 0;
+        self.evaluation_row_index += 1;
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -190,13 +190,11 @@ impl<S: Scalar> MockVerificationBuilder<S> {
 /// The length of the vector should be the length of the data.
 ///
 /// The return vector indicates the results of each constraint for the entire column
-pub fn run_verify_for_each_row<
-    F: FnMut(&mut MockVerificationBuilder<TestScalar>, TestScalar, &[TestScalar]),
->(
+pub fn run_verify_for_each_row(
     table_length: usize,
     final_round_builder: &FinalRoundBuilder<'_, TestScalar>,
     subpolynomial_max_multiplicands: usize,
-    mut row_verification: F,
+    row_verification: impl Fn(&mut MockVerificationBuilder<TestScalar>, TestScalar, &[TestScalar]),
 ) -> MockVerificationBuilder<TestScalar> {
     let evaluation_points: Vec<Vec<_>> = (0..table_length)
         .map(|i| {

--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -35,28 +35,16 @@ impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
     ) -> Result<(), ProofSizeMismatch> {
         match subpolynomial_type {
             SumcheckSubpolynomialType::Identity => {
-                if self.identity_subpolynomial_evaluations.len() <= self.evaluation_row_index {
-                    self.identity_subpolynomial_evaluations
-                        .extend(iter::repeat(Vec::new()).take(
-                            self.evaluation_row_index
-                                - self.identity_subpolynomial_evaluations.len()
-                                + 1,
-                        ));
-                }
+                self.identity_subpolynomial_evaluations
+                    .resize_with(self.evaluation_row_index + 1, Vec::new);
                 if degree + 1 > self.subpolynomial_max_multiplicands {
                     Err(ProofSizeMismatch::SumcheckProofTooSmall)?;
                 }
                 self.identity_subpolynomial_evaluations[self.evaluation_row_index].push(eval);
             }
             SumcheckSubpolynomialType::ZeroSum => {
-                if self.zerosum_subpolynomial_evaluations.len() <= self.evaluation_row_index {
-                    self.zerosum_subpolynomial_evaluations
-                        .extend(iter::repeat(Vec::new()).take(
-                            self.evaluation_row_index
-                                - self.zerosum_subpolynomial_evaluations.len()
-                                + 1,
-                        ));
-                }
+                self.zerosum_subpolynomial_evaluations
+                    .resize_with(self.evaluation_row_index + 1, Vec::new);
                 if degree > self.subpolynomial_max_multiplicands {
                     Err(ProofSizeMismatch::SumcheckProofTooSmall)?;
                 }
@@ -119,11 +107,6 @@ impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
 }
 
 impl<S: Scalar> MockVerificationBuilder<S> {
-    #[allow(
-        clippy::missing_panics_doc,
-        reason = "The only possible panic is from the assertion comparing lengths, which is clear from context."
-    )]
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bit_distributions: Vec<BitDistribution>,
         subpolynomial_max_multiplicands: usize,

--- a/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/mock_verification_builder.rs
@@ -17,12 +17,8 @@ pub struct MockVerificationBuilder<S: Scalar> {
 }
 
 impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
-    /// Consume the evaluation of a one evaluation
-    ///
-    /// # Panics
-    /// It should never panic, as the length of the one evaluation is guaranteed to be present
     fn try_consume_chi_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
-        unimplemented!()
+        unimplemented!("No tests currently use this function")
     }
 
     fn try_produce_sumcheck_subpolynomial_evaluation(
@@ -75,11 +71,11 @@ impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
     }
 
     fn try_consume_rho_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
-        unimplemented!()
+        unimplemented!("No tests currently use this function")
     }
 
     fn try_consume_first_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
-        unimplemented!()
+        unimplemented!("No tests currently use this function")
     }
 
     fn try_consume_final_round_mle_evaluation(&mut self) -> Result<S, ProofSizeMismatch> {
@@ -95,15 +91,15 @@ impl<S: Scalar> VerificationBuilder<S> for MockVerificationBuilder<S> {
     }
 
     fn singleton_chi_evaluation(&self) -> S {
-        unimplemented!()
+        unimplemented!("No tests currently use this function")
     }
 
     fn rho_256_evaluation(&self) -> Option<S> {
-        unimplemented!()
+        unimplemented!("No tests currently use this function")
     }
 
     fn try_consume_post_result_challenge(&mut self) -> Result<S, ProofSizeMismatch> {
-        unimplemented!()
+        unimplemented!("No tests currently use this function")
     }
 
     fn try_consume_final_round_mle_evaluations(

--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -1,6 +1,8 @@
 //! TODO: add docs
 
 mod final_round_builder;
+#[cfg(test)]
+pub(crate) mod mock_verification_builder;
 pub(crate) use final_round_builder::FinalRoundBuilder;
 #[cfg(all(test, feature = "blitzar"))]
 mod final_round_builder_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -11,7 +11,8 @@ use crate::{
     },
     sql::{
         proof::{
-            exercise_verification, mock_verification_builder::MockVerificationBuilder,
+            exercise_verification,
+            mock_verification_builder::{run_verify_for_each_row, MockVerificationBuilder},
             FinalRoundBuilder, VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, AndExpr, ColumnExpr, DynProofExpr, ProofExpr},
@@ -207,7 +208,7 @@ fn we_can_verify_a_simple_proof() {
 
     and_expr.prover_evaluate(&mut final_round_builder, &alloc, &table);
 
-    let matrix = verify_row_by_row(
+    let verification_builder = run_verify_for_each_row(
         4,
         &final_round_builder,
         3,
@@ -221,7 +222,10 @@ fn we_can_verify_a_simple_proof() {
                 .unwrap();
         },
     );
-    assert_eq!(matrix, vec![vec![true]; 4]);
+    assert_eq!(
+        verification_builder.get_identity_results(),
+        vec![vec![true]; 4]
+    );
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -2,14 +2,19 @@ use crate::{
     base::{
         commitment::InnerProductProof,
         database::{
-            owned_table_utility::*, table_utility::*, Column, OwnedTableTestAccessor, TableRef,
-            TableTestAccessor,
+            owned_table_utility::*, table_utility::*, Column, ColumnRef, ColumnType,
+            OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
         },
-        scalar::test_scalar::TestScalar,
+        map::indexmap,
+        polynomial::MultilinearExtension,
+        scalar::{test_scalar::TestScalar, Scalar},
     },
     sql::{
-        proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
+        proof::{
+            exercise_verification, mock_verification_builder::MockVerificationBuilder,
+            FinalRoundBuilder, VerifiableQueryResult,
+        },
+        proof_exprs::{test_utility::*, AndExpr, ColumnExpr, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
     },
 };
@@ -20,6 +25,8 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+use sqlparser::ast::Ident;
+use std::collections::VecDeque;
 
 #[test]
 fn we_can_prove_a_simple_and_query() {
@@ -175,4 +182,96 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
     let res = and_expr.result_evaluate(&alloc, &data);
     let expected_res = Column::Boolean(&[false, true, false, false]);
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_verify_a_simple_proof() {
+    let alloc = Bump::new();
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let lhs = &[true, true, false, false];
+    let rhs = &[true, false, true, false];
+    let table = Table::try_new(indexmap! {
+        "a".into() => Column::Boolean::<TestScalar>(lhs),
+        "b".into() => Column::Boolean::<TestScalar>(rhs),
+    })
+    .unwrap();
+    let a = ColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
+    let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+    let and_expr = AndExpr::new(
+        Box::new(DynProofExpr::Column(ColumnExpr::new(a.clone()))),
+        Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),
+    );
+
+    let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
+        FinalRoundBuilder::new(4, VecDeque::new());
+
+    and_expr.prover_evaluate(&mut final_round_builder, &alloc, &table);
+
+    let matrix = verify_row_by_row(
+        4,
+        &final_round_builder,
+        3,
+        |verification_builder, chi_eval, evaluation_point| {
+            let accessor = indexmap! {
+                a.clone() => lhs.inner_product(evaluation_point),
+                b.clone() => rhs.inner_product(evaluation_point)
+            };
+            and_expr
+                .verifier_evaluate(verification_builder, &accessor, chi_eval)
+                .unwrap();
+        },
+    );
+    assert_eq!(matrix, vec![vec![true]; 4]);
+}
+
+#[test]
+fn we_can_reject_a_simple_tampered_proof() {
+    let alloc = Bump::new();
+    let t: TableRef = "sxt.t".parse().unwrap();
+    let lhs = &[true, true, false, false];
+    let rhs = &[true, false, true, false];
+    let a = ColumnRef::new(t.clone(), Ident::from("a"), ColumnType::Boolean);
+    let b = ColumnRef::new(t, Ident::from("b"), ColumnType::Boolean);
+    let and_expr = AndExpr::new(
+        Box::new(DynProofExpr::Column(ColumnExpr::new(a.clone()))),
+        Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),
+    );
+
+    let evaluation_points = (0..4).map(|i| {
+        alloc.alloc_slice_fill_with(4, |j| {
+            if i == j {
+                TestScalar::ONE
+            } else {
+                TestScalar::ZERO
+            }
+        })
+    });
+    let zero_vec = vec![TestScalar::ZERO];
+    // Tampering occurs here. All four rows return false for lhs and rhs
+    let final_round_mles: Vec<_> = evaluation_points
+        .clone()
+        .map(|_| zero_vec.clone())
+        .collect();
+    let mut verification_builder = MockVerificationBuilder::new(Vec::new(), 3, final_round_mles);
+
+    for evaluation_point in evaluation_points {
+        let chi_eval = (&[1, 1, 1, 1]).inner_product(evaluation_point);
+        let accessor = indexmap! {
+            a.clone() => lhs.inner_product(evaluation_point),
+            b.clone() => rhs.inner_product(evaluation_point)
+        };
+        and_expr
+            .verifier_evaluate(&mut verification_builder, &accessor, chi_eval)
+            .unwrap();
+        verification_builder.increment_row_index();
+    }
+    assert_eq!(
+        verification_builder.identity_subpolynomial_evaluations,
+        vec![
+            vec![-TestScalar::ONE],
+            zero_vec.clone(),
+            zero_vec.clone(),
+            zero_vec
+        ]
+    );
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -1,8 +1,12 @@
 use super::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr};
-use crate::base::{
-    database::{ColumnRef, LiteralValue, SchemaAccessor, TableRef},
-    math::{decimal::Precision, i256::I256},
-    scalar::Scalar,
+use crate::{
+    base::{
+        database::{ColumnRef, LiteralValue, SchemaAccessor, TableRef},
+        math::{decimal::Precision, i256::I256},
+        polynomial::MultilinearExtension,
+        scalar::{test_scalar::TestScalar, Scalar},
+    },
+    sql::proof::{mock_verification_builder::MockVerificationBuilder, FinalRoundBuilder},
 };
 use proof_of_sql_parser::intermediate_ast::AggregationOperator;
 use sqlparser::ast::Ident;
@@ -217,4 +221,50 @@ pub fn sum_expr(expr: DynProofExpr, alias: &str) -> AliasedDynProofExpr {
         expr: DynProofExpr::new_aggregate(AggregationOperator::Sum, expr),
         alias: alias.into(),
     }
+}
+
+/// Allows testing `verify_evaluate` and other verify gadgets row by row.
+/// The return matrix will tell which constraints failed.
+/// The length of the vector should be the length of the data.
+pub fn verify_row_by_row<
+    F: FnMut(&mut MockVerificationBuilder<TestScalar>, TestScalar, &[TestScalar]),
+>(
+    table_length: usize,
+    final_round_builder: &FinalRoundBuilder<'_, TestScalar>,
+    subpolynomial_max_multiplicands: usize,
+    mut row_verification: F,
+) -> Vec<Vec<bool>> {
+    let evaluation_points: Vec<Vec<_>> = (0..table_length)
+        .map(|i| {
+            (0..table_length)
+                .map(|j| {
+                    if i == j {
+                        TestScalar::ONE
+                    } else {
+                        TestScalar::ZERO
+                    }
+                })
+                .collect()
+        })
+        .collect();
+    let final_round_mles: Vec<_> = evaluation_points
+        .iter()
+        .map(|evaluation_point| final_round_builder.evaluate_pcs_proof_mles(evaluation_point))
+        .collect();
+    let mut verification_builder = MockVerificationBuilder::new(
+        final_round_builder.bit_distributions().to_vec(),
+        subpolynomial_max_multiplicands,
+        final_round_mles,
+    );
+
+    for evaluation_point in evaluation_points {
+        let one_eval = (&[1, 1, 1, 1]).inner_product(&evaluation_point);
+        row_verification(&mut verification_builder, one_eval, &evaluation_point);
+        verification_builder.increment_row_index();
+    }
+    verification_builder
+        .identity_subpolynomial_evaluations
+        .iter()
+        .map(|v| v.iter().map(|s| *s == TestScalar::ZERO).collect())
+        .collect()
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

This will add a test implementation of `VerificationBuilder` to make testing verifier_evaluate easier.

# What changes are included in this PR?

- New `MockVerificationBuilder`
- New test utility `verify_row_by_row` which returns a matrix of bools, indicating failing and passing constraints
- New `and_expr` tests to showcase the new utilities.

# Are these changes tested?
Yes
