### PR TITLE
feat(sol): add queues for first round MLEs and rho evals

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -45,10 +45,14 @@ uint256 constant INVALID_EC_PAIRING_INPUTS = 0x4385b511_00000000_00000000_000000
 uint256 constant ROUND_EVALUATION_MISMATCH = 0x741f5c3f_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 /// @dev Error code for when too few challenges are provided to the verification builder.
 uint256 constant TOO_FEW_CHALLENGES = 0x700caebe_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when too few first round mles are provided to the verification builder.
+uint256 constant TOO_FEW_FIRST_ROUND_MLES = 0x82a47d4f_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 /// @dev Error code for when too few final round mles are provided to the verification builder.
 uint256 constant TOO_FEW_FINAL_ROUND_MLES = 0xfb828ab5_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 /// @dev Error code for when too few chi evaluations are provided to the verification builder.
 uint256 constant TOO_FEW_CHI_EVALUATIONS = 0x8ef4e6c9_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
+/// @dev Error code for when too few rho evaluations are provided to the verification builder.
+uint256 constant TOO_FEW_RHO_EVALUATIONS = 0x3784ad97_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 
 /// @dev The X coordinate of the G1 generator point.
 uint256 constant G1_GEN_X = 1;
@@ -79,19 +83,27 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 6;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 10;
 /// @dev Offset of the pointer to the head of the challenge queue in the verification builder.
 uint256 constant CHALLENGE_HEAD_OFFSET = 0x20 * 0;
 /// @dev Offset of the pointer to the tail of the challenge queue in the verification builder.
 uint256 constant CHALLENGE_TAIL_OFFSET = 0x20 * 1;
+/// @dev Offset of the pointer to the head of the first round mles in the verification builder.
+uint256 constant FIRST_ROUND_MLE_HEAD_OFFSET = 0x20 * 2;
+/// @dev Offset of the pointer to the tail of the first round mles in the verification builder.
+uint256 constant FIRST_ROUND_MLE_TAIL_OFFSET = 0x20 * 3;
 /// @dev Offset of the pointer to the head of the final round mles in the verification builder.
-uint256 constant FINAL_ROUND_MLE_HEAD_OFFSET = 0x20 * 2;
+uint256 constant FINAL_ROUND_MLE_HEAD_OFFSET = 0x20 * 4;
 /// @dev Offset of the pointer to the tail of the final round mles in the verification builder.
-uint256 constant FINAL_ROUND_MLE_TAIL_OFFSET = 0x20 * 3;
+uint256 constant FINAL_ROUND_MLE_TAIL_OFFSET = 0x20 * 5;
 /// @dev Offset of the pointer to the head of the chi evaluations in the verification builder.
-uint256 constant CHI_EVALUATION_HEAD_OFFSET = 0x20 * 4;
+uint256 constant CHI_EVALUATION_HEAD_OFFSET = 0x20 * 6;
 /// @dev Offset of the pointer to the tail of the chi evaluations in the verification builder.
-uint256 constant CHI_EVALUATION_TAIL_OFFSET = 0x20 * 5;
+uint256 constant CHI_EVALUATION_TAIL_OFFSET = 0x20 * 7;
+/// @dev Offset of the pointer to the head of the rho evaluations in the verification builder.
+uint256 constant RHO_EVALUATION_HEAD_OFFSET = 0x20 * 8;
+/// @dev Offset of the pointer to the tail of the rho evaluations in the verification builder.
+uint256 constant RHO_EVALUATION_TAIL_OFFSET = 0x20 * 9;
 
 /// @title Errors library
 /// @notice Library containing custom error definitions.
@@ -106,8 +118,12 @@ library Errors {
     error RoundEvaluationMismatch();
     /// @notice Error thrown when too few challenges are provided to the verification builder.
     error TooFewChallenges();
+    /// @notice Error thrown when too few first round mles are provided to the verification builder.
+    error TooFewFirstRoundMLEs();
     /// @notice Error thrown when too few final round mles are provided to the verification builder.
     error TooFewFinalRoundMLEs();
     /// @notice Error thrown when too few chi evaluations are provided to the verification builder.
     error TooFewChiEvaluations();
+    /// @notice Error thrown when too few rho evaluations are provided to the verification builder.
+    error TooFewRhoEvaluations();
 }

--- a/solidity/src/proof/VerificationBuilder.sol
+++ b/solidity/src/proof/VerificationBuilder.sol
@@ -52,6 +52,46 @@ library VerificationBuilder {
         }
     }
 
+    /// @notice Sets the first round mles in the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @param __firstRoundMLEPtr The pointer to the first round mles.
+    /// @param __firstRoundMLELength The number of first round mles.
+    function __setFirstRoundMLEs(uint256 __builderPtr, uint256 __firstRoundMLEPtr, uint256 __firstRoundMLELength)
+        internal
+        pure
+    {
+        assembly {
+            function builder_set_first_round_mles(builder_ptr, first_round_mle_ptr, first_round_mle_length) {
+                mstore(add(builder_ptr, FIRST_ROUND_MLE_HEAD_OFFSET), first_round_mle_ptr)
+                mstore(
+                    add(builder_ptr, FIRST_ROUND_MLE_TAIL_OFFSET),
+                    add(first_round_mle_ptr, mul(WORD_SIZE, first_round_mle_length))
+                )
+            }
+            builder_set_first_round_mles(__builderPtr, __firstRoundMLEPtr, __firstRoundMLELength)
+        }
+    }
+
+    /// @notice Consumes a first round mle from the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @return __evaluation The consumed first round mle.
+    /// @dev Reverts if there are no first round mles left.
+    function __consumeFirstRoundMLE(uint256 __builderPtr) internal pure returns (uint256 __evaluation) {
+        assembly {
+            function builder_consume_first_round_mle(builder_ptr) -> evaluation {
+                let head_ptr := mload(add(builder_ptr, FIRST_ROUND_MLE_HEAD_OFFSET))
+                evaluation := mload(head_ptr)
+                head_ptr := add(head_ptr, WORD_SIZE)
+                if gt(head_ptr, mload(add(builder_ptr, FIRST_ROUND_MLE_TAIL_OFFSET))) {
+                    mstore(0, TOO_FEW_FIRST_ROUND_MLES)
+                    revert(0, 4)
+                }
+                mstore(add(builder_ptr, FIRST_ROUND_MLE_HEAD_OFFSET), head_ptr)
+            }
+            __evaluation := builder_consume_first_round_mle(__builderPtr)
+        }
+    }
+
     /// @notice Sets the final round mles in the verification builder.
     /// @param __builderPtr The pointer to the verification builder.
     /// @param __finalRoundMLEPtr The pointer to the final round mles.
@@ -129,6 +169,46 @@ library VerificationBuilder {
                 mstore(add(builder_ptr, CHI_EVALUATION_HEAD_OFFSET), head_ptr)
             }
             __evaluation := builder_consume_chi_evaluation(__builderPtr)
+        }
+    }
+
+    /// @notice Sets the rho evaluations in the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @param __rhoEvaluationPtr The pointer to the rho evaluations.
+    /// @param __rhoEvaluationLength The number of rho evaluations.
+    function __setRhoEvaluations(uint256 __builderPtr, uint256 __rhoEvaluationPtr, uint256 __rhoEvaluationLength)
+        internal
+        pure
+    {
+        assembly {
+            function builder_set_rho_evaluations(builder_ptr, rho_evaluation_ptr, rho_evaluation_length) {
+                mstore(add(builder_ptr, RHO_EVALUATION_HEAD_OFFSET), rho_evaluation_ptr)
+                mstore(
+                    add(builder_ptr, RHO_EVALUATION_TAIL_OFFSET),
+                    add(rho_evaluation_ptr, mul(WORD_SIZE, rho_evaluation_length))
+                )
+            }
+            builder_set_rho_evaluations(__builderPtr, __rhoEvaluationPtr, __rhoEvaluationLength)
+        }
+    }
+
+    /// @notice Consumes a rho evaluation from the verification builder.
+    /// @param __builderPtr The pointer to the verification builder.
+    /// @return __evaluation The consumed rho evaluation.
+    /// @dev Reverts if there are no rho evaluations left.
+    function __consumeRhoEvaluation(uint256 __builderPtr) internal pure returns (uint256 __evaluation) {
+        assembly {
+            function builder_consume_rho_evaluation(builder_ptr) -> evaluation {
+                let head_ptr := mload(add(builder_ptr, RHO_EVALUATION_HEAD_OFFSET))
+                evaluation := mload(head_ptr)
+                head_ptr := add(head_ptr, WORD_SIZE)
+                if gt(head_ptr, mload(add(builder_ptr, RHO_EVALUATION_TAIL_OFFSET))) {
+                    mstore(0, TOO_FEW_RHO_EVALUATIONS)
+                    revert(0, 4)
+                }
+                mstore(add(builder_ptr, RHO_EVALUATION_HEAD_OFFSET), head_ptr)
+            }
+            __evaluation := builder_consume_rho_evaluation(__builderPtr)
         }
     }
 }

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -46,6 +46,14 @@ contract ConstantsTest is Test {
         }
     }
 
+    function testErrorFailedTooFewFirstRoundMLEs() public {
+        vm.expectRevert(Errors.TooFewFirstRoundMLEs.selector);
+        assembly {
+            mstore(0, TOO_FEW_FIRST_ROUND_MLES)
+            revert(0, 4)
+        }
+    }
+
     function testErrorFailedTooFewFinalRoundMLEs() public {
         vm.expectRevert(Errors.TooFewFinalRoundMLEs.selector);
         assembly {
@@ -58,6 +66,14 @@ contract ConstantsTest is Test {
         vm.expectRevert(Errors.TooFewChiEvaluations.selector);
         assembly {
             mstore(0, TOO_FEW_CHI_EVALUATIONS)
+            revert(0, 4)
+        }
+    }
+
+    function testErrorFailedTooFewRhoEvaluations() public {
+        vm.expectRevert(Errors.TooFewRhoEvaluations.selector);
+        assembly {
+            mstore(0, TOO_FEW_RHO_EVALUATIONS)
             revert(0, 4)
         }
     }
@@ -87,13 +103,17 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[6] memory offsets = [
+        uint256[10] memory offsets = [
             CHALLENGE_HEAD_OFFSET,
             CHALLENGE_TAIL_OFFSET,
+            FIRST_ROUND_MLE_HEAD_OFFSET,
+            FIRST_ROUND_MLE_TAIL_OFFSET,
             FINAL_ROUND_MLE_HEAD_OFFSET,
             FINAL_ROUND_MLE_TAIL_OFFSET,
             CHI_EVALUATION_HEAD_OFFSET,
-            CHI_EVALUATION_TAIL_OFFSET
+            CHI_EVALUATION_TAIL_OFFSET,
+            RHO_EVALUATION_HEAD_OFFSET,
+            RHO_EVALUATION_TAIL_OFFSET
         ];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This is a follow-up to #531 that is dependent on #544. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add queue for first round MLEs
- add queue for rho evals
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.