### PR TITLE
docs: add solidity README with dev dependencies installation

### DIFF
--- a/solidity/README.md
+++ b/solidity/README.md
@@ -1,0 +1,22 @@
+# Development Dependencies Installation
+1. `forge`
+    ```bash
+    curl -L https://foundry.paradigm.xyz | bash
+    foundryup
+    ```
+2. `lcov`/`genhtml`
+    ```bash
+    sudo apt install lcov
+    ```
+3. `solhint`
+    ```bash
+    npm install -g solhint
+    ```
+4. `slither`
+    ```bash
+    pipx install slither-analyzer
+    ```
+4. `aderyn` (Recommended)
+    ```bash
+    npm install -g @cyfrin/aderyn
+    ```


### PR DESCRIPTION
# Rationale for this change

We should have documentation explaining how to install dependencies for development

# What changes are included in this PR?

The documentation is added.

# Are these changes tested?

Yes. I just reinstalled these, so they work from a clean Ubuntu install.