### PR TITLE
refactor(sol): add `Queue` library and leverage it in `VerificationBuilder`

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -68,24 +68,14 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 10;
-/// @dev Offset of the pointer to the head of the challenge queue in the verification builder.
-uint256 constant CHALLENGE_HEAD_OFFSET = 0x20 * 0;
-/// @dev Offset of the pointer to the tail of the challenge queue in the verification builder.
-uint256 constant CHALLENGE_TAIL_OFFSET = 0x20 * 1;
-/// @dev Offset of the pointer to the head of the first round mles in the verification builder.
-uint256 constant FIRST_ROUND_MLE_HEAD_OFFSET = 0x20 * 2;
-/// @dev Offset of the pointer to the tail of the first round mles in the verification builder.
-uint256 constant FIRST_ROUND_MLE_TAIL_OFFSET = 0x20 * 3;
-/// @dev Offset of the pointer to the head of the final round mles in the verification builder.
-uint256 constant FINAL_ROUND_MLE_HEAD_OFFSET = 0x20 * 4;
-/// @dev Offset of the pointer to the tail of the final round mles in the verification builder.
-uint256 constant FINAL_ROUND_MLE_TAIL_OFFSET = 0x20 * 5;
-/// @dev Offset of the pointer to the head of the chi evaluations in the verification builder.
-uint256 constant CHI_EVALUATION_HEAD_OFFSET = 0x20 * 6;
-/// @dev Offset of the pointer to the tail of the chi evaluations in the verification builder.
-uint256 constant CHI_EVALUATION_TAIL_OFFSET = 0x20 * 7;
-/// @dev Offset of the pointer to the head of the rho evaluations in the verification builder.
-uint256 constant RHO_EVALUATION_HEAD_OFFSET = 0x20 * 8;
-/// @dev Offset of the pointer to the tail of the rho evaluations in the verification builder.
-uint256 constant RHO_EVALUATION_TAIL_OFFSET = 0x20 * 9;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 5;
+/// @dev Offset of the pointer to the challenge queue in the verification builder.
+uint256 constant BUILDER_CHALLENGES_OFFSET = 0x20 * 0;
+/// @dev Offset of the pointer to the first round MLEs in the verification builder.
+uint256 constant BUILDER_FIRST_ROUND_MLES_OFFSET = 0x20 * 1;
+/// @dev Offset of the pointer to the final round MLEs in the verification builder.
+uint256 constant BUILDER_FINAL_ROUND_MLES_OFFSET = 0x20 * 2;
+/// @dev Offset of the pointer to the chi evaluations in the verification builder.
+uint256 constant BUILDER_CHI_EVALUATIONS_OFFSET = 0x20 * 3;
+/// @dev Offset of the pointer to the rho evaluations in the verification builder.
+uint256 constant BUILDER_RHO_EVALUATIONS_OFFSET = 0x20 * 4;

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -20,6 +20,8 @@ uint32 constant ERR_TOO_FEW_FINAL_ROUND_MLES = 0xfb828ab5;
 uint32 constant ERR_TOO_FEW_CHI_EVALUATIONS = 0x8ef4e6c9;
 /// @dev Error code for when too few rho evaluations are provided to the verification builder.
 uint32 constant ERR_TOO_FEW_RHO_EVALUATIONS = 0x3784ad97;
+/// @dev Error code for when a dequeue attempt was made on an empty queue.
+uint32 constant ERR_EMPTY_QUEUE = 0x31dcf2b5;
 /// @dev Error code for when the HyperKZG proof has an inconsistent v.
 uint32 constant ERR_HYPER_KZG_INCONSISTENT_V = 0x6a5ae827;
 
@@ -42,6 +44,8 @@ library Errors {
     error TooFewChiEvaluations();
     /// @notice Error thrown when too few rho evaluations are provided to the verification builder.
     error TooFewRhoEvaluations();
+    /// @notice Error thrown when a dequeue attempt was made on an empty queue.
+    error EmptyQueue();
     /// @notice Error thrown when the HyperKZG proof has an inconsistent v.
     error HyperKZGInconsistentV();
 

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -10,16 +10,6 @@ uint32 constant ERR_INVALID_EC_MUL_INPUTS = 0xe32c7472;
 uint32 constant ERR_INVALID_EC_PAIRING_INPUTS = 0x4385b511;
 /// @dev Error code for when the evaluation of a round in a sumcheck proof does not match the expected value.
 uint32 constant ERR_ROUND_EVALUATION_MISMATCH = 0x741f5c3f;
-/// @dev Error code for when too few challenges are provided to the verification builder.
-uint32 constant ERR_TOO_FEW_CHALLENGES = 0x700caebe;
-/// @dev Error code for when too few first round mles are provided to the verification builder.
-uint32 constant ERR_TOO_FEW_FIRST_ROUND_MLES = 0x82a47d4f;
-/// @dev Error code for when too few final round mles are provided to the verification builder.
-uint32 constant ERR_TOO_FEW_FINAL_ROUND_MLES = 0xfb828ab5;
-/// @dev Error code for when too few chi evaluations are provided to the verification builder.
-uint32 constant ERR_TOO_FEW_CHI_EVALUATIONS = 0x8ef4e6c9;
-/// @dev Error code for when too few rho evaluations are provided to the verification builder.
-uint32 constant ERR_TOO_FEW_RHO_EVALUATIONS = 0x3784ad97;
 /// @dev Error code for when a dequeue attempt was made on an empty queue.
 uint32 constant ERR_EMPTY_QUEUE = 0x31dcf2b5;
 /// @dev Error code for when the HyperKZG proof has an inconsistent v.
@@ -34,16 +24,6 @@ library Errors {
     error InvalidECPairingInputs();
     /// @notice Error thrown when the evaluation of a round in a sumcheck proof does not match the expected value.
     error RoundEvaluationMismatch();
-    /// @notice Error thrown when too few challenges are provided to the verification builder.
-    error TooFewChallenges();
-    /// @notice Error thrown when too few first round mles are provided to the verification builder.
-    error TooFewFirstRoundMLEs();
-    /// @notice Error thrown when too few final round mles are provided to the verification builder.
-    error TooFewFinalRoundMLEs();
-    /// @notice Error thrown when too few chi evaluations are provided to the verification builder.
-    error TooFewChiEvaluations();
-    /// @notice Error thrown when too few rho evaluations are provided to the verification builder.
-    error TooFewRhoEvaluations();
     /// @notice Error thrown when a dequeue attempt was made on an empty queue.
     error EmptyQueue();
     /// @notice Error thrown when the HyperKZG proof has an inconsistent v.

--- a/solidity/src/base/Queue.pre.sol
+++ b/solidity/src/base/Queue.pre.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "./Constants.sol";
+import "./Errors.sol";
+
+/// @title Queue
+/// @dev Library providing queue operations for memory-based queues.
+library Queue {
+    /// @notice Dequeues a value from the front of the queue
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// dequeue(queue_ptr) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `queue_ptr` - pointer to the array in memory. In Solidity memory layout,
+    ///   this points to where the array length is stored, followed by the array elements
+    /// ##### Return Values
+    /// * `value` - the dequeued value from the front of the queue
+    /// @dev Removes and returns the first element from the queue.
+    /// Reverts with Errors.EmptyQueue if the queue is empty.
+    /// @param __queue Single-element array containing the queue array
+    /// @return __value The dequeued value
+    function __dequeue(uint256[][1] memory __queue) internal pure returns (uint256 __value) {
+        assembly {
+            // IMPORT-YUL Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            function dequeue(queue_ptr) -> value {
+                let queue := mload(queue_ptr)
+                let length := mload(queue)
+                if iszero(length) { err(ERR_EMPTY_QUEUE) }
+                queue := add(queue, WORD_SIZE)
+                value := mload(queue)
+                mstore(queue, sub(length, 1))
+                mstore(queue_ptr, queue)
+            }
+            __value := dequeue(__queue)
+        }
+    }
+}

--- a/solidity/src/proof/VerificationBuilder.pre.sol
+++ b/solidity/src/proof/VerificationBuilder.pre.sol
@@ -5,224 +5,316 @@ pragma solidity ^0.8.28;
 import "../base/Constants.sol";
 import "../base/Errors.sol";
 
+/// @title VerificationBuilder
+/// @dev Library providing memory management and state tracking for the verification process.
+/// Maintains queues of challenges and various MLE evaluations.
 library VerificationBuilder {
-    /// @notice Allocates and reserves a block of memory for a verification builder.
-    /// @return __builderPtr The pointer to the allocated builder region.
-    function __allocate() internal pure returns (uint256 __builderPtr) {
+    struct Builder {
+        uint256[] challenges;
+        uint256[] firstRoundMLEs;
+        uint256[] finalRoundMLEs;
+        uint256[] chiEvaluations;
+        uint256[] rhoEvaluations;
+    }
+
+    /// @notice Allocates and reserves a block of memory for a verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_new() -> builder_ptr
+    /// ```
+    /// ##### Return Values
+    /// * `builder_ptr` - memory pointer to the newly allocated builder region
+    /// @dev Allocates memory for the builder structure and updates the free memory pointer
+    /// @return __builder The builder struct
+    function __builderNew() internal pure returns (Builder memory __builder) {
         assembly {
-            function builder_allocate() -> builder_ptr {
+            function builder_new() -> builder_ptr {
                 builder_ptr := mload(FREE_PTR)
                 mstore(FREE_PTR, add(builder_ptr, VERIFICATION_BUILDER_SIZE))
             }
-            __builderPtr := builder_allocate()
+            __builder := builder_new()
         }
     }
 
-    /// @notice Sets the challenges in the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @param __challengePtr The pointer to the challenges.
-    /// @param __challengeLength The number of challenges.
-    /// This is assumed to be "small", i.e. anything less than 2^64 will work.
-    function __setChallenges(uint256 __builderPtr, uint256 __challengePtr, uint256 __challengeLength) internal pure {
+    /// @notice Sets the challenges in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_challenges(builder_ptr, challenges_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `challenges_ptr` - pointer to the array in memory. In Solidity memory layout,
+    ///   this points to where the array length is stored, followed by the array elements
+    /// @dev Stores the challenges array pointer in the builder structure.
+    /// WARNING: The challenges array will be mutated during verification and should not
+    /// be used after passing to this function.
+    /// @param __builder The builder struct
+    /// @param __challenges The challenges array
+    function __setChallenges(Builder memory __builder, uint256[] memory __challenges) internal pure {
         assembly {
-            function builder_set_challenges(builder_ptr, challenge_ptr, challenge_length) {
-                mstore(add(builder_ptr, CHALLENGE_HEAD_OFFSET), challenge_ptr)
-                mstore(add(builder_ptr, CHALLENGE_TAIL_OFFSET), add(challenge_ptr, mul(WORD_SIZE, challenge_length)))
+            function builder_set_challenges(builder_ptr, challenges_ptr) {
+                mstore(add(builder_ptr, BUILDER_CHALLENGES_OFFSET), challenges_ptr)
             }
-            builder_set_challenges(__builderPtr, __challengePtr, __challengeLength)
+            builder_set_challenges(__builder, __challenges)
         }
     }
 
-    /// @notice Consumes a challenge from the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @return __challenge The consumed challenge.
-    /// @dev This function will revert if there are no challenges left to consume.
-    function __consumeChallenge(uint256 __builderPtr) internal pure returns (uint256 __challenge) {
+    /// @notice Consumes a challenge from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_consume_challenge(builder_ptr) -> challenge
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - pointer to the verification builder
+    /// ##### Return Values
+    /// * `challenge` - the consumed challenge value
+    /// @dev Dequeues and returns a challenge. Reverts with Errors.EmptyQueue if no challenges remain
+    /// @param __builder The pointer to the verification builder
+    /// @return __challenge The consumed challenge
+    function __consumeChallenge(Builder memory __builder) internal pure returns (uint256 __challenge) {
         assembly {
             // IMPORT-YUL ../base/Errors.sol
             function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
                 revert(0, 0)
             }
             function builder_consume_challenge(builder_ptr) -> challenge {
-                let head_ptr := mload(add(builder_ptr, CHALLENGE_HEAD_OFFSET))
-                challenge := mload(head_ptr)
-                head_ptr := add(head_ptr, WORD_SIZE)
-                if gt(head_ptr, mload(add(builder_ptr, CHALLENGE_TAIL_OFFSET))) { err(ERR_TOO_FEW_CHALLENGES) }
-                mstore(add(builder_ptr, CHALLENGE_HEAD_OFFSET), head_ptr)
+                challenge := dequeue(add(builder_ptr, BUILDER_CHALLENGES_OFFSET))
             }
-            __challenge := builder_consume_challenge(__builderPtr)
+            __challenge := builder_consume_challenge(__builder)
         }
     }
 
-    /// @notice Sets the first round mles in the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @param __firstRoundMLEPtr The pointer to the first round mles.
-    /// @param __firstRoundMLELength The number of first round mles.
-    function __setFirstRoundMLEs(uint256 __builderPtr, uint256 __firstRoundMLEPtr, uint256 __firstRoundMLELength)
-        internal
-        pure
-    {
+    /// @notice Sets the first round MLE evaluations in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_first_round_mles(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - pointer to the array in memory. In Solidity memory layout,
+    ///   this points to where the array length is stored, followed by the array elements
+    /// @dev Stores the first round MLE array pointer in the builder structure.
+    /// WARNING: The values array will be mutated during verification and should not
+    /// be used after passing to this function.
+    /// @param __builder The builder struct
+    /// @param __values The first round MLE values array
+    function __setFirstRoundMLEs(Builder memory __builder, uint256[] memory __values) internal pure {
         assembly {
-            function builder_set_first_round_mles(builder_ptr, first_round_mle_ptr, first_round_mle_length) {
-                mstore(add(builder_ptr, FIRST_ROUND_MLE_HEAD_OFFSET), first_round_mle_ptr)
-                mstore(
-                    add(builder_ptr, FIRST_ROUND_MLE_TAIL_OFFSET),
-                    add(first_round_mle_ptr, mul(WORD_SIZE, first_round_mle_length))
-                )
+            function builder_set_first_round_mles(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_FIRST_ROUND_MLES_OFFSET), values_ptr)
             }
-            builder_set_first_round_mles(__builderPtr, __firstRoundMLEPtr, __firstRoundMLELength)
+            builder_set_first_round_mles(__builder, __values)
         }
     }
 
-    /// @notice Consumes a first round mle from the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @return __evaluation The consumed first round mle.
-    /// @dev Reverts if there are no first round mles left.
-    function __consumeFirstRoundMLE(uint256 __builderPtr) internal pure returns (uint256 __evaluation) {
-        assembly {
-            // IMPORT-YUL ../base/Errors.sol
-            function err(code) {
-                revert(0, 0)
-            }
-            function builder_consume_first_round_mle(builder_ptr) -> evaluation {
-                let head_ptr := mload(add(builder_ptr, FIRST_ROUND_MLE_HEAD_OFFSET))
-                evaluation := mload(head_ptr)
-                head_ptr := add(head_ptr, WORD_SIZE)
-                if gt(head_ptr, mload(add(builder_ptr, FIRST_ROUND_MLE_TAIL_OFFSET))) {
-                    err(ERR_TOO_FEW_FIRST_ROUND_MLES)
-                }
-                mstore(add(builder_ptr, FIRST_ROUND_MLE_HEAD_OFFSET), head_ptr)
-            }
-            __evaluation := builder_consume_first_round_mle(__builderPtr)
-        }
-    }
-
-    /// @notice Sets the final round mles in the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @param __finalRoundMLEPtr The pointer to the final round mles.
-    /// @param __finalRoundMLELength The number of final round mles.
-    function __setFinalRoundMLEs(uint256 __builderPtr, uint256 __finalRoundMLEPtr, uint256 __finalRoundMLELength)
-        internal
-        pure
-    {
-        assembly {
-            function builder_set_final_round_mles(builder_ptr, final_round_mle_ptr, final_round_mle_length) {
-                mstore(add(builder_ptr, FINAL_ROUND_MLE_HEAD_OFFSET), final_round_mle_ptr)
-                mstore(
-                    add(builder_ptr, FINAL_ROUND_MLE_TAIL_OFFSET),
-                    add(final_round_mle_ptr, mul(WORD_SIZE, final_round_mle_length))
-                )
-            }
-            builder_set_final_round_mles(__builderPtr, __finalRoundMLEPtr, __finalRoundMLELength)
-        }
-    }
-
-    /// @notice Consumes a final round mle from the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @return __evaluation The consumed final round mle.
-    /// @dev Reverts if there are no final round mles left.
-    function __consumeFinalRoundMLE(uint256 __builderPtr) internal pure returns (uint256 __evaluation) {
+    /// @notice Consumes a first round MLE evaluation from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_consume_first_round_mle(builder_ptr) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `value` - the consumed first round MLE value
+    /// @dev Dequeues and returns a first round MLE value. Reverts with Errors.EmptyQueue if no values remain
+    /// @param __builder The builder struct
+    /// @return __value The consumed first round MLE value
+    function __consumeFirstRoundMLE(Builder memory __builder) internal pure returns (uint256 __value) {
         assembly {
             // IMPORT-YUL ../base/Errors.sol
             function err(code) {
                 revert(0, 0)
             }
-            function builder_consume_final_round_mle(builder_ptr) -> evaluation {
-                let head_ptr := mload(add(builder_ptr, FINAL_ROUND_MLE_HEAD_OFFSET))
-                evaluation := mload(head_ptr)
-                head_ptr := add(head_ptr, WORD_SIZE)
-                if gt(head_ptr, mload(add(builder_ptr, FINAL_ROUND_MLE_TAIL_OFFSET))) {
-                    err(ERR_TOO_FEW_FINAL_ROUND_MLES)
-                }
-                mstore(add(builder_ptr, FINAL_ROUND_MLE_HEAD_OFFSET), head_ptr)
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
             }
-            __evaluation := builder_consume_final_round_mle(__builderPtr)
+            function builder_consume_first_round_mle(builder_ptr) -> value {
+                value := dequeue(add(builder_ptr, BUILDER_FIRST_ROUND_MLES_OFFSET))
+            }
+            __value := builder_consume_first_round_mle(__builder)
         }
     }
 
-    /// @notice Sets the chi evaluations in the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @param __chiEvaluationPtr The pointer to the chi evaluations.
-    /// @param __chiEvaluationLength The number of chi evaluations.
-    function __setChiEvaluations(uint256 __builderPtr, uint256 __chiEvaluationPtr, uint256 __chiEvaluationLength)
-        internal
-        pure
-    {
+    /// @notice Sets the final round MLE evaluations in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_final_round_mles(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - pointer to the array in memory. In Solidity memory layout,
+    ///   this points to where the array length is stored, followed by the array elements
+    /// @dev Stores the final round MLE array pointer in the builder structure.
+    /// WARNING: The values array will be mutated during verification and should not
+    /// be used after passing to this function.
+    /// @param __builder The builder struct
+    /// @param __values The final round MLE values array
+    function __setFinalRoundMLEs(Builder memory __builder, uint256[] memory __values) internal pure {
         assembly {
-            function builder_set_chi_evaluations(builder_ptr, chi_evaluation_ptr, chi_evaluation_length) {
-                mstore(add(builder_ptr, CHI_EVALUATION_HEAD_OFFSET), chi_evaluation_ptr)
-                mstore(
-                    add(builder_ptr, CHI_EVALUATION_TAIL_OFFSET),
-                    add(chi_evaluation_ptr, mul(WORD_SIZE, chi_evaluation_length))
-                )
+            function builder_set_final_round_mles(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_FINAL_ROUND_MLES_OFFSET), values_ptr)
             }
-            builder_set_chi_evaluations(__builderPtr, __chiEvaluationPtr, __chiEvaluationLength)
+            builder_set_final_round_mles(__builder, __values)
         }
     }
 
-    /// @notice Consumes a chi evaluation from the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @return __evaluation The consumed chi evaluation.
-    /// @dev Reverts if there are no chi evaluations left.
-    function __consumeChiEvaluation(uint256 __builderPtr) internal pure returns (uint256 __evaluation) {
+    /// @notice Consumes a final round MLE evaluation from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_consume_final_round_mle(builder_ptr) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `value` - the consumed final round MLE value
+    /// @dev Dequeues and returns a final round MLE value. Reverts with Errors.EmptyQueue if no values remain
+    /// @param __builder The builder struct
+    /// @return __value The consumed final round MLE value
+    function __consumeFinalRoundMLE(Builder memory __builder) internal pure returns (uint256 __value) {
         assembly {
             // IMPORT-YUL ../base/Errors.sol
             function err(code) {
                 revert(0, 0)
             }
-            function builder_consume_chi_evaluation(builder_ptr) -> evaluation {
-                let head_ptr := mload(add(builder_ptr, CHI_EVALUATION_HEAD_OFFSET))
-                evaluation := mload(head_ptr)
-                head_ptr := add(head_ptr, WORD_SIZE)
-                if gt(head_ptr, mload(add(builder_ptr, CHI_EVALUATION_TAIL_OFFSET))) {
-                    err(ERR_TOO_FEW_CHI_EVALUATIONS)
-                }
-                mstore(add(builder_ptr, CHI_EVALUATION_HEAD_OFFSET), head_ptr)
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
             }
-            __evaluation := builder_consume_chi_evaluation(__builderPtr)
+            function builder_consume_final_round_mle(builder_ptr) -> value {
+                value := dequeue(add(builder_ptr, BUILDER_FINAL_ROUND_MLES_OFFSET))
+            }
+            __value := builder_consume_final_round_mle(__builder)
         }
     }
 
-    /// @notice Sets the rho evaluations in the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @param __rhoEvaluationPtr The pointer to the rho evaluations.
-    /// @param __rhoEvaluationLength The number of rho evaluations.
-    function __setRhoEvaluations(uint256 __builderPtr, uint256 __rhoEvaluationPtr, uint256 __rhoEvaluationLength)
-        internal
-        pure
-    {
+    /// @notice Sets the chi column evaluations in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_chi_evaluations(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - pointer to the array in memory. In Solidity memory layout,
+    ///   this points to where the array length is stored, followed by the array elements
+    /// @dev Stores the chi column evaluations array pointer in the builder structure.
+    /// WARNING: The values array will be mutated during verification and should not
+    /// be used after passing to this function.
+    /// @param __builder The builder struct
+    /// @param __values The chi column evaluation values array
+    function __setChiEvaluations(Builder memory __builder, uint256[] memory __values) internal pure {
         assembly {
-            function builder_set_rho_evaluations(builder_ptr, rho_evaluation_ptr, rho_evaluation_length) {
-                mstore(add(builder_ptr, RHO_EVALUATION_HEAD_OFFSET), rho_evaluation_ptr)
-                mstore(
-                    add(builder_ptr, RHO_EVALUATION_TAIL_OFFSET),
-                    add(rho_evaluation_ptr, mul(WORD_SIZE, rho_evaluation_length))
-                )
+            function builder_set_chi_evaluations(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_CHI_EVALUATIONS_OFFSET), values_ptr)
             }
-            builder_set_rho_evaluations(__builderPtr, __rhoEvaluationPtr, __rhoEvaluationLength)
+            builder_set_chi_evaluations(__builder, __values)
         }
     }
 
-    /// @notice Consumes a rho evaluation from the verification builder.
-    /// @param __builderPtr The pointer to the verification builder.
-    /// @return __evaluation The consumed rho evaluation.
-    /// @dev Reverts if there are no rho evaluations left.
-    function __consumeRhoEvaluation(uint256 __builderPtr) internal pure returns (uint256 __evaluation) {
+    /// @notice Consumes a chi column evaluation from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_consume_chi_evaluation(builder_ptr) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `value` - the consumed chi evaluation value
+    /// @dev Dequeues and returns a chi column evaluation value. Reverts with Errors.EmptyQueue if no values remain
+    /// @param __builder The builder struct
+    /// @return __value The consumed chi column evaluation value
+    function __consumeChiEvaluation(Builder memory __builder) internal pure returns (uint256 __value) {
         assembly {
             // IMPORT-YUL ../base/Errors.sol
             function err(code) {
                 revert(0, 0)
             }
-            function builder_consume_rho_evaluation(builder_ptr) -> evaluation {
-                let head_ptr := mload(add(builder_ptr, RHO_EVALUATION_HEAD_OFFSET))
-                evaluation := mload(head_ptr)
-                head_ptr := add(head_ptr, WORD_SIZE)
-                if gt(head_ptr, mload(add(builder_ptr, RHO_EVALUATION_TAIL_OFFSET))) {
-                    err(ERR_TOO_FEW_RHO_EVALUATIONS)
-                }
-                mstore(add(builder_ptr, RHO_EVALUATION_HEAD_OFFSET), head_ptr)
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
             }
-            __evaluation := builder_consume_rho_evaluation(__builderPtr)
+            function builder_consume_chi_evaluation(builder_ptr) -> value {
+                value := dequeue(add(builder_ptr, BUILDER_CHI_EVALUATIONS_OFFSET))
+            }
+            __value := builder_consume_chi_evaluation(__builder)
+        }
+    }
+
+    /// @notice Sets the rho column evaluations in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_rho_evaluations(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - pointer to the array in memory. In Solidity memory layout,
+    ///   this points to where the array length is stored, followed by the array elements
+    /// @dev Stores the rho column evaluations array pointer in the builder structure.
+    /// WARNING: The values array will be mutated during verification and should not
+    /// be used after passing to this function.
+    /// @param __builder The builder struct
+    /// @param __values The rho column evaluation values array
+    function __setRhoEvaluations(Builder memory __builder, uint256[] memory __values) internal pure {
+        assembly {
+            function builder_set_rho_evaluations(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_RHO_EVALUATIONS_OFFSET), values_ptr)
+            }
+            builder_set_rho_evaluations(__builder, __values)
+        }
+    }
+
+    /// @notice Consumes a rho column evaluation from the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_consume_rho_evaluation(builder_ptr) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// ##### Return Values
+    /// * `value` - the consumed rho evaluation value
+    /// @dev Dequeues and returns a rho column evaluation value. Reverts with Errors.EmptyQueue if no values remain
+    /// @param __builder The builder struct
+    /// @return __value The consumed rho column evaluation value
+    function __consumeRhoEvaluation(Builder memory __builder) internal pure returns (uint256 __value) {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            function builder_consume_rho_evaluation(builder_ptr) -> value {
+                value := dequeue(add(builder_ptr, BUILDER_RHO_EVALUATIONS_OFFSET))
+            }
+            __value := builder_consume_rho_evaluation(__builder)
         }
     }
 }

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -33,17 +33,12 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[10] memory offsets = [
-            CHALLENGE_HEAD_OFFSET,
-            CHALLENGE_TAIL_OFFSET,
-            FIRST_ROUND_MLE_HEAD_OFFSET,
-            FIRST_ROUND_MLE_TAIL_OFFSET,
-            FINAL_ROUND_MLE_HEAD_OFFSET,
-            FINAL_ROUND_MLE_TAIL_OFFSET,
-            CHI_EVALUATION_HEAD_OFFSET,
-            CHI_EVALUATION_TAIL_OFFSET,
-            RHO_EVALUATION_HEAD_OFFSET,
-            RHO_EVALUATION_TAIL_OFFSET
+        uint256[5] memory offsets = [
+            BUILDER_CHALLENGES_OFFSET,
+            BUILDER_FIRST_ROUND_MLES_OFFSET,
+            BUILDER_FINAL_ROUND_MLES_OFFSET,
+            BUILDER_CHI_EVALUATIONS_OFFSET,
+            BUILDER_RHO_EVALUATIONS_OFFSET
         ];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -7,29 +7,19 @@ import "../../src/base/Errors.sol";
 
 contract ErrorsTest is Test {
     function testErrorConstantsMatchSelectors() public pure {
-        bytes4[11] memory selectors = [
+        bytes4[6] memory selectors = [
             Errors.InvalidECAddInputs.selector,
             Errors.InvalidECMulInputs.selector,
             Errors.InvalidECPairingInputs.selector,
             Errors.RoundEvaluationMismatch.selector,
-            Errors.TooFewChallenges.selector,
-            Errors.TooFewFirstRoundMLEs.selector,
-            Errors.TooFewFinalRoundMLEs.selector,
-            Errors.TooFewChiEvaluations.selector,
-            Errors.TooFewRhoEvaluations.selector,
             Errors.EmptyQueue.selector,
             Errors.HyperKZGInconsistentV.selector
         ];
-        uint32[11] memory selectorConstants = [
+        uint32[6] memory selectorConstants = [
             ERR_INVALID_EC_ADD_INPUTS,
             ERR_INVALID_EC_MUL_INPUTS,
             ERR_INVALID_EC_PAIRING_INPUTS,
             ERR_ROUND_EVALUATION_MISMATCH,
-            ERR_TOO_FEW_CHALLENGES,
-            ERR_TOO_FEW_FIRST_ROUND_MLES,
-            ERR_TOO_FEW_FINAL_ROUND_MLES,
-            ERR_TOO_FEW_CHI_EVALUATIONS,
-            ERR_TOO_FEW_RHO_EVALUATIONS,
             ERR_EMPTY_QUEUE,
             ERR_HYPER_KZG_INCONSISTENT_V
         ];

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -7,7 +7,7 @@ import "../../src/base/Errors.sol";
 
 contract ErrorsTest is Test {
     function testErrorConstantsMatchSelectors() public pure {
-        bytes4[10] memory selectors = [
+        bytes4[11] memory selectors = [
             Errors.InvalidECAddInputs.selector,
             Errors.InvalidECMulInputs.selector,
             Errors.InvalidECPairingInputs.selector,
@@ -17,9 +17,10 @@ contract ErrorsTest is Test {
             Errors.TooFewFinalRoundMLEs.selector,
             Errors.TooFewChiEvaluations.selector,
             Errors.TooFewRhoEvaluations.selector,
+            Errors.EmptyQueue.selector,
             Errors.HyperKZGInconsistentV.selector
         ];
-        uint32[10] memory selectorConstants = [
+        uint32[11] memory selectorConstants = [
             ERR_INVALID_EC_ADD_INPUTS,
             ERR_INVALID_EC_MUL_INPUTS,
             ERR_INVALID_EC_PAIRING_INPUTS,
@@ -29,6 +30,7 @@ contract ErrorsTest is Test {
             ERR_TOO_FEW_FINAL_ROUND_MLES,
             ERR_TOO_FEW_CHI_EVALUATIONS,
             ERR_TOO_FEW_RHO_EVALUATIONS,
+            ERR_EMPTY_QUEUE,
             ERR_HYPER_KZG_INCONSISTENT_V
         ];
         assert(selectors.length == selectorConstants.length);
@@ -63,33 +65,9 @@ contract ErrorsTest is Test {
     }
 
     /// forge-config: default.allow_internal_expect_revert = true
-    function testErrorFailedTooFewChallenges() public {
-        vm.expectRevert(Errors.TooFewChallenges.selector);
-        Errors.__err(ERR_TOO_FEW_CHALLENGES);
-    }
-
-    /// forge-config: default.allow_internal_expect_revert = true
-    function testErrorFailedTooFewFirstRoundMLEs() public {
-        vm.expectRevert(Errors.TooFewFirstRoundMLEs.selector);
-        Errors.__err(ERR_TOO_FEW_FIRST_ROUND_MLES);
-    }
-
-    /// forge-config: default.allow_internal_expect_revert = true
-    function testErrorFailedTooFewFinalRoundMLEs() public {
-        vm.expectRevert(Errors.TooFewFinalRoundMLEs.selector);
-        Errors.__err(ERR_TOO_FEW_FINAL_ROUND_MLES);
-    }
-
-    /// forge-config: default.allow_internal_expect_revert = true
-    function testErrorFailedTooFewChiEvaluations() public {
-        vm.expectRevert(Errors.TooFewChiEvaluations.selector);
-        Errors.__err(ERR_TOO_FEW_CHI_EVALUATIONS);
-    }
-
-    /// forge-config: default.allow_internal_expect_revert = true
-    function testErrorFailedTooFewRhoEvaluations() public {
-        vm.expectRevert(Errors.TooFewRhoEvaluations.selector);
-        Errors.__err(ERR_TOO_FEW_RHO_EVALUATIONS);
+    function testErrorFailedEmptyQueue() public {
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        Errors.__err(ERR_EMPTY_QUEUE);
     }
 
     /// forge-config: default.allow_internal_expect_revert = true

--- a/solidity/test/base/Queue.t.pre.sol
+++ b/solidity/test/base/Queue.t.pre.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {Errors} from "../../src/base/Errors.sol";
+import "../../src/base/Queue.pre.sol";
+
+contract ErrorsTest is Test {
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testEmptyDequeue() public {
+        uint256[][1] memory queue = [new uint256[](0)];
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        Queue.__dequeue(queue);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testDequeue() public {
+        uint256[][1] memory queue = [new uint256[](3)];
+        queue[0][0] = 1001;
+        queue[0][1] = 1002;
+        queue[0][2] = 1003;
+        assert(Queue.__dequeue(queue) == 1001);
+        assert(Queue.__dequeue(queue) == 1002);
+        assert(Queue.__dequeue(queue) == 1003);
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        Queue.__dequeue(queue);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testFuzzDequeue(uint256[][1] memory queue) public {
+        uint256 length = queue[0].length;
+        uint256[] memory original = new uint256[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            original[i] = queue[0][i];
+        }
+        for (uint256 i = 0; i < length; ++i) {
+            assert(Queue.__dequeue(queue) == original[i]);
+        }
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        Queue.__dequeue(queue);
+    }
+}


### PR DESCRIPTION
# Rationale for this change

The VerificationBuilder has a lot of redundant code

# What changes are included in this PR?

* a `dequeue` method is added to the Queue library
* the VerificationBuilder methods are updated to use this method to manage the queues

NOTE: this is a large PR. Look at the individual commits. The majority of the changes are very repetitive and also add lots of documentation. The actual code is greatly simplified.

# Are these changes tested?
Yes