### PR TITLE
ci: upload coverage report to codecov

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -191,20 +191,16 @@ jobs:
       #- name: Run Tests to Generate Coverage Data (std only)
       #  run: cargo llvm-cov --no-report --no-default-features --features="std"
       - name: Generate Final LCOV Report (Merged Coverage)
-        run: cargo llvm-cov report --summary-only --fail-under-lines 90
-      # Future CodeCov Integration
-      # To integrate with CodeCov in the future,, follow these steps: 
-      # 1. Add the CodeCov token to the repository secrets.
-      # 2. Use the CodeCov Action to upload the coverage report. For more detailed info refer to [CodeCov Documentation](https://docs.codecov.com/docs).
-      #
-      # - name: Generate Final LCOV Report (Merged Coverage)
-      #   run: cargo llvm-cov report --lcov --output-path lcov.info --fail-under-lines 95
-      # - name: Upload Coverage to Codecov
-      # uses: codecov/codecov-action@v2
-      # with:
-      #   token: ${{ secrets.CODECOV_TOKEN }}
-      #   files: lcov.info
-      #   fail_ci_if_error: true
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+      - name: Enforce Coverage Threshold
+        run: cargo llvm-cov report --summary-only --fail-under-lines 95
         
   # Run cargo f --check
   format:


### PR DESCRIPTION
# Rationale for this change

Codecov provides nice coverage report viewing, and is free for public repos. This PR uploads the coverage report to Codecov.

# Are these changes tested?
It will need to be fully tested on the next PR.