### PR TITLE
chore: pin foundry to v1.0.0 and fix related issues

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.0.0
       - name: Install dependencies
         run: solidity/scripts/install_deps.sh
       - name: Run tests

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -38,51 +38,61 @@ contract ErrorsTest is Test {
         }
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedInvalidECAddInputs() public {
         vm.expectRevert(Errors.InvalidECAddInputs.selector);
         Errors.__err(ERR_INVALID_EC_ADD_INPUTS);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedInvalidECMulInputs() public {
         vm.expectRevert(Errors.InvalidECMulInputs.selector);
         Errors.__err(ERR_INVALID_EC_MUL_INPUTS);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedInvalidECPairingInputs() public {
         vm.expectRevert(Errors.InvalidECPairingInputs.selector);
         Errors.__err(ERR_INVALID_EC_PAIRING_INPUTS);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedRoundEvaluationMismatch() public {
         vm.expectRevert(Errors.RoundEvaluationMismatch.selector);
         Errors.__err(ERR_ROUND_EVALUATION_MISMATCH);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedTooFewChallenges() public {
         vm.expectRevert(Errors.TooFewChallenges.selector);
         Errors.__err(ERR_TOO_FEW_CHALLENGES);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedTooFewFirstRoundMLEs() public {
         vm.expectRevert(Errors.TooFewFirstRoundMLEs.selector);
         Errors.__err(ERR_TOO_FEW_FIRST_ROUND_MLES);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedTooFewFinalRoundMLEs() public {
         vm.expectRevert(Errors.TooFewFinalRoundMLEs.selector);
         Errors.__err(ERR_TOO_FEW_FINAL_ROUND_MLES);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedTooFewChiEvaluations() public {
         vm.expectRevert(Errors.TooFewChiEvaluations.selector);
         Errors.__err(ERR_TOO_FEW_CHI_EVALUATIONS);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedTooFewRhoEvaluations() public {
         vm.expectRevert(Errors.TooFewRhoEvaluations.selector);
         Errors.__err(ERR_TOO_FEW_RHO_EVALUATIONS);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedHyperKZGInconsistentV() public {
         vm.expectRevert(Errors.HyperKZGInconsistentV.selector);
         Errors.__err(ERR_HYPER_KZG_INCONSISTENT_V);

--- a/solidity/test/proof/VerificationBuilder.t.pre.sol
+++ b/solidity/test/proof/VerificationBuilder.t.pre.sol
@@ -92,6 +92,7 @@ contract VerificationBuilderTest is Test {
         assert(tail == challengePtr + WORD_SIZE * challengeLength);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeZeroChallenges() public {
         uint256[] memory challenges = new uint256[](0);
         uint256 builderPtr = VerificationBuilder.__allocate();
@@ -100,6 +101,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeChallenge(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeOneChallenge() public {
         uint256[] memory challenges = new uint256[](1);
         challenges[0] = 0x12345678;
@@ -110,6 +112,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeChallenge(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeChallenges() public {
         uint256[] memory challenges = new uint256[](3);
         challenges[0] = 0x12345678;
@@ -124,6 +127,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeChallenge(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testFuzzSetAndConsumeChallenges(uint256[] memory, uint256[] memory challenges) public {
         uint256 builderPtr = VerificationBuilder.__allocate();
         VerificationBuilderTestHelper.setChallenges(builderPtr, challenges);
@@ -166,6 +170,7 @@ contract VerificationBuilderTest is Test {
         assert(tail == firstRoundMLEPtr + WORD_SIZE * firstRoundMLELength);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeZeroFirstRoundMLEs() public {
         uint256[] memory firstRoundMLEs = new uint256[](0);
         uint256 builderPtr = VerificationBuilder.__allocate();
@@ -174,6 +179,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeFirstRoundMLE(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeOneFirstRoundMLE() public {
         uint256[] memory firstRoundMLEs = new uint256[](1);
         firstRoundMLEs[0] = 0x12345678;
@@ -184,6 +190,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeFirstRoundMLE(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeFirstRoundMLEs() public {
         uint256[] memory firstRoundMLEs = new uint256[](3);
         firstRoundMLEs[0] = 0x12345678;
@@ -229,6 +236,7 @@ contract VerificationBuilderTest is Test {
         assert(tail == finalRoundMLEPtr + WORD_SIZE * finalRoundMLELength);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeZeroFinalRoundMLEs() public {
         uint256[] memory finalRoundMLEs = new uint256[](0);
         uint256 builderPtr = VerificationBuilder.__allocate();
@@ -237,6 +245,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeFinalRoundMLE(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeOneFinalRoundMLE() public {
         uint256[] memory finalRoundMLEs = new uint256[](1);
         finalRoundMLEs[0] = 0x12345678;
@@ -247,6 +256,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeFinalRoundMLE(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeFinalRoundMLEs() public {
         uint256[] memory finalRoundMLEs = new uint256[](3);
         finalRoundMLEs[0] = 0x12345678;
@@ -261,6 +271,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeFinalRoundMLE(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testFuzzSetAndConsumeFinalRoundMLEs(uint256[] memory, uint256[] memory finalRoundMLEs) public {
         uint256 builderPtr = VerificationBuilder.__allocate();
         VerificationBuilderTestHelper.setFinalRoundMLEs(builderPtr, finalRoundMLEs);
@@ -303,6 +314,7 @@ contract VerificationBuilderTest is Test {
         assert(tail == chiEvaluationPtr + WORD_SIZE * chiEvaluationLength);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeZeroChiEvaluations() public {
         uint256[] memory chiEvaluations = new uint256[](0);
         uint256 builderPtr = VerificationBuilder.__allocate();
@@ -311,6 +323,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeChiEvaluation(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeOneChiEvaluation() public {
         uint256[] memory chiEvaluations = new uint256[](1);
         chiEvaluations[0] = 0x12345678;
@@ -321,6 +334,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeChiEvaluation(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeChiEvaluations() public {
         uint256[] memory chiEvaluations = new uint256[](3);
         chiEvaluations[0] = 0x12345678;
@@ -335,6 +349,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeChiEvaluation(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testFuzzSetAndConsumeChiEvaluations(uint256[] memory, uint256[] memory chiEvaluations) public {
         uint256 builderPtr = VerificationBuilder.__allocate();
         VerificationBuilderTestHelper.setChiEvaluations(builderPtr, chiEvaluations);
@@ -377,6 +392,7 @@ contract VerificationBuilderTest is Test {
         assert(tail == rhoEvaluationPtr + WORD_SIZE * rhoEvaluationLength);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeZeroRhoEvaluations() public {
         uint256[] memory rhoEvaluations = new uint256[](0);
         uint256 builderPtr = VerificationBuilder.__allocate();
@@ -385,6 +401,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeRhoEvaluation(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeOneRhoEvaluation() public {
         uint256[] memory rhoEvaluations = new uint256[](1);
         rhoEvaluations[0] = 0x12345678;
@@ -395,6 +412,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeRhoEvaluation(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSetAndConsumeRhoEvaluations() public {
         uint256[] memory rhoEvaluations = new uint256[](3);
         rhoEvaluations[0] = 0x12345678;
@@ -409,6 +427,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.__consumeRhoEvaluation(builderPtr);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testFuzzSetAndConsumeRhoEvaluations(uint256[] memory, uint256[] memory rhoEvaluations) public {
         uint256 builderPtr = VerificationBuilder.__allocate();
         VerificationBuilderTestHelper.setRhoEvaluations(builderPtr, rhoEvaluations);


### PR DESCRIPTION
# Rationale for this change

Foundry just upgraded `v.1.0.0` to `stable`. This broke some tests.

# What changes are included in this PR?

* Pinned the CI foundry version to `v1.0.0`.
* Fixed the failing tests.

# Are these changes tested?
Yes
