### PR TITLE
feat(sol): add constraint methods to `VerificationBuilder` library

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -68,7 +68,7 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 5;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 9;
 /// @dev Offset of the pointer to the challenge queue in the verification builder.
 uint256 constant BUILDER_CHALLENGES_OFFSET = 0x20 * 0;
 /// @dev Offset of the pointer to the first round MLEs in the verification builder.
@@ -79,3 +79,11 @@ uint256 constant BUILDER_FINAL_ROUND_MLES_OFFSET = 0x20 * 2;
 uint256 constant BUILDER_CHI_EVALUATIONS_OFFSET = 0x20 * 3;
 /// @dev Offset of the pointer to the rho evaluations in the verification builder.
 uint256 constant BUILDER_RHO_EVALUATIONS_OFFSET = 0x20 * 4;
+/// @dev Offset of the pointer to the constraint multipliers in the verification builder.
+uint256 constant BUILDER_CONSTRAINT_MULTIPLIERS_OFFSET = 0x20 * 5;
+/// @dev Offset of the max degree in the verification builder.
+uint256 constant BUILDER_MAX_DEGREE_OFFSET = 0x20 * 6;
+/// @dev Offset of the aggregate evaluation in the verification builder.
+uint256 constant BUILDER_AGGREGATE_EVALUATION_OFFSET = 0x20 * 7;
+/// @dev Offset of the row multipliers evaluation in the verification builder.
+uint256 constant BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET = 0x20 * 8;

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -14,6 +14,8 @@ uint32 constant ERR_ROUND_EVALUATION_MISMATCH = 0x741f5c3f;
 uint32 constant ERR_EMPTY_QUEUE = 0x31dcf2b5;
 /// @dev Error code for when the HyperKZG proof has an inconsistent v.
 uint32 constant ERR_HYPER_KZG_INCONSISTENT_V = 0x6a5ae827;
+/// @dev Error code for when the produces constraint degree is higher than the provided proof.
+uint32 constant ERR_CONSTRAINT_DEGREE_TOO_HIGH = 0x8568ae69;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -28,6 +30,8 @@ library Errors {
     error EmptyQueue();
     /// @notice Error thrown when the HyperKZG proof has an inconsistent v.
     error HyperKZGInconsistentV();
+    /// @notice Error thrown when the produces constraint degree is higher than the provided proof.
+    error ConstraintDegreeTooHigh();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/src/proof/VerificationBuilder.pre.sol
+++ b/solidity/src/proof/VerificationBuilder.pre.sol
@@ -15,6 +15,10 @@ library VerificationBuilder {
         uint256[] finalRoundMLEs;
         uint256[] chiEvaluations;
         uint256[] rhoEvaluations;
+        uint256[] constraintMultipliers;
+        uint256 maxDegree;
+        uint256 aggregateEvaluation;
+        uint256 rowMultipliersEvaluation;
     }
 
     /// @notice Allocates and reserves a block of memory for a verification builder
@@ -315,6 +319,149 @@ library VerificationBuilder {
                 value := dequeue(add(builder_ptr, BUILDER_RHO_EVALUATIONS_OFFSET))
             }
             __value := builder_consume_rho_evaluation(__builder)
+        }
+    }
+
+    /// @notice Sets the constraint multipliers in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_constraint_multipliers(builder_ptr, values_ptr)
+    /// ```
+    /// @param __builder The builder struct
+    /// @param __values The constraint multipliers array
+    function __setConstraintMultipliers(Builder memory __builder, uint256[] memory __values) internal pure {
+        assembly {
+            function builder_set_constraint_multipliers(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_CONSTRAINT_MULTIPLIERS_OFFSET), values_ptr)
+            }
+            builder_set_constraint_multipliers(__builder, __values)
+        }
+    }
+
+    /// @notice Sets the max degree in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_max_degree(builder_ptr, value)
+    /// ```
+    /// @param __builder The builder struct
+    /// @param __value The max degree value
+    function __setMaxDegree(Builder memory __builder, uint256 __value) internal pure {
+        assembly {
+            function builder_set_max_degree(builder_ptr, value) {
+                mstore(add(builder_ptr, BUILDER_MAX_DEGREE_OFFSET), value)
+            }
+            builder_set_max_degree(__builder, __value)
+        }
+    }
+
+    /// @notice Sets the aggregate evaluation in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_aggregate_evaluation(builder_ptr, value)
+    /// ```
+    /// @param __builder The builder struct
+    /// @param __value The aggregate evaluation value
+    function __setAggregateEvaluation(Builder memory __builder, uint256 __value) internal pure {
+        assembly {
+            function builder_set_aggregate_evaluation(builder_ptr, value) {
+                mstore(add(builder_ptr, BUILDER_AGGREGATE_EVALUATION_OFFSET), value)
+            }
+            builder_set_aggregate_evaluation(__builder, __value)
+        }
+    }
+
+    /// @notice Sets the row multipliers evaluation in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_row_multipliers_evaluation(builder_ptr, value)
+    /// ```
+    /// @param __builder The builder struct
+    /// @param __value The row multipliers evaluation value
+    function __setRowMultipliersEvaluation(Builder memory __builder, uint256 __value) internal pure {
+        assembly {
+            function builder_set_row_multipliers_evaluation(builder_ptr, value) {
+                mstore(add(builder_ptr, BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET), value)
+            }
+            builder_set_row_multipliers_evaluation(__builder, __value)
+        }
+    }
+
+    function __produceZerosumConstraint(Builder memory __builder, uint256 __evaluation, uint256 __degree)
+        internal
+        pure
+    {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            function builder_produce_zerosum_constraint(builder_ptr, evaluation, degree) {
+                if gt(degree, mload(add(builder_ptr, BUILDER_MAX_DEGREE_OFFSET))) {
+                    err(ERR_CONSTRAINT_DEGREE_TOO_HIGH)
+                }
+                // builder.aggregateEvaluation += evaluation * dequeue(builder.constraintMultipliers)
+                mstore(
+                    add(builder_ptr, BUILDER_AGGREGATE_EVALUATION_OFFSET),
+                    addmod(
+                        mload(add(builder_ptr, BUILDER_AGGREGATE_EVALUATION_OFFSET)),
+                        mulmod(evaluation, dequeue(add(builder_ptr, BUILDER_CONSTRAINT_MULTIPLIERS_OFFSET)), MODULUS),
+                        MODULUS
+                    )
+                )
+            }
+            builder_produce_zerosum_constraint(__builder, __evaluation, __degree)
+        }
+    }
+
+    function __produceIdentityConstraint(Builder memory __builder, uint256 __evaluation, uint256 __degree)
+        internal
+        pure
+    {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Queue.pre.sol
+            function dequeue(queue_ptr) -> value {
+                revert(0, 0)
+            }
+            function builder_produce_identity_constraint(builder_ptr, evaluation, degree) {
+                if gt(add(degree, 1), mload(add(builder_ptr, BUILDER_MAX_DEGREE_OFFSET))) {
+                    err(ERR_CONSTRAINT_DEGREE_TOO_HIGH)
+                }
+                // builder.aggregateEvaluation +=
+                //     evaluation * dequeue(builder.constraintMultipliers) * builder.rowMultipliersEvaluation;
+                mstore(
+                    add(builder_ptr, BUILDER_AGGREGATE_EVALUATION_OFFSET),
+                    addmod(
+                        mload(add(builder_ptr, BUILDER_AGGREGATE_EVALUATION_OFFSET)),
+                        mulmod(
+                            evaluation,
+                            mulmod(
+                                dequeue(add(builder_ptr, BUILDER_CONSTRAINT_MULTIPLIERS_OFFSET)),
+                                mload(add(builder_ptr, BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET)),
+                                MODULUS
+                            ),
+                            MODULUS
+                        ),
+                        MODULUS
+                    )
+                )
+            }
+            builder_produce_identity_constraint(__builder, __evaluation, __degree)
         }
     }
 }

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -33,12 +33,16 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[5] memory offsets = [
+        uint256[9] memory offsets = [
             BUILDER_CHALLENGES_OFFSET,
             BUILDER_FIRST_ROUND_MLES_OFFSET,
             BUILDER_FINAL_ROUND_MLES_OFFSET,
             BUILDER_CHI_EVALUATIONS_OFFSET,
-            BUILDER_RHO_EVALUATIONS_OFFSET
+            BUILDER_RHO_EVALUATIONS_OFFSET,
+            BUILDER_CONSTRAINT_MULTIPLIERS_OFFSET,
+            BUILDER_MAX_DEGREE_OFFSET,
+            BUILDER_AGGREGATE_EVALUATION_OFFSET,
+            BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET
         ];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -7,21 +7,23 @@ import "../../src/base/Errors.sol";
 
 contract ErrorsTest is Test {
     function testErrorConstantsMatchSelectors() public pure {
-        bytes4[6] memory selectors = [
+        bytes4[7] memory selectors = [
             Errors.InvalidECAddInputs.selector,
             Errors.InvalidECMulInputs.selector,
             Errors.InvalidECPairingInputs.selector,
             Errors.RoundEvaluationMismatch.selector,
             Errors.EmptyQueue.selector,
-            Errors.HyperKZGInconsistentV.selector
+            Errors.HyperKZGInconsistentV.selector,
+            Errors.ConstraintDegreeTooHigh.selector
         ];
-        uint32[6] memory selectorConstants = [
+        uint32[7] memory selectorConstants = [
             ERR_INVALID_EC_ADD_INPUTS,
             ERR_INVALID_EC_MUL_INPUTS,
             ERR_INVALID_EC_PAIRING_INPUTS,
             ERR_ROUND_EVALUATION_MISMATCH,
             ERR_EMPTY_QUEUE,
-            ERR_HYPER_KZG_INCONSISTENT_V
+            ERR_HYPER_KZG_INCONSISTENT_V,
+            ERR_CONSTRAINT_DEGREE_TOO_HIGH
         ];
         assert(selectors.length == selectorConstants.length);
         uint256 length = selectors.length;
@@ -64,5 +66,11 @@ contract ErrorsTest is Test {
     function testErrorFailedHyperKZGInconsistentV() public {
         vm.expectRevert(Errors.HyperKZGInconsistentV.selector);
         Errors.__err(ERR_HYPER_KZG_INCONSISTENT_V);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorFailedConstraintDegreeTooHigh() public {
+        vm.expectRevert(Errors.ConstraintDegreeTooHigh.selector);
+        Errors.__err(ERR_CONSTRAINT_DEGREE_TOO_HIGH);
     }
 }

--- a/solidity/test/proof/VerificationBuilder.t.pre.sol
+++ b/solidity/test/proof/VerificationBuilder.t.pre.sol
@@ -379,4 +379,227 @@ contract VerificationBuilderTest is Test {
         vm.expectRevert(Errors.EmptyQueue.selector);
         VerificationBuilder.__consumeRhoEvaluation(builder);
     }
+
+    function testSetZeroConstraintMultipliers() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory values = new uint256[](0);
+        VerificationBuilder.__setConstraintMultipliers(builder, values);
+        assert(builder.constraintMultipliers.length == 0);
+    }
+
+    function testSetConstraintMultipliers() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        VerificationBuilder.__setConstraintMultipliers(builder, values);
+        assert(builder.constraintMultipliers.length == 3);
+        assert(builder.constraintMultipliers[0] == 0x12345678);
+        assert(builder.constraintMultipliers[1] == 0x23456789);
+        assert(builder.constraintMultipliers[2] == 0x3456789A);
+    }
+
+    function testFuzzSetConstraintMultipliers(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setConstraintMultipliers(builder, values);
+        assert(builder.constraintMultipliers.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(builder.constraintMultipliers[i] == values[i]);
+        }
+    }
+
+    function testSetMaxDegree() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setMaxDegree(builder, 42);
+        assert(builder.maxDegree == 42);
+    }
+
+    function testFuzzSetMaxDegree(uint256 value) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setMaxDegree(builder, value);
+        assert(builder.maxDegree == value);
+    }
+
+    function testSetAggregateEvaluation() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setAggregateEvaluation(builder, 42);
+        assert(builder.aggregateEvaluation == 42);
+    }
+
+    function testFuzzSetAggregateEvaluation(uint256 value) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setAggregateEvaluation(builder, value);
+        assert(builder.aggregateEvaluation == value);
+    }
+
+    function testSetRowMultipliersEvaluation() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setRowMultipliersEvaluation(builder, 42);
+        assert(builder.rowMultipliersEvaluation == 42);
+    }
+
+    function testFuzzSetRowMultipliersEvaluation(uint256 value) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setRowMultipliersEvaluation(builder, value);
+        assert(builder.rowMultipliersEvaluation == value);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testProduceZerosumConstraint() public {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory multipliers = new uint256[](3);
+        multipliers[0] = 101;
+        multipliers[1] = 103;
+        multipliers[2] = 107;
+        builder.constraintMultipliers = multipliers;
+        builder.maxDegree = 3;
+        builder.aggregateEvaluation = 211;
+
+        VerificationBuilder.__produceZerosumConstraint(builder, 307, 0);
+        assert(builder.aggregateEvaluation == 211 + 101 * 307);
+        VerificationBuilder.__produceZerosumConstraint(builder, 311, 1);
+        assert(builder.aggregateEvaluation == 211 + 101 * 307 + 103 * 311);
+        VerificationBuilder.__produceZerosumConstraint(builder, 313, 2);
+        assert(builder.aggregateEvaluation == 211 + 101 * 307 + 103 * 311 + 107 * 313);
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        VerificationBuilder.__produceZerosumConstraint(builder, 317, 3);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testProduceZerosumConstraintDegreeError() public {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.maxDegree = 3;
+        vm.expectRevert(Errors.ConstraintDegreeTooHigh.selector);
+        VerificationBuilder.__produceZerosumConstraint(builder, 1, 4);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testFuzzProduceZerosumConstraint(uint256[] memory multipliers, uint256[] memory values) public {
+        vm.assume(multipliers.length < values.length);
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.constraintMultipliers = multipliers;
+        builder.maxDegree = 3;
+        builder.aggregateEvaluation = 0;
+
+        uint256 length = multipliers.length;
+
+        uint256 aggregate = 0;
+        for (uint256 i = 0; i < length; ++i) {
+            aggregate = addmod(aggregate, mulmod(multipliers[i], values[i], MODULUS), MODULUS);
+        }
+        for (uint256 i = 0; i < length; ++i) {
+            VerificationBuilder.__produceZerosumConstraint(builder, values[i], 3);
+        }
+        assert(builder.aggregateEvaluation == aggregate);
+
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        VerificationBuilder.__produceZerosumConstraint(builder, values[length], 3);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testProduceIdentityConstraint() public {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory multipliers = new uint256[](3);
+        multipliers[0] = 101;
+        multipliers[1] = 103;
+        multipliers[2] = 107;
+        builder.constraintMultipliers = multipliers;
+        builder.maxDegree = 4;
+        builder.aggregateEvaluation = 211;
+        builder.rowMultipliersEvaluation = 223;
+
+        VerificationBuilder.__produceIdentityConstraint(builder, 307, 0);
+        assert(builder.aggregateEvaluation == 211 + 223 * (101 * 307));
+        VerificationBuilder.__produceIdentityConstraint(builder, 311, 1);
+        assert(builder.aggregateEvaluation == 211 + 223 * (101 * 307 + 103 * 311));
+        VerificationBuilder.__produceIdentityConstraint(builder, 313, 2);
+        assert(builder.aggregateEvaluation == 211 + 223 * (101 * 307 + 103 * 311 + 107 * 313));
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        VerificationBuilder.__produceIdentityConstraint(builder, 317, 3);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testProduceIdentityConstraintDegreeError() public {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.maxDegree = 3;
+        vm.expectRevert(Errors.ConstraintDegreeTooHigh.selector);
+        VerificationBuilder.__produceIdentityConstraint(builder, 1, 3);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testFuzzProduceIdentityConstraint(
+        uint256[] memory multipliers,
+        uint256[] memory values,
+        uint256 rowMultipliersEvaluation
+    ) public {
+        vm.assume(multipliers.length < values.length);
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.constraintMultipliers = multipliers;
+        builder.maxDegree = 3;
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = rowMultipliersEvaluation;
+
+        uint256 length = multipliers.length;
+
+        uint256 aggregate = 0;
+        for (uint256 i = 0; i < length; ++i) {
+            aggregate = addmod(aggregate, mulmod(multipliers[i], values[i], MODULUS), MODULUS);
+        }
+        aggregate = mulmod(aggregate, rowMultipliersEvaluation, MODULUS);
+        for (uint256 i = 0; i < length; ++i) {
+            VerificationBuilder.__produceIdentityConstraint(builder, values[i], 2);
+        }
+        assert(builder.aggregateEvaluation == aggregate);
+
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        VerificationBuilder.__produceIdentityConstraint(builder, values[length], 2);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testFuzzProduceMixedConstraints(
+        uint256[] memory multipliers,
+        uint256[] memory values,
+        bool[] memory isZerosum,
+        uint256 rowMultipliersEvaluation
+    ) public {
+        vm.assume(multipliers.length < values.length);
+        vm.assume(multipliers.length < isZerosum.length);
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        builder.constraintMultipliers = multipliers;
+        builder.maxDegree = 3;
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = rowMultipliersEvaluation;
+
+        uint256 length = multipliers.length;
+
+        uint256 aggregate = 0;
+        for (uint256 i = 0; i < length; ++i) {
+            if (isZerosum[i]) {
+                aggregate = addmod(aggregate, mulmod(multipliers[i], values[i], MODULUS), MODULUS);
+            } else {
+                aggregate = addmod(
+                    aggregate,
+                    mulmod(mulmod(multipliers[i], values[i], MODULUS), rowMultipliersEvaluation, MODULUS),
+                    MODULUS
+                );
+            }
+        }
+        for (uint256 i = 0; i < length; ++i) {
+            if (isZerosum[i]) {
+                VerificationBuilder.__produceZerosumConstraint(builder, values[i], 3);
+            } else {
+                VerificationBuilder.__produceIdentityConstraint(builder, values[i], 2);
+            }
+        }
+        assert(builder.aggregateEvaluation == aggregate);
+
+        vm.expectRevert(Errors.EmptyQueue.selector);
+        if (isZerosum[length]) {
+            VerificationBuilder.__produceZerosumConstraint(builder, values[length], 3);
+        } else {
+            VerificationBuilder.__produceIdentityConstraint(builder, values[length], 2);
+        }
+    }
 }


### PR DESCRIPTION
# Rationale for this change

This continues to expand the VerificationBuilder, making it mirror the rust code.

# What changes are included in this PR?

Primary changes are around adding the methods `builder_produce_zerosum_constraint` and `builder_produce_identity_constraint`.

Note: this depends on #550 and somewhat motivated it, hence why it in draft.

# Are these changes tested?
Yes