### PR TITLE
feat: add minimal `new_parse`

### DIFF
--- a/crates/proof-of-sql/src/sql/mod.rs
+++ b/crates/proof-of-sql/src/sql/mod.rs
@@ -2,6 +2,7 @@
 
 /// This module holds the [`EVMProofPlan`] struct and its implementation, which allows for EVM compatible serialization.
 pub mod evm_proof_plan;
+pub mod new_parse;
 pub mod parse;
 pub mod postprocessing;
 pub mod proof;

--- a/crates/proof-of-sql/src/sql/new_parse/error.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/error.rs
@@ -1,0 +1,191 @@
+use crate::base::{
+    database::{ColumnOperationError, ColumnType, TableRef},
+    math::decimal::{DecimalError, IntermediateDecimalError},
+};
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+};
+use core::result::Result;
+use snafu::Snafu;
+use sqlparser::ast::{Ident, ObjectName};
+
+/// Errors from converting an intermediate AST into a provable AST.
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum ConversionError {
+    #[snafu(display("Column '{identifier}' was not found in table '{table_ref}'"))]
+    /// The column is missing in the table
+    MissingColumn {
+        /// The missing column identifier
+        identifier: Box<Ident>,
+        /// The table ref
+        table_ref: TableRef,
+    },
+
+    #[snafu(display("Missing schema or table identifier in ObjectName"))]
+    /// Missing schema or table identifier
+    MissingSchemaOrTable {
+        /// The `ObjectName`
+        object_name: ObjectName,
+    },
+
+    #[snafu(display("Column '{identifier}' was not found"))]
+    /// The column is missing (without table information)
+    MissingColumnWithoutTable {
+        /// The missing column identifier
+        identifier: Box<Ident>,
+    },
+
+    #[snafu(display("Expected '{expected}' but found '{actual}'"))]
+    /// Invalid data type received
+    InvalidDataType {
+        /// Expected data type
+        expected: ColumnType,
+        /// Actual data type found
+        actual: ColumnType,
+    },
+
+    #[snafu(display("Left side has '{left_type}' type but right side has '{right_type}' type"))]
+    /// Data types do not match
+    DataTypeMismatch {
+        /// The left side datatype
+        left_type: String,
+        /// The right side datatype
+        right_type: String,
+    },
+
+    #[snafu(display("Columns have different lengths: {len_a} != {len_b}"))]
+    /// Two columns do not have the same length
+    DifferentColumnLength {
+        /// The length of the first column
+        len_a: usize,
+        /// The length of the second column
+        len_b: usize,
+    },
+
+    #[snafu(display("Multiple result columns with the same alias '{alias}' have been found."))]
+    /// Duplicate alias in result columns
+    DuplicateResultAlias {
+        /// The duplicate alias
+        alias: String,
+    },
+
+    #[snafu(display(
+        "A WHERE clause must has boolean type. It is currently of type '{datatype}'."
+    ))]
+    /// WHERE clause is not boolean
+    NonbooleanWhereClause {
+        /// The actual datatype of the WHERE clause
+        datatype: ColumnType,
+    },
+
+    #[snafu(display(
+        "Invalid order by: alias '{alias}' does not appear in the result expressions."
+    ))]
+    /// ORDER BY clause references a non-existent alias
+    InvalidOrderBy {
+        /// The non-existent alias in the ORDER BY clause
+        alias: String,
+    },
+
+    #[snafu(display(
+        "Invalid group by: column '{column}' must appear in the group by expression."
+    ))]
+    /// GROUP BY clause references a non-existent column
+    InvalidGroupByColumnRef {
+        /// The non-existent column in the GROUP BY clause
+        column: String,
+    },
+
+    #[snafu(display("Invalid expression: {expression}"))]
+    /// General error for invalid expressions
+    InvalidExpression {
+        /// The invalid expression error
+        expression: String,
+    },
+
+    #[snafu(display("Encountered parsing error: {error}"))]
+    /// General parsing error
+    ParseError {
+        /// The underlying error
+        error: String,
+    },
+
+    #[snafu(transparent)]
+    /// Errors related to decimal operations
+    DecimalConversionError {
+        /// The underlying source error
+        source: DecimalError,
+    },
+
+    /// Errors related to timestamp parsing
+    #[snafu(context(false), display("Timestamp conversion error: {source}"))]
+    TimestampConversionError {
+        /// The underlying source error
+        source: PoSQLTimestampError,
+    },
+
+    /// Errors related to column operations
+    #[snafu(transparent)]
+    ColumnOperationError {
+        /// The underlying source error
+        source: ColumnOperationError,
+    },
+
+    /// Errors related to postprocessing
+    #[snafu(transparent)]
+    PostprocessingError {
+        /// The underlying source error
+        source: crate::sql::postprocessing::PostprocessingError,
+    },
+
+    #[snafu(display("Query not provable because: {error}"))]
+    /// Query requires unprovable feature
+    Unprovable {
+        /// The underlying error
+        error: String,
+    },
+
+    #[snafu(display("Unsupported operator: {message}"))]
+    /// Unsupported operation
+    UnsupportedOperation {
+        /// The operator that is unsupported
+        message: String,
+    },
+}
+
+impl From<String> for ConversionError {
+    fn from(value: String) -> Self {
+        ConversionError::ParseError { error: value }
+    }
+}
+
+impl From<ConversionError> for String {
+    fn from(error: ConversionError) -> Self {
+        error.to_string()
+    }
+}
+
+impl From<IntermediateDecimalError> for ConversionError {
+    fn from(err: IntermediateDecimalError) -> ConversionError {
+        ConversionError::DecimalConversionError {
+            source: DecimalError::IntermediateDecimalConversionError { source: err },
+        }
+    }
+}
+
+impl ConversionError {
+    /// Returns a `ConversionError::InvalidExpression` for non-numeric types used in numeric aggregation functions.
+    pub fn non_numeric_expr_in_agg<S: Into<String>>(dtype: S, func: S) -> Self {
+        ConversionError::InvalidExpression {
+            expression: format!(
+                "cannot use expression of type '{}' with numeric aggregation function '{}'",
+                dtype.into().to_lowercase(),
+                func.into().to_lowercase()
+            ),
+        }
+    }
+}
+
+pub type ConversionResult<T> = Result<T, ConversionError>;

--- a/crates/proof-of-sql/src/sql/new_parse/expr/binary_op.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/expr/binary_op.rs
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::ConversionResult;
+use crate::planner::{ContextProvider, SqlToRel};
+use datafusion_common::{not_impl_err, Result};
+use datafusion_expr::Operator;
+use sqlparser::ast::BinaryOperator;
+
+impl SqlToRel<'_> {
+    pub(crate) fn parse_sql_binary_op(&self, op: BinaryOperator) -> ConversionResult<Operator> {
+        match op {
+            BinaryOperator::Gt => Ok(Operator::Gt),
+            BinaryOperator::GtEq => Ok(Operator::GtEq),
+            BinaryOperator::Lt => Ok(Operator::Lt),
+            BinaryOperator::LtEq => Ok(Operator::LtEq),
+            BinaryOperator::Eq => Ok(Operator::Eq),
+            BinaryOperator::NotEq => Ok(Operator::NotEq),
+            BinaryOperator::Plus => Ok(Operator::Plus),
+            BinaryOperator::Minus => Ok(Operator::Minus),
+            BinaryOperator::Multiply => Ok(Operator::Multiply),
+            BinaryOperator::And => Ok(Operator::And),
+            BinaryOperator::Or => Ok(Operator::Or),
+            _ => Err(ConversionError::NotImplemented(format!(
+                "Binary operator {:?} is not supported",
+                op
+            ))),
+        }
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/expr/identifier.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/expr/identifier.rs
@@ -1,0 +1,506 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::Field;
+use datafusion_common::{
+    internal_err, not_impl_err, plan_datafusion_err, plan_err, Column, DFSchema,
+    DataFusionError, Result, Span, TableReference,
+};
+use datafusion_expr::planner::PlannerResult;
+use datafusion_expr::{Case, Expr};
+use sqlparser::ast::{Expr as SQLExpr, Ident};
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use datafusion_expr::UNNAMED_TABLE;
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    pub(super) fn sql_identifier_to_expr(
+        &self,
+        id: Ident,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let id_span = id.span;
+        if id.value.starts_with('@') {
+            // TODO: figure out if ScalarVariables should be insensitive.
+            let var_names = vec![id.value];
+            let ty = self
+                .context_provider
+                .get_variable_type(&var_names)
+                .ok_or_else(|| {
+                    plan_datafusion_err!("variable {var_names:?} has no type information")
+                })?;
+            Ok(Expr::ScalarVariable(ty, var_names))
+        } else {
+            // Don't use `col()` here because it will try to
+            // interpret names with '.' as if they were
+            // compound identifiers, but this is not a compound
+            // identifier. (e.g. it is "foo.bar" not foo.bar)
+            let normalize_ident = self.ident_normalizer.normalize(id);
+
+            // Check for qualified field with unqualified name
+            if let Ok((qualifier, _)) =
+                schema.qualified_field_with_unqualified_name(normalize_ident.as_str())
+            {
+                let mut column = Column::new(
+                    qualifier.filter(|q| q.table() != UNNAMED_TABLE).cloned(),
+                    normalize_ident,
+                );
+                if self.options.collect_spans {
+                    if let Some(span) = Span::try_from_sqlparser_span(id_span) {
+                        column.spans_mut().add_span(span);
+                    }
+                }
+                return Ok(Expr::Column(column));
+            }
+
+            // Check the outer query schema
+            if let Some(outer) = planner_context.outer_query_schema() {
+                if let Ok((qualifier, field)) =
+                    outer.qualified_field_with_unqualified_name(normalize_ident.as_str())
+                {
+                    // Found an exact match on a qualified name in the outer plan schema, so this is an outer reference column
+                    return Ok(Expr::OuterReferenceColumn(
+                        field.data_type().clone(),
+                        Column::from((qualifier, field)),
+                    ));
+                }
+            }
+
+            // Default case
+            let mut column = Column::new_unqualified(normalize_ident);
+            if self.options.collect_spans {
+                if let Some(span) = Span::try_from_sqlparser_span(id_span) {
+                    column.spans_mut().add_span(span);
+                }
+            }
+            Ok(Expr::Column(column))
+        }
+    }
+
+    pub(crate) fn sql_compound_identifier_to_expr(
+        &self,
+        ids: Vec<Ident>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        if ids.len() < 2 {
+            return internal_err!("Not a compound identifier: {ids:?}");
+        }
+
+        let ids_span = Span::union_iter(
+            ids.iter()
+                .filter_map(|id| Span::try_from_sqlparser_span(id.span)),
+        );
+
+        if ids[0].value.starts_with('@') {
+            let var_names: Vec<_> = ids
+                .into_iter()
+                .map(|id| self.ident_normalizer.normalize(id))
+                .collect();
+            let ty = self
+                .context_provider
+                .get_variable_type(&var_names)
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "variable {var_names:?} has no type information"
+                    ))
+                })?;
+            Ok(Expr::ScalarVariable(ty, var_names))
+        } else {
+            let ids = ids
+                .into_iter()
+                .map(|id| self.ident_normalizer.normalize(id))
+                .collect::<Vec<_>>();
+
+            let search_result = search_dfschema(&ids, schema);
+            match search_result {
+                // Found matching field with spare identifier(s) for nested field(s) in structure
+                Some((field, qualifier, nested_names)) if !nested_names.is_empty() => {
+                    // Found matching field with spare identifier(s) for nested field(s) in structure
+                    for planner in self.context_provider.get_expr_planners() {
+                        if let Ok(planner_result) = planner.plan_compound_identifier(
+                            field,
+                            qualifier,
+                            nested_names,
+                        ) {
+                            match planner_result {
+                                PlannerResult::Planned(expr) => {
+                                    return Ok(expr);
+                                }
+                                PlannerResult::Original(_args) => {}
+                            }
+                        }
+                    }
+                    plan_err!("could not parse compound identifier from {ids:?}")
+                }
+                // Found matching field with no spare identifier(s)
+                Some((field, qualifier, _nested_names)) => {
+                    let mut column = Column::from((qualifier, field));
+                    if self.options.collect_spans {
+                        if let Some(span) = ids_span {
+                            column.spans_mut().add_span(span);
+                        }
+                    }
+                    Ok(Expr::Column(column))
+                }
+                None => {
+                    // Return default where use all identifiers to not have a nested field
+                    // this len check is because at 5 identifiers will have to have a nested field
+                    if ids.len() == 5 {
+                        not_impl_err!("compound identifier: {ids:?}")
+                    } else {
+                        // Check the outer_query_schema and try to find a match
+                        if let Some(outer) = planner_context.outer_query_schema() {
+                            let search_result = search_dfschema(&ids, outer);
+                            match search_result {
+                                // Found matching field with spare identifier(s) for nested field(s) in structure
+                                Some((field, qualifier, nested_names))
+                                    if !nested_names.is_empty() =>
+                                {
+                                    // TODO: remove when can support nested identifiers for OuterReferenceColumn
+                                    not_impl_err!(
+                                        "Nested identifiers are not yet supported for OuterReferenceColumn {}",
+                                        Column::from((qualifier, field)).quoted_flat_name()
+                                    )
+                                }
+                                // Found matching field with no spare identifier(s)
+                                Some((field, qualifier, _nested_names)) => {
+                                    // Found an exact match on a qualified name in the outer plan schema, so this is an outer reference column
+                                    Ok(Expr::OuterReferenceColumn(
+                                        field.data_type().clone(),
+                                        Column::from((qualifier, field)),
+                                    ))
+                                }
+                                // Found no matching field, will return a default
+                                None => {
+                                    let s = &ids[0..ids.len()];
+                                    // safe unwrap as s can never be empty or exceed the bounds
+                                    let (relation, column_name) =
+                                        form_identifier(s).unwrap();
+                                    Ok(Expr::Column(Column::new(relation, column_name)))
+                                }
+                            }
+                        } else {
+                            let s = &ids[0..ids.len()];
+                            // Safe unwrap as s can never be empty or exceed the bounds
+                            let (relation, column_name) = form_identifier(s).unwrap();
+                            let mut column = Column::new(relation, column_name);
+                            if self.options.collect_spans {
+                                if let Some(span) = ids_span {
+                                    column.spans_mut().add_span(span);
+                                }
+                            }
+                            Ok(Expr::Column(column))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) fn sql_case_identifier_to_expr(
+        &self,
+        operand: Option<Box<SQLExpr>>,
+        conditions: Vec<SQLExpr>,
+        results: Vec<SQLExpr>,
+        else_result: Option<Box<SQLExpr>>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let expr = if let Some(e) = operand {
+            Some(Box::new(self.sql_expr_to_logical_expr(
+                *e,
+                schema,
+                planner_context,
+            )?))
+        } else {
+            None
+        };
+        let when_expr = conditions
+            .into_iter()
+            .map(|e| self.sql_expr_to_logical_expr(e, schema, planner_context))
+            .collect::<Result<Vec<_>>>()?;
+        let then_expr = results
+            .into_iter()
+            .map(|e| self.sql_expr_to_logical_expr(e, schema, planner_context))
+            .collect::<Result<Vec<_>>>()?;
+        let else_expr = if let Some(e) = else_result {
+            Some(Box::new(self.sql_expr_to_logical_expr(
+                *e,
+                schema,
+                planner_context,
+            )?))
+        } else {
+            None
+        };
+
+        Ok(Expr::Case(Case::new(
+            expr,
+            when_expr
+                .iter()
+                .zip(then_expr.iter())
+                .map(|(w, t)| (Box::new(w.to_owned()), Box::new(t.to_owned())))
+                .collect(),
+            else_expr,
+        )))
+    }
+}
+
+// (relation, column name)
+fn form_identifier(idents: &[String]) -> Result<(Option<TableReference>, &String)> {
+    match idents.len() {
+        1 => Ok((None, &idents[0])),
+        2 => Ok((
+            Some(TableReference::Bare {
+                table: idents[0].clone().into(),
+            }),
+            &idents[1],
+        )),
+        3 => Ok((
+            Some(TableReference::Partial {
+                schema: idents[0].clone().into(),
+                table: idents[1].clone().into(),
+            }),
+            &idents[2],
+        )),
+        4 => Ok((
+            Some(TableReference::Full {
+                catalog: idents[0].clone().into(),
+                schema: idents[1].clone().into(),
+                table: idents[2].clone().into(),
+            }),
+            &idents[3],
+        )),
+        _ => internal_err!("Incorrect number of identifiers: {}", idents.len()),
+    }
+}
+
+fn search_dfschema<'ids, 'schema>(
+    ids: &'ids [String],
+    schema: &'schema DFSchema,
+) -> Option<(
+    &'schema Field,
+    Option<&'schema TableReference>,
+    &'ids [String],
+)> {
+    generate_schema_search_terms(ids).find_map(|(qualifier, column, nested_names)| {
+        let qualifier_and_field = schema
+            .qualified_field_with_name(qualifier.as_ref(), column)
+            .ok();
+        qualifier_and_field.map(|(qualifier, field)| (field, qualifier, nested_names))
+    })
+}
+
+// Possibilities we search with, in order from top to bottom for each len:
+//
+// len = 2:
+// 1. (table.column)
+// 2. (column).nested
+//
+// len = 3:
+// 1. (schema.table.column)
+// 2. (table.column).nested
+// 3. (column).nested1.nested2
+//
+// len = 4:
+// 1. (catalog.schema.table.column)
+// 2. (schema.table.column).nested1
+// 3. (table.column).nested1.nested2
+// 4. (column).nested1.nested2.nested3
+//
+// len = 5:
+// 1. (catalog.schema.table.column).nested
+// 2. (schema.table.column).nested1.nested2
+// 3. (table.column).nested1.nested2.nested3
+// 4. (column).nested1.nested2.nested3.nested4
+//
+// len > 5:
+// 1. (catalog.schema.table.column).nested[.nestedN]+
+// 2. (schema.table.column).nested1.nested2[.nestedN]+
+// 3. (table.column).nested1.nested2.nested3[.nestedN]+
+// 4. (column).nested1.nested2.nested3.nested4[.nestedN]+
+fn generate_schema_search_terms(
+    ids: &[String],
+) -> impl Iterator<Item = (Option<TableReference>, &String, &[String])> {
+    // Take at most 4 identifiers to form a Column to search with
+    // - 1 for the column name
+    // - 0 to 3 for the TableReference
+    let bound = ids.len().min(4);
+    // Search terms from most specific to least specific
+    (0..bound).rev().map(|i| {
+        let nested_names_index = i + 1;
+        let qualifier_and_column = &ids[0..nested_names_index];
+        // Safe unwrap as qualifier_and_column can never be empty or exceed the bounds
+        let (relation, column_name) = form_identifier(qualifier_and_column).unwrap();
+        (relation, column_name, &ids[nested_names_index..])
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    // testing according to documentation of generate_schema_search_terms function
+    // where it ensures generated search terms are in correct order with correct values
+    fn test_generate_schema_search_terms() -> Result<()> {
+        type ExpectedItem = (
+            Option<TableReference>,
+            &'static str,
+            &'static [&'static str],
+        );
+        fn assert_vec_eq(
+            expected: Vec<ExpectedItem>,
+            actual: Vec<(Option<TableReference>, &String, &[String])>,
+        ) {
+            for (expected, actual) in expected.into_iter().zip(actual) {
+                assert_eq!(expected.0, actual.0, "qualifier");
+                assert_eq!(expected.1, actual.1, "column name");
+                assert_eq!(expected.2, actual.2, "nested names");
+            }
+        }
+
+        let actual = generate_schema_search_terms(&[]).collect::<Vec<_>>();
+        assert!(actual.is_empty());
+
+        let ids = vec!["a".to_string()];
+        let actual = generate_schema_search_terms(&ids).collect::<Vec<_>>();
+        let expected: Vec<ExpectedItem> = vec![(None, "a", &[])];
+        assert_vec_eq(expected, actual);
+
+        let ids = vec!["a".to_string(), "b".to_string()];
+        let actual = generate_schema_search_terms(&ids).collect::<Vec<_>>();
+        let expected: Vec<ExpectedItem> = vec![
+            (Some(TableReference::bare("a")), "b", &[]),
+            (None, "a", &["b"]),
+        ];
+        assert_vec_eq(expected, actual);
+
+        let ids = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let actual = generate_schema_search_terms(&ids).collect::<Vec<_>>();
+        let expected: Vec<ExpectedItem> = vec![
+            (Some(TableReference::partial("a", "b")), "c", &[]),
+            (Some(TableReference::bare("a")), "b", &["c"]),
+            (None, "a", &["b", "c"]),
+        ];
+        assert_vec_eq(expected, actual);
+
+        let ids = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ];
+        let actual = generate_schema_search_terms(&ids).collect::<Vec<_>>();
+        let expected: Vec<ExpectedItem> = vec![
+            (Some(TableReference::full("a", "b", "c")), "d", &[]),
+            (Some(TableReference::partial("a", "b")), "c", &["d"]),
+            (Some(TableReference::bare("a")), "b", &["c", "d"]),
+            (None, "a", &["b", "c", "d"]),
+        ];
+        assert_vec_eq(expected, actual);
+
+        let ids = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+            "e".to_string(),
+        ];
+        let actual = generate_schema_search_terms(&ids).collect::<Vec<_>>();
+        let expected: Vec<ExpectedItem> = vec![
+            (Some(TableReference::full("a", "b", "c")), "d", &["e"]),
+            (Some(TableReference::partial("a", "b")), "c", &["d", "e"]),
+            (Some(TableReference::bare("a")), "b", &["c", "d", "e"]),
+            (None, "a", &["b", "c", "d", "e"]),
+        ];
+        assert_vec_eq(expected, actual);
+
+        let ids = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+            "e".to_string(),
+            "f".to_string(),
+        ];
+        let actual = generate_schema_search_terms(&ids).collect::<Vec<_>>();
+        let expected: Vec<ExpectedItem> = vec![
+            (Some(TableReference::full("a", "b", "c")), "d", &["e", "f"]),
+            (
+                Some(TableReference::partial("a", "b")),
+                "c",
+                &["d", "e", "f"],
+            ),
+            (Some(TableReference::bare("a")), "b", &["c", "d", "e", "f"]),
+            (None, "a", &["b", "c", "d", "e", "f"]),
+        ];
+        assert_vec_eq(expected, actual);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_form_identifier() -> Result<()> {
+        let err = form_identifier(&[]).expect_err("empty identifiers didn't fail");
+        let expected = "Internal error: Incorrect number of identifiers: 0.\n\
+        This was likely caused by a bug in DataFusion's code and we would \
+        welcome that you file an bug report in our issue tracker";
+        assert!(expected.starts_with(&err.strip_backtrace()));
+
+        let ids = vec!["a".to_string()];
+        let (qualifier, column) = form_identifier(&ids)?;
+        assert_eq!(qualifier, None);
+        assert_eq!(column, "a");
+
+        let ids = vec!["a".to_string(), "b".to_string()];
+        let (qualifier, column) = form_identifier(&ids)?;
+        assert_eq!(qualifier, Some(TableReference::bare("a")));
+        assert_eq!(column, "b");
+
+        let ids = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let (qualifier, column) = form_identifier(&ids)?;
+        assert_eq!(qualifier, Some(TableReference::partial("a", "b")));
+        assert_eq!(column, "c");
+
+        let ids = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ];
+        let (qualifier, column) = form_identifier(&ids)?;
+        assert_eq!(qualifier, Some(TableReference::full("a", "b", "c")));
+        assert_eq!(column, "d");
+
+        let err = form_identifier(&[
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+            "e".to_string(),
+        ])
+        .expect_err("too many identifiers didn't fail");
+        let expected = "Internal error: Incorrect number of identifiers: 5.\n\
+        This was likely caused by a bug in DataFusion's code and we would \
+        welcome that you file an bug report in our issue tracker";
+        assert!(expected.starts_with(&err.strip_backtrace()));
+
+        Ok(())
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/expr/mod.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/expr/mod.rs
@@ -1,0 +1,1277 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::datatypes::{DataType, TimeUnit};
+use datafusion_expr::planner::{
+    PlannerResult, RawBinaryExpr, RawDictionaryExpr, RawFieldAccessExpr,
+};
+use sqlparser::ast::{
+    AccessExpr, BinaryOperator, CastFormat, CastKind, DataType as SQLDataType,
+    DictionaryField, Expr as SQLExpr, ExprWithAlias as SQLExprWithAlias, MapEntry,
+    StructField, Subscript, TrimWhereField, Value,
+};
+
+use datafusion_common::{
+    internal_datafusion_err, internal_err, not_impl_err, plan_err, Column, DFSchema,
+    Result, ScalarValue,
+};
+
+use datafusion_expr::expr::ScalarFunction;
+use datafusion_expr::expr::{InList, WildcardOptions};
+use datafusion_expr::{
+    lit, Between, BinaryExpr, Cast, Expr, ExprSchemable, GetFieldAccess, Like, Literal,
+    Operator, TryCast,
+};
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+
+mod binary_op;
+mod identifier;
+mod order_by;
+mod subquery;
+mod substring;
+mod unary_op;
+mod value;
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    pub(crate) fn sql_expr_to_logical_expr_with_alias(
+        &self,
+        sql: SQLExprWithAlias,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let mut expr =
+            self.sql_expr_to_logical_expr(sql.expr, schema, planner_context)?;
+        if let Some(alias) = sql.alias {
+            expr = expr.alias(alias.value);
+        }
+        Ok(expr)
+    }
+    pub(crate) fn sql_expr_to_logical_expr(
+        &self,
+        sql: SQLExpr,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        enum StackEntry {
+            SQLExpr(Box<SQLExpr>),
+            Operator(BinaryOperator),
+        }
+
+        // Virtual stack machine to convert SQLExpr to Expr
+        // This allows visiting the expr tree in a depth-first manner which
+        // produces expressions in postfix notations, i.e. `a + b` => `a b +`.
+        // See https://github.com/apache/datafusion/issues/1444
+        let mut stack = vec![StackEntry::SQLExpr(Box::new(sql))];
+        let mut eval_stack = vec![];
+
+        while let Some(entry) = stack.pop() {
+            match entry {
+                StackEntry::SQLExpr(sql_expr) => {
+                    match *sql_expr {
+                        SQLExpr::BinaryOp { left, op, right } => {
+                            // Note the order that we push the entries to the stack
+                            // is important. We want to visit the left node first.
+                            stack.push(StackEntry::Operator(op));
+                            stack.push(StackEntry::SQLExpr(right));
+                            stack.push(StackEntry::SQLExpr(left));
+                        }
+                        _ => {
+                            let expr = self.sql_expr_to_logical_expr_internal(
+                                *sql_expr,
+                                schema,
+                                planner_context,
+                            )?;
+                            eval_stack.push(expr);
+                        }
+                    }
+                }
+                StackEntry::Operator(op) => {
+                    let right = eval_stack.pop().unwrap();
+                    let left = eval_stack.pop().unwrap();
+                    let expr = self.build_logical_expr(op, left, right, schema)?;
+                    eval_stack.push(expr);
+                }
+            }
+        }
+
+        assert_eq!(1, eval_stack.len());
+        let expr = eval_stack.pop().unwrap();
+        Ok(expr)
+    }
+
+    fn build_logical_expr(
+        &self,
+        op: BinaryOperator,
+        left: Expr,
+        right: Expr,
+        schema: &DFSchema,
+    ) -> Result<Expr> {
+        // try extension planers
+        let mut binary_expr = RawBinaryExpr { op, left, right };
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_binary_op(binary_expr, schema)? {
+                PlannerResult::Planned(expr) => {
+                    return Ok(expr);
+                }
+                PlannerResult::Original(expr) => {
+                    binary_expr = expr;
+                }
+            }
+        }
+
+        let RawBinaryExpr { op, left, right } = binary_expr;
+        Ok(Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(left),
+            self.parse_sql_binary_op(op)?,
+            Box::new(right),
+        )))
+    }
+
+    pub fn sql_to_expr_with_alias(
+        &self,
+        sql: SQLExprWithAlias,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let mut expr =
+            self.sql_expr_to_logical_expr_with_alias(sql, schema, planner_context)?;
+        expr = self.rewrite_partial_qualifier(expr, schema);
+        self.validate_schema_satisfies_exprs(schema, &[expr.clone()])?;
+        let (expr, _) = expr.infer_placeholder_types(schema)?;
+        Ok(expr)
+    }
+
+    /// Generate a relational expression from a SQL expression
+    pub fn sql_to_expr(
+        &self,
+        sql: SQLExpr,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        // The location of the original SQL expression in the source code
+        let mut expr = self.sql_expr_to_logical_expr(sql, schema, planner_context)?;
+        expr = self.rewrite_partial_qualifier(expr, schema);
+        self.validate_schema_satisfies_exprs(schema, std::slice::from_ref(&expr))?;
+        let (expr, _) = expr.infer_placeholder_types(schema)?;
+        Ok(expr)
+    }
+
+    /// Rewrite aliases which are not-complete (e.g. ones that only include only table qualifier in a schema.table qualified relation)
+    fn rewrite_partial_qualifier(&self, expr: Expr, schema: &DFSchema) -> Expr {
+        match expr {
+            Expr::Column(col) => match &col.relation {
+                Some(q) => {
+                    match schema.iter().find(|(qualifier, field)| match qualifier {
+                        Some(field_q) => {
+                            field.name() == &col.name
+                                && field_q.to_string().ends_with(&format!(".{q}"))
+                        }
+                        _ => false,
+                    }) {
+                        Some((qualifier, df_field)) => Expr::from((qualifier, df_field)),
+                        None => Expr::Column(col),
+                    }
+                }
+                None => Expr::Column(col),
+            },
+            _ => expr,
+        }
+    }
+
+    /// Internal implementation. Use
+    /// [`Self::sql_expr_to_logical_expr`] to plan exprs.
+    #[cfg_attr(feature = "recursive_protection", recursive::recursive)]
+    fn sql_expr_to_logical_expr_internal(
+        &self,
+        sql: SQLExpr,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        // NOTE: This function is called recursively, so each match arm body should be as
+        //       small as possible to decrease stack requirement.
+        //       Follow the common pattern of extracting into a separate function for
+        //       non-trivial arms. See https://github.com/apache/datafusion/pull/12384 for
+        //       more context.
+        match sql {
+            SQLExpr::Value(value) => {
+                self.parse_value(value, planner_context.prepare_param_data_types())
+            }
+            SQLExpr::Extract { field, expr, .. } => {
+                let mut extract_args = vec![
+                    Expr::Literal(ScalarValue::from(format!("{field}"))),
+                    self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+                ];
+
+                for planner in self.context_provider.get_expr_planners() {
+                    match planner.plan_extract(extract_args)? {
+                        PlannerResult::Planned(expr) => return Ok(expr),
+                        PlannerResult::Original(args) => {
+                            extract_args = args;
+                        }
+                    }
+                }
+
+                not_impl_err!("Extract not supported by ExprPlanner: {extract_args:?}")
+            }
+
+            SQLExpr::Array(arr) => self.sql_array_literal(arr.elem, schema),
+            SQLExpr::Interval(interval) => self.sql_interval_to_expr(false, interval),
+            SQLExpr::Identifier(id) => {
+                self.sql_identifier_to_expr(id, schema, planner_context)
+            }
+
+            // <expr>["foo"], <expr>[4] or <expr>[4:5]
+            SQLExpr::CompoundFieldAccess { root, access_chain } => self
+                .sql_compound_field_access_to_expr(
+                    *root,
+                    access_chain,
+                    schema,
+                    planner_context,
+                ),
+
+            SQLExpr::CompoundIdentifier(ids) => {
+                self.sql_compound_identifier_to_expr(ids, schema, planner_context)
+            }
+
+            SQLExpr::Case {
+                operand,
+                conditions,
+                results,
+                else_result,
+            } => self.sql_case_identifier_to_expr(
+                operand,
+                conditions,
+                results,
+                else_result,
+                schema,
+                planner_context,
+            ),
+
+            SQLExpr::Cast {
+                kind: CastKind::Cast | CastKind::DoubleColon,
+                expr,
+                data_type,
+                format,
+            } => self.sql_cast_to_expr(*expr, data_type, format, schema, planner_context),
+
+            SQLExpr::Cast {
+                kind: CastKind::TryCast | CastKind::SafeCast,
+                expr,
+                data_type,
+                format,
+            } => {
+                if let Some(format) = format {
+                    return not_impl_err!("CAST with format is not supported: {format}");
+                }
+
+                Ok(Expr::TryCast(TryCast::new(
+                    Box::new(self.sql_expr_to_logical_expr(
+                        *expr,
+                        schema,
+                        planner_context,
+                    )?),
+                    self.convert_data_type(&data_type)?,
+                )))
+            }
+
+            SQLExpr::TypedString { data_type, value } => Ok(Expr::Cast(Cast::new(
+                Box::new(lit(value)),
+                self.convert_data_type(&data_type)?,
+            ))),
+
+            SQLExpr::IsNull(expr) => Ok(Expr::IsNull(Box::new(
+                self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+            ))),
+
+            SQLExpr::IsNotNull(expr) => Ok(Expr::IsNotNull(Box::new(
+                self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+            ))),
+
+            SQLExpr::IsDistinctFrom(left, right) => {
+                Ok(Expr::BinaryExpr(BinaryExpr::new(
+                    Box::new(self.sql_expr_to_logical_expr(
+                        *left,
+                        schema,
+                        planner_context,
+                    )?),
+                    Operator::IsDistinctFrom,
+                    Box::new(self.sql_expr_to_logical_expr(
+                        *right,
+                        schema,
+                        planner_context,
+                    )?),
+                )))
+            }
+
+            SQLExpr::IsNotDistinctFrom(left, right) => {
+                Ok(Expr::BinaryExpr(BinaryExpr::new(
+                    Box::new(self.sql_expr_to_logical_expr(
+                        *left,
+                        schema,
+                        planner_context,
+                    )?),
+                    Operator::IsNotDistinctFrom,
+                    Box::new(self.sql_expr_to_logical_expr(
+                        *right,
+                        schema,
+                        planner_context,
+                    )?),
+                )))
+            }
+
+            SQLExpr::IsTrue(expr) => Ok(Expr::IsTrue(Box::new(
+                self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+            ))),
+
+            SQLExpr::IsFalse(expr) => Ok(Expr::IsFalse(Box::new(
+                self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+            ))),
+
+            SQLExpr::IsNotTrue(expr) => Ok(Expr::IsNotTrue(Box::new(
+                self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+            ))),
+
+            SQLExpr::IsNotFalse(expr) => Ok(Expr::IsNotFalse(Box::new(
+                self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+            ))),
+
+            SQLExpr::IsUnknown(expr) => Ok(Expr::IsUnknown(Box::new(
+                self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+            ))),
+
+            SQLExpr::IsNotUnknown(expr) => Ok(Expr::IsNotUnknown(Box::new(
+                self.sql_expr_to_logical_expr(*expr, schema, planner_context)?,
+            ))),
+
+            SQLExpr::UnaryOp { op, expr } => {
+                self.parse_sql_unary_op(op, *expr, schema, planner_context)
+            }
+
+            SQLExpr::Between {
+                expr,
+                negated,
+                low,
+                high,
+            } => Ok(Expr::Between(Between::new(
+                Box::new(self.sql_expr_to_logical_expr(
+                    *expr,
+                    schema,
+                    planner_context,
+                )?),
+                negated,
+                Box::new(self.sql_expr_to_logical_expr(*low, schema, planner_context)?),
+                Box::new(self.sql_expr_to_logical_expr(
+                    *high,
+                    schema,
+                    planner_context,
+                )?),
+            ))),
+
+            SQLExpr::InList {
+                expr,
+                list,
+                negated,
+            } => self.sql_in_list_to_expr(*expr, list, negated, schema, planner_context),
+
+            SQLExpr::Like {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+                any,
+            } => self.sql_like_to_expr(
+                negated,
+                *expr,
+                *pattern,
+                escape_char,
+                schema,
+                planner_context,
+                false,
+                any,
+            ),
+
+            SQLExpr::ILike {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+                any,
+            } => self.sql_like_to_expr(
+                negated,
+                *expr,
+                *pattern,
+                escape_char,
+                schema,
+                planner_context,
+                true,
+                any,
+            ),
+
+            SQLExpr::SimilarTo {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+            } => self.sql_similarto_to_expr(
+                negated,
+                *expr,
+                *pattern,
+                escape_char,
+                schema,
+                planner_context,
+            ),
+
+            SQLExpr::BinaryOp { .. } => {
+                internal_err!("binary_op should be handled by sql_expr_to_logical_expr.")
+            }
+
+            #[cfg(feature = "unicode_expressions")]
+            SQLExpr::Substring {
+                expr,
+                substring_from,
+                substring_for,
+                special: _,
+            } => self.sql_substring_to_expr(
+                expr,
+                substring_from,
+                substring_for,
+                schema,
+                planner_context,
+            ),
+
+            #[cfg(not(feature = "unicode_expressions"))]
+            SQLExpr::Substring { .. } => {
+                internal_err!(
+                    "statement substring requires compilation with feature flag: unicode_expressions."
+                )
+            }
+
+            SQLExpr::Trim {
+                expr,
+                trim_where,
+                trim_what,
+                trim_characters,
+            } => self.sql_trim_to_expr(
+                *expr,
+                trim_where,
+                trim_what,
+                trim_characters,
+                schema,
+                planner_context,
+            ),
+
+            SQLExpr::Function(function) => {
+                self.sql_function_to_expr(function, schema, planner_context)
+            }
+
+            SQLExpr::Rollup(exprs) => {
+                self.sql_rollup_to_expr(exprs, schema, planner_context)
+            }
+            SQLExpr::Cube(exprs) => self.sql_cube_to_expr(exprs, schema, planner_context),
+            SQLExpr::GroupingSets(exprs) => {
+                self.sql_grouping_sets_to_expr(exprs, schema, planner_context)
+            }
+
+            SQLExpr::Floor {
+                expr,
+                field: _field,
+            } => self.sql_fn_name_to_expr(*expr, "floor", schema, planner_context),
+            SQLExpr::Ceil {
+                expr,
+                field: _field,
+            } => self.sql_fn_name_to_expr(*expr, "ceil", schema, planner_context),
+            SQLExpr::Overlay {
+                expr,
+                overlay_what,
+                overlay_from,
+                overlay_for,
+            } => self.sql_overlay_to_expr(
+                *expr,
+                *overlay_what,
+                *overlay_from,
+                overlay_for,
+                schema,
+                planner_context,
+            ),
+            SQLExpr::Nested(e) => {
+                self.sql_expr_to_logical_expr(*e, schema, planner_context)
+            }
+
+            SQLExpr::Exists { subquery, negated } => {
+                self.parse_exists_subquery(*subquery, negated, schema, planner_context)
+            }
+            SQLExpr::InSubquery {
+                expr,
+                subquery,
+                negated,
+            } => {
+                self.parse_in_subquery(*expr, *subquery, negated, schema, planner_context)
+            }
+            SQLExpr::Subquery(subquery) => {
+                self.parse_scalar_subquery(*subquery, schema, planner_context)
+            }
+
+            SQLExpr::Struct { values, fields } => {
+                self.parse_struct(schema, planner_context, values, fields)
+            }
+            SQLExpr::Position { expr, r#in } => {
+                self.sql_position_to_expr(*expr, *r#in, schema, planner_context)
+            }
+            SQLExpr::AtTimeZone {
+                timestamp,
+                time_zone,
+            } => Ok(Expr::Cast(Cast::new(
+                Box::new(self.sql_expr_to_logical_expr_internal(
+                    *timestamp,
+                    schema,
+                    planner_context,
+                )?),
+                match *time_zone {
+                    SQLExpr::Value(Value::SingleQuotedString(s)) => {
+                        DataType::Timestamp(TimeUnit::Nanosecond, Some(s.into()))
+                    }
+                    _ => {
+                        return not_impl_err!(
+                            "Unsupported ast node in sqltorel: {time_zone:?}"
+                        )
+                    }
+                },
+            ))),
+            SQLExpr::Dictionary(fields) => {
+                self.try_plan_dictionary_literal(fields, schema, planner_context)
+            }
+            SQLExpr::Map(map) => {
+                self.try_plan_map_literal(map.entries, schema, planner_context)
+            }
+            SQLExpr::AnyOp {
+                left,
+                compare_op,
+                right,
+                // ANY/SOME are equivalent, this field specifies which the user
+                // specified but it doesn't affect the plan so ignore the field
+                is_some: _,
+            } => {
+                let mut binary_expr = RawBinaryExpr {
+                    op: compare_op,
+                    left: self.sql_expr_to_logical_expr(
+                        *left,
+                        schema,
+                        planner_context,
+                    )?,
+                    right: self.sql_expr_to_logical_expr(
+                        *right,
+                        schema,
+                        planner_context,
+                    )?,
+                };
+                for planner in self.context_provider.get_expr_planners() {
+                    match planner.plan_any(binary_expr)? {
+                        PlannerResult::Planned(expr) => {
+                            return Ok(expr);
+                        }
+                        PlannerResult::Original(expr) => {
+                            binary_expr = expr;
+                        }
+                    }
+                }
+                not_impl_err!("AnyOp not supported by ExprPlanner: {binary_expr:?}")
+            }
+            SQLExpr::Wildcard(_token) => Ok(Expr::Wildcard {
+                qualifier: None,
+                options: Box::new(WildcardOptions::default()),
+            }),
+            SQLExpr::QualifiedWildcard(object_name, _token) => Ok(Expr::Wildcard {
+                qualifier: Some(self.object_name_to_table_reference(object_name)?),
+                options: Box::new(WildcardOptions::default()),
+            }),
+            SQLExpr::Tuple(values) => self.parse_tuple(schema, planner_context, values),
+            _ => not_impl_err!("Unsupported ast node in sqltorel: {sql:?}"),
+        }
+    }
+
+    /// Parses a struct(..) expression and plans it creation
+    fn parse_struct(
+        &self,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+        values: Vec<SQLExpr>,
+        fields: Vec<StructField>,
+    ) -> Result<Expr> {
+        if !fields.is_empty() {
+            return not_impl_err!("Struct fields are not supported yet");
+        }
+        let is_named_struct = values
+            .iter()
+            .any(|value| matches!(value, SQLExpr::Named { .. }));
+
+        let mut create_struct_args = if is_named_struct {
+            self.create_named_struct_expr(values, schema, planner_context)?
+        } else {
+            self.create_struct_expr(values, schema, planner_context)?
+        };
+
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_struct_literal(create_struct_args, is_named_struct)? {
+                PlannerResult::Planned(expr) => return Ok(expr),
+                PlannerResult::Original(args) => create_struct_args = args,
+            }
+        }
+        not_impl_err!("Struct not supported by ExprPlanner: {create_struct_args:?}")
+    }
+
+    fn parse_tuple(
+        &self,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+        values: Vec<SQLExpr>,
+    ) -> Result<Expr> {
+        match values.first() {
+            Some(SQLExpr::Identifier(_)) | Some(SQLExpr::Value(_)) => {
+                self.parse_struct(schema, planner_context, values, vec![])
+            }
+            None => not_impl_err!("Empty tuple not supported yet"),
+            _ => {
+                not_impl_err!("Only identifiers and literals are supported in tuples")
+            }
+        }
+    }
+
+    fn sql_position_to_expr(
+        &self,
+        substr_expr: SQLExpr,
+        str_expr: SQLExpr,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let substr =
+            self.sql_expr_to_logical_expr(substr_expr, schema, planner_context)?;
+        let fullstr = self.sql_expr_to_logical_expr(str_expr, schema, planner_context)?;
+        let mut position_args = vec![fullstr, substr];
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_position(position_args)? {
+                PlannerResult::Planned(expr) => return Ok(expr),
+                PlannerResult::Original(args) => {
+                    position_args = args;
+                }
+            }
+        }
+
+        not_impl_err!("Position not supported by ExprPlanner: {position_args:?}")
+    }
+
+    fn try_plan_dictionary_literal(
+        &self,
+        fields: Vec<DictionaryField>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let mut keys = vec![];
+        let mut values = vec![];
+        for field in fields {
+            let key = lit(field.key.value);
+            let value =
+                self.sql_expr_to_logical_expr(*field.value, schema, planner_context)?;
+            keys.push(key);
+            values.push(value);
+        }
+
+        let mut raw_expr = RawDictionaryExpr { keys, values };
+
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_dictionary_literal(raw_expr, schema)? {
+                PlannerResult::Planned(expr) => {
+                    return Ok(expr);
+                }
+                PlannerResult::Original(expr) => raw_expr = expr,
+            }
+        }
+        not_impl_err!("Dictionary not supported by ExprPlanner: {raw_expr:?}")
+    }
+
+    fn try_plan_map_literal(
+        &self,
+        entries: Vec<MapEntry>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let mut exprs: Vec<_> = entries
+            .into_iter()
+            .flat_map(|entry| vec![entry.key, entry.value].into_iter())
+            .map(|expr| self.sql_expr_to_logical_expr(*expr, schema, planner_context))
+            .collect::<Result<Vec<_>>>()?;
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_make_map(exprs)? {
+                PlannerResult::Planned(expr) => {
+                    return Ok(expr);
+                }
+                PlannerResult::Original(expr) => exprs = expr,
+            }
+        }
+        not_impl_err!("MAP not supported by ExprPlanner: {exprs:?}")
+    }
+
+    // Handles a call to struct(...) where the arguments are named. For example
+    // `struct (v as foo, v2 as bar)` by creating a call to the `named_struct` function
+    fn create_named_struct_expr(
+        &self,
+        values: Vec<SQLExpr>,
+        input_schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Vec<Expr>> {
+        Ok(values
+            .into_iter()
+            .enumerate()
+            .map(|(i, value)| {
+                let args = if let SQLExpr::Named { expr, name } = value {
+                    [
+                        name.value.lit(),
+                        self.sql_expr_to_logical_expr(
+                            *expr,
+                            input_schema,
+                            planner_context,
+                        )?,
+                    ]
+                } else {
+                    [
+                        format!("c{i}").lit(),
+                        self.sql_expr_to_logical_expr(
+                            value,
+                            input_schema,
+                            planner_context,
+                        )?,
+                    ]
+                };
+
+                Ok(args)
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect())
+    }
+
+    // Handles a call to struct(...) where the arguments are not named. For example
+    // `struct (v, v2)` by creating a call to the `struct` function
+    // which will create a struct with fields named `c0`, `c1`, etc.
+    fn create_struct_expr(
+        &self,
+        values: Vec<SQLExpr>,
+        input_schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Vec<Expr>> {
+        values
+            .into_iter()
+            .map(|value| {
+                self.sql_expr_to_logical_expr(value, input_schema, planner_context)
+            })
+            .collect::<Result<Vec<_>>>()
+    }
+
+    fn sql_in_list_to_expr(
+        &self,
+        expr: SQLExpr,
+        list: Vec<SQLExpr>,
+        negated: bool,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let list_expr = list
+            .into_iter()
+            .map(|e| self.sql_expr_to_logical_expr(e, schema, planner_context))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Expr::InList(InList::new(
+            Box::new(self.sql_expr_to_logical_expr(expr, schema, planner_context)?),
+            list_expr,
+            negated,
+        )))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn sql_like_to_expr(
+        &self,
+        negated: bool,
+        expr: SQLExpr,
+        pattern: SQLExpr,
+        escape_char: Option<String>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+        case_insensitive: bool,
+        any: bool,
+    ) -> Result<Expr> {
+        if any {
+            return not_impl_err!("ANY in LIKE expression");
+        }
+        let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
+        let escape_char = if let Some(char) = escape_char {
+            if char.len() != 1 {
+                return plan_err!("Invalid escape character in LIKE expression");
+            }
+            Some(char.chars().next().unwrap())
+        } else {
+            None
+        };
+        Ok(Expr::Like(Like::new(
+            negated,
+            Box::new(self.sql_expr_to_logical_expr(expr, schema, planner_context)?),
+            Box::new(pattern),
+            escape_char,
+            case_insensitive,
+        )))
+    }
+
+    fn sql_similarto_to_expr(
+        &self,
+        negated: bool,
+        expr: SQLExpr,
+        pattern: SQLExpr,
+        escape_char: Option<String>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let pattern = self.sql_expr_to_logical_expr(pattern, schema, planner_context)?;
+        let pattern_type = pattern.get_type(schema)?;
+        if pattern_type != DataType::Utf8 && pattern_type != DataType::Null {
+            return plan_err!("Invalid pattern in SIMILAR TO expression");
+        }
+        let escape_char = if let Some(char) = escape_char {
+            if char.len() != 1 {
+                return plan_err!("Invalid escape character in SIMILAR TO expression");
+            }
+            Some(char.chars().next().unwrap())
+        } else {
+            None
+        };
+        Ok(Expr::SimilarTo(Like::new(
+            negated,
+            Box::new(self.sql_expr_to_logical_expr(expr, schema, planner_context)?),
+            Box::new(pattern),
+            escape_char,
+            false,
+        )))
+    }
+
+    fn sql_trim_to_expr(
+        &self,
+        expr: SQLExpr,
+        trim_where: Option<TrimWhereField>,
+        trim_what: Option<Box<SQLExpr>>,
+        trim_characters: Option<Vec<SQLExpr>>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let arg = self.sql_expr_to_logical_expr(expr, schema, planner_context)?;
+        let args = match (trim_what, trim_characters) {
+            (Some(to_trim), None) => {
+                let to_trim =
+                    self.sql_expr_to_logical_expr(*to_trim, schema, planner_context)?;
+                Ok(vec![arg, to_trim])
+            }
+            (None, Some(trim_characters)) => {
+                if let Some(first) = trim_characters.first() {
+                    let to_trim = self.sql_expr_to_logical_expr(
+                        first.clone(),
+                        schema,
+                        planner_context,
+                    )?;
+                    Ok(vec![arg, to_trim])
+                } else {
+                    plan_err!("TRIM CHARACTERS cannot be empty")
+                }
+            }
+            (Some(_), Some(_)) => {
+                plan_err!("Both TRIM and TRIM CHARACTERS cannot be specified")
+            }
+            (None, None) => Ok(vec![arg]),
+        }?;
+
+        let fun_name = match trim_where {
+            Some(TrimWhereField::Leading) => "ltrim",
+            Some(TrimWhereField::Trailing) => "rtrim",
+            Some(TrimWhereField::Both) => "btrim",
+            None => "trim",
+        };
+        let fun = self
+            .context_provider
+            .get_function_meta(fun_name)
+            .ok_or_else(|| {
+                internal_datafusion_err!("Unable to find expected '{fun_name}' function")
+            })?;
+
+        Ok(Expr::ScalarFunction(ScalarFunction::new_udf(fun, args)))
+    }
+
+    fn sql_overlay_to_expr(
+        &self,
+        expr: SQLExpr,
+        overlay_what: SQLExpr,
+        overlay_from: SQLExpr,
+        overlay_for: Option<Box<SQLExpr>>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let arg = self.sql_expr_to_logical_expr(expr, schema, planner_context)?;
+        let what_arg =
+            self.sql_expr_to_logical_expr(overlay_what, schema, planner_context)?;
+        let from_arg =
+            self.sql_expr_to_logical_expr(overlay_from, schema, planner_context)?;
+        let mut overlay_args = match overlay_for {
+            Some(for_expr) => {
+                let for_expr =
+                    self.sql_expr_to_logical_expr(*for_expr, schema, planner_context)?;
+                vec![arg, what_arg, from_arg, for_expr]
+            }
+            None => vec![arg, what_arg, from_arg],
+        };
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_overlay(overlay_args)? {
+                PlannerResult::Planned(expr) => return Ok(expr),
+                PlannerResult::Original(args) => overlay_args = args,
+            }
+        }
+        not_impl_err!("Overlay not supported by ExprPlanner: {overlay_args:?}")
+    }
+
+    fn sql_cast_to_expr(
+        &self,
+        expr: SQLExpr,
+        data_type: SQLDataType,
+        format: Option<CastFormat>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        if let Some(format) = format {
+            return not_impl_err!("CAST with format is not supported: {format}");
+        }
+
+        let dt = self.convert_data_type(&data_type)?;
+        let expr = self.sql_expr_to_logical_expr(expr, schema, planner_context)?;
+
+        // numeric constants are treated as seconds (rather as nanoseconds)
+        // to align with postgres / duckdb semantics
+        let expr = match &dt {
+            DataType::Timestamp(TimeUnit::Nanosecond, tz)
+                if expr.get_type(schema)? == DataType::Int64 =>
+            {
+                Expr::Cast(Cast::new(
+                    Box::new(expr),
+                    DataType::Timestamp(TimeUnit::Second, tz.clone()),
+                ))
+            }
+            _ => expr,
+        };
+
+        Ok(Expr::Cast(Cast::new(Box::new(expr), dt)))
+    }
+
+    fn sql_compound_field_access_to_expr(
+        &self,
+        root: SQLExpr,
+        access_chain: Vec<AccessExpr>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let mut root = self.sql_expr_to_logical_expr(root, schema, planner_context)?;
+        let fields = access_chain
+            .into_iter()
+            .map(|field| match field {
+                AccessExpr::Subscript(subscript) => {
+                    match subscript {
+                        Subscript::Index { index } => {
+                            // index can be a name, in which case it is a named field access
+                            match index {
+                                SQLExpr::Value(
+                                    Value::SingleQuotedString(s)
+                                    | Value::DoubleQuotedString(s),
+                                ) => Ok(Some(GetFieldAccess::NamedStructField {
+                                    name: ScalarValue::from(s),
+                                })),
+                                SQLExpr::JsonAccess { .. } => {
+                                    not_impl_err!("JsonAccess")
+                                }
+                                // otherwise treat like a list index
+                                _ => Ok(Some(GetFieldAccess::ListIndex {
+                                    key: Box::new(self.sql_expr_to_logical_expr(
+                                        index,
+                                        schema,
+                                        planner_context,
+                                    )?),
+                                })),
+                            }
+                        }
+                        Subscript::Slice {
+                            lower_bound,
+                            upper_bound,
+                            stride,
+                        } => {
+                            // Means access like [:2]
+                            let lower_bound = if let Some(lower_bound) = lower_bound {
+                                self.sql_expr_to_logical_expr(
+                                    lower_bound,
+                                    schema,
+                                    planner_context,
+                                )
+                            } else {
+                                not_impl_err!("Slice subscript requires a lower bound")
+                            }?;
+
+                            // means access like [2:]
+                            let upper_bound = if let Some(upper_bound) = upper_bound {
+                                self.sql_expr_to_logical_expr(
+                                    upper_bound,
+                                    schema,
+                                    planner_context,
+                                )
+                            } else {
+                                not_impl_err!("Slice subscript requires an upper bound")
+                            }?;
+
+                            // stride, default to 1
+                            let stride = if let Some(stride) = stride {
+                                self.sql_expr_to_logical_expr(
+                                    stride,
+                                    schema,
+                                    planner_context,
+                                )?
+                            } else {
+                                lit(1i64)
+                            };
+
+                            Ok(Some(GetFieldAccess::ListRange {
+                                start: Box::new(lower_bound),
+                                stop: Box::new(upper_bound),
+                                stride: Box::new(stride),
+                            }))
+                        }
+                    }
+                }
+                AccessExpr::Dot(expr) => {
+                    let expr =
+                        self.sql_expr_to_logical_expr(expr, schema, planner_context)?;
+                    match expr {
+                        Expr::Column(Column {
+                            name,
+                            relation,
+                            spans,
+                        }) => {
+                            if let Some(relation) = &relation {
+                                // If the first part of the dot access is a column reference, we should
+                                // check if the column is from the same table as the root expression.
+                                // If it is, we should replace the root expression with the column reference.
+                                // Otherwise, we should treat the dot access as a named field access.
+                                if relation.table() == root.schema_name().to_string() {
+                                    root = Expr::Column(Column {
+                                        name,
+                                        relation: Some(relation.clone()),
+                                        spans,
+                                    });
+                                    Ok(None)
+                                } else {
+                                    plan_err!(
+                                        "table name mismatch: {} != {}",
+                                        relation.table(),
+                                        root.schema_name()
+                                    )
+                                }
+                            } else {
+                                Ok(Some(GetFieldAccess::NamedStructField {
+                                    name: ScalarValue::from(name),
+                                }))
+                            }
+                        }
+                        _ => not_impl_err!(
+                            "Dot access not supported for non-column expr: {expr:?}"
+                        ),
+                    }
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        fields
+            .into_iter()
+            .flatten()
+            .try_fold(root, |expr, field_access| {
+                let mut field_access_expr = RawFieldAccessExpr { expr, field_access };
+                for planner in self.context_provider.get_expr_planners() {
+                    match planner.plan_field_access(field_access_expr, schema)? {
+                        PlannerResult::Planned(expr) => return Ok(expr),
+                        PlannerResult::Original(expr) => {
+                            field_access_expr = expr;
+                        }
+                    }
+                }
+                not_impl_err!(
+                    "GetFieldAccess not supported by ExprPlanner: {field_access_expr:?}"
+                )
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use arrow::datatypes::{Field, Schema};
+    use sqlparser::dialect::GenericDialect;
+    use sqlparser::parser::Parser;
+
+    use datafusion_common::config::ConfigOptions;
+    use datafusion_common::TableReference;
+    use datafusion_expr::logical_plan::builder::LogicalTableSource;
+    use datafusion_expr::{AggregateUDF, ScalarUDF, TableSource, WindowUDF};
+
+    use super::*;
+
+    struct TestContextProvider {
+        options: ConfigOptions,
+        tables: HashMap<String, Arc<dyn TableSource>>,
+    }
+
+    impl TestContextProvider {
+        pub fn new() -> Self {
+            let mut tables = HashMap::new();
+            tables.insert(
+                "table1".to_string(),
+                create_table_source(vec![Field::new(
+                    "column1".to_string(),
+                    DataType::Utf8,
+                    false,
+                )]),
+            );
+
+            Self {
+                options: Default::default(),
+                tables,
+            }
+        }
+    }
+
+    impl ContextProvider for TestContextProvider {
+        fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
+            match self.tables.get(name.table()) {
+                Some(table) => Ok(Arc::clone(table)),
+                _ => plan_err!("Table not found: {}", name.table()),
+            }
+        }
+
+        fn get_function_meta(&self, _name: &str) -> Option<Arc<ScalarUDF>> {
+            None
+        }
+
+        fn get_aggregate_meta(&self, name: &str) -> Option<Arc<AggregateUDF>> {
+            match name {
+                "sum" => Some(datafusion_functions_aggregate::sum::sum_udaf()),
+                _ => None,
+            }
+        }
+
+        fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
+            None
+        }
+
+        fn options(&self) -> &ConfigOptions {
+            &self.options
+        }
+
+        fn get_window_meta(&self, _name: &str) -> Option<Arc<WindowUDF>> {
+            None
+        }
+
+        fn udf_names(&self) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn udaf_names(&self) -> Vec<String> {
+            vec!["sum".to_string()]
+        }
+
+        fn udwf_names(&self) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    fn create_table_source(fields: Vec<Field>) -> Arc<dyn TableSource> {
+        Arc::new(LogicalTableSource::new(Arc::new(
+            Schema::new_with_metadata(fields, HashMap::new()),
+        )))
+    }
+
+    macro_rules! test_stack_overflow {
+        ($num_expr:expr) => {
+            paste::item! {
+                #[test]
+                fn [<test_stack_overflow_ $num_expr>]() {
+                    let schema = DFSchema::empty();
+                    let mut planner_context = PlannerContext::default();
+
+                    let expr_str = (0..$num_expr)
+                        .map(|i| format!("column1 = 'value{:?}'", i))
+                        .collect::<Vec<String>>()
+                        .join(" OR ");
+
+                    let dialect = GenericDialect{};
+                    let mut parser = Parser::new(&dialect)
+                        .try_with_sql(expr_str.as_str())
+                        .unwrap();
+                    let sql_expr = parser.parse_expr().unwrap();
+
+                    let context_provider = TestContextProvider::new();
+                    let sql_to_rel = SqlToRel::new(&context_provider);
+
+                    // Should not stack overflow
+                    sql_to_rel.sql_expr_to_logical_expr(
+                        sql_expr,
+                        &schema,
+                        &mut planner_context,
+                    ).unwrap();
+                }
+            }
+        };
+    }
+
+    test_stack_overflow!(64);
+    test_stack_overflow!(128);
+    test_stack_overflow!(256);
+    test_stack_overflow!(512);
+    test_stack_overflow!(1024);
+    test_stack_overflow!(2048);
+    test_stack_overflow!(4096);
+    test_stack_overflow!(8192);
+    #[test]
+    fn test_sql_to_expr_with_alias() {
+        let schema = DFSchema::empty();
+        let mut planner_context = PlannerContext::default();
+
+        let expr_str = "SUM(int_col) as sum_int_col";
+
+        let dialect = GenericDialect {};
+        let mut parser = Parser::new(&dialect).try_with_sql(expr_str).unwrap();
+        // from sqlparser
+        let sql_expr = parser.parse_expr_with_alias().unwrap();
+
+        let context_provider = TestContextProvider::new();
+        let sql_to_rel = SqlToRel::new(&context_provider);
+
+        let expr = sql_to_rel
+            .sql_expr_to_logical_expr_with_alias(sql_expr, &schema, &mut planner_context)
+            .unwrap();
+
+        assert!(matches!(expr, Expr::Alias(_)));
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/expr/order_by.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/expr/order_by.rs
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use datafusion_common::{
+    not_impl_err, plan_datafusion_err, plan_err, Column, DFSchema, Result,
+};
+use datafusion_expr::expr::Sort;
+use datafusion_expr::{Expr, SortExpr};
+use sqlparser::ast::{Expr as SQLExpr, OrderByExpr, Value};
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    /// Convert sql [OrderByExpr] to `Vec<Expr>`.
+    ///
+    /// `input_schema` and `additional_schema` are used to resolve column references in the order-by expressions.
+    /// `input_schema` is the schema of the input logical plan, typically derived from the SELECT list.
+    ///
+    /// Usually order-by expressions can only reference the input plan's columns.
+    /// But the `SELECT ... FROM ... ORDER BY ...` syntax is a special case. Besides the input schema,
+    /// it can reference an `additional_schema` derived from the `FROM` clause.
+    ///
+    /// If `literal_to_column` is true, treat any numeric literals (e.g. `2`) as a 1 based index into the
+    /// SELECT list (e.g. `SELECT a, b FROM table ORDER BY 2`). Literals only reference the `input_schema`.
+    ///
+    /// If false, interpret numeric literals as constant values.
+    pub(crate) fn order_by_to_sort_expr(
+        &self,
+        exprs: Vec<OrderByExpr>,
+        input_schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+        literal_to_column: bool,
+        additional_schema: Option<&DFSchema>,
+    ) -> Result<Vec<SortExpr>> {
+        if exprs.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut combined_schema;
+        let order_by_schema = match additional_schema {
+            Some(schema) => {
+                combined_schema = input_schema.clone();
+                combined_schema.merge(schema);
+                &combined_schema
+            }
+            None => input_schema,
+        };
+
+        let mut expr_vec = vec![];
+        for e in exprs {
+            let OrderByExpr {
+                asc,
+                expr,
+                nulls_first,
+                with_fill,
+            } = e;
+
+            if let Some(with_fill) = with_fill {
+                return not_impl_err!("ORDER BY WITH FILL is not supported: {with_fill}");
+            }
+
+            let expr = match expr {
+                SQLExpr::Value(Value::Number(v, _)) if literal_to_column => {
+                    let field_index = v
+                        .parse::<usize>()
+                        .map_err(|err| plan_datafusion_err!("{}", err))?;
+
+                    if field_index == 0 {
+                        return plan_err!(
+                            "Order by index starts at 1 for column indexes"
+                        );
+                    } else if input_schema.fields().len() < field_index {
+                        return plan_err!(
+                            "Order by column out of bounds, specified: {}, max: {}",
+                            field_index,
+                            input_schema.fields().len()
+                        );
+                    }
+
+                    Expr::Column(Column::from(
+                        input_schema.qualified_field(field_index - 1),
+                    ))
+                }
+                e => {
+                    self.sql_expr_to_logical_expr(e, order_by_schema, planner_context)?
+                }
+            };
+            let asc = asc.unwrap_or(true);
+            expr_vec.push(Sort::new(
+                expr,
+                asc,
+                // When asc is true, by default nulls last to be consistent with postgres
+                // postgres rule: https://www.postgresql.org/docs/current/queries-order.html
+                nulls_first.unwrap_or(!asc),
+            ))
+        }
+        Ok(expr_vec)
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/expr/subquery.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/expr/subquery.rs
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use datafusion_common::{DFSchema, Result};
+use datafusion_expr::expr::Exists;
+use datafusion_expr::expr::InSubquery;
+use datafusion_expr::{Expr, Subquery};
+use sqlparser::ast::Expr as SQLExpr;
+use sqlparser::ast::Query;
+use std::sync::Arc;
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    pub(super) fn parse_exists_subquery(
+        &self,
+        subquery: Query,
+        negated: bool,
+        input_schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let old_outer_query_schema =
+            planner_context.set_outer_query_schema(Some(input_schema.clone().into()));
+        let sub_plan = self.query_to_plan(subquery, planner_context)?;
+        let outer_ref_columns = sub_plan.all_out_ref_exprs();
+        planner_context.set_outer_query_schema(old_outer_query_schema);
+        Ok(Expr::Exists(Exists {
+            subquery: Subquery {
+                subquery: Arc::new(sub_plan),
+                outer_ref_columns,
+            },
+            negated,
+        }))
+    }
+
+    pub(super) fn parse_in_subquery(
+        &self,
+        expr: SQLExpr,
+        subquery: Query,
+        negated: bool,
+        input_schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let old_outer_query_schema =
+            planner_context.set_outer_query_schema(Some(input_schema.clone().into()));
+        let sub_plan = self.query_to_plan(subquery, planner_context)?;
+        let outer_ref_columns = sub_plan.all_out_ref_exprs();
+        planner_context.set_outer_query_schema(old_outer_query_schema);
+        let expr = Box::new(self.sql_to_expr(expr, input_schema, planner_context)?);
+        Ok(Expr::InSubquery(InSubquery::new(
+            expr,
+            Subquery {
+                subquery: Arc::new(sub_plan),
+                outer_ref_columns,
+            },
+            negated,
+        )))
+    }
+
+    pub(super) fn parse_scalar_subquery(
+        &self,
+        subquery: Query,
+        input_schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let old_outer_query_schema =
+            planner_context.set_outer_query_schema(Some(input_schema.clone().into()));
+        let sub_plan = self.query_to_plan(subquery, planner_context)?;
+        let outer_ref_columns = sub_plan.all_out_ref_exprs();
+        planner_context.set_outer_query_schema(old_outer_query_schema);
+        Ok(Expr::ScalarSubquery(Subquery {
+            subquery: Arc::new(sub_plan),
+            outer_ref_columns,
+        }))
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/expr/substring.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/expr/substring.rs
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use datafusion_common::{not_impl_err, plan_err};
+use datafusion_common::{DFSchema, Result, ScalarValue};
+use datafusion_expr::planner::PlannerResult;
+use datafusion_expr::Expr;
+use sqlparser::ast::Expr as SQLExpr;
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    pub(super) fn sql_substring_to_expr(
+        &self,
+        expr: Box<SQLExpr>,
+        substring_from: Option<Box<SQLExpr>>,
+        substring_for: Option<Box<SQLExpr>>,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        let mut substring_args = match (substring_from, substring_for) {
+            (Some(from_expr), Some(for_expr)) => {
+                let arg =
+                    self.sql_expr_to_logical_expr(*expr, schema, planner_context)?;
+                let from_logic =
+                    self.sql_expr_to_logical_expr(*from_expr, schema, planner_context)?;
+                let for_logic =
+                    self.sql_expr_to_logical_expr(*for_expr, schema, planner_context)?;
+                vec![arg, from_logic, for_logic]
+            }
+            (Some(from_expr), None) => {
+                let arg =
+                    self.sql_expr_to_logical_expr(*expr, schema, planner_context)?;
+                let from_logic =
+                    self.sql_expr_to_logical_expr(*from_expr, schema, planner_context)?;
+                vec![arg, from_logic]
+            }
+            (None, Some(for_expr)) => {
+                let arg =
+                    self.sql_expr_to_logical_expr(*expr, schema, planner_context)?;
+                let from_logic = Expr::Literal(ScalarValue::Int64(Some(1)));
+                let for_logic =
+                    self.sql_expr_to_logical_expr(*for_expr, schema, planner_context)?;
+                vec![arg, from_logic, for_logic]
+            }
+            (None, None) => {
+                let orig_sql = SQLExpr::Substring {
+                    expr,
+                    substring_from: None,
+                    substring_for: None,
+                    special: false,
+                };
+
+                return plan_err!("Substring without for/from is not valid {orig_sql:?}");
+            }
+        };
+
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_substring(substring_args)? {
+                PlannerResult::Planned(expr) => return Ok(expr),
+                PlannerResult::Original(args) => {
+                    substring_args = args;
+                }
+            }
+        }
+
+        not_impl_err!(
+            "Substring not supported by UserDefinedExtensionPlanners: {substring_args:?}"
+        )
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/expr/unary_op.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/expr/unary_op.rs
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use datafusion_common::{not_impl_err, plan_err, DFSchema, Result};
+use datafusion_expr::{
+    type_coercion::{is_interval, is_timestamp},
+    Expr, ExprSchemable,
+};
+use sqlparser::ast::{Expr as SQLExpr, UnaryOperator, Value};
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    pub(crate) fn parse_sql_unary_op(
+        &self,
+        op: UnaryOperator,
+        expr: SQLExpr,
+        schema: &DFSchema,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        match op {
+            UnaryOperator::Not => Ok(Expr::Not(Box::new(
+                self.sql_expr_to_logical_expr(expr, schema, planner_context)?,
+            ))),
+            UnaryOperator::Plus => {
+                let operand =
+                    self.sql_expr_to_logical_expr(expr, schema, planner_context)?;
+                let (data_type, _) = operand.data_type_and_nullable(schema)?;
+                if data_type.is_numeric()
+                    || is_interval(&data_type)
+                    || is_timestamp(&data_type)
+                {
+                    Ok(operand)
+                } else {
+                    plan_err!("Unary operator '+' only supports numeric, interval and timestamp types")
+                }
+            }
+            UnaryOperator::Minus => {
+                match expr {
+                    // Optimization: if it's a number literal, we apply the negative operator
+                    // here directly to calculate the new literal.
+                    SQLExpr::Value(Value::Number(n, _)) => {
+                        self.parse_sql_number(&n, true)
+                    }
+                    SQLExpr::Interval(interval) => {
+                        self.sql_interval_to_expr(true, interval)
+                    }
+                    // Not a literal, apply negative operator on expression
+                    _ => Ok(Expr::Negative(Box::new(self.sql_expr_to_logical_expr(
+                        expr,
+                        schema,
+                        planner_context,
+                    )?))),
+                }
+            }
+            _ => not_impl_err!("Unsupported SQL unary operator {op:?}"),
+        }
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/expr/value.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/expr/value.rs
@@ -1,0 +1,503 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use arrow::compute::kernels::cast_utils::{
+    parse_interval_month_day_nano_config, IntervalParseConfig, IntervalUnit,
+};
+use arrow::datatypes::{
+    i256, DataType, DECIMAL128_MAX_PRECISION, DECIMAL256_MAX_PRECISION,
+};
+use bigdecimal::num_bigint::BigInt;
+use bigdecimal::{BigDecimal, Signed, ToPrimitive};
+use datafusion_common::{
+    internal_datafusion_err, not_impl_err, plan_err, DFSchema, DataFusionError, Result,
+    ScalarValue,
+};
+use datafusion_expr::expr::{BinaryExpr, Placeholder};
+use datafusion_expr::planner::PlannerResult;
+use datafusion_expr::{lit, Expr, Operator};
+use log::debug;
+use sqlparser::ast::{BinaryOperator, Expr as SQLExpr, Interval, UnaryOperator, Value};
+use sqlparser::parser::ParserError::ParserError;
+use std::borrow::Cow;
+use std::cmp::Ordering;
+use std::ops::Neg;
+use std::str::FromStr;
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    pub(crate) fn parse_value(
+        &self,
+        value: Value,
+        param_data_types: &[DataType],
+    ) -> Result<Expr> {
+        match value {
+            Value::Number(n, _) => self.parse_sql_number(&n, false),
+            Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => Ok(lit(s)),
+            Value::Null => Ok(Expr::Literal(ScalarValue::Null)),
+            Value::Boolean(n) => Ok(lit(n)),
+            Value::Placeholder(param) => {
+                Self::create_placeholder_expr(param, param_data_types)
+            }
+            Value::HexStringLiteral(s) => {
+                if let Some(v) = try_decode_hex_literal(&s) {
+                    Ok(lit(v))
+                } else {
+                    plan_err!("Invalid HexStringLiteral '{s}'")
+                }
+            }
+            Value::DollarQuotedString(s) => Ok(lit(s.value)),
+            Value::EscapedStringLiteral(s) => Ok(lit(s)),
+            _ => plan_err!("Unsupported Value '{value:?}'"),
+        }
+    }
+
+    /// Parse number in sql string, convert to Expr::Literal
+    pub(super) fn parse_sql_number(
+        &self,
+        unsigned_number: &str,
+        negative: bool,
+    ) -> Result<Expr> {
+        let signed_number: Cow<str> = if negative {
+            Cow::Owned(format!("-{unsigned_number}"))
+        } else {
+            Cow::Borrowed(unsigned_number)
+        };
+
+        // Try to parse as i64 first, then u64 if negative is false, then decimal or f64
+
+        if let Ok(n) = signed_number.parse::<i64>() {
+            return Ok(lit(n));
+        }
+
+        if !negative {
+            if let Ok(n) = unsigned_number.parse::<u64>() {
+                return Ok(lit(n));
+            }
+        }
+
+        if self.options.parse_float_as_decimal {
+            parse_decimal(unsigned_number, negative)
+        } else {
+            signed_number.parse::<f64>().map(lit).map_err(|_| {
+                DataFusionError::from(ParserError(format!(
+                    "Cannot parse {signed_number} as f64"
+                )))
+            })
+        }
+    }
+
+    /// Create a placeholder expression
+    /// This is the same as Postgres's prepare statement syntax in which a placeholder starts with `$` sign and then
+    /// number 1, 2, ... etc. For example, `$1` is the first placeholder; $2 is the second one and so on.
+    fn create_placeholder_expr(
+        param: String,
+        param_data_types: &[DataType],
+    ) -> Result<Expr> {
+        // Parse the placeholder as a number because it is the only support from sqlparser and postgres
+        let index = param[1..].parse::<usize>();
+        let idx = match index {
+            Ok(0) => {
+                return plan_err!(
+                    "Invalid placeholder, zero is not a valid index: {param}"
+                );
+            }
+            Ok(index) => index - 1,
+            Err(_) => {
+                return if param_data_types.is_empty() {
+                    Ok(Expr::Placeholder(Placeholder::new(param, None)))
+                } else {
+                    // when PREPARE Statement, param_data_types length is always 0
+                    plan_err!("Invalid placeholder, not a number: {param}")
+                };
+            }
+        };
+        // Check if the placeholder is in the parameter list
+        let param_type = param_data_types.get(idx);
+        // Data type of the parameter
+        debug!(
+            "type of param {} param_data_types[idx]: {:?}",
+            param, param_type
+        );
+
+        Ok(Expr::Placeholder(Placeholder::new(
+            param,
+            param_type.cloned(),
+        )))
+    }
+
+    pub(super) fn sql_array_literal(
+        &self,
+        elements: Vec<SQLExpr>,
+        schema: &DFSchema,
+    ) -> Result<Expr> {
+        let values = elements
+            .into_iter()
+            .map(|element| {
+                self.sql_expr_to_logical_expr(element, schema, &mut PlannerContext::new())
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        self.try_plan_array_literal(values, schema)
+    }
+
+    fn try_plan_array_literal(
+        &self,
+        values: Vec<Expr>,
+        schema: &DFSchema,
+    ) -> Result<Expr> {
+        let mut exprs = values;
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_array_literal(exprs, schema)? {
+                PlannerResult::Planned(expr) => {
+                    return Ok(expr);
+                }
+                PlannerResult::Original(values) => exprs = values,
+            }
+        }
+
+        not_impl_err!("Could not plan array literal. Hint: Please try with `nested_expressions` DataFusion feature enabled")
+    }
+
+    /// Convert a SQL interval expression to a DataFusion logical plan
+    /// expression
+    #[allow(clippy::only_used_in_recursion)]
+    pub(super) fn sql_interval_to_expr(
+        &self,
+        negative: bool,
+        interval: Interval,
+    ) -> Result<Expr> {
+        if interval.leading_precision.is_some() {
+            return not_impl_err!(
+                "Unsupported Interval Expression with leading_precision {:?}",
+                interval.leading_precision
+            );
+        }
+
+        if interval.last_field.is_some() {
+            return not_impl_err!(
+                "Unsupported Interval Expression with last_field {:?}",
+                interval.last_field
+            );
+        }
+
+        if interval.fractional_seconds_precision.is_some() {
+            return not_impl_err!(
+                "Unsupported Interval Expression with fractional_seconds_precision {:?}",
+                interval.fractional_seconds_precision
+            );
+        }
+
+        if let SQLExpr::BinaryOp { left, op, right } = *interval.value {
+            let df_op = match op {
+                BinaryOperator::Plus => Operator::Plus,
+                BinaryOperator::Minus => Operator::Minus,
+                _ => {
+                    return not_impl_err!("Unsupported interval operator: {op:?}");
+                }
+            };
+            let left_expr = self.sql_interval_to_expr(
+                negative,
+                Interval {
+                    value: left,
+                    leading_field: interval.leading_field.clone(),
+                    leading_precision: None,
+                    last_field: None,
+                    fractional_seconds_precision: None,
+                },
+            )?;
+            let right_expr = self.sql_interval_to_expr(
+                false,
+                Interval {
+                    value: right,
+                    leading_field: interval.leading_field,
+                    leading_precision: None,
+                    last_field: None,
+                    fractional_seconds_precision: None,
+                },
+            )?;
+            return Ok(Expr::BinaryExpr(BinaryExpr::new(
+                Box::new(left_expr),
+                df_op,
+                Box::new(right_expr),
+            )));
+        }
+
+        let value = interval_literal(*interval.value, negative)?;
+
+        // leading_field really means the unit if specified
+        // For example, "month" in  `INTERVAL '5' month`
+        let value = match interval.leading_field.as_ref() {
+            Some(leading_field) => format!("{value} {leading_field}"),
+            None => value,
+        };
+
+        let config = IntervalParseConfig::new(IntervalUnit::Second);
+        let val = parse_interval_month_day_nano_config(&value, config)?;
+        Ok(lit(ScalarValue::IntervalMonthDayNano(Some(val))))
+    }
+}
+
+fn interval_literal(interval_value: SQLExpr, negative: bool) -> Result<String> {
+    let s = match interval_value {
+        SQLExpr::Value(Value::SingleQuotedString(s) | Value::DoubleQuotedString(s)) => s,
+        SQLExpr::Value(Value::Number(ref v, long)) => {
+            if long {
+                return not_impl_err!(
+                    "Unsupported interval argument. Long number not supported: {interval_value:?}"
+                );
+            } else {
+                v.to_string()
+            }
+        }
+        SQLExpr::UnaryOp { op, expr } => {
+            let negative = match op {
+                UnaryOperator::Minus => !negative,
+                UnaryOperator::Plus => negative,
+                _ => {
+                    return not_impl_err!(
+                        "Unsupported SQL unary operator in interval {op:?}"
+                    );
+                }
+            };
+            interval_literal(*expr, negative)?
+        }
+        _ => {
+            return not_impl_err!("Unsupported interval argument. Expected string literal or number, got: {interval_value:?}");
+        }
+    };
+    if negative {
+        Ok(format!("-{s}"))
+    } else {
+        Ok(s)
+    }
+}
+
+/// Try to decode bytes from hex literal string.
+///
+/// None will be returned if the input literal is hex-invalid.
+fn try_decode_hex_literal(s: &str) -> Option<Vec<u8>> {
+    let hex_bytes = s.as_bytes();
+
+    let mut decoded_bytes = Vec::with_capacity((hex_bytes.len() + 1) / 2);
+
+    let start_idx = hex_bytes.len() % 2;
+    if start_idx > 0 {
+        // The first byte is formed of only one char.
+        decoded_bytes.push(try_decode_hex_char(hex_bytes[0])?);
+    }
+
+    for i in (start_idx..hex_bytes.len()).step_by(2) {
+        let high = try_decode_hex_char(hex_bytes[i])?;
+        let low = try_decode_hex_char(hex_bytes[i + 1])?;
+        decoded_bytes.push(high << 4 | low);
+    }
+
+    Some(decoded_bytes)
+}
+
+/// Try to decode a byte from a hex char.
+///
+/// None will be returned if the input char is hex-invalid.
+const fn try_decode_hex_char(c: u8) -> Option<u8> {
+    match c {
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'0'..=b'9' => Some(c - b'0'),
+        _ => None,
+    }
+}
+
+/// Returns None if the value can't be converted to i256.
+/// Modified from <https://github.com/apache/arrow-rs/blob/c4dbf0d8af6ca5a19b8b2ea777da3c276807fc5e/arrow-buffer/src/bigint/mod.rs#L303>
+fn bigint_to_i256(v: &BigInt) -> Option<i256> {
+    let v_bytes = v.to_signed_bytes_le();
+    match v_bytes.len().cmp(&32) {
+        Ordering::Less => {
+            let mut bytes = if v.is_negative() {
+                [255_u8; 32]
+            } else {
+                [0; 32]
+            };
+            bytes[0..v_bytes.len()].copy_from_slice(&v_bytes[..v_bytes.len()]);
+            Some(i256::from_le_bytes(bytes))
+        }
+        Ordering::Equal => Some(i256::from_le_bytes(v_bytes.try_into().unwrap())),
+        Ordering::Greater => None,
+    }
+}
+
+fn parse_decimal(unsigned_number: &str, negative: bool) -> Result<Expr> {
+    let mut dec = BigDecimal::from_str(unsigned_number).map_err(|e| {
+        DataFusionError::from(ParserError(format!(
+            "Cannot parse {unsigned_number} as BigDecimal: {e}"
+        )))
+    })?;
+    if negative {
+        dec = dec.neg();
+    }
+
+    let digits = dec.digits();
+    let (int_val, scale) = dec.into_bigint_and_exponent();
+    if scale < i8::MIN as i64 {
+        return not_impl_err!(
+            "Decimal scale {} exceeds the minimum supported scale: {}",
+            scale,
+            i8::MIN
+        );
+    }
+    let precision = if scale > 0 {
+        // arrow-rs requires the precision to include the positive scale.
+        // See <https://github.com/apache/arrow-rs/blob/123045cc766d42d1eb06ee8bb3f09e39ea995ddc/arrow-array/src/types.rs#L1230>
+        std::cmp::max(digits, scale.unsigned_abs())
+    } else {
+        digits
+    };
+    if precision <= DECIMAL128_MAX_PRECISION as u64 {
+        let val = int_val.to_i128().ok_or_else(|| {
+            // Failures are unexpected here as we have already checked the precision
+            internal_datafusion_err!(
+                "Unexpected overflow when converting {} to i128",
+                int_val
+            )
+        })?;
+        Ok(Expr::Literal(ScalarValue::Decimal128(
+            Some(val),
+            precision as u8,
+            scale as i8,
+        )))
+    } else if precision <= DECIMAL256_MAX_PRECISION as u64 {
+        let val = bigint_to_i256(&int_val).ok_or_else(|| {
+            // Failures are unexpected here as we have already checked the precision
+            internal_datafusion_err!(
+                "Unexpected overflow when converting {} to i256",
+                int_val
+            )
+        })?;
+        Ok(Expr::Literal(ScalarValue::Decimal256(
+            Some(val),
+            precision as u8,
+            scale as i8,
+        )))
+    } else {
+        not_impl_err!(
+            "Decimal precision {} exceeds the maximum supported precision: {}",
+            precision,
+            DECIMAL256_MAX_PRECISION
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_hex_literal() {
+        let cases = [
+            ("", Some(vec![])),
+            ("FF00", Some(vec![255, 0])),
+            ("a00a", Some(vec![160, 10])),
+            ("FF0", Some(vec![15, 240])),
+            ("f", Some(vec![15])),
+            ("FF0X", None),
+            ("X0", None),
+            ("XX", None),
+            ("x", None),
+        ];
+
+        for (input, expect) in cases {
+            let output = try_decode_hex_literal(input);
+            assert_eq!(output, expect);
+        }
+    }
+
+    #[test]
+    fn test_bigint_to_i256() {
+        let cases = [
+            (BigInt::from(0), Some(i256::from(0))),
+            (BigInt::from(1), Some(i256::from(1))),
+            (BigInt::from(-1), Some(i256::from(-1))),
+            (
+                BigInt::from_str(i256::MAX.to_string().as_str()).unwrap(),
+                Some(i256::MAX),
+            ),
+            (
+                BigInt::from_str(i256::MIN.to_string().as_str()).unwrap(),
+                Some(i256::MIN),
+            ),
+            (
+                // Can't fit into i256
+                BigInt::from_str((i256::MAX.to_string() + "1").as_str()).unwrap(),
+                None,
+            ),
+        ];
+
+        for (input, expect) in cases {
+            let output = bigint_to_i256(&input);
+            assert_eq!(output, expect);
+        }
+    }
+
+    #[test]
+    fn test_parse_decimal() {
+        // Supported cases
+        let cases = [
+            ("0", ScalarValue::Decimal128(Some(0), 1, 0)),
+            ("1", ScalarValue::Decimal128(Some(1), 1, 0)),
+            ("123.45", ScalarValue::Decimal128(Some(12345), 5, 2)),
+            // Digit count is less than scale
+            ("0.001", ScalarValue::Decimal128(Some(1), 3, 3)),
+            // Scientific notation
+            ("123.456e-2", ScalarValue::Decimal128(Some(123456), 6, 5)),
+            // Negative scale
+            ("123456e128", ScalarValue::Decimal128(Some(123456), 6, -128)),
+            // Decimal256
+            (
+                &("9".repeat(39) + "." + "99999"),
+                ScalarValue::Decimal256(
+                    Some(i256::from_string(&"9".repeat(44)).unwrap()),
+                    44,
+                    5,
+                ),
+            ),
+        ];
+        for (input, expect) in cases {
+            let output = parse_decimal(input, true).unwrap();
+            assert_eq!(output, Expr::Literal(expect.arithmetic_negate().unwrap()));
+
+            let output = parse_decimal(input, false).unwrap();
+            assert_eq!(output, Expr::Literal(expect));
+        }
+
+        // scale < i8::MIN
+        assert_eq!(
+            parse_decimal("1e129", false)
+                .unwrap_err()
+                .strip_backtrace(),
+            "This feature is not implemented: Decimal scale -129 exceeds the minimum supported scale: -128"
+        );
+
+        // Unsupported precision
+        assert_eq!(
+            parse_decimal(&"1".repeat(77), false)
+                .unwrap_err()
+                .strip_backtrace(),
+            "This feature is not implemented: Decimal precision 77 exceeds the maximum supported precision: 76"
+        );
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/lib.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/lib.rs
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Make cheap clones clear: https://github.com/apache/datafusion/issues/11143
+#![deny(clippy::clone_on_ref_ptr)]
+
+//! This crate provides:
+//!
+//! 1. A SQL parser, [`DFParser`], that translates SQL query text into
+//!    an abstract syntax tree (AST), [`Statement`].
+//!
+//! 2. A SQL query planner [`SqlToRel`] that creates [`LogicalPlan`]s
+//!    from [`Statement`]s.
+//!
+//! [`DFParser`]: parser::DFParser
+//! [`Statement`]: parser::Statement
+//! [`SqlToRel`]: planner::SqlToRel
+//! [`LogicalPlan`]: datafusion_expr::logical_plan::LogicalPlan
+//! [`Expr`]: datafusion_expr::expr::Expr
+
+mod expr;
+pub mod parser;
+pub mod planner;
+mod query;
+mod relation;
+pub mod resolve;
+mod select;
+mod set_expr;
+mod statement;
+pub mod utils;

--- a/crates/proof-of-sql/src/sql/new_parse/parser.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/parser.rs
@@ -1,0 +1,1440 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`DFParser`]: DataFusion SQL Parser based on [`sqlparser`]
+
+use std::collections::VecDeque;
+use std::fmt;
+
+use sqlparser::ast::ExprWithAlias;
+use sqlparser::tokenizer::TokenWithSpan;
+use sqlparser::{
+    ast::{
+        ColumnDef, ColumnOptionDef, ObjectName, OrderByExpr, Query,
+        Statement as SQLStatement, TableConstraint, Value,
+    },
+    dialect::{keywords::Keyword, Dialect, GenericDialect},
+    parser::{Parser, ParserError},
+    tokenizer::{Token, Tokenizer, Word},
+};
+
+// Use `Parser::expected` instead, if possible
+macro_rules! parser_err {
+    ($MSG:expr) => {
+        Err(ParserError::ParserError($MSG.to_string()))
+    };
+}
+
+/// This type defines a lexicographical ordering.
+pub(crate) type LexOrdering = Vec<OrderByExpr>;
+
+/// DataFusion SQL Statement.
+///
+/// This can either be a [`Statement`] from [`sqlparser`] from a
+/// standard SQL dialect, or a DataFusion extension such as `CREATE
+/// EXTERNAL TABLE`. See [`DFParser`] for more information.
+///
+/// [`Statement`]: sqlparser::ast::Statement
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Statement {
+    /// ANSI SQL AST node (from sqlparser-rs)
+    Statement(Box<SQLStatement>),
+    /// Extension: `CREATE EXTERNAL TABLE`
+    CreateExternalTable(CreateExternalTable),
+    /// Extension: `COPY TO`
+    CopyTo(CopyToStatement),
+    /// EXPLAIN for extensions
+    Explain(ExplainStatement),
+}
+
+impl fmt::Display for Statement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Statement::Statement(stmt) => write!(f, "{stmt}"),
+            Statement::CreateExternalTable(stmt) => write!(f, "{stmt}"),
+            Statement::CopyTo(stmt) => write!(f, "{stmt}"),
+            Statement::Explain(stmt) => write!(f, "{stmt}"),
+        }
+    }
+}
+
+fn ensure_not_set<T>(field: &Option<T>, name: &str) -> Result<(), ParserError> {
+    if field.is_some() {
+        return Err(ParserError::ParserError(format!(
+            "{name} specified more than once",
+        )));
+    }
+    Ok(())
+}
+
+/// DataFusion SQL Parser based on [`sqlparser`]
+///
+/// Parses DataFusion's SQL dialect, often delegating to [`sqlparser`]'s [`Parser`].
+///
+/// DataFusion mostly follows existing SQL dialects via
+/// `sqlparser`. However, certain statements such as `COPY` and
+/// `CREATE EXTERNAL TABLE` have special syntax in DataFusion. See
+/// [`Statement`] for a list of this special syntax
+pub struct DFParser<'a> {
+    pub parser: Parser<'a>,
+}
+
+impl<'a> DFParser<'a> {
+    /// Create a new parser for the specified tokens using the
+    /// [`GenericDialect`].
+    pub fn new(sql: &str) -> Result<Self, ParserError> {
+        let dialect = &GenericDialect {};
+        DFParser::new_with_dialect(sql, dialect)
+    }
+
+    /// Create a new parser for the specified tokens with the
+    /// specified dialect.
+    pub fn new_with_dialect(
+        sql: &str,
+        dialect: &'a dyn Dialect,
+    ) -> Result<Self, ParserError> {
+        let mut tokenizer = Tokenizer::new(dialect, sql);
+        let tokens = tokenizer.tokenize_with_location()?;
+
+        Ok(DFParser {
+            parser: Parser::new(dialect).with_tokens_with_locations(tokens),
+        })
+    }
+
+    /// Parse a sql string into one or [`Statement`]s using the
+    /// [`GenericDialect`].
+    pub fn parse_sql(sql: &str) -> Result<VecDeque<Statement>, ParserError> {
+        let dialect = &GenericDialect {};
+        DFParser::parse_sql_with_dialect(sql, dialect)
+    }
+
+    /// Parse a SQL string and produce one or more [`Statement`]s with
+    /// with the specified dialect.
+    pub fn parse_sql_with_dialect(
+        sql: &str,
+        dialect: &dyn Dialect,
+    ) -> Result<VecDeque<Statement>, ParserError> {
+        let mut parser = DFParser::new_with_dialect(sql, dialect)?;
+        let mut stmts = VecDeque::new();
+        let mut expecting_statement_delimiter = false;
+        loop {
+            // ignore empty statements (between successive statement delimiters)
+            while parser.parser.consume_token(&Token::SemiColon) {
+                expecting_statement_delimiter = false;
+            }
+
+            if parser.parser.peek_token() == Token::EOF {
+                break;
+            }
+            if expecting_statement_delimiter {
+                return parser.expected("end of statement", parser.parser.peek_token());
+            }
+
+            let statement = parser.parse_statement()?;
+            stmts.push_back(statement);
+            expecting_statement_delimiter = true;
+        }
+        Ok(stmts)
+    }
+
+    pub fn parse_sql_into_expr_with_dialect(
+        sql: &str,
+        dialect: &dyn Dialect,
+    ) -> Result<ExprWithAlias, ParserError> {
+        let mut parser = DFParser::new_with_dialect(sql, dialect)?;
+        parser.parse_expr()
+    }
+
+    /// Report an unexpected token
+    fn expected<T>(
+        &self,
+        expected: &str,
+        found: TokenWithSpan,
+    ) -> Result<T, ParserError> {
+        parser_err!(format!("Expected {expected}, found: {found}"))
+    }
+
+    /// Parse a new expression
+    pub fn parse_statement(&mut self) -> Result<Statement, ParserError> {
+        match self.parser.peek_token().token {
+            Token::Word(w) => {
+                match w.keyword {
+                    Keyword::CREATE => {
+                        self.parser.next_token(); // CREATE
+                        self.parse_create()
+                    }
+                    Keyword::COPY => {
+                        if let Token::Word(w) = self.parser.peek_nth_token(1).token {
+                            // use native parser for COPY INTO
+                            if w.keyword == Keyword::INTO {
+                                return Ok(Statement::Statement(Box::from(
+                                    self.parser.parse_statement()?,
+                                )));
+                            }
+                        }
+                        self.parser.next_token(); // COPY
+                        self.parse_copy()
+                    }
+                    Keyword::EXPLAIN => {
+                        // (TODO parse all supported statements)
+                        self.parser.next_token(); // EXPLAIN
+                        self.parse_explain()
+                    }
+                    _ => {
+                        // use sqlparser-rs parser
+                        Ok(Statement::Statement(Box::from(
+                            self.parser.parse_statement()?,
+                        )))
+                    }
+                }
+            }
+            _ => {
+                // use the native parser
+                Ok(Statement::Statement(Box::from(
+                    self.parser.parse_statement()?,
+                )))
+            }
+        }
+    }
+
+    pub fn parse_expr(&mut self) -> Result<ExprWithAlias, ParserError> {
+        if let Token::Word(w) = self.parser.peek_token().token {
+            match w.keyword {
+                Keyword::CREATE | Keyword::COPY | Keyword::EXPLAIN => {
+                    return parser_err!("Unsupported command in expression");
+                }
+                _ => {}
+            }
+        }
+
+        self.parser.parse_expr_with_alias()
+    }
+
+    /// Parse a SQL `COPY TO` statement
+    pub fn parse_copy(&mut self) -> Result<Statement, ParserError> {
+        // parse as a query
+        let source = if self.parser.consume_token(&Token::LParen) {
+            let query = self.parser.parse_query()?;
+            self.parser.expect_token(&Token::RParen)?;
+            CopyToSource::Query(query)
+        } else {
+            // parse as table reference
+            let table_name = self.parser.parse_object_name(true)?;
+            CopyToSource::Relation(table_name)
+        };
+
+        #[derive(Default)]
+        struct Builder {
+            stored_as: Option<String>,
+            target: Option<String>,
+            partitioned_by: Option<Vec<String>>,
+            options: Option<Vec<(String, Value)>>,
+        }
+
+        let mut builder = Builder::default();
+
+        loop {
+            if let Some(keyword) = self.parser.parse_one_of_keywords(&[
+                Keyword::STORED,
+                Keyword::TO,
+                Keyword::PARTITIONED,
+                Keyword::OPTIONS,
+                Keyword::WITH,
+            ]) {
+                match keyword {
+                    Keyword::STORED => {
+                        self.parser.expect_keyword(Keyword::AS)?;
+                        ensure_not_set(&builder.stored_as, "STORED AS")?;
+                        builder.stored_as = Some(self.parse_file_format()?);
+                    }
+                    Keyword::TO => {
+                        ensure_not_set(&builder.target, "TO")?;
+                        builder.target = Some(self.parser.parse_literal_string()?);
+                    }
+                    Keyword::WITH => {
+                        self.parser.expect_keyword(Keyword::HEADER)?;
+                        self.parser.expect_keyword(Keyword::ROW)?;
+                        return parser_err!("WITH HEADER ROW clause is no longer in use. Please use the OPTIONS clause with 'format.has_header' set appropriately, e.g., OPTIONS ('format.has_header' 'true')");
+                    }
+                    Keyword::PARTITIONED => {
+                        self.parser.expect_keyword(Keyword::BY)?;
+                        ensure_not_set(&builder.partitioned_by, "PARTITIONED BY")?;
+                        builder.partitioned_by = Some(self.parse_partitions()?);
+                    }
+                    Keyword::OPTIONS => {
+                        ensure_not_set(&builder.options, "OPTIONS")?;
+                        builder.options = Some(self.parse_value_options()?);
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                }
+            } else {
+                let token = self.parser.next_token();
+                if token == Token::EOF || token == Token::SemiColon {
+                    break;
+                } else {
+                    return Err(ParserError::ParserError(format!(
+                        "Unexpected token {token}"
+                    )));
+                }
+            }
+        }
+
+        let Some(target) = builder.target else {
+            return Err(ParserError::ParserError(
+                "Missing TO clause in COPY statement".into(),
+            ));
+        };
+
+        Ok(Statement::CopyTo(CopyToStatement {
+            source,
+            target,
+            partitioned_by: builder.partitioned_by.unwrap_or(vec![]),
+            stored_as: builder.stored_as,
+            options: builder.options.unwrap_or(vec![]),
+        }))
+    }
+
+    /// Parse the next token as a key name for an option list
+    ///
+    /// Note this is different than [`parse_literal_string`]
+    /// because it allows keywords as well as other non words
+    ///
+    /// [`parse_literal_string`]: sqlparser::parser::Parser::parse_literal_string
+    pub fn parse_option_key(&mut self) -> Result<String, ParserError> {
+        let next_token = self.parser.next_token();
+        match next_token.token {
+            Token::Word(Word { value, .. }) => {
+                let mut parts = vec![value];
+                while self.parser.consume_token(&Token::Period) {
+                    let next_token = self.parser.next_token();
+                    if let Token::Word(Word { value, .. }) = next_token.token {
+                        parts.push(value);
+                    } else {
+                        // Unquoted namespaced keys have to conform to the syntax
+                        // "<WORD>[\.<WORD>]*". If we have a key that breaks this
+                        // pattern, error out:
+                        return self.parser.expected("key name", next_token);
+                    }
+                }
+                Ok(parts.join("."))
+            }
+            Token::SingleQuotedString(s) => Ok(s),
+            Token::DoubleQuotedString(s) => Ok(s),
+            Token::EscapedStringLiteral(s) => Ok(s),
+            _ => self.parser.expected("key name", next_token),
+        }
+    }
+
+    /// Parse the next token as a value for an option list
+    ///
+    /// Note this is different than [`parse_value`] as it allows any
+    /// word or keyword in this location.
+    ///
+    /// [`parse_value`]: sqlparser::parser::Parser::parse_value
+    pub fn parse_option_value(&mut self) -> Result<Value, ParserError> {
+        let next_token = self.parser.next_token();
+        match next_token.token {
+            // e.g. things like "snappy" or "gzip" that may be keywords
+            Token::Word(word) => Ok(Value::SingleQuotedString(word.value)),
+            Token::SingleQuotedString(s) => Ok(Value::SingleQuotedString(s)),
+            Token::DoubleQuotedString(s) => Ok(Value::DoubleQuotedString(s)),
+            Token::EscapedStringLiteral(s) => Ok(Value::EscapedStringLiteral(s)),
+            Token::Number(n, l) => Ok(Value::Number(n, l)),
+            _ => self.parser.expected("string or numeric value", next_token),
+        }
+    }
+
+    /// Parse a SQL `EXPLAIN`
+    pub fn parse_explain(&mut self) -> Result<Statement, ParserError> {
+        let analyze = self.parser.parse_keyword(Keyword::ANALYZE);
+        let verbose = self.parser.parse_keyword(Keyword::VERBOSE);
+        let statement = self.parse_statement()?;
+
+        Ok(Statement::Explain(ExplainStatement {
+            statement: Box::new(statement),
+            analyze,
+            verbose,
+        }))
+    }
+
+    /// Parse a SQL `CREATE` statement handling `CREATE EXTERNAL TABLE`
+    pub fn parse_create(&mut self) -> Result<Statement, ParserError> {
+        if self.parser.parse_keyword(Keyword::EXTERNAL) {
+            self.parse_create_external_table(false)
+        } else if self.parser.parse_keyword(Keyword::UNBOUNDED) {
+            self.parser.expect_keyword(Keyword::EXTERNAL)?;
+            self.parse_create_external_table(true)
+        } else {
+            Ok(Statement::Statement(Box::from(self.parser.parse_create()?)))
+        }
+    }
+
+    fn parse_partitions(&mut self) -> Result<Vec<String>, ParserError> {
+        let mut partitions: Vec<String> = vec![];
+        if !self.parser.consume_token(&Token::LParen)
+            || self.parser.consume_token(&Token::RParen)
+        {
+            return Ok(partitions);
+        }
+
+        loop {
+            if let Token::Word(_) = self.parser.peek_token().token {
+                let identifier = self.parser.parse_identifier()?;
+                partitions.push(identifier.to_string());
+            } else {
+                return self.expected("partition name", self.parser.peek_token());
+            }
+            let comma = self.parser.consume_token(&Token::Comma);
+            if self.parser.consume_token(&Token::RParen) {
+                // allow a trailing comma, even though it's not in standard
+                break;
+            } else if !comma {
+                return self.expected(
+                    "',' or ')' after partition definition",
+                    self.parser.peek_token(),
+                );
+            }
+        }
+        Ok(partitions)
+    }
+
+    /// Parse the ordering clause of a `CREATE EXTERNAL TABLE` SQL statement
+    pub fn parse_order_by_exprs(&mut self) -> Result<Vec<OrderByExpr>, ParserError> {
+        let mut values = vec![];
+        self.parser.expect_token(&Token::LParen)?;
+        loop {
+            values.push(self.parse_order_by_expr()?);
+            if !self.parser.consume_token(&Token::Comma) {
+                self.parser.expect_token(&Token::RParen)?;
+                return Ok(values);
+            }
+        }
+    }
+
+    /// Parse an ORDER BY sub-expression optionally followed by ASC or DESC.
+    pub fn parse_order_by_expr(&mut self) -> Result<OrderByExpr, ParserError> {
+        let expr = self.parser.parse_expr()?;
+
+        let asc = if self.parser.parse_keyword(Keyword::ASC) {
+            Some(true)
+        } else if self.parser.parse_keyword(Keyword::DESC) {
+            Some(false)
+        } else {
+            None
+        };
+
+        let nulls_first = if self
+            .parser
+            .parse_keywords(&[Keyword::NULLS, Keyword::FIRST])
+        {
+            Some(true)
+        } else if self.parser.parse_keywords(&[Keyword::NULLS, Keyword::LAST]) {
+            Some(false)
+        } else {
+            None
+        };
+
+        Ok(OrderByExpr {
+            expr,
+            asc,
+            nulls_first,
+            with_fill: None,
+        })
+    }
+
+    // This is a copy of the equivalent implementation in sqlparser.
+    fn parse_columns(
+        &mut self,
+    ) -> Result<(Vec<ColumnDef>, Vec<TableConstraint>), ParserError> {
+        let mut columns = vec![];
+        let mut constraints = vec![];
+        if !self.parser.consume_token(&Token::LParen)
+            || self.parser.consume_token(&Token::RParen)
+        {
+            return Ok((columns, constraints));
+        }
+
+        loop {
+            if let Some(constraint) = self.parser.parse_optional_table_constraint()? {
+                constraints.push(constraint);
+            } else if let Token::Word(_) = self.parser.peek_token().token {
+                let column_def = self.parse_column_def()?;
+                columns.push(column_def);
+            } else {
+                return self.expected(
+                    "column name or constraint definition",
+                    self.parser.peek_token(),
+                );
+            }
+            let comma = self.parser.consume_token(&Token::Comma);
+            if self.parser.consume_token(&Token::RParen) {
+                // allow a trailing comma, even though it's not in standard
+                break;
+            } else if !comma {
+                return self.expected(
+                    "',' or ')' after column definition",
+                    self.parser.peek_token(),
+                );
+            }
+        }
+
+        Ok((columns, constraints))
+    }
+
+    fn parse_column_def(&mut self) -> Result<ColumnDef, ParserError> {
+        let name = self.parser.parse_identifier()?;
+        let data_type = self.parser.parse_data_type()?;
+        let collation = if self.parser.parse_keyword(Keyword::COLLATE) {
+            Some(self.parser.parse_object_name(false)?)
+        } else {
+            None
+        };
+        let mut options = vec![];
+        loop {
+            if self.parser.parse_keyword(Keyword::CONSTRAINT) {
+                let name = Some(self.parser.parse_identifier()?);
+                if let Some(option) = self.parser.parse_optional_column_option()? {
+                    options.push(ColumnOptionDef { name, option });
+                } else {
+                    return self.expected(
+                        "constraint details after CONSTRAINT <name>",
+                        self.parser.peek_token(),
+                    );
+                }
+            } else if let Some(option) = self.parser.parse_optional_column_option()? {
+                options.push(ColumnOptionDef { name: None, option });
+            } else {
+                break;
+            };
+        }
+        Ok(ColumnDef {
+            name,
+            data_type,
+            collation,
+            options,
+        })
+    }
+
+    fn parse_create_external_table(
+        &mut self,
+        unbounded: bool,
+    ) -> Result<Statement, ParserError> {
+        let temporary = self
+            .parser
+            .parse_one_of_keywords(&[Keyword::TEMP, Keyword::TEMPORARY])
+            .is_some();
+        self.parser.expect_keyword(Keyword::TABLE)?;
+        let if_not_exists =
+            self.parser
+                .parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
+        let table_name = self.parser.parse_object_name(true)?;
+        let (mut columns, constraints) = self.parse_columns()?;
+
+        #[derive(Default)]
+        struct Builder {
+            file_type: Option<String>,
+            location: Option<String>,
+            table_partition_cols: Option<Vec<String>>,
+            order_exprs: Vec<LexOrdering>,
+            options: Option<Vec<(String, Value)>>,
+        }
+        let mut builder = Builder::default();
+
+        loop {
+            if let Some(keyword) = self.parser.parse_one_of_keywords(&[
+                Keyword::STORED,
+                Keyword::LOCATION,
+                Keyword::WITH,
+                Keyword::DELIMITER,
+                Keyword::COMPRESSION,
+                Keyword::PARTITIONED,
+                Keyword::OPTIONS,
+            ]) {
+                match keyword {
+                    Keyword::STORED => {
+                        self.parser.expect_keyword(Keyword::AS)?;
+                        ensure_not_set(&builder.file_type, "STORED AS")?;
+                        builder.file_type = Some(self.parse_file_format()?);
+                    }
+                    Keyword::LOCATION => {
+                        ensure_not_set(&builder.location, "LOCATION")?;
+                        builder.location = Some(self.parser.parse_literal_string()?);
+                    }
+                    Keyword::WITH => {
+                        if self.parser.parse_keyword(Keyword::ORDER) {
+                            builder.order_exprs.push(self.parse_order_by_exprs()?);
+                        } else {
+                            self.parser.expect_keyword(Keyword::HEADER)?;
+                            self.parser.expect_keyword(Keyword::ROW)?;
+                            return parser_err!("WITH HEADER ROW clause is no longer in use. Please use the OPTIONS clause with 'format.has_header' set appropriately, e.g., OPTIONS (format.has_header true)");
+                        }
+                    }
+                    Keyword::DELIMITER => {
+                        return parser_err!("DELIMITER clause is no longer in use. Please use the OPTIONS clause with 'format.delimiter' set appropriately, e.g., OPTIONS (format.delimiter ',')");
+                    }
+                    Keyword::COMPRESSION => {
+                        self.parser.expect_keyword(Keyword::TYPE)?;
+                        return parser_err!("COMPRESSION TYPE clause is no longer in use. Please use the OPTIONS clause with 'format.compression' set appropriately, e.g., OPTIONS (format.compression gzip)");
+                    }
+                    Keyword::PARTITIONED => {
+                        self.parser.expect_keyword(Keyword::BY)?;
+                        ensure_not_set(&builder.table_partition_cols, "PARTITIONED BY")?;
+                        // Expects either list of column names (col_name [, col_name]*)
+                        // or list of column definitions (col_name datatype [, col_name datatype]* )
+                        // use the token after the name to decide which parsing rule to use
+                        // Note that mixing both names and definitions is not allowed
+                        let peeked = self.parser.peek_nth_token(2);
+                        if peeked == Token::Comma || peeked == Token::RParen {
+                            // List of column names
+                            builder.table_partition_cols = Some(self.parse_partitions()?)
+                        } else {
+                            // List of column defs
+                            let (cols, cons) = self.parse_columns()?;
+                            builder.table_partition_cols = Some(
+                                cols.iter().map(|col| col.name.to_string()).collect(),
+                            );
+
+                            columns.extend(cols);
+
+                            if !cons.is_empty() {
+                                return Err(ParserError::ParserError(
+                                    "Constraints on Partition Columns are not supported"
+                                        .to_string(),
+                                ));
+                            }
+                        }
+                    }
+                    Keyword::OPTIONS => {
+                        ensure_not_set(&builder.options, "OPTIONS")?;
+                        builder.options = Some(self.parse_value_options()?);
+                    }
+                    _ => {
+                        unreachable!()
+                    }
+                }
+            } else {
+                let token = self.parser.next_token();
+                if token == Token::EOF || token == Token::SemiColon {
+                    break;
+                } else {
+                    return Err(ParserError::ParserError(format!(
+                        "Unexpected token {token}"
+                    )));
+                }
+            }
+        }
+
+        // Validations: location and file_type are required
+        if builder.file_type.is_none() {
+            return Err(ParserError::ParserError(
+                "Missing STORED AS clause in CREATE EXTERNAL TABLE statement".into(),
+            ));
+        }
+        if builder.location.is_none() {
+            return Err(ParserError::ParserError(
+                "Missing LOCATION clause in CREATE EXTERNAL TABLE statement".into(),
+            ));
+        }
+
+        let create = CreateExternalTable {
+            name: table_name,
+            columns,
+            file_type: builder.file_type.unwrap(),
+            location: builder.location.unwrap(),
+            table_partition_cols: builder.table_partition_cols.unwrap_or(vec![]),
+            order_exprs: builder.order_exprs,
+            if_not_exists,
+            temporary,
+            unbounded,
+            options: builder.options.unwrap_or(Vec::new()),
+            constraints,
+        };
+        Ok(Statement::CreateExternalTable(create))
+    }
+
+    /// Parses the set of valid formats
+    fn parse_file_format(&mut self) -> Result<String, ParserError> {
+        let token = self.parser.next_token();
+        match &token.token {
+            Token::Word(w) => parse_file_type(&w.value),
+            _ => self.expected("one of ARROW, PARQUET, NDJSON, or CSV", token),
+        }
+    }
+
+    /// Parses (key value) style options into a map of String --> [`Value`].
+    ///
+    /// This method supports keywords as key names as well as multiple
+    /// value types such as Numbers as well as Strings.
+    fn parse_value_options(&mut self) -> Result<Vec<(String, Value)>, ParserError> {
+        let mut options = vec![];
+        self.parser.expect_token(&Token::LParen)?;
+
+        loop {
+            let key = self.parse_option_key()?;
+            let value = self.parse_option_value()?;
+            options.push((key, value));
+            let comma = self.parser.consume_token(&Token::Comma);
+            if self.parser.consume_token(&Token::RParen) {
+                // Allow a trailing comma, even though it's not in standard
+                break;
+            } else if !comma {
+                return self.expected(
+                    "',' or ')' after option definition",
+                    self.parser.peek_token(),
+                );
+            }
+        }
+        Ok(options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlparser::ast::Expr::Identifier;
+    use sqlparser::ast::{BinaryOperator, DataType, Expr, Ident};
+    use sqlparser::dialect::SnowflakeDialect;
+    use sqlparser::tokenizer::Span;
+
+    fn expect_parse_ok(sql: &str, expected: Statement) -> Result<(), ParserError> {
+        let statements = DFParser::parse_sql(sql)?;
+        assert_eq!(
+            statements.len(),
+            1,
+            "Expected to parse exactly one statement"
+        );
+        assert_eq!(statements[0], expected, "actual:\n{:#?}", statements[0]);
+        Ok(())
+    }
+
+    /// Parses sql and asserts that the expected error message was found
+    fn expect_parse_error(sql: &str, expected_error: &str) {
+        match DFParser::parse_sql(sql) {
+            Ok(statements) => {
+                panic!(
+                    "Expected parse error for '{sql}', but was successful: {statements:?}"
+                );
+            }
+            Err(e) => {
+                let error_message = e.to_string();
+                assert!(
+                    error_message.contains(expected_error),
+                    "Expected error '{expected_error}' not found in actual error '{error_message}'"
+                );
+            }
+        }
+    }
+
+    fn make_column_def(name: impl Into<String>, data_type: DataType) -> ColumnDef {
+        ColumnDef {
+            name: Ident {
+                value: name.into(),
+                quote_style: None,
+                span: Span::empty(),
+            },
+            data_type,
+            collation: None,
+            options: vec![],
+        }
+    }
+
+    #[test]
+    fn create_external_table() -> Result<(), ParserError> {
+        // positive case
+        let sql = "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv'";
+        let display = None;
+        let name = ObjectName(vec![Ident::from("t")]);
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![make_column_def("c1", DataType::Int(display))],
+            file_type: "CSV".to_string(),
+            location: "foo.csv".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: leading space
+        let sql = "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv'     ";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![make_column_def("c1", DataType::Int(None))],
+            file_type: "CSV".to_string(),
+            location: "foo.csv".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: leading space + semicolon
+        let sql =
+            "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv'      ;";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![make_column_def("c1", DataType::Int(None))],
+            file_type: "CSV".to_string(),
+            location: "foo.csv".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case with delimiter
+        let sql = "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv' OPTIONS (format.delimiter '|')";
+        let display = None;
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![make_column_def("c1", DataType::Int(display))],
+            file_type: "CSV".to_string(),
+            location: "foo.csv".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![(
+                "format.delimiter".into(),
+                Value::SingleQuotedString("|".into()),
+            )],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: partitioned by
+        let sql = "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV PARTITIONED BY (p1, p2) LOCATION 'foo.csv'";
+        let display = None;
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![make_column_def("c1", DataType::Int(display))],
+            file_type: "CSV".to_string(),
+            location: "foo.csv".into(),
+            table_partition_cols: vec!["p1".to_string(), "p2".to_string()],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: it is ok for sql stmt with `COMPRESSION TYPE GZIP` tokens
+        let sqls =
+            vec![
+             ("CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv' OPTIONS
+             ('format.compression' 'GZIP')", "GZIP"),
+             ("CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv' OPTIONS
+             ('format.compression' 'BZIP2')", "BZIP2"),
+             ("CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv' OPTIONS
+             ('format.compression' 'XZ')", "XZ"),
+             ("CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV LOCATION 'foo.csv' OPTIONS
+             ('format.compression' 'ZSTD')", "ZSTD"),
+         ];
+        for (sql, compression) in sqls {
+            let expected = Statement::CreateExternalTable(CreateExternalTable {
+                name: name.clone(),
+                columns: vec![make_column_def("c1", DataType::Int(display))],
+                file_type: "CSV".to_string(),
+                location: "foo.csv".into(),
+                table_partition_cols: vec![],
+                order_exprs: vec![],
+                if_not_exists: false,
+                temporary: false,
+                unbounded: false,
+                options: vec![(
+                    "format.compression".into(),
+                    Value::SingleQuotedString(compression.into()),
+                )],
+                constraints: vec![],
+            });
+            expect_parse_ok(sql, expected)?;
+        }
+
+        // positive case: it is ok for parquet files not to have columns specified
+        let sql = "CREATE EXTERNAL TABLE t STORED AS PARQUET LOCATION 'foo.parquet'";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![],
+            file_type: "PARQUET".to_string(),
+            location: "foo.parquet".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: it is ok for parquet files to be other than upper case
+        let sql = "CREATE EXTERNAL TABLE t STORED AS parqueT LOCATION 'foo.parquet'";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![],
+            file_type: "PARQUET".to_string(),
+            location: "foo.parquet".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: it is ok for avro files not to have columns specified
+        let sql = "CREATE EXTERNAL TABLE t STORED AS AVRO LOCATION 'foo.avro'";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![],
+            file_type: "AVRO".to_string(),
+            location: "foo.avro".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: it is ok for avro files not to have columns specified
+        let sql =
+            "CREATE EXTERNAL TABLE IF NOT EXISTS t STORED AS PARQUET LOCATION 'foo.parquet'";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![],
+            file_type: "PARQUET".to_string(),
+            location: "foo.parquet".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: true,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: column definition allowed in 'partition by' clause
+        let sql =
+            "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV PARTITIONED BY (p1 int) LOCATION 'foo.csv'";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![
+                make_column_def("c1", DataType::Int(None)),
+                make_column_def("p1", DataType::Int(None)),
+            ],
+            file_type: "CSV".to_string(),
+            location: "foo.csv".into(),
+            table_partition_cols: vec!["p1".to_string()],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // negative case: mixed column defs and column names in `PARTITIONED BY` clause
+        let sql =
+            "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV PARTITIONED BY (p1 int, c1) LOCATION 'foo.csv'";
+        expect_parse_error(
+            sql,
+            "sql parser error: Expected: a data type name, found: )",
+        );
+
+        // negative case: mixed column defs and column names in `PARTITIONED BY` clause
+        let sql =
+            "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV PARTITIONED BY (c1, p1 int) LOCATION 'foo.csv'";
+        expect_parse_error(sql, "sql parser error: Expected ',' or ')' after partition definition, found: int");
+
+        // positive case: additional options (one entry) can be specified
+        let sql =
+            "CREATE EXTERNAL TABLE t STORED AS x OPTIONS ('k1' 'v1') LOCATION 'blahblah'";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![],
+            file_type: "X".to_string(),
+            location: "blahblah".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![("k1".into(), Value::SingleQuotedString("v1".into()))],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // positive case: additional options (multiple entries) can be specified
+        let sql =
+            "CREATE EXTERNAL TABLE t STORED AS x OPTIONS ('k1' 'v1', k2 v2) LOCATION 'blahblah'";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![],
+            file_type: "X".to_string(),
+            location: "blahblah".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![
+                ("k1".into(), Value::SingleQuotedString("v1".into())),
+                ("k2".into(), Value::SingleQuotedString("v2".into())),
+            ],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // Ordered Col
+        let sqls = ["CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1) LOCATION 'foo.csv'",
+                        "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1 NULLS FIRST) LOCATION 'foo.csv'",
+                        "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1 NULLS LAST) LOCATION 'foo.csv'",
+                        "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1 ASC) LOCATION 'foo.csv'",
+                        "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1 DESC) LOCATION 'foo.csv'",
+                        "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1 DESC NULLS FIRST) LOCATION 'foo.csv'",
+                        "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1 DESC NULLS LAST) LOCATION 'foo.csv'",
+                        "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1 ASC NULLS FIRST) LOCATION 'foo.csv'",
+                        "CREATE EXTERNAL TABLE t(c1 int) STORED AS CSV WITH ORDER (c1 ASC NULLS LAST) LOCATION 'foo.csv'"];
+        let expected = vec![
+            (None, None),
+            (None, Some(true)),
+            (None, Some(false)),
+            (Some(true), None),
+            (Some(false), None),
+            (Some(false), Some(true)),
+            (Some(false), Some(false)),
+            (Some(true), Some(true)),
+            (Some(true), Some(false)),
+        ];
+        for (sql, (asc, nulls_first)) in sqls.iter().zip(expected.into_iter()) {
+            let expected = Statement::CreateExternalTable(CreateExternalTable {
+                name: name.clone(),
+                columns: vec![make_column_def("c1", DataType::Int(None))],
+                file_type: "CSV".to_string(),
+                location: "foo.csv".into(),
+                table_partition_cols: vec![],
+                order_exprs: vec![vec![OrderByExpr {
+                    expr: Identifier(Ident {
+                        value: "c1".to_owned(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }),
+                    asc,
+                    nulls_first,
+                    with_fill: None,
+                }]],
+                if_not_exists: false,
+                temporary: false,
+                unbounded: false,
+                options: vec![],
+                constraints: vec![],
+            });
+            expect_parse_ok(sql, expected)?;
+        }
+
+        // Ordered Col
+        let sql = "CREATE EXTERNAL TABLE t(c1 int, c2 int) STORED AS CSV WITH ORDER (c1 ASC, c2 DESC NULLS FIRST) LOCATION 'foo.csv'";
+        let display = None;
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![
+                make_column_def("c1", DataType::Int(display)),
+                make_column_def("c2", DataType::Int(display)),
+            ],
+            file_type: "CSV".to_string(),
+            location: "foo.csv".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![vec![
+                OrderByExpr {
+                    expr: Identifier(Ident {
+                        value: "c1".to_owned(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }),
+                    asc: Some(true),
+                    nulls_first: None,
+                    with_fill: None,
+                },
+                OrderByExpr {
+                    expr: Identifier(Ident {
+                        value: "c2".to_owned(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }),
+                    asc: Some(false),
+                    nulls_first: Some(true),
+                    with_fill: None,
+                },
+            ]],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // Ordered Binary op
+        let sql = "CREATE EXTERNAL TABLE t(c1 int, c2 int) STORED AS CSV WITH ORDER (c1 - c2 ASC) LOCATION 'foo.csv'";
+        let display = None;
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![
+                make_column_def("c1", DataType::Int(display)),
+                make_column_def("c2", DataType::Int(display)),
+            ],
+            file_type: "CSV".to_string(),
+            location: "foo.csv".into(),
+            table_partition_cols: vec![],
+            order_exprs: vec![vec![OrderByExpr {
+                expr: Expr::BinaryOp {
+                    left: Box::new(Identifier(Ident {
+                        value: "c1".to_owned(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    })),
+                    op: BinaryOperator::Minus,
+                    right: Box::new(Identifier(Ident {
+                        value: "c2".to_owned(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    })),
+                },
+                asc: Some(true),
+                nulls_first: None,
+                with_fill: None,
+            }]],
+            if_not_exists: false,
+            temporary: false,
+            unbounded: false,
+            options: vec![],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // Most complete CREATE EXTERNAL TABLE statement possible
+        let sql = "
+            CREATE UNBOUNDED EXTERNAL TABLE IF NOT EXISTS t (c1 int, c2 float)
+            STORED AS PARQUET
+            WITH ORDER (c1 - c2 ASC)
+            PARTITIONED BY (c1)
+            LOCATION 'foo.parquet'
+            OPTIONS ('format.compression' 'zstd',
+                     'format.delimiter' '*',
+                     'ROW_GROUP_SIZE' '1024',
+                     'TRUNCATE' 'NO',
+                     'format.has_header' 'true')";
+        let expected = Statement::CreateExternalTable(CreateExternalTable {
+            name: name.clone(),
+            columns: vec![
+                make_column_def("c1", DataType::Int(None)),
+                make_column_def("c2", DataType::Float(None)),
+            ],
+            file_type: "PARQUET".to_string(),
+            location: "foo.parquet".into(),
+            table_partition_cols: vec!["c1".into()],
+            order_exprs: vec![vec![OrderByExpr {
+                expr: Expr::BinaryOp {
+                    left: Box::new(Identifier(Ident {
+                        value: "c1".to_owned(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    })),
+                    op: BinaryOperator::Minus,
+                    right: Box::new(Identifier(Ident {
+                        value: "c2".to_owned(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    })),
+                },
+                asc: Some(true),
+                nulls_first: None,
+                with_fill: None,
+            }]],
+            if_not_exists: true,
+            temporary: false,
+            unbounded: true,
+            options: vec![
+                (
+                    "format.compression".into(),
+                    Value::SingleQuotedString("zstd".into()),
+                ),
+                (
+                    "format.delimiter".into(),
+                    Value::SingleQuotedString("*".into()),
+                ),
+                (
+                    "ROW_GROUP_SIZE".into(),
+                    Value::SingleQuotedString("1024".into()),
+                ),
+                ("TRUNCATE".into(), Value::SingleQuotedString("NO".into())),
+                (
+                    "format.has_header".into(),
+                    Value::SingleQuotedString("true".into()),
+                ),
+            ],
+            constraints: vec![],
+        });
+        expect_parse_ok(sql, expected)?;
+
+        // For error cases, see: `create_external_table.slt`
+
+        Ok(())
+    }
+
+    #[test]
+    fn copy_to_table_to_table() -> Result<(), ParserError> {
+        // positive case
+        let sql = "COPY foo TO bar STORED AS CSV";
+        let expected = Statement::CopyTo(CopyToStatement {
+            source: object_name("foo"),
+            target: "bar".to_string(),
+            partitioned_by: vec![],
+            stored_as: Some("CSV".to_owned()),
+            options: vec![],
+        });
+
+        assert_eq!(verified_stmt(sql), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn skip_copy_into_snowflake() -> Result<(), ParserError> {
+        let sql = "COPY INTO foo FROM @~/staged FILE_FORMAT = (FORMAT_NAME = 'mycsv');";
+        let dialect = Box::new(SnowflakeDialect);
+        let statements = DFParser::parse_sql_with_dialect(sql, dialect.as_ref())?;
+
+        assert_eq!(
+            statements.len(),
+            1,
+            "Expected to parse exactly one statement"
+        );
+        if let Statement::CopyTo(_) = &statements[0] {
+            panic!("Expected non COPY TO statement, but was successful: {statements:?}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn explain_copy_to_table_to_table() -> Result<(), ParserError> {
+        let cases = vec![
+            ("EXPLAIN COPY foo TO bar STORED AS PARQUET", false, false),
+            (
+                "EXPLAIN ANALYZE COPY foo TO bar STORED AS PARQUET",
+                true,
+                false,
+            ),
+            (
+                "EXPLAIN VERBOSE COPY foo TO bar STORED AS PARQUET",
+                false,
+                true,
+            ),
+            (
+                "EXPLAIN ANALYZE VERBOSE COPY foo TO bar STORED AS PARQUET",
+                true,
+                true,
+            ),
+        ];
+        for (sql, analyze, verbose) in cases {
+            println!("sql: {sql}, analyze: {analyze}, verbose: {verbose}");
+
+            let expected_copy = Statement::CopyTo(CopyToStatement {
+                source: object_name("foo"),
+                target: "bar".to_string(),
+                partitioned_by: vec![],
+                stored_as: Some("PARQUET".to_owned()),
+                options: vec![],
+            });
+            let expected = Statement::Explain(ExplainStatement {
+                analyze,
+                verbose,
+                statement: Box::new(expected_copy),
+            });
+            assert_eq!(verified_stmt(sql), expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn copy_to_query_to_table() -> Result<(), ParserError> {
+        let statement = verified_stmt("SELECT 1");
+
+        // unwrap the various layers
+        let statement = if let Statement::Statement(statement) = statement {
+            *statement
+        } else {
+            panic!("Expected statement, got {statement:?}");
+        };
+
+        let query = if let SQLStatement::Query(query) = statement {
+            query
+        } else {
+            panic!("Expected query, got {statement:?}");
+        };
+
+        let sql =
+            "COPY (SELECT 1) TO bar STORED AS CSV OPTIONS ('format.has_header' 'true')";
+        let expected = Statement::CopyTo(CopyToStatement {
+            source: CopyToSource::Query(query),
+            target: "bar".to_string(),
+            partitioned_by: vec![],
+            stored_as: Some("CSV".to_owned()),
+            options: vec![(
+                "format.has_header".into(),
+                Value::SingleQuotedString("true".into()),
+            )],
+        });
+        assert_eq!(verified_stmt(sql), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn copy_to_options() -> Result<(), ParserError> {
+        let sql = "COPY foo TO bar STORED AS CSV OPTIONS ('row_group_size' '55')";
+        let expected = Statement::CopyTo(CopyToStatement {
+            source: object_name("foo"),
+            target: "bar".to_string(),
+            partitioned_by: vec![],
+            stored_as: Some("CSV".to_owned()),
+            options: vec![(
+                "row_group_size".to_string(),
+                Value::SingleQuotedString("55".to_string()),
+            )],
+        });
+        assert_eq!(verified_stmt(sql), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn copy_to_partitioned_by() -> Result<(), ParserError> {
+        let sql = "COPY foo TO bar STORED AS CSV PARTITIONED BY (a) OPTIONS ('row_group_size' '55')";
+        let expected = Statement::CopyTo(CopyToStatement {
+            source: object_name("foo"),
+            target: "bar".to_string(),
+            partitioned_by: vec!["a".to_string()],
+            stored_as: Some("CSV".to_owned()),
+            options: vec![(
+                "row_group_size".to_string(),
+                Value::SingleQuotedString("55".to_string()),
+            )],
+        });
+        assert_eq!(verified_stmt(sql), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn copy_to_multi_options() -> Result<(), ParserError> {
+        // order of options is preserved
+        let sql =
+            "COPY foo TO bar STORED AS parquet OPTIONS ('format.row_group_size' 55, 'format.compression' snappy, 'execution.keep_partition_by_columns' true)";
+
+        let expected_options = vec![
+            (
+                "format.row_group_size".to_string(),
+                Value::Number("55".to_string(), false),
+            ),
+            (
+                "format.compression".to_string(),
+                Value::SingleQuotedString("snappy".to_string()),
+            ),
+            (
+                "execution.keep_partition_by_columns".to_string(),
+                Value::SingleQuotedString("true".to_string()),
+            ),
+        ];
+
+        let mut statements = DFParser::parse_sql(sql).unwrap();
+        assert_eq!(statements.len(), 1);
+        let only_statement = statements.pop_front().unwrap();
+
+        let options = if let Statement::CopyTo(copy_to) = only_statement {
+            copy_to.options
+        } else {
+            panic!("Expected copy");
+        };
+
+        assert_eq!(options, expected_options);
+
+        Ok(())
+    }
+
+    // For error cases, see: `copy.slt`
+
+    fn object_name(name: &str) -> CopyToSource {
+        CopyToSource::Relation(ObjectName(vec![Ident::new(name)]))
+    }
+
+    // Based on  sqlparser-rs
+    // https://github.com/sqlparser-rs/sqlparser-rs/blob/ae3b5844c839072c235965fe0d1bddc473dced87/src/test_utils.rs#L104-L116
+
+    /// Ensures that `sql` parses as a single [Statement]
+    ///
+    /// If `canonical` is non empty,this function additionally asserts
+    /// that:
+    ///
+    /// 1. parsing `sql` results in the same [`Statement`] as parsing
+    ///    `canonical`.
+    ///
+    /// 2. re-serializing the result of parsing `sql` produces the same
+    ///    `canonical` sql string
+    fn one_statement_parses_to(sql: &str, canonical: &str) -> Statement {
+        let mut statements = DFParser::parse_sql(sql).unwrap();
+        assert_eq!(statements.len(), 1);
+
+        if sql != canonical {
+            assert_eq!(DFParser::parse_sql(canonical).unwrap(), statements);
+        }
+
+        let only_statement = statements.pop_front().unwrap();
+        assert_eq!(
+            canonical.to_uppercase(),
+            only_statement.to_string().to_uppercase()
+        );
+        only_statement
+    }
+
+    /// Ensures that `sql` parses as a single [Statement], and that
+    /// re-serializing the parse result produces the same `sql`
+    /// string (is not modified after a serialization round-trip).
+    fn verified_stmt(sql: &str) -> Statement {
+        one_statement_parses_to(sql, sql)
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/planner.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/planner.rs
@@ -1,0 +1,736 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`SqlToRel`]: SQL Query Planner (produces [`LogicalPlan`] from SQL AST)
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::vec;
+
+use arrow::datatypes::*;
+use datafusion_common::error::add_possible_columns_to_diag;
+use datafusion_common::{
+    field_not_found, internal_err, plan_datafusion_err, DFSchemaRef, Diagnostic,
+    SchemaError,
+};
+use sqlparser::ast::TimezoneInfo;
+use sqlparser::ast::{ArrayElemTypeDef, ExactNumberInfo};
+use sqlparser::ast::{ColumnDef as SQLColumnDef, ColumnOption};
+use sqlparser::ast::{DataType as SQLDataType, Ident, ObjectName, TableAlias};
+
+use datafusion_common::TableReference;
+use datafusion_common::{not_impl_err, plan_err, DFSchema, DataFusionError, Result};
+use datafusion_expr::logical_plan::{LogicalPlan, LogicalPlanBuilder};
+use datafusion_expr::utils::find_column_exprs;
+use datafusion_expr::{col, Expr};
+
+use crate::utils::make_decimal_type;
+pub use datafusion_expr::planner::ContextProvider;
+
+/// SQL parser options
+#[derive(Debug, Clone, Copy)]
+pub struct ParserOptions {
+    pub parse_float_as_decimal: bool,
+    pub enable_ident_normalization: bool,
+    pub support_varchar_with_length: bool,
+    pub enable_options_value_normalization: bool,
+    pub collect_spans: bool,
+}
+
+impl Default for ParserOptions {
+    fn default() -> Self {
+        Self {
+            parse_float_as_decimal: false,
+            enable_ident_normalization: true,
+            support_varchar_with_length: true,
+            enable_options_value_normalization: false,
+            collect_spans: false,
+        }
+    }
+}
+
+/// Ident Normalizer
+#[derive(Debug)]
+pub struct IdentNormalizer {
+    normalize: bool,
+}
+
+impl Default for IdentNormalizer {
+    fn default() -> Self {
+        Self { normalize: true }
+    }
+}
+
+impl IdentNormalizer {
+    pub fn new(normalize: bool) -> Self {
+        Self { normalize }
+    }
+
+    pub fn normalize(&self, ident: Ident) -> String {
+        if self.normalize {
+            crate::utils::normalize_ident(ident)
+        } else {
+            ident.value
+        }
+    }
+}
+
+/// Struct to store the states used by the Planner. The Planner will leverage the states to resolve
+/// CTEs, Views, subqueries and PREPARE statements. The states include
+/// Common Table Expression (CTE) provided with WITH clause and
+/// Parameter Data Types provided with PREPARE statement and the query schema of the
+/// outer query plan.
+///
+/// # Cloning
+///
+/// Only the `ctes` are truly cloned when the `PlannerContext` is cloned. This helps resolve
+/// scoping issues of CTEs. By using cloning, a subquery can inherit CTEs from the outer query
+/// and can also define its own private CTEs without affecting the outer query.
+///
+#[derive(Debug, Clone)]
+pub struct PlannerContext {
+    /// Data types for numbered parameters ($1, $2, etc), if supplied
+    /// in `PREPARE` statement
+    prepare_param_data_types: Arc<Vec<DataType>>,
+    /// Map of CTE name to logical plan of the WITH clause.
+    /// Use `Arc<LogicalPlan>` to allow cheap cloning
+    ctes: HashMap<String, Arc<LogicalPlan>>,
+    /// The query schema of the outer query plan, used to resolve the columns in subquery
+    outer_query_schema: Option<DFSchemaRef>,
+    /// The joined schemas of all FROM clauses planned so far. When planning LATERAL
+    /// FROM clauses, this should become a suffix of the `outer_query_schema`.
+    outer_from_schema: Option<DFSchemaRef>,
+    /// The query schema defined by the table
+    create_table_schema: Option<DFSchemaRef>,
+}
+
+impl Default for PlannerContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PlannerContext {
+    /// Create an empty PlannerContext
+    pub fn new() -> Self {
+        Self {
+            prepare_param_data_types: Arc::new(vec![]),
+            ctes: HashMap::new(),
+            outer_query_schema: None,
+            outer_from_schema: None,
+            create_table_schema: None,
+        }
+    }
+
+    /// Update the PlannerContext with provided prepare_param_data_types
+    pub fn with_prepare_param_data_types(
+        mut self,
+        prepare_param_data_types: Vec<DataType>,
+    ) -> Self {
+        self.prepare_param_data_types = prepare_param_data_types.into();
+        self
+    }
+
+    // Return a reference to the outer query's schema
+    pub fn outer_query_schema(&self) -> Option<&DFSchema> {
+        self.outer_query_schema.as_ref().map(|s| s.as_ref())
+    }
+
+    /// Sets the outer query schema, returning the existing one, if
+    /// any
+    pub fn set_outer_query_schema(
+        &mut self,
+        mut schema: Option<DFSchemaRef>,
+    ) -> Option<DFSchemaRef> {
+        std::mem::swap(&mut self.outer_query_schema, &mut schema);
+        schema
+    }
+
+    pub fn set_table_schema(
+        &mut self,
+        mut schema: Option<DFSchemaRef>,
+    ) -> Option<DFSchemaRef> {
+        std::mem::swap(&mut self.create_table_schema, &mut schema);
+        schema
+    }
+
+    pub fn table_schema(&self) -> Option<DFSchemaRef> {
+        self.create_table_schema.clone()
+    }
+
+    // Return a clone of the outer FROM schema
+    pub fn outer_from_schema(&self) -> Option<Arc<DFSchema>> {
+        self.outer_from_schema.clone()
+    }
+
+    /// Sets the outer FROM schema, returning the existing one, if any
+    pub fn set_outer_from_schema(
+        &mut self,
+        mut schema: Option<DFSchemaRef>,
+    ) -> Option<DFSchemaRef> {
+        std::mem::swap(&mut self.outer_from_schema, &mut schema);
+        schema
+    }
+
+    /// Extends the FROM schema, returning the existing one, if any
+    pub fn extend_outer_from_schema(&mut self, schema: &DFSchemaRef) -> Result<()> {
+        match self.outer_from_schema.as_mut() {
+            Some(from_schema) => Arc::make_mut(from_schema).merge(schema),
+            None => self.outer_from_schema = Some(Arc::clone(schema)),
+        };
+        Ok(())
+    }
+
+    /// Return the types of parameters (`$1`, `$2`, etc) if known
+    pub fn prepare_param_data_types(&self) -> &[DataType] {
+        &self.prepare_param_data_types
+    }
+
+    /// Returns true if there is a Common Table Expression (CTE) /
+    /// Subquery for the specified name
+    pub fn contains_cte(&self, cte_name: &str) -> bool {
+        self.ctes.contains_key(cte_name)
+    }
+
+    /// Inserts a LogicalPlan for the Common Table Expression (CTE) /
+    /// Subquery for the specified name
+    pub fn insert_cte(&mut self, cte_name: impl Into<String>, plan: LogicalPlan) {
+        let cte_name = cte_name.into();
+        self.ctes.insert(cte_name, Arc::new(plan));
+    }
+
+    /// Return a plan for the Common Table Expression (CTE) / Subquery for the
+    /// specified name
+    pub fn get_cte(&self, cte_name: &str) -> Option<&LogicalPlan> {
+        self.ctes.get(cte_name).map(|cte| cte.as_ref())
+    }
+
+    /// Remove the plan of CTE / Subquery for the specified name
+    pub(super) fn remove_cte(&mut self, cte_name: &str) {
+        self.ctes.remove(cte_name);
+    }
+}
+
+/// SQL query planner
+pub struct SqlToRel<'a, S: ContextProvider> {
+    pub(crate) context_provider: &'a S,
+    pub(crate) options: ParserOptions,
+    pub(crate) ident_normalizer: IdentNormalizer,
+}
+
+impl<'a, S: ContextProvider> SqlToRel<'a, S> {
+    /// Create a new query planner
+    pub fn new(context_provider: &'a S) -> Self {
+        Self::new_with_options(context_provider, ParserOptions::default())
+    }
+
+    /// Create a new query planner
+    pub fn new_with_options(context_provider: &'a S, options: ParserOptions) -> Self {
+        let ident_normalize = options.enable_ident_normalization;
+
+        SqlToRel {
+            context_provider,
+            options,
+            ident_normalizer: IdentNormalizer::new(ident_normalize),
+        }
+    }
+
+    pub fn build_schema(&self, columns: Vec<SQLColumnDef>) -> Result<Schema> {
+        let mut fields = Vec::with_capacity(columns.len());
+
+        for column in columns {
+            let data_type = self.convert_data_type(&column.data_type)?;
+            let not_nullable = column
+                .options
+                .iter()
+                .any(|x| x.option == ColumnOption::NotNull);
+            fields.push(Field::new(
+                self.ident_normalizer.normalize(column.name),
+                data_type,
+                !not_nullable,
+            ));
+        }
+
+        Ok(Schema::new(fields))
+    }
+
+    /// Returns a vector of (column_name, default_expr) pairs
+    pub(super) fn build_column_defaults(
+        &self,
+        columns: &Vec<SQLColumnDef>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Vec<(String, Expr)>> {
+        let mut column_defaults = vec![];
+        // Default expressions are restricted, column references are not allowed
+        let empty_schema = DFSchema::empty();
+        let error_desc = |e: DataFusionError| match e {
+            DataFusionError::SchemaError(SchemaError::FieldNotFound { .. }, _) => {
+                plan_datafusion_err!(
+                    "Column reference is not allowed in the DEFAULT expression : {}",
+                    e
+                )
+            }
+            _ => e,
+        };
+
+        for column in columns {
+            if let Some(default_sql_expr) =
+                column.options.iter().find_map(|o| match &o.option {
+                    ColumnOption::Default(expr) => Some(expr),
+                    _ => None,
+                })
+            {
+                let default_expr = self
+                    .sql_to_expr(default_sql_expr.clone(), &empty_schema, planner_context)
+                    .map_err(error_desc)?;
+                column_defaults.push((
+                    self.ident_normalizer.normalize(column.name.clone()),
+                    default_expr,
+                ));
+            }
+        }
+        Ok(column_defaults)
+    }
+
+    /// Apply the given TableAlias to the input plan
+    pub(crate) fn apply_table_alias(
+        &self,
+        plan: LogicalPlan,
+        alias: TableAlias,
+    ) -> Result<LogicalPlan> {
+        let idents = alias.columns.into_iter().map(|c| c.name).collect();
+        let plan = self.apply_expr_alias(plan, idents)?;
+
+        LogicalPlanBuilder::from(plan)
+            .alias(TableReference::bare(
+                self.ident_normalizer.normalize(alias.name),
+            ))?
+            .build()
+    }
+
+    pub(crate) fn apply_expr_alias(
+        &self,
+        plan: LogicalPlan,
+        idents: Vec<Ident>,
+    ) -> Result<LogicalPlan> {
+        if idents.is_empty() {
+            Ok(plan)
+        } else if idents.len() != plan.schema().fields().len() {
+            plan_err!(
+                "Source table contains {} columns but only {} names given as column alias",
+                plan.schema().fields().len(),
+                idents.len()
+            )
+        } else {
+            let fields = plan.schema().fields().clone();
+            LogicalPlanBuilder::from(plan)
+                .project(fields.iter().zip(idents.into_iter()).map(|(field, ident)| {
+                    col(field.name()).alias(self.ident_normalizer.normalize(ident))
+                }))?
+                .build()
+        }
+    }
+
+    /// Validate the schema provides all of the columns referenced in the expressions.
+    pub(crate) fn validate_schema_satisfies_exprs(
+        &self,
+        schema: &DFSchema,
+        exprs: &[Expr],
+    ) -> Result<()> {
+        find_column_exprs(exprs)
+            .iter()
+            .try_for_each(|col| match col {
+                Expr::Column(col) => match &col.relation {
+                    Some(r) => schema.field_with_qualified_name(r, &col.name).map(|_| ()),
+                    None => {
+                        if !schema.fields_with_unqualified_name(&col.name).is_empty() {
+                            Ok(())
+                        } else {
+                            Err(field_not_found(
+                                col.relation.clone(),
+                                col.name.as_str(),
+                                schema,
+                            ))
+                        }
+                    }
+                }
+                .map_err(|err: DataFusionError| match &err {
+                    DataFusionError::SchemaError(
+                        SchemaError::FieldNotFound {
+                            field,
+                            valid_fields,
+                        },
+                        _,
+                    ) => {
+                        let mut diagnostic = if let Some(relation) = &col.relation {
+                            Diagnostic::new_error(
+                                format!(
+                                    "column '{}' not found in '{}'",
+                                    &col.name, relation
+                                ),
+                                col.spans().first(),
+                            )
+                        } else {
+                            Diagnostic::new_error(
+                                format!("column '{}' not found", &col.name),
+                                col.spans().first(),
+                            )
+                        };
+                        add_possible_columns_to_diag(
+                            &mut diagnostic,
+                            field,
+                            valid_fields,
+                        );
+                        err.with_diagnostic(diagnostic)
+                    }
+                    _ => err,
+                }),
+                _ => internal_err!("Not a column"),
+            })
+    }
+
+    pub(crate) fn convert_data_type(&self, sql_type: &SQLDataType) -> Result<DataType> {
+        // First check if any of the registered type_planner can handle this type
+        if let Some(type_planner) = self.context_provider.get_type_planner() {
+            if let Some(data_type) = type_planner.plan_type(sql_type)? {
+                return Ok(data_type);
+            }
+        }
+
+        // If no type_planner can handle this type, use the default conversion
+        match sql_type {
+            SQLDataType::Array(ArrayElemTypeDef::AngleBracket(inner_sql_type)) => {
+                // Arrays may be multi-dimensional.
+                let inner_data_type = self.convert_data_type(inner_sql_type)?;
+                Ok(DataType::new_list(inner_data_type, true))
+            }
+            SQLDataType::Array(ArrayElemTypeDef::SquareBracket(
+                inner_sql_type,
+                maybe_array_size,
+            )) => {
+                let inner_data_type = self.convert_data_type(inner_sql_type)?;
+                if let Some(array_size) = maybe_array_size {
+                    Ok(DataType::new_fixed_size_list(
+                        inner_data_type,
+                        *array_size as i32,
+                        true,
+                    ))
+                } else {
+                    Ok(DataType::new_list(inner_data_type, true))
+                }
+            }
+            SQLDataType::Array(ArrayElemTypeDef::None) => {
+                not_impl_err!("Arrays with unspecified type is not supported")
+            }
+            other => self.convert_simple_data_type(other),
+        }
+    }
+
+    fn convert_simple_data_type(&self, sql_type: &SQLDataType) -> Result<DataType> {
+        match sql_type {
+            SQLDataType::Boolean | SQLDataType::Bool => Ok(DataType::Boolean),
+            SQLDataType::TinyInt(_) => Ok(DataType::Int8),
+            SQLDataType::SmallInt(_) | SQLDataType::Int2(_) => Ok(DataType::Int16),
+            SQLDataType::Int(_) | SQLDataType::Integer(_) | SQLDataType::Int4(_) => Ok(DataType::Int32),
+            SQLDataType::BigInt(_) | SQLDataType::Int8(_) => Ok(DataType::Int64),
+            SQLDataType::UnsignedTinyInt(_) => Ok(DataType::UInt8),
+            SQLDataType::UnsignedSmallInt(_) | SQLDataType::UnsignedInt2(_) => Ok(DataType::UInt16),
+            SQLDataType::UnsignedInt(_) | SQLDataType::UnsignedInteger(_) | SQLDataType::UnsignedInt4(_) => {
+                Ok(DataType::UInt32)
+            }
+            SQLDataType::Varchar(length) => {
+                match (length, self.options.support_varchar_with_length) {
+                    (Some(_), false) => plan_err!("does not support Varchar with length, please set `support_varchar_with_length` to be true"),
+                    _ => Ok(DataType::Utf8),
+                }
+            }
+            SQLDataType::UnsignedBigInt(_) | SQLDataType::UnsignedInt8(_) => Ok(DataType::UInt64),
+            SQLDataType::Float(_) => Ok(DataType::Float32),
+            SQLDataType::Real | SQLDataType::Float4 => Ok(DataType::Float32),
+            SQLDataType::Double(ExactNumberInfo::None) | SQLDataType::DoublePrecision | SQLDataType::Float8 => Ok(DataType::Float64),
+            SQLDataType::Double(ExactNumberInfo::Precision(_)|ExactNumberInfo::PrecisionAndScale(_, _)) => {
+                not_impl_err!("Unsupported SQL type (precision/scale not supported) {sql_type}")
+            }
+            SQLDataType::Char(_)
+            | SQLDataType::Text
+            | SQLDataType::String(_) => Ok(DataType::Utf8),
+            SQLDataType::Timestamp(precision, tz_info)
+            if precision.is_none() || [0, 3, 6, 9].contains(&precision.unwrap()) => {
+                let tz = if matches!(tz_info, TimezoneInfo::Tz)
+                    || matches!(tz_info, TimezoneInfo::WithTimeZone)
+                {
+                    // Timestamp With Time Zone
+                    // INPUT : [SQLDataType]   TimestampTz + [Config] Time Zone
+                    // OUTPUT: [ArrowDataType] Timestamp<TimeUnit, Some(Time Zone)>
+                    self.context_provider.options().execution.time_zone.clone()
+                } else {
+                    // Timestamp Without Time zone
+                    None
+                };
+                let precision = match precision {
+                    Some(0) => TimeUnit::Second,
+                    Some(3) => TimeUnit::Millisecond,
+                    Some(6) => TimeUnit::Microsecond,
+                    None | Some(9) => TimeUnit::Nanosecond,
+                    _ => unreachable!(),
+                };
+                Ok(DataType::Timestamp(precision, tz.map(Into::into)))
+            }
+            SQLDataType::Date => Ok(DataType::Date32),
+            SQLDataType::Time(None, tz_info) => {
+                if matches!(tz_info, TimezoneInfo::None)
+                    || matches!(tz_info, TimezoneInfo::WithoutTimeZone)
+                {
+                    Ok(DataType::Time64(TimeUnit::Nanosecond))
+                } else {
+                    // We don't support TIMETZ and TIME WITH TIME ZONE for now
+                    not_impl_err!(
+                        "Unsupported SQL type {sql_type:?}"
+                    )
+                }
+            }
+            SQLDataType::Numeric(exact_number_info)
+            | SQLDataType::Decimal(exact_number_info) => {
+                let (precision, scale) = match *exact_number_info {
+                    ExactNumberInfo::None => (None, None),
+                    ExactNumberInfo::Precision(precision) => (Some(precision), None),
+                    ExactNumberInfo::PrecisionAndScale(precision, scale) => {
+                        (Some(precision), Some(scale))
+                    }
+                };
+                make_decimal_type(precision, scale)
+            }
+            SQLDataType::Bytea => Ok(DataType::Binary),
+            SQLDataType::Interval => Ok(DataType::Interval(IntervalUnit::MonthDayNano)),
+            SQLDataType::Struct(fields, _) => {
+                let fields = fields
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, field)| {
+                        let data_type = self.convert_data_type(&field.field_type)?;
+                        let field_name = match &field.field_name{
+                            Some(ident) => ident.clone(),
+                            None => Ident::new(format!("c{idx}"))
+                        };
+                        Ok(Arc::new(Field::new(
+                            self.ident_normalizer.normalize(field_name),
+                            data_type,
+                            true,
+                        )))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(DataType::Struct(Fields::from(fields)))
+            }
+            // Explicitly list all other types so that if sqlparser
+            // adds/changes the `SQLDataType` the compiler will tell us on upgrade
+            // and avoid bugs like https://github.com/apache/datafusion/issues/3059
+            SQLDataType::Nvarchar(_)
+            | SQLDataType::JSON
+            | SQLDataType::Uuid
+            | SQLDataType::Binary(_)
+            | SQLDataType::Varbinary(_)
+            | SQLDataType::Blob(_)
+            | SQLDataType::Datetime(_)
+            | SQLDataType::Regclass
+            | SQLDataType::Custom(_, _)
+            | SQLDataType::Array(_)
+            | SQLDataType::Enum(_, _)
+            | SQLDataType::Set(_)
+            | SQLDataType::MediumInt(_)
+            | SQLDataType::UnsignedMediumInt(_)
+            | SQLDataType::Character(_)
+            | SQLDataType::CharacterVarying(_)
+            | SQLDataType::CharVarying(_)
+            | SQLDataType::CharacterLargeObject(_)
+            | SQLDataType::CharLargeObject(_)
+            // Unsupported precision
+            | SQLDataType::Timestamp(_, _)
+            // Precision is not supported
+            | SQLDataType::Time(Some(_), _)
+            | SQLDataType::Dec(_)
+            | SQLDataType::BigNumeric(_)
+            | SQLDataType::BigDecimal(_)
+            | SQLDataType::Clob(_)
+            | SQLDataType::Bytes(_)
+            | SQLDataType::Int64
+            | SQLDataType::Float64
+            | SQLDataType::JSONB
+            | SQLDataType::Unspecified
+            // Clickhouse datatypes
+            | SQLDataType::Int16
+            | SQLDataType::Int32
+            | SQLDataType::Int128
+            | SQLDataType::Int256
+            | SQLDataType::UInt8
+            | SQLDataType::UInt16
+            | SQLDataType::UInt32
+            | SQLDataType::UInt64
+            | SQLDataType::UInt128
+            | SQLDataType::UInt256
+            | SQLDataType::Float32
+            | SQLDataType::Date32
+            | SQLDataType::Datetime64(_, _)
+            | SQLDataType::FixedString(_)
+            | SQLDataType::Map(_, _)
+            | SQLDataType::Tuple(_)
+            | SQLDataType::Nested(_)
+            | SQLDataType::Union(_)
+            | SQLDataType::Nullable(_)
+            | SQLDataType::LowCardinality(_)
+            | SQLDataType::Trigger
+            // MySQL datatypes
+            | SQLDataType::TinyBlob
+            | SQLDataType::MediumBlob
+            | SQLDataType::LongBlob
+            | SQLDataType::TinyText
+            | SQLDataType::MediumText
+            | SQLDataType::LongText
+            | SQLDataType::Bit(_)
+            | SQLDataType::BitVarying(_)
+            // BigQuery UDFs
+            | SQLDataType::AnyType
+            => not_impl_err!(
+                "Unsupported SQL type {sql_type:?}"
+            ),
+        }
+    }
+
+    pub(crate) fn object_name_to_table_reference(
+        &self,
+        object_name: ObjectName,
+    ) -> Result<TableReference> {
+        object_name_to_table_reference(
+            object_name,
+            self.options.enable_ident_normalization,
+        )
+    }
+}
+
+/// Create a [`TableReference`] after normalizing the specified ObjectName
+///
+/// Examples
+/// ```text
+/// ['foo']          -> Bare { table: "foo" }
+/// ['"foo.bar"]]    -> Bare { table: "foo.bar" }
+/// ['foo', 'Bar']   -> Partial { schema: "foo", table: "bar" } <-- note lower case "bar"
+/// ['foo', 'bar']   -> Partial { schema: "foo", table: "bar" }
+/// ['foo', '"Bar"'] -> Partial { schema: "foo", table: "Bar" }
+/// ```
+pub fn object_name_to_table_reference(
+    object_name: ObjectName,
+    enable_normalization: bool,
+) -> Result<TableReference> {
+    // Use destructure to make it clear no fields on ObjectName are ignored
+    let ObjectName(idents) = object_name;
+    idents_to_table_reference(idents, enable_normalization)
+}
+
+struct IdentTaker {
+    normalizer: IdentNormalizer,
+    idents: Vec<Ident>,
+}
+
+/// Take the next identifier from the back of idents, panic'ing if
+/// there are none left
+impl IdentTaker {
+    fn new(idents: Vec<Ident>, enable_normalization: bool) -> Self {
+        Self {
+            normalizer: IdentNormalizer::new(enable_normalization),
+            idents,
+        }
+    }
+
+    fn take(&mut self) -> String {
+        let ident = self.idents.pop().expect("no more identifiers");
+        self.normalizer.normalize(ident)
+    }
+
+    /// Returns the number of remaining identifiers
+    fn len(&self) -> usize {
+        self.idents.len()
+    }
+}
+
+// impl Display for a nicer error message
+impl std::fmt::Display for IdentTaker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut first = true;
+        for ident in self.idents.iter() {
+            if !first {
+                write!(f, ".")?;
+            }
+            write!(f, "{}", ident)?;
+            first = false;
+        }
+
+        Ok(())
+    }
+}
+
+/// Create a [`TableReference`] after normalizing the specified identifier
+pub(crate) fn idents_to_table_reference(
+    idents: Vec<Ident>,
+    enable_normalization: bool,
+) -> Result<TableReference> {
+    let mut taker = IdentTaker::new(idents, enable_normalization);
+
+    match taker.len() {
+        1 => {
+            let table = taker.take();
+            Ok(TableReference::bare(table))
+        }
+        2 => {
+            let table = taker.take();
+            let schema = taker.take();
+            Ok(TableReference::partial(schema, table))
+        }
+        3 => {
+            let table = taker.take();
+            let schema = taker.take();
+            let catalog = taker.take();
+            Ok(TableReference::full(catalog, schema, table))
+        }
+        _ => plan_err!(
+            "Unsupported compound identifier '{}'. Expected 1, 2 or 3 parts, got {}",
+            taker,
+            taker.len()
+        ),
+    }
+}
+
+/// Construct a WHERE qualifier suitable for e.g. information_schema filtering
+/// from the provided object identifiers (catalog, schema and table names).
+pub fn object_name_to_qualifier(
+    sql_table_name: &ObjectName,
+    enable_normalization: bool,
+) -> String {
+    let columns = vec!["table_name", "table_schema", "table_catalog"].into_iter();
+    let normalizer = IdentNormalizer::new(enable_normalization);
+    sql_table_name
+        .0
+        .iter()
+        .rev()
+        .zip(columns)
+        .map(|(ident, column_name)| {
+            format!(
+                r#"{} = '{}'"#,
+                column_name,
+                normalizer.normalize(ident.clone())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}

--- a/crates/proof-of-sql/src/sql/new_parse/query.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/query.rs
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+
+use crate::stack::StackGuard;
+use datafusion_common::{not_impl_err, Constraints, DFSchema, Result};
+use datafusion_expr::expr::Sort;
+use datafusion_expr::{
+    CreateMemoryTable, DdlStatement, Distinct, LogicalPlan, LogicalPlanBuilder,
+};
+use sqlparser::ast::{
+    Expr as SQLExpr, Offset as SQLOffset, OrderBy, OrderByExpr, Query, SelectInto,
+    SetExpr,
+};
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    /// Generate a logical plan from an SQL query/subquery
+    pub(crate) fn query_to_plan(
+        &self,
+        query: Query,
+    ) -> ConversionResult<LogicalPlan> {
+        // Each query has its own planner context, including CTEs that are visible within that query.
+        // It also inherits the CTEs from the outer query by cloning the outer planner context.
+        let mut query_plan_context = outer_planner_context.clone();
+        let planner_context = &mut query_plan_context;
+
+        if let Some(with) = query.with {
+            self.plan_with_clause(with, planner_context)?;
+        }
+
+        let set_expr = *query.body;
+        match set_expr {
+            SetExpr::Select(mut select) => {
+                let select_into = select.into.take();
+                // Order-by expressions may refer to columns in the `FROM` clause,
+                // so we need to process `SELECT` and `ORDER BY` together.
+                let oby_exprs = to_order_by_exprs(query.order_by)?;
+                let plan = self.select_to_plan(*select, oby_exprs, planner_context)?;
+                let plan =
+                    self.limit(plan, query.offset, query.limit, planner_context)?;
+                // Process the `SELECT INTO` after `LIMIT`.
+                self.select_into(plan, select_into)
+            }
+            other => {
+                // The functions called from `set_expr_to_plan()` need more than 128KB
+                // stack in debug builds as investigated in:
+                // https://github.com/apache/datafusion/pull/13310#discussion_r1836813902
+                let plan = {
+                    // scope for dropping _guard
+                    let _guard = StackGuard::new(256 * 1024);
+                    self.set_expr_to_plan(other, planner_context)
+                }?;
+                let oby_exprs = to_order_by_exprs(query.order_by)?;
+                let order_by_rex = self.order_by_to_sort_expr(
+                    oby_exprs,
+                    plan.schema(),
+                    planner_context,
+                    true,
+                    None,
+                )?;
+                let plan = self.order_by(plan, order_by_rex)?;
+                self.limit(plan, query.offset, query.limit, planner_context)
+            }
+        }
+    }
+
+    /// Wrap a plan in a limit
+    fn limit(
+        &self,
+        input: LogicalPlan,
+        skip: Option<SQLOffset>,
+        fetch: Option<SQLExpr>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        if skip.is_none() && fetch.is_none() {
+            return Ok(input);
+        }
+
+        // skip and fetch expressions are not allowed to reference columns from the input plan
+        let empty_schema = DFSchema::empty();
+
+        let skip = skip
+            .map(|o| self.sql_to_expr(o.value, &empty_schema, planner_context))
+            .transpose()?;
+        let fetch = fetch
+            .map(|e| self.sql_to_expr(e, &empty_schema, planner_context))
+            .transpose()?;
+        LogicalPlanBuilder::from(input)
+            .limit_by_expr(skip, fetch)?
+            .build()
+    }
+
+    /// Wrap the logical in a sort
+    pub(super) fn order_by(
+        &self,
+        plan: LogicalPlan,
+        order_by: Vec<Sort>,
+    ) -> Result<LogicalPlan> {
+        if order_by.is_empty() {
+            return Ok(plan);
+        }
+
+        if let LogicalPlan::Distinct(Distinct::On(ref distinct_on)) = plan {
+            // In case of `DISTINCT ON` we must capture the sort expressions since during the plan
+            // optimization we're effectively doing a `first_value` aggregation according to them.
+            let distinct_on = distinct_on.clone().with_sort_expr(order_by)?;
+            Ok(LogicalPlan::Distinct(Distinct::On(distinct_on)))
+        } else {
+            LogicalPlanBuilder::from(plan).sort(order_by)?.build()
+        }
+    }
+
+    /// Wrap the logical plan in a `SelectInto`
+    fn select_into(
+        &self,
+        plan: LogicalPlan,
+        select_into: Option<SelectInto>,
+    ) -> Result<LogicalPlan> {
+        match select_into {
+            Some(into) => Ok(LogicalPlan::Ddl(DdlStatement::CreateMemoryTable(
+                CreateMemoryTable {
+                    name: self.object_name_to_table_reference(into.name)?,
+                    constraints: Constraints::empty(),
+                    input: Arc::new(plan),
+                    if_not_exists: false,
+                    or_replace: false,
+                    temporary: false,
+                    column_defaults: vec![],
+                },
+            ))),
+            _ => Ok(plan),
+        }
+    }
+}
+
+/// Returns the order by expressions from the query.
+fn to_order_by_exprs(order_by: Option<OrderBy>) -> Result<Vec<OrderByExpr>> {
+    let Some(OrderBy { exprs, interpolate }) = order_by else {
+        // If no order by, return an empty array.
+        return Ok(vec![]);
+    };
+    if let Some(_interpolate) = interpolate {
+        return not_impl_err!("ORDER BY INTERPOLATE is not supported");
+    }
+    Ok(exprs)
+}

--- a/crates/proof-of-sql/src/sql/new_parse/relation/join.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/relation/join.rs
@@ -1,0 +1,203 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use datafusion_common::{not_impl_err, Column, Result};
+use datafusion_expr::{JoinType, LogicalPlan, LogicalPlanBuilder};
+use sqlparser::ast::{
+    Join, JoinConstraint, JoinOperator, ObjectName, TableFactor, TableWithJoins,
+};
+use std::collections::HashSet;
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    pub(crate) fn plan_table_with_joins(
+        &self,
+        t: TableWithJoins,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        let mut left = if is_lateral(&t.relation) {
+            self.create_relation_subquery(t.relation, planner_context)?
+        } else {
+            self.create_relation(t.relation, planner_context)?
+        };
+        let old_outer_from_schema = planner_context.outer_from_schema();
+        for join in t.joins {
+            planner_context.extend_outer_from_schema(left.schema())?;
+            left = self.parse_relation_join(left, join, planner_context)?;
+        }
+        planner_context.set_outer_from_schema(old_outer_from_schema);
+        Ok(left)
+    }
+
+    fn parse_relation_join(
+        &self,
+        left: LogicalPlan,
+        join: Join,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        let right = if is_lateral_join(&join)? {
+            self.create_relation_subquery(join.relation, planner_context)?
+        } else {
+            self.create_relation(join.relation, planner_context)?
+        };
+        match join.join_operator {
+            JoinOperator::LeftOuter(constraint) => {
+                self.parse_join(left, right, constraint, JoinType::Left, planner_context)
+            }
+            JoinOperator::RightOuter(constraint) => {
+                self.parse_join(left, right, constraint, JoinType::Right, planner_context)
+            }
+            JoinOperator::Inner(constraint) => {
+                self.parse_join(left, right, constraint, JoinType::Inner, planner_context)
+            }
+            JoinOperator::LeftSemi(constraint) => self.parse_join(
+                left,
+                right,
+                constraint,
+                JoinType::LeftSemi,
+                planner_context,
+            ),
+            JoinOperator::RightSemi(constraint) => self.parse_join(
+                left,
+                right,
+                constraint,
+                JoinType::RightSemi,
+                planner_context,
+            ),
+            JoinOperator::LeftAnti(constraint) => self.parse_join(
+                left,
+                right,
+                constraint,
+                JoinType::LeftAnti,
+                planner_context,
+            ),
+            JoinOperator::RightAnti(constraint) => self.parse_join(
+                left,
+                right,
+                constraint,
+                JoinType::RightAnti,
+                planner_context,
+            ),
+            JoinOperator::FullOuter(constraint) => {
+                self.parse_join(left, right, constraint, JoinType::Full, planner_context)
+            }
+            JoinOperator::CrossJoin => self.parse_cross_join(left, right),
+            other => not_impl_err!("Unsupported JOIN operator {other:?}"),
+        }
+    }
+
+    fn parse_cross_join(
+        &self,
+        left: LogicalPlan,
+        right: LogicalPlan,
+    ) -> Result<LogicalPlan> {
+        LogicalPlanBuilder::from(left).cross_join(right)?.build()
+    }
+
+    fn parse_join(
+        &self,
+        left: LogicalPlan,
+        right: LogicalPlan,
+        constraint: JoinConstraint,
+        join_type: JoinType,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        match constraint {
+            JoinConstraint::On(sql_expr) => {
+                let join_schema = left.schema().join(right.schema())?;
+                // parse ON expression
+                let expr = self.sql_to_expr(sql_expr, &join_schema, planner_context)?;
+                LogicalPlanBuilder::from(left)
+                    .join_on(right, join_type, Some(expr))?
+                    .build()
+            }
+            JoinConstraint::Using(object_names) => {
+                let keys = object_names
+                    .into_iter()
+                    .map(|object_name| {
+                        let ObjectName(mut object_names) = object_name;
+                        if object_names.len() != 1 {
+                            not_impl_err!(
+                                "Invalid identifier in USING clause. Expected single identifier, got {}", ObjectName(object_names)
+                            )
+                        } else {
+                            let id = object_names.swap_remove(0);
+                            Ok(self.ident_normalizer.normalize(id))
+                        }
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                LogicalPlanBuilder::from(left)
+                    .join_using(right, join_type, keys)?
+                    .build()
+            }
+            JoinConstraint::Natural => {
+                let left_cols: HashSet<&String> =
+                    left.schema().fields().iter().map(|f| f.name()).collect();
+                let keys: Vec<Column> = right
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|f| f.name())
+                    .filter(|f| left_cols.contains(f))
+                    .map(Column::from_name)
+                    .collect();
+                if keys.is_empty() {
+                    self.parse_cross_join(left, right)
+                } else {
+                    LogicalPlanBuilder::from(left)
+                        .join_using(right, join_type, keys)?
+                        .build()
+                }
+            }
+            JoinConstraint::None => LogicalPlanBuilder::from(left)
+                .join_on(right, join_type, [])?
+                .build(),
+        }
+    }
+}
+
+/// Return `true` iff the given [`TableFactor`] is lateral.
+pub(crate) fn is_lateral(factor: &TableFactor) -> bool {
+    match factor {
+        TableFactor::Derived { lateral, .. } => *lateral,
+        TableFactor::Function { lateral, .. } => *lateral,
+        TableFactor::UNNEST { .. } => true,
+        _ => false,
+    }
+}
+
+/// Return `true` iff the given [`Join`] is lateral.
+pub(crate) fn is_lateral_join(join: &Join) -> Result<bool> {
+    let is_lateral_syntax = is_lateral(&join.relation);
+    let is_apply_syntax = match join.join_operator {
+        JoinOperator::FullOuter(..)
+        | JoinOperator::RightOuter(..)
+        | JoinOperator::RightAnti(..)
+        | JoinOperator::RightSemi(..)
+            if is_lateral_syntax =>
+        {
+            return not_impl_err!(
+                "LATERAL syntax is not supported for \
+                 FULL OUTER and RIGHT [OUTER | ANTI | SEMI] joins"
+            );
+        }
+        JoinOperator::CrossApply | JoinOperator::OuterApply => true,
+        _ => false,
+    };
+    Ok(is_lateral_syntax || is_apply_syntax)
+}

--- a/crates/proof-of-sql/src/sql/new_parse/relation/mod.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/relation/mod.rs
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+
+use datafusion_common::tree_node::{Transformed, TreeNode};
+use datafusion_common::{
+    not_impl_err, plan_err, DFSchema, Diagnostic, Result, Span, TableReference,
+};
+use datafusion_expr::builder::subquery_alias;
+use datafusion_expr::{expr::Unnest, Expr, LogicalPlan, LogicalPlanBuilder};
+use datafusion_expr::{Subquery, SubqueryAlias};
+use sqlparser::ast::{FunctionArg, FunctionArgExpr, Spanned, TableFactor};
+
+mod join;
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    /// Create a `LogicalPlan` that scans the named relation
+    fn create_relation(
+        &self,
+        relation: TableFactor,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        let relation_span = relation.span();
+        let (plan, alias) = match relation {
+            TableFactor::Table {
+                name, alias, args, ..
+            } => {
+                if let Some(func_args) = args {
+                    let tbl_func_name = name.0.first().unwrap().value.to_string();
+                    let args = func_args
+                        .args
+                        .into_iter()
+                        .flat_map(|arg| {
+                            if let FunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) = arg
+                            {
+                                self.sql_expr_to_logical_expr(
+                                    expr,
+                                    &DFSchema::empty(),
+                                    planner_context,
+                                )
+                            } else {
+                                plan_err!("Unsupported function argument type: {:?}", arg)
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    let provider = self
+                        .context_provider
+                        .get_table_function_source(&tbl_func_name, args)?;
+                    let plan = LogicalPlanBuilder::scan(
+                        TableReference::Bare {
+                            table: "tmp_table".into(),
+                        },
+                        provider,
+                        None,
+                    )?
+                    .build()?;
+                    (plan, alias)
+                } else {
+                    // Normalize name and alias
+                    let table_ref = self.object_name_to_table_reference(name)?;
+                    let table_name = table_ref.to_string();
+                    let cte = planner_context.get_cte(&table_name);
+                    (
+                        match (
+                            cte,
+                            self.context_provider.get_table_source(table_ref.clone()),
+                        ) {
+                            (Some(cte_plan), _) => Ok(cte_plan.clone()),
+                            (_, Ok(provider)) => LogicalPlanBuilder::scan(
+                                table_ref.clone(),
+                                provider,
+                                None,
+                            )?
+                            .build(),
+                            (None, Err(e)) => {
+                                let e = e.with_diagnostic(Diagnostic::new_error(
+                                    format!("table '{}' not found", table_ref),
+                                    Span::try_from_sqlparser_span(relation_span),
+                                ));
+                                Err(e)
+                            }
+                        }?,
+                        alias,
+                    )
+                }
+            }
+            TableFactor::Derived {
+                subquery, alias, ..
+            } => {
+                let logical_plan = self.query_to_plan(*subquery, planner_context)?;
+                (logical_plan, alias)
+            }
+            TableFactor::NestedJoin {
+                table_with_joins,
+                alias,
+            } => (
+                self.plan_table_with_joins(*table_with_joins, planner_context)?,
+                alias,
+            ),
+            TableFactor::UNNEST {
+                alias,
+                array_exprs,
+                with_offset: false,
+                with_offset_alias: None,
+                with_ordinality,
+            } => {
+                if with_ordinality {
+                    return not_impl_err!("UNNEST with ordinality is not supported yet");
+                }
+
+                // Unnest table factor has empty input
+                let schema = DFSchema::empty();
+                let input = LogicalPlanBuilder::empty(true).build()?;
+                // Unnest table factor can have multiple arguments.
+                // We treat each argument as a separate unnest expression.
+                let unnest_exprs = array_exprs
+                    .into_iter()
+                    .map(|sql_expr| {
+                        let expr = self.sql_expr_to_logical_expr(
+                            sql_expr,
+                            &schema,
+                            planner_context,
+                        )?;
+                        Self::check_unnest_arg(&expr, &schema)?;
+                        Ok(Expr::Unnest(Unnest::new(expr)))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                if unnest_exprs.is_empty() {
+                    return plan_err!("UNNEST must have at least one argument");
+                }
+                let logical_plan = self.try_process_unnest(input, unnest_exprs)?;
+                (logical_plan, alias)
+            }
+            TableFactor::UNNEST { .. } => {
+                return not_impl_err!(
+                    "UNNEST table factor with offset is not supported yet"
+                );
+            }
+            // @todo Support TableFactory::TableFunction?
+            _ => {
+                return not_impl_err!(
+                    "Unsupported ast node {relation:?} in create_relation"
+                );
+            }
+        };
+
+        let optimized_plan = optimize_subquery_sort(plan)?.data;
+        if let Some(alias) = alias {
+            self.apply_table_alias(optimized_plan, alias)
+        } else {
+            Ok(optimized_plan)
+        }
+    }
+
+    pub(crate) fn create_relation_subquery(
+        &self,
+        subquery: TableFactor,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        // At this point for a syntactically valid query the outer_from_schema is
+        // guaranteed to be set, so the `.unwrap()` call will never panic. This
+        // is the case because we only call this method for lateral table
+        // factors, and those can never be the first factor in a FROM list. This
+        // means we arrived here through the `for` loop in `plan_from_tables` or
+        // the `for` loop in `plan_table_with_joins`.
+        let old_from_schema = planner_context
+            .set_outer_from_schema(None)
+            .unwrap_or_else(|| Arc::new(DFSchema::empty()));
+        let new_query_schema = match planner_context.outer_query_schema() {
+            Some(old_query_schema) => {
+                let mut new_query_schema = old_from_schema.as_ref().clone();
+                new_query_schema.merge(old_query_schema);
+                Some(Arc::new(new_query_schema))
+            }
+            None => Some(Arc::clone(&old_from_schema)),
+        };
+        let old_query_schema = planner_context.set_outer_query_schema(new_query_schema);
+
+        let plan = self.create_relation(subquery, planner_context)?;
+        let outer_ref_columns = plan.all_out_ref_exprs();
+
+        planner_context.set_outer_query_schema(old_query_schema);
+        planner_context.set_outer_from_schema(Some(old_from_schema));
+
+        // We can omit the subquery wrapper if there are no columns
+        // referencing the outer scope.
+        if outer_ref_columns.is_empty() {
+            return Ok(plan);
+        }
+
+        match plan {
+            LogicalPlan::SubqueryAlias(SubqueryAlias { input, alias, .. }) => {
+                subquery_alias(
+                    LogicalPlan::Subquery(Subquery {
+                        subquery: input,
+                        outer_ref_columns,
+                    }),
+                    alias,
+                )
+            }
+            plan => Ok(LogicalPlan::Subquery(Subquery {
+                subquery: Arc::new(plan),
+                outer_ref_columns,
+            })),
+        }
+    }
+}
+
+fn optimize_subquery_sort(plan: LogicalPlan) -> Result<Transformed<LogicalPlan>> {
+    // When initializing subqueries, we examine sort options since they might be unnecessary.
+    // They are only important if the subquery result is affected by the ORDER BY statement,
+    // which can happen when we have:
+    // 1. DISTINCT ON / ARRAY_AGG ... => Handled by an `Aggregate` and its requirements.
+    // 2. RANK / ROW_NUMBER ... => Handled by a `WindowAggr` and its requirements.
+    // 3. LIMIT => Handled by a `Sort`, so we need to search for it.
+    let mut has_limit = false;
+    let new_plan = plan.transform_down(|c| {
+        if let LogicalPlan::Limit(_) = c {
+            has_limit = true;
+            return Ok(Transformed::no(c));
+        }
+        match c {
+            LogicalPlan::Sort(s) => {
+                if !has_limit {
+                    has_limit = false;
+                    return Ok(Transformed::yes(s.input.as_ref().clone()));
+                }
+                Ok(Transformed::no(LogicalPlan::Sort(s)))
+            }
+            _ => Ok(Transformed::no(c)),
+        }
+    });
+    new_plan
+}

--- a/crates/proof-of-sql/src/sql/new_parse/select.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/select.rs
@@ -1,0 +1,879 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use crate::utils::{
+    check_columns_satisfy_exprs, extract_aliases, rebase_expr, resolve_aliases_to_exprs,
+    resolve_columns, resolve_positions_to_exprs, rewrite_recursive_unnests_bottom_up,
+    CheckColumnsSatisfyExprsPurpose,
+};
+
+use datafusion_common::error::DataFusionErrorBuilder;
+use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion_common::{not_impl_err, plan_err, Result};
+use datafusion_common::{RecursionUnnestOption, UnnestOptions};
+use datafusion_expr::expr::{Alias, PlannedReplaceSelectItem, WildcardOptions};
+use datafusion_expr::expr_rewriter::{
+    normalize_col, normalize_col_with_schemas_and_ambiguity_check, normalize_sorts,
+};
+use datafusion_expr::utils::{
+    expr_as_column_expr, expr_to_columns, find_aggregate_exprs, find_window_exprs,
+};
+use datafusion_expr::{
+    qualified_wildcard_with_options, wildcard_with_options, Aggregate, Expr, Filter,
+    GroupingSet, LogicalPlan, LogicalPlanBuilder, Partitioning,
+};
+
+use indexmap::IndexMap;
+use sqlparser::ast::{
+    Distinct, Expr as SQLExpr, GroupByExpr, NamedWindowExpr, OrderByExpr,
+    WildcardAdditionalOptions, WindowType,
+};
+use sqlparser::ast::{NamedWindowDefinition, Select, SelectItem, TableWithJoins};
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    /// Generate a logic plan from an SQL select
+    pub(super) fn select_to_plan(
+        &self,
+        mut select: Select,
+        order_by: Vec<OrderByExpr>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        // Check for unsupported syntax first
+        if !select.cluster_by.is_empty() {
+            return not_impl_err!("CLUSTER BY");
+        }
+        if !select.lateral_views.is_empty() {
+            return not_impl_err!("LATERAL VIEWS");
+        }
+        if select.qualify.is_some() {
+            return not_impl_err!("QUALIFY");
+        }
+        if select.top.is_some() {
+            return not_impl_err!("TOP");
+        }
+        if !select.sort_by.is_empty() {
+            return not_impl_err!("SORT BY");
+        }
+
+        // Process `from` clause
+        let plan = self.plan_from_tables(select.from, planner_context)?;
+        let empty_from = matches!(plan, LogicalPlan::EmptyRelation(_));
+
+        // Process `where` clause
+        let base_plan = self.plan_selection(select.selection, plan, planner_context)?;
+
+        // Handle named windows before processing the projection expression
+        check_conflicting_windows(&select.named_window)?;
+        match_window_definitions(&mut select.projection, &select.named_window)?;
+        // Process the SELECT expressions
+        let select_exprs = self.prepare_select_exprs(
+            &base_plan,
+            select.projection,
+            empty_from,
+            planner_context,
+        )?;
+
+        // Having and group by clause may reference aliases defined in select projection
+        let projected_plan = self.project(base_plan.clone(), select_exprs.clone())?;
+
+        // Place the fields of the base plan at the front so that when there are references
+        // with the same name, the fields of the base plan will be searched first.
+        // See https://github.com/apache/datafusion/issues/9162
+        let mut combined_schema = base_plan.schema().as_ref().clone();
+        combined_schema.merge(projected_plan.schema());
+
+        // Order-by expressions prioritize referencing columns from the select list,
+        // then from the FROM clause.
+        let order_by_rex = self.order_by_to_sort_expr(
+            order_by,
+            projected_plan.schema().as_ref(),
+            planner_context,
+            true,
+            Some(base_plan.schema().as_ref()),
+        )?;
+        let order_by_rex = normalize_sorts(order_by_rex, &projected_plan)?;
+
+        // This alias map is resolved and looked up in both having exprs and group by exprs
+        let alias_map = extract_aliases(&select_exprs);
+
+        // Optionally the HAVING expression.
+        let having_expr_opt = select
+            .having
+            .map::<Result<Expr>, _>(|having_expr| {
+                let having_expr = self.sql_expr_to_logical_expr(
+                    having_expr,
+                    &combined_schema,
+                    planner_context,
+                )?;
+                // This step "dereferences" any aliases in the HAVING clause.
+                //
+                // This is how we support queries with HAVING expressions that
+                // refer to aliased columns.
+                //
+                // For example:
+                //
+                //   SELECT c1, MAX(c2) AS m FROM t GROUP BY c1 HAVING m > 10;
+                //
+                // are rewritten as, respectively:
+                //
+                //   SELECT c1, MAX(c2) AS m FROM t GROUP BY c1 HAVING MAX(c2) > 10;
+                //
+                let having_expr = resolve_aliases_to_exprs(having_expr, &alias_map)?;
+                normalize_col(having_expr, &projected_plan)
+            })
+            .transpose()?;
+
+        // The outer expressions we will search through for aggregates.
+        // Aggregates may be sourced from the SELECT list or from the HAVING expression.
+        let aggr_expr_haystack = select_exprs.iter().chain(having_expr_opt.iter());
+        // All of the aggregate expressions (deduplicated).
+        let aggr_exprs = find_aggregate_exprs(aggr_expr_haystack);
+
+        // All of the group by expressions
+        let group_by_exprs = if let GroupByExpr::Expressions(exprs, _) = select.group_by {
+            exprs
+                .into_iter()
+                .map(|e| {
+                    let group_by_expr = self.sql_expr_to_logical_expr(
+                        e,
+                        &combined_schema,
+                        planner_context,
+                    )?;
+
+                    // Aliases from the projection can conflict with same-named expressions in the input
+                    let mut alias_map = alias_map.clone();
+                    for f in base_plan.schema().fields() {
+                        alias_map.remove(f.name());
+                    }
+                    let group_by_expr =
+                        resolve_aliases_to_exprs(group_by_expr, &alias_map)?;
+                    let group_by_expr =
+                        resolve_positions_to_exprs(group_by_expr, &select_exprs)?;
+                    let group_by_expr = normalize_col(group_by_expr, &projected_plan)?;
+                    self.validate_schema_satisfies_exprs(
+                        base_plan.schema(),
+                        std::slice::from_ref(&group_by_expr),
+                    )?;
+                    Ok(group_by_expr)
+                })
+                .collect::<Result<Vec<Expr>>>()?
+        } else {
+            // 'group by all' groups wrt. all select expressions except 'AggregateFunction's.
+            // Filter and collect non-aggregate select expressions
+            select_exprs
+                .iter()
+                .filter(|select_expr| match select_expr {
+                    Expr::AggregateFunction(_) => false,
+                    Expr::Alias(Alias { expr, name: _, .. }) => {
+                        !matches!(**expr, Expr::AggregateFunction(_))
+                    }
+                    _ => true,
+                })
+                .cloned()
+                .collect()
+        };
+
+        // Process group by, aggregation or having
+        let (plan, mut select_exprs_post_aggr, having_expr_post_aggr) = if !group_by_exprs
+            .is_empty()
+            || !aggr_exprs.is_empty()
+        {
+            self.aggregate(
+                &base_plan,
+                &select_exprs,
+                having_expr_opt.as_ref(),
+                &group_by_exprs,
+                &aggr_exprs,
+            )?
+        } else {
+            match having_expr_opt {
+                Some(having_expr) => return plan_err!("HAVING clause references: {having_expr} must appear in the GROUP BY clause or be used in an aggregate function"),
+                None => (base_plan.clone(), select_exprs.clone(), having_expr_opt)
+            }
+        };
+
+        let plan = if let Some(having_expr_post_aggr) = having_expr_post_aggr {
+            LogicalPlanBuilder::from(plan)
+                .having(having_expr_post_aggr)?
+                .build()?
+        } else {
+            plan
+        };
+
+        // Process window function
+        let window_func_exprs = find_window_exprs(&select_exprs_post_aggr);
+
+        let plan = if window_func_exprs.is_empty() {
+            plan
+        } else {
+            let plan = LogicalPlanBuilder::window_plan(plan, window_func_exprs.clone())?;
+
+            // Re-write the projection
+            select_exprs_post_aggr = select_exprs_post_aggr
+                .iter()
+                .map(|expr| rebase_expr(expr, &window_func_exprs, &plan))
+                .collect::<Result<Vec<Expr>>>()?;
+
+            plan
+        };
+
+        // Try processing unnest expression or do the final projection
+        let plan = self.try_process_unnest(plan, select_exprs_post_aggr)?;
+
+        // Process distinct clause
+        let plan = match select.distinct {
+            None => Ok(plan),
+            Some(Distinct::Distinct) => {
+                LogicalPlanBuilder::from(plan).distinct()?.build()
+            }
+            Some(Distinct::On(on_expr)) => {
+                if !aggr_exprs.is_empty()
+                    || !group_by_exprs.is_empty()
+                    || !window_func_exprs.is_empty()
+                {
+                    return not_impl_err!("DISTINCT ON expressions with GROUP BY, aggregation or window functions are not supported ");
+                }
+
+                let on_expr = on_expr
+                    .into_iter()
+                    .map(|e| {
+                        self.sql_expr_to_logical_expr(e, plan.schema(), planner_context)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                // Build the final plan
+                LogicalPlanBuilder::from(base_plan)
+                    .distinct_on(on_expr, select_exprs, None)?
+                    .build()
+            }
+        }?;
+
+        // DISTRIBUTE BY
+        let plan = if !select.distribute_by.is_empty() {
+            let x = select
+                .distribute_by
+                .iter()
+                .map(|e| {
+                    self.sql_expr_to_logical_expr(
+                        e.clone(),
+                        &combined_schema,
+                        planner_context,
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?;
+            LogicalPlanBuilder::from(plan)
+                .repartition(Partitioning::DistributeBy(x))?
+                .build()?
+        } else {
+            plan
+        };
+
+        self.order_by(plan, order_by_rex)
+    }
+
+    /// Try converting Expr(Unnest(Expr)) to Projection/Unnest/Projection
+    pub(super) fn try_process_unnest(
+        &self,
+        input: LogicalPlan,
+        select_exprs: Vec<Expr>,
+    ) -> Result<LogicalPlan> {
+        // Try process group by unnest
+        let input = self.try_process_aggregate_unnest(input)?;
+
+        let mut intermediate_plan = input;
+        let mut intermediate_select_exprs = select_exprs;
+
+        // Each expr in select_exprs can contains multiple unnest stage
+        // The transformation happen bottom up, one at a time for each iteration
+        // Only exhaust the loop if no more unnest transformation is found
+        for i in 0.. {
+            let mut unnest_columns = IndexMap::new();
+            // from which column used for projection, before the unnest happen
+            // including non unnest column and unnest column
+            let mut inner_projection_exprs = vec![];
+
+            // expr returned here maybe different from the originals in inner_projection_exprs
+            // for example:
+            // - unnest(struct_col) will be transformed into unnest(struct_col).field1, unnest(struct_col).field2
+            // - unnest(array_col) will be transformed into unnest(array_col).element
+            // - unnest(array_col) + 1 will be transformed into unnest(array_col).element +1
+            let outer_projection_exprs = rewrite_recursive_unnests_bottom_up(
+                &intermediate_plan,
+                &mut unnest_columns,
+                &mut inner_projection_exprs,
+                &intermediate_select_exprs,
+            )?;
+
+            // No more unnest is possible
+            if unnest_columns.is_empty() {
+                // The original expr does not contain any unnest
+                if i == 0 {
+                    return LogicalPlanBuilder::from(intermediate_plan)
+                        .project(intermediate_select_exprs)?
+                        .build();
+                }
+                break;
+            } else {
+                // Set preserve_nulls to false to ensure compatibility with DuckDB and PostgreSQL
+                let mut unnest_options = UnnestOptions::new().with_preserve_nulls(false);
+                let mut unnest_col_vec = vec![];
+
+                for (col, maybe_list_unnest) in unnest_columns.into_iter() {
+                    if let Some(list_unnest) = maybe_list_unnest {
+                        unnest_options = list_unnest.into_iter().fold(
+                            unnest_options,
+                            |options, unnest_list| {
+                                options.with_recursions(RecursionUnnestOption {
+                                    input_column: col.clone(),
+                                    output_column: unnest_list.output_column,
+                                    depth: unnest_list.depth,
+                                })
+                            },
+                        );
+                    }
+                    unnest_col_vec.push(col);
+                }
+                let plan = LogicalPlanBuilder::from(intermediate_plan)
+                    .project(inner_projection_exprs)?
+                    .unnest_columns_with_options(unnest_col_vec, unnest_options)?
+                    .build()?;
+                intermediate_plan = plan;
+                intermediate_select_exprs = outer_projection_exprs;
+            }
+        }
+
+        LogicalPlanBuilder::from(intermediate_plan)
+            .project(intermediate_select_exprs)?
+            .build()
+    }
+
+    fn try_process_aggregate_unnest(&self, input: LogicalPlan) -> Result<LogicalPlan> {
+        match input {
+            LogicalPlan::Aggregate(agg) => {
+                let agg_expr = agg.aggr_expr.clone();
+                let (new_input, new_group_by_exprs) =
+                    self.try_process_group_by_unnest(agg)?;
+                LogicalPlanBuilder::from(new_input)
+                    .aggregate(new_group_by_exprs, agg_expr)?
+                    .build()
+            }
+            LogicalPlan::Filter(mut filter) => {
+                filter.input =
+                    Arc::new(self.try_process_aggregate_unnest(Arc::unwrap_or_clone(
+                        filter.input,
+                    ))?);
+                Ok(LogicalPlan::Filter(filter))
+            }
+            _ => Ok(input),
+        }
+    }
+
+    /// Try converting Unnest(Expr) of group by to Unnest/Projection.
+    /// Return the new input and group_by_exprs of Aggregate.
+    /// Select exprs can be different from agg exprs, for example:
+    fn try_process_group_by_unnest(
+        &self,
+        agg: Aggregate,
+    ) -> Result<(LogicalPlan, Vec<Expr>)> {
+        let mut aggr_expr_using_columns: Option<HashSet<Expr>> = None;
+
+        let Aggregate {
+            input,
+            group_expr,
+            aggr_expr,
+            ..
+        } = agg;
+
+        // Process unnest of group_by_exprs, and input of agg will be rewritten
+        // for example:
+        //
+        // ```
+        // Aggregate: groupBy=[[UNNEST(Column(Column { relation: Some(Bare { table: "tab" }), name: "array_col" }))]], aggr=[[]]
+        //   TableScan: tab
+        // ```
+        //
+        // will be transformed into
+        //
+        // ```
+        // Aggregate: groupBy=[[unnest(tab.array_col)]], aggr=[[]]
+        //   Unnest: lists[unnest(tab.array_col)] structs[]
+        //     Projection: tab.array_col AS unnest(tab.array_col)
+        //       TableScan: tab
+        // ```
+        let mut intermediate_plan = Arc::unwrap_or_clone(input);
+        let mut intermediate_select_exprs = group_expr;
+
+        loop {
+            let mut unnest_columns = IndexMap::new();
+            let mut inner_projection_exprs = vec![];
+
+            let outer_projection_exprs = rewrite_recursive_unnests_bottom_up(
+                &intermediate_plan,
+                &mut unnest_columns,
+                &mut inner_projection_exprs,
+                &intermediate_select_exprs,
+            )?;
+
+            if unnest_columns.is_empty() {
+                break;
+            } else {
+                let mut unnest_options = UnnestOptions::new().with_preserve_nulls(false);
+
+                let mut projection_exprs = match &aggr_expr_using_columns {
+                    Some(exprs) => (*exprs).clone(),
+                    None => {
+                        let mut columns = HashSet::new();
+                        for expr in &aggr_expr {
+                            expr.apply(|expr| {
+                                if let Expr::Column(c) = expr {
+                                    columns.insert(Expr::Column(c.clone()));
+                                }
+                                Ok(TreeNodeRecursion::Continue)
+                            })
+                            // As the closure always returns Ok, this "can't" error
+                            .expect("Unexpected error");
+                        }
+                        aggr_expr_using_columns = Some(columns.clone());
+                        columns
+                    }
+                };
+                projection_exprs.extend(inner_projection_exprs);
+
+                let mut unnest_col_vec = vec![];
+
+                for (col, maybe_list_unnest) in unnest_columns.into_iter() {
+                    if let Some(list_unnest) = maybe_list_unnest {
+                        unnest_options = list_unnest.into_iter().fold(
+                            unnest_options,
+                            |options, unnest_list| {
+                                options.with_recursions(RecursionUnnestOption {
+                                    input_column: col.clone(),
+                                    output_column: unnest_list.output_column,
+                                    depth: unnest_list.depth,
+                                })
+                            },
+                        );
+                    }
+                    unnest_col_vec.push(col);
+                }
+
+                intermediate_plan = LogicalPlanBuilder::from(intermediate_plan)
+                    .project(projection_exprs)?
+                    .unnest_columns_with_options(unnest_col_vec, unnest_options)?
+                    .build()?;
+
+                intermediate_select_exprs = outer_projection_exprs;
+            }
+        }
+
+        Ok((intermediate_plan, intermediate_select_exprs))
+    }
+
+    fn plan_selection(
+        &self,
+        selection: Option<SQLExpr>,
+        plan: LogicalPlan,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        match selection {
+            Some(predicate_expr) => {
+                let fallback_schemas = plan.fallback_normalize_schemas();
+                let outer_query_schema = planner_context.outer_query_schema().cloned();
+                let outer_query_schema_vec = outer_query_schema
+                    .as_ref()
+                    .map(|schema| vec![schema])
+                    .unwrap_or_else(Vec::new);
+
+                let filter_expr =
+                    self.sql_to_expr(predicate_expr, plan.schema(), planner_context)?;
+
+                // Check for aggregation functions
+                let aggregate_exprs =
+                    find_aggregate_exprs(std::slice::from_ref(&filter_expr));
+                if !aggregate_exprs.is_empty() {
+                    return plan_err!(
+                        "Aggregate functions are not allowed in the WHERE clause. Consider using HAVING instead"
+                    );
+                }
+
+                let mut using_columns = HashSet::new();
+                expr_to_columns(&filter_expr, &mut using_columns)?;
+                let filter_expr = normalize_col_with_schemas_and_ambiguity_check(
+                    filter_expr,
+                    &[&[plan.schema()], &fallback_schemas, &outer_query_schema_vec],
+                    &[using_columns],
+                )?;
+
+                Ok(LogicalPlan::Filter(Filter::try_new(
+                    filter_expr,
+                    Arc::new(plan),
+                )?))
+            }
+            None => Ok(plan),
+        }
+    }
+
+    pub(crate) fn plan_from_tables(
+        &self,
+        mut from: Vec<TableWithJoins>,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        match from.len() {
+            0 => Ok(LogicalPlanBuilder::empty(true).build()?),
+            1 => {
+                let input = from.remove(0);
+                self.plan_table_with_joins(input, planner_context)
+            }
+            _ => {
+                let mut from = from.into_iter();
+
+                let mut left = LogicalPlanBuilder::from({
+                    let input = from.next().unwrap();
+                    self.plan_table_with_joins(input, planner_context)?
+                });
+                let old_outer_from_schema = {
+                    let left_schema = Some(Arc::clone(left.schema()));
+                    planner_context.set_outer_from_schema(left_schema)
+                };
+                for input in from {
+                    // Join `input` with the current result (`left`).
+                    let right = self.plan_table_with_joins(input, planner_context)?;
+                    left = left.cross_join(right)?;
+                    // Update the outer FROM schema.
+                    let left_schema = Some(Arc::clone(left.schema()));
+                    planner_context.set_outer_from_schema(left_schema);
+                }
+                planner_context.set_outer_from_schema(old_outer_from_schema);
+                left.build()
+            }
+        }
+    }
+
+    /// Returns the `Expr`'s corresponding to a SQL query's SELECT expressions.
+    fn prepare_select_exprs(
+        &self,
+        plan: &LogicalPlan,
+        projection: Vec<SelectItem>,
+        empty_from: bool,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Vec<Expr>> {
+        let mut prepared_select_exprs = vec![];
+        let mut error_builder = DataFusionErrorBuilder::new();
+        for expr in projection {
+            match self.sql_select_to_rex(expr, plan, empty_from, planner_context) {
+                Ok(expr) => prepared_select_exprs.push(expr),
+                Err(err) => error_builder.add_error(err),
+            }
+        }
+        error_builder.error_or(prepared_select_exprs)
+    }
+
+    /// Generate a relational expression from a select SQL expression
+    fn sql_select_to_rex(
+        &self,
+        sql: SelectItem,
+        plan: &LogicalPlan,
+        empty_from: bool,
+        planner_context: &mut PlannerContext,
+    ) -> Result<Expr> {
+        match sql {
+            SelectItem::UnnamedExpr(expr) => {
+                let expr = self.sql_to_expr(expr, plan.schema(), planner_context)?;
+                let col = normalize_col_with_schemas_and_ambiguity_check(
+                    expr,
+                    &[&[plan.schema()]],
+                    &plan.using_columns()?,
+                )?;
+                Ok(col)
+            }
+            SelectItem::ExprWithAlias { expr, alias } => {
+                let select_expr =
+                    self.sql_to_expr(expr, plan.schema(), planner_context)?;
+                let col = normalize_col_with_schemas_and_ambiguity_check(
+                    select_expr,
+                    &[&[plan.schema()]],
+                    &plan.using_columns()?,
+                )?;
+                let name = self.ident_normalizer.normalize(alias);
+                // avoiding adding an alias if the column name is the same.
+                let expr = match &col {
+                    Expr::Column(column) if column.name.eq(&name) => col,
+                    _ => col.alias(name),
+                };
+                Ok(expr)
+            }
+            SelectItem::Wildcard(options) => {
+                Self::check_wildcard_options(&options)?;
+                if empty_from {
+                    return plan_err!("SELECT * with no tables specified is not valid");
+                }
+                let planned_options = self.plan_wildcard_options(
+                    plan,
+                    empty_from,
+                    planner_context,
+                    options,
+                )?;
+                Ok(wildcard_with_options(planned_options))
+            }
+            SelectItem::QualifiedWildcard(object_name, options) => {
+                Self::check_wildcard_options(&options)?;
+                let qualifier = self.object_name_to_table_reference(object_name)?;
+                let planned_options = self.plan_wildcard_options(
+                    plan,
+                    empty_from,
+                    planner_context,
+                    options,
+                )?;
+                Ok(qualified_wildcard_with_options(qualifier, planned_options))
+            }
+        }
+    }
+
+    fn check_wildcard_options(options: &WildcardAdditionalOptions) -> Result<()> {
+        let WildcardAdditionalOptions {
+            // opt_exclude is handled
+            opt_exclude: _opt_exclude,
+            opt_except: _opt_except,
+            opt_rename,
+            opt_replace: _opt_replace,
+            opt_ilike: _opt_ilike,
+            wildcard_token: _wildcard_token,
+        } = options;
+
+        if opt_rename.is_some() {
+            not_impl_err!("wildcard * with RENAME not supported ")
+        } else {
+            Ok(())
+        }
+    }
+
+    /// If there is a REPLACE statement in the projected expression in the form of
+    /// "REPLACE (some_column_within_an_expr AS some_column)", we should plan the
+    /// replace expressions first.
+    fn plan_wildcard_options(
+        &self,
+        plan: &LogicalPlan,
+        empty_from: bool,
+        planner_context: &mut PlannerContext,
+        options: WildcardAdditionalOptions,
+    ) -> Result<WildcardOptions> {
+        let planned_option = WildcardOptions {
+            ilike: options.opt_ilike,
+            exclude: options.opt_exclude,
+            except: options.opt_except,
+            replace: None,
+            rename: options.opt_rename,
+        };
+        if let Some(replace) = options.opt_replace {
+            let replace_expr = replace
+                .items
+                .iter()
+                .map(|item| {
+                    self.sql_select_to_rex(
+                        SelectItem::UnnamedExpr(item.expr.clone()),
+                        plan,
+                        empty_from,
+                        planner_context,
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let planned_replace = PlannedReplaceSelectItem {
+                items: replace.items.into_iter().map(|i| *i).collect(),
+                planned_expressions: replace_expr,
+            };
+            Ok(planned_option.with_replace(planned_replace))
+        } else {
+            Ok(planned_option)
+        }
+    }
+
+    /// Wrap a plan in a projection
+    fn project(&self, input: LogicalPlan, expr: Vec<Expr>) -> Result<LogicalPlan> {
+        self.validate_schema_satisfies_exprs(input.schema(), &expr)?;
+        LogicalPlanBuilder::from(input).project(expr)?.build()
+    }
+
+    /// Create an aggregate plan.
+    ///
+    /// An aggregate plan consists of grouping expressions, aggregate expressions, and an
+    /// optional HAVING expression (which is a filter on the output of the aggregate).
+    ///
+    /// # Arguments
+    ///
+    /// * `input`           - The input plan that will be aggregated. The grouping, aggregate, and
+    ///                       "having" expressions must all be resolvable from this plan.
+    /// * `select_exprs`    - The projection expressions from the SELECT clause.
+    /// * `having_expr_opt` - Optional HAVING clause.
+    /// * `group_by_exprs`  - Grouping expressions from the GROUP BY clause. These can be column
+    ///                       references or more complex expressions.
+    /// * `aggr_exprs`      - Aggregate expressions, such as `SUM(a)` or `COUNT(1)`.
+    ///
+    /// # Return
+    ///
+    /// The return value is a triplet of the following items:
+    ///
+    /// * `plan`                   - A [LogicalPlan::Aggregate] plan for the newly created aggregate.
+    /// * `select_exprs_post_aggr` - The projection expressions rewritten to reference columns from
+    ///                              the aggregate
+    /// * `having_expr_post_aggr`  - The "having" expression rewritten to reference a column from
+    ///                              the aggregate
+    fn aggregate(
+        &self,
+        input: &LogicalPlan,
+        select_exprs: &[Expr],
+        having_expr_opt: Option<&Expr>,
+        group_by_exprs: &[Expr],
+        aggr_exprs: &[Expr],
+    ) -> Result<(LogicalPlan, Vec<Expr>, Option<Expr>)> {
+        // create the aggregate plan
+        let plan = LogicalPlanBuilder::from(input.clone())
+            .aggregate(group_by_exprs.to_vec(), aggr_exprs.to_vec())?
+            .build()?;
+        let group_by_exprs = if let LogicalPlan::Aggregate(agg) = &plan {
+            &agg.group_expr
+        } else {
+            unreachable!();
+        };
+
+        // in this next section of code we are re-writing the projection to refer to columns
+        // output by the aggregate plan. For example, if the projection contains the expression
+        // `SUM(a)` then we replace that with a reference to a column `SUM(a)` produced by
+        // the aggregate plan.
+
+        // combine the original grouping and aggregate expressions into one list (note that
+        // we do not add the "having" expression since that is not part of the projection)
+        let mut aggr_projection_exprs = vec![];
+        for expr in group_by_exprs {
+            match expr {
+                Expr::GroupingSet(GroupingSet::Rollup(exprs)) => {
+                    aggr_projection_exprs.extend_from_slice(exprs)
+                }
+                Expr::GroupingSet(GroupingSet::Cube(exprs)) => {
+                    aggr_projection_exprs.extend_from_slice(exprs)
+                }
+                Expr::GroupingSet(GroupingSet::GroupingSets(lists_of_exprs)) => {
+                    for exprs in lists_of_exprs {
+                        aggr_projection_exprs.extend_from_slice(exprs)
+                    }
+                }
+                _ => aggr_projection_exprs.push(expr.clone()),
+            }
+        }
+        aggr_projection_exprs.extend_from_slice(aggr_exprs);
+
+        // now attempt to resolve columns and replace with fully-qualified columns
+        let aggr_projection_exprs = aggr_projection_exprs
+            .iter()
+            .map(|expr| resolve_columns(expr, input))
+            .collect::<Result<Vec<Expr>>>()?;
+
+        // next we replace any expressions that are not a column with a column referencing
+        // an output column from the aggregate schema
+        let column_exprs_post_aggr = aggr_projection_exprs
+            .iter()
+            .map(|expr| expr_as_column_expr(expr, input))
+            .collect::<Result<Vec<Expr>>>()?;
+
+        // next we re-write the projection
+        let select_exprs_post_aggr = select_exprs
+            .iter()
+            .map(|expr| rebase_expr(expr, &aggr_projection_exprs, input))
+            .collect::<Result<Vec<Expr>>>()?;
+
+        // finally, we have some validation that the re-written projection can be resolved
+        // from the aggregate output columns
+        check_columns_satisfy_exprs(
+            &column_exprs_post_aggr,
+            &select_exprs_post_aggr,
+            CheckColumnsSatisfyExprsPurpose::ProjectionMustReferenceAggregate,
+        )?;
+
+        // Rewrite the HAVING expression to use the columns produced by the
+        // aggregation.
+        let having_expr_post_aggr = if let Some(having_expr) = having_expr_opt {
+            let having_expr_post_aggr =
+                rebase_expr(having_expr, &aggr_projection_exprs, input)?;
+
+            check_columns_satisfy_exprs(
+                &column_exprs_post_aggr,
+                std::slice::from_ref(&having_expr_post_aggr),
+                CheckColumnsSatisfyExprsPurpose::HavingMustReferenceAggregate,
+            )?;
+
+            Some(having_expr_post_aggr)
+        } else {
+            None
+        };
+
+        Ok((plan, select_exprs_post_aggr, having_expr_post_aggr))
+    }
+}
+
+// If there are any multiple-defined windows, we raise an error.
+fn check_conflicting_windows(window_defs: &[NamedWindowDefinition]) -> Result<()> {
+    for (i, window_def_i) in window_defs.iter().enumerate() {
+        for window_def_j in window_defs.iter().skip(i + 1) {
+            if window_def_i.0 == window_def_j.0 {
+                return plan_err!(
+                    "The window {} is defined multiple times!",
+                    window_def_i.0
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+// If the projection is done over a named window, that window
+// name must be defined. Otherwise, it gives an error.
+fn match_window_definitions(
+    projection: &mut [SelectItem],
+    named_windows: &[NamedWindowDefinition],
+) -> Result<()> {
+    for proj in projection.iter_mut() {
+        if let SelectItem::ExprWithAlias {
+            expr: SQLExpr::Function(f),
+            alias: _,
+        }
+        | SelectItem::UnnamedExpr(SQLExpr::Function(f)) = proj
+        {
+            for NamedWindowDefinition(window_ident, window_expr) in named_windows.iter() {
+                if let Some(WindowType::NamedWindow(ident)) = &f.over {
+                    if ident.eq(window_ident) {
+                        f.over = Some(match window_expr {
+                            NamedWindowExpr::NamedWindow(ident) => {
+                                WindowType::NamedWindow(ident.clone())
+                            }
+                            NamedWindowExpr::WindowSpec(spec) => {
+                                WindowType::WindowSpec(spec.clone())
+                            }
+                        })
+                    }
+                }
+            }
+            // All named windows must be defined with a WindowSpec.
+            if let Some(WindowType::NamedWindow(ident)) = &f.over {
+                return plan_err!("The window {ident} is not defined!");
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/proof-of-sql/src/sql/new_parse/set_expr.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/set_expr.rs
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::planner::{ContextProvider, PlannerContext, SqlToRel};
+use datafusion_common::{
+    not_impl_err, plan_err, DataFusionError, Diagnostic, Result, Span,
+};
+use datafusion_expr::{LogicalPlan, LogicalPlanBuilder};
+use sqlparser::ast::{SetExpr, SetOperator, SetQuantifier, Spanned};
+
+impl<S: ContextProvider> SqlToRel<'_, S> {
+    #[cfg_attr(feature = "recursive_protection", recursive::recursive)]
+    pub(super) fn set_expr_to_plan(
+        &self,
+        set_expr: SetExpr,
+        planner_context: &mut PlannerContext,
+    ) -> Result<LogicalPlan> {
+        let set_expr_span = Span::try_from_sqlparser_span(set_expr.span());
+        match set_expr {
+            SetExpr::Select(s) => self.select_to_plan(*s, vec![], planner_context),
+            SetExpr::Values(v) => self.sql_values_to_plan(v, planner_context),
+            SetExpr::SetOperation {
+                op,
+                left,
+                right,
+                set_quantifier,
+            } => {
+                let left_span = Span::try_from_sqlparser_span(left.span());
+                let right_span = Span::try_from_sqlparser_span(right.span());
+                let left_plan = self.set_expr_to_plan(*left, planner_context);
+                let right_plan = self.set_expr_to_plan(*right, planner_context);
+                let (left_plan, right_plan) = match (left_plan, right_plan) {
+                    (Ok(left_plan), Ok(right_plan)) => (left_plan, right_plan),
+                    (Err(left_err), Err(right_err)) => {
+                        return Err(DataFusionError::Collection(vec![
+                            left_err, right_err,
+                        ]));
+                    }
+                    (Err(err), _) | (_, Err(err)) => {
+                        return Err(err);
+                    }
+                };
+                self.validate_set_expr_num_of_columns(
+                    op,
+                    left_span,
+                    right_span,
+                    &left_plan,
+                    &right_plan,
+                    set_expr_span,
+                )?;
+
+                self.set_operation_to_plan(op, left_plan, right_plan, set_quantifier)
+            }
+            SetExpr::Query(q) => self.query_to_plan(*q, planner_context),
+            _ => not_impl_err!("Query {set_expr} not implemented yet"),
+        }
+    }
+
+    pub(super) fn is_union_all(set_quantifier: SetQuantifier) -> Result<bool> {
+        match set_quantifier {
+            SetQuantifier::All => Ok(true),
+            SetQuantifier::Distinct | SetQuantifier::None => Ok(false),
+            SetQuantifier::ByName => {
+                not_impl_err!("UNION BY NAME not implemented")
+            }
+            SetQuantifier::AllByName => {
+                not_impl_err!("UNION ALL BY NAME not implemented")
+            }
+            SetQuantifier::DistinctByName => {
+                not_impl_err!("UNION DISTINCT BY NAME not implemented")
+            }
+        }
+    }
+
+    fn validate_set_expr_num_of_columns(
+        &self,
+        op: SetOperator,
+        left_span: Option<Span>,
+        right_span: Option<Span>,
+        left_plan: &LogicalPlan,
+        right_plan: &LogicalPlan,
+        set_expr_span: Option<Span>,
+    ) -> Result<()> {
+        if left_plan.schema().fields().len() == right_plan.schema().fields().len() {
+            return Ok(());
+        }
+
+        plan_err!("{} queries have different number of columns", op).map_err(|err| {
+            err.with_diagnostic(
+                Diagnostic::new_error(
+                    format!("{} queries have different number of columns", op),
+                    set_expr_span,
+                )
+                .with_note(
+                    format!("this side has {} fields", left_plan.schema().fields().len()),
+                    left_span,
+                )
+                .with_note(
+                    format!(
+                        "this side has {} fields",
+                        right_plan.schema().fields().len()
+                    ),
+                    right_span,
+                ),
+            )
+        })
+    }
+
+    pub(super) fn set_operation_to_plan(
+        &self,
+        op: SetOperator,
+        left_plan: LogicalPlan,
+        right_plan: LogicalPlan,
+        set_quantifier: SetQuantifier,
+    ) -> Result<LogicalPlan> {
+        let all = Self::is_union_all(set_quantifier)?;
+        match (op, all) {
+            (SetOperator::Union, true) => LogicalPlanBuilder::from(left_plan)
+                .union(right_plan)?
+                .build(),
+            (SetOperator::Union, false) => LogicalPlanBuilder::from(left_plan)
+                .union_distinct(right_plan)?
+                .build(),
+            (SetOperator::Intersect, true) => {
+                LogicalPlanBuilder::intersect(left_plan, right_plan, true)
+            }
+            (SetOperator::Intersect, false) => {
+                LogicalPlanBuilder::intersect(left_plan, right_plan, false)
+            }
+            (SetOperator::Except, true) => {
+                LogicalPlanBuilder::except(left_plan, right_plan, true)
+            }
+            (SetOperator::Except, false) => {
+                LogicalPlanBuilder::except(left_plan, right_plan, false)
+            }
+            (SetOperator::Minus, _) => {
+                not_impl_err!("MINUS Set Operator not implemented")
+            }
+        }
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/statement.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/statement.rs
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::planner::SqlToRel;
+use crate::utils::normalize_ident;
+use sqlparser::ast::{
+    Statement
+};
+
+fn ident_to_string(ident: &Ident) -> String {
+    normalize_ident(ident.to_owned())
+}
+
+fn object_name_to_string(object_name: &ObjectName) -> String {
+    object_name
+        .0
+        .iter()
+        .map(ident_to_string)
+        .collect::<Vec<String>>()
+        .join(".")
+}
+
+impl SqlToRel<'_> {
+    pub fn sql_statement_to_plan(
+        &self,
+        statement: Statement,
+    ) -> ConversionResult<ProofPlan> {
+        self.sql_statement_to_plan_impl(statement)
+    }
+
+    fn sql_statement_to_plan_impl(
+        &self,
+        statement: Statement,
+    ) -> ConversionResult<ProofPlan> {
+        match statement {
+            // We do not support anything other than Query yet
+            Statement::Query(query) => self.query_to_plan(*query),
+            _ => ConversionError::UnsupportedOperation {
+                message: "We don't support any Statement other than Query".to_string(),
+            }
+        }
+    }
+}

--- a/crates/proof-of-sql/src/sql/new_parse/utils.rs
+++ b/crates/proof-of-sql/src/sql/new_parse/utils.rs
@@ -1,0 +1,1023 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! SQL Utility Functions
+
+use std::vec;
+
+use arrow::datatypes::{
+    DataType, DECIMAL128_MAX_PRECISION, DECIMAL256_MAX_PRECISION, DECIMAL_DEFAULT_SCALE,
+};
+use datafusion_common::tree_node::{
+    Transformed, TransformedResult, TreeNode, TreeNodeRecursion, TreeNodeRewriter,
+};
+use datafusion_common::{
+    exec_err, internal_err, plan_err, Column, DFSchemaRef, DataFusionError, Diagnostic,
+    HashMap, Result, ScalarValue,
+};
+use datafusion_expr::builder::get_struct_unnested_columns;
+use datafusion_expr::expr::{Alias, GroupingSet, Unnest, WindowFunction};
+use datafusion_expr::utils::{expr_as_column_expr, find_column_exprs};
+use datafusion_expr::{
+    col, expr_vec_fmt, ColumnUnnestList, Expr, ExprSchemable, LogicalPlan,
+};
+
+use indexmap::IndexMap;
+use sqlparser::ast::{Ident, Value};
+
+/// Make a best-effort attempt at resolving all columns in the expression tree
+pub(crate) fn resolve_columns(expr: &Expr, plan: &LogicalPlan) -> Result<Expr> {
+    expr.clone()
+        .transform_up(|nested_expr| {
+            match nested_expr {
+                Expr::Column(col) => {
+                    let (qualifier, field) =
+                        plan.schema().qualified_field_from_column(&col)?;
+                    Ok(Transformed::yes(Expr::Column(Column::from((
+                        qualifier, field,
+                    )))))
+                }
+                _ => {
+                    // keep recursing
+                    Ok(Transformed::no(nested_expr))
+                }
+            }
+        })
+        .data()
+}
+
+/// Rebuilds an `Expr` as a projection on top of a collection of `Expr`'s.
+///
+/// For example, the expression `a + b < 1` would require, as input, the 2
+/// individual columns, `a` and `b`. But, if the base expressions already
+/// contain the `a + b` result, then that may be used in lieu of the `a` and
+/// `b` columns.
+///
+/// This is useful in the context of a query like:
+///
+/// SELECT a + b < 1 ... GROUP BY a + b
+///
+/// where post-aggregation, `a + b` need not be a projection against the
+/// individual columns `a` and `b`, but rather it is a projection against the
+/// `a + b` found in the GROUP BY.
+pub(crate) fn rebase_expr(
+    expr: &Expr,
+    base_exprs: &[Expr],
+    plan: &LogicalPlan,
+) -> Result<Expr> {
+    expr.clone()
+        .transform_down(|nested_expr| {
+            if base_exprs.contains(&nested_expr) {
+                Ok(Transformed::yes(expr_as_column_expr(&nested_expr, plan)?))
+            } else {
+                Ok(Transformed::no(nested_expr))
+            }
+        })
+        .data()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckColumnsSatisfyExprsPurpose {
+    ProjectionMustReferenceAggregate,
+    HavingMustReferenceAggregate,
+}
+
+impl CheckColumnsSatisfyExprsPurpose {
+    fn message_prefix(&self) -> &'static str {
+        match self {
+            CheckColumnsSatisfyExprsPurpose::ProjectionMustReferenceAggregate => {
+                "Projection references non-aggregate values"
+            }
+            CheckColumnsSatisfyExprsPurpose::HavingMustReferenceAggregate => {
+                "HAVING clause references non-aggregate values"
+            }
+        }
+    }
+
+    fn diagnostic_message(&self, expr: &Expr) -> String {
+        format!("'{expr}' must appear in GROUP BY clause because it's not an aggregate expression")
+    }
+}
+
+/// Determines if the set of `Expr`'s are a valid projection on the input
+/// `Expr::Column`'s.
+pub(crate) fn check_columns_satisfy_exprs(
+    columns: &[Expr],
+    exprs: &[Expr],
+    purpose: CheckColumnsSatisfyExprsPurpose,
+) -> Result<()> {
+    columns.iter().try_for_each(|c| match c {
+        Expr::Column(_) => Ok(()),
+        _ => internal_err!("Expr::Column are required"),
+    })?;
+    let column_exprs = find_column_exprs(exprs);
+    for e in &column_exprs {
+        match e {
+            Expr::GroupingSet(GroupingSet::Rollup(exprs)) => {
+                for e in exprs {
+                    check_column_satisfies_expr(columns, e, purpose)?;
+                }
+            }
+            Expr::GroupingSet(GroupingSet::Cube(exprs)) => {
+                for e in exprs {
+                    check_column_satisfies_expr(columns, e, purpose)?;
+                }
+            }
+            Expr::GroupingSet(GroupingSet::GroupingSets(lists_of_exprs)) => {
+                for exprs in lists_of_exprs {
+                    for e in exprs {
+                        check_column_satisfies_expr(columns, e, purpose)?;
+                    }
+                }
+            }
+            _ => check_column_satisfies_expr(columns, e, purpose)?,
+        }
+    }
+    Ok(())
+}
+
+fn check_column_satisfies_expr(
+    columns: &[Expr],
+    expr: &Expr,
+    purpose: CheckColumnsSatisfyExprsPurpose,
+) -> Result<()> {
+    if !columns.contains(expr) {
+        return plan_err!(
+            "{}: Expression {} could not be resolved from available columns: {}",
+            purpose.message_prefix(),
+            expr,
+            expr_vec_fmt!(columns)
+        )
+        .map_err(|err| {
+            let diagnostic = Diagnostic::new_error(
+                purpose.diagnostic_message(expr),
+                expr.spans().and_then(|spans| spans.first()),
+            )
+            .with_help(format!("add '{expr}' to GROUP BY clause"), None);
+            err.with_diagnostic(diagnostic)
+        });
+    }
+    Ok(())
+}
+
+/// Returns mapping of each alias (`String`) to the expression (`Expr`) it is
+/// aliasing.
+pub(crate) fn extract_aliases(exprs: &[Expr]) -> HashMap<String, Expr> {
+    exprs
+        .iter()
+        .filter_map(|expr| match expr {
+            Expr::Alias(Alias { expr, name, .. }) => Some((name.clone(), *expr.clone())),
+            _ => None,
+        })
+        .collect::<HashMap<String, Expr>>()
+}
+
+/// Given an expression that's literal int encoding position, lookup the corresponding expression
+/// in the select_exprs list, if the index is within the bounds and it is indeed a position literal,
+/// otherwise, returns planning error.
+/// If input expression is not an int literal, returns expression as-is.
+pub(crate) fn resolve_positions_to_exprs(
+    expr: Expr,
+    select_exprs: &[Expr],
+) -> Result<Expr> {
+    match expr {
+        // sql_expr_to_logical_expr maps number to i64
+        // https://github.com/apache/datafusion/blob/8d175c759e17190980f270b5894348dc4cff9bbf/datafusion/src/sql/planner.rs#L882-L887
+        Expr::Literal(ScalarValue::Int64(Some(position)))
+            if position > 0_i64 && position <= select_exprs.len() as i64 =>
+        {
+            let index = (position - 1) as usize;
+            let select_expr = &select_exprs[index];
+            Ok(match select_expr {
+                Expr::Alias(Alias { expr, .. }) => *expr.clone(),
+                _ => select_expr.clone(),
+            })
+        }
+        Expr::Literal(ScalarValue::Int64(Some(position))) => plan_err!(
+            "Cannot find column with position {} in SELECT clause. Valid columns: 1 to {}",
+            position, select_exprs.len()
+        ),
+        _ => Ok(expr),
+    }
+}
+
+/// Rebuilds an `Expr` with columns that refer to aliases replaced by the
+/// alias' underlying `Expr`.
+pub(crate) fn resolve_aliases_to_exprs(
+    expr: Expr,
+    aliases: &HashMap<String, Expr>,
+) -> Result<Expr> {
+    expr.transform_up(|nested_expr| match nested_expr {
+        Expr::Column(c) if c.relation.is_none() => {
+            if let Some(aliased_expr) = aliases.get(&c.name) {
+                Ok(Transformed::yes(aliased_expr.clone()))
+            } else {
+                Ok(Transformed::no(Expr::Column(c)))
+            }
+        }
+        _ => Ok(Transformed::no(nested_expr)),
+    })
+    .data()
+}
+
+/// Given a slice of window expressions sharing the same sort key, find their common partition
+/// keys.
+pub fn window_expr_common_partition_keys(window_exprs: &[Expr]) -> Result<&[Expr]> {
+    let all_partition_keys = window_exprs
+        .iter()
+        .map(|expr| match expr {
+            Expr::WindowFunction(WindowFunction { partition_by, .. }) => Ok(partition_by),
+            Expr::Alias(Alias { expr, .. }) => match expr.as_ref() {
+                Expr::WindowFunction(WindowFunction { partition_by, .. }) => {
+                    Ok(partition_by)
+                }
+                expr => exec_err!("Impossibly got non-window expr {expr:?}"),
+            },
+            expr => exec_err!("Impossibly got non-window expr {expr:?}"),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let result = all_partition_keys
+        .iter()
+        .min_by_key(|s| s.len())
+        .ok_or_else(|| {
+            DataFusionError::Execution("No window expressions found".to_owned())
+        })?;
+    Ok(result)
+}
+
+/// Returns a validated `DataType` for the specified precision and
+/// scale
+pub(crate) fn make_decimal_type(
+    precision: Option<u64>,
+    scale: Option<u64>,
+) -> Result<DataType> {
+    // postgres like behavior
+    let (precision, scale) = match (precision, scale) {
+        (Some(p), Some(s)) => (p as u8, s as i8),
+        (Some(p), None) => (p as u8, 0),
+        (None, Some(_)) => {
+            return plan_err!("Cannot specify only scale for decimal data type")
+        }
+        (None, None) => (DECIMAL128_MAX_PRECISION, DECIMAL_DEFAULT_SCALE),
+    };
+
+    if precision == 0
+        || precision > DECIMAL256_MAX_PRECISION
+        || scale.unsigned_abs() > precision
+    {
+        plan_err!(
+            "Decimal(precision = {precision}, scale = {scale}) should satisfy `0 < precision <= 76`, and `scale <= precision`."
+        )
+    } else if precision > DECIMAL128_MAX_PRECISION
+        && precision <= DECIMAL256_MAX_PRECISION
+    {
+        Ok(DataType::Decimal256(precision, scale))
+    } else {
+        Ok(DataType::Decimal128(precision, scale))
+    }
+}
+
+/// Normalize an owned identifier to a lowercase string, unless the identifier is quoted.
+pub(crate) fn normalize_ident(id: Ident) -> String {
+    match id.quote_style {
+        Some(_) => id.value,
+        None => id.value.to_ascii_lowercase(),
+    }
+}
+
+pub(crate) fn value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::SingleQuotedString(s) => Some(s.to_string()),
+        Value::DollarQuotedString(s) => Some(s.to_string()),
+        Value::Number(_, _) | Value::Boolean(_) => Some(value.to_string()),
+        Value::UnicodeStringLiteral(s) => Some(s.to_string()),
+        Value::EscapedStringLiteral(s) => Some(s.to_string()),
+        Value::DoubleQuotedString(_)
+        | Value::NationalStringLiteral(_)
+        | Value::SingleQuotedByteStringLiteral(_)
+        | Value::DoubleQuotedByteStringLiteral(_)
+        | Value::TripleSingleQuotedString(_)
+        | Value::TripleDoubleQuotedString(_)
+        | Value::TripleSingleQuotedByteStringLiteral(_)
+        | Value::TripleDoubleQuotedByteStringLiteral(_)
+        | Value::SingleQuotedRawStringLiteral(_)
+        | Value::DoubleQuotedRawStringLiteral(_)
+        | Value::TripleSingleQuotedRawStringLiteral(_)
+        | Value::TripleDoubleQuotedRawStringLiteral(_)
+        | Value::HexStringLiteral(_)
+        | Value::Null
+        | Value::Placeholder(_) => None,
+    }
+}
+
+pub(crate) fn rewrite_recursive_unnests_bottom_up(
+    input: &LogicalPlan,
+    unnest_placeholder_columns: &mut IndexMap<Column, Option<Vec<ColumnUnnestList>>>,
+    inner_projection_exprs: &mut Vec<Expr>,
+    original_exprs: &[Expr],
+) -> Result<Vec<Expr>> {
+    Ok(original_exprs
+        .iter()
+        .map(|expr| {
+            rewrite_recursive_unnest_bottom_up(
+                input,
+                unnest_placeholder_columns,
+                inner_projection_exprs,
+                expr,
+            )
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>())
+}
+
+pub const UNNEST_PLACEHOLDER: &str = "__unnest_placeholder";
+
+/*
+This is only usedful when used with transform down up
+A full example of how the transformation works:
+ */
+struct RecursiveUnnestRewriter<'a> {
+    input_schema: &'a DFSchemaRef,
+    root_expr: &'a Expr,
+    // Useful to detect which child expr is a part of/ not a part of unnest operation
+    top_most_unnest: Option<Unnest>,
+    consecutive_unnest: Vec<Option<Unnest>>,
+    inner_projection_exprs: &'a mut Vec<Expr>,
+    columns_unnestings: &'a mut IndexMap<Column, Option<Vec<ColumnUnnestList>>>,
+    transformed_root_exprs: Option<Vec<Expr>>,
+}
+impl RecursiveUnnestRewriter<'_> {
+    /// This struct stores the history of expr
+    /// during its tree-traversal with a notation of
+    /// \[None,**Unnest(exprA)**,**Unnest(exprB)**,None,None\]
+    /// then this function will returns \[**Unnest(exprA)**,**Unnest(exprB)**\]
+    ///
+    /// The first item will be the inner most expr
+    fn get_latest_consecutive_unnest(&self) -> Vec<Unnest> {
+        self.consecutive_unnest
+            .iter()
+            .rev()
+            .skip_while(|item| item.is_none())
+            .take_while(|item| item.is_some())
+            .to_owned()
+            .cloned()
+            .map(|item| item.unwrap())
+            .collect()
+    }
+
+    fn transform(
+        &mut self,
+        level: usize,
+        alias_name: String,
+        expr_in_unnest: &Expr,
+        struct_allowed: bool,
+    ) -> Result<Vec<Expr>> {
+        let inner_expr_name = expr_in_unnest.schema_name().to_string();
+
+        // Full context, we are trying to plan the execution as InnerProjection->Unnest->OuterProjection
+        // inside unnest execution, each column inside the inner projection
+        // will be transformed into new columns. Thus we need to keep track of these placeholding column names
+        let placeholder_name = format!("{UNNEST_PLACEHOLDER}({})", inner_expr_name);
+        let post_unnest_name =
+            format!("{UNNEST_PLACEHOLDER}({},depth={})", inner_expr_name, level);
+        // This is due to the fact that unnest transformation should keep the original
+        // column name as is, to comply with group by and order by
+        let placeholder_column = Column::from_name(placeholder_name.clone());
+
+        let (data_type, _) = expr_in_unnest.data_type_and_nullable(self.input_schema)?;
+
+        match data_type {
+            DataType::Struct(inner_fields) => {
+                if !struct_allowed {
+                    return internal_err!("unnest on struct can only be applied at the root level of select expression");
+                }
+                push_projection_dedupl(
+                    self.inner_projection_exprs,
+                    expr_in_unnest.clone().alias(placeholder_name.clone()),
+                );
+                self.columns_unnestings
+                    .insert(Column::from_name(placeholder_name.clone()), None);
+                Ok(
+                    get_struct_unnested_columns(&placeholder_name, &inner_fields)
+                        .into_iter()
+                        .map(Expr::Column)
+                        .collect(),
+                )
+            }
+            DataType::List(_)
+            | DataType::FixedSizeList(_, _)
+            | DataType::LargeList(_) => {
+                push_projection_dedupl(
+                    self.inner_projection_exprs,
+                    expr_in_unnest.clone().alias(placeholder_name.clone()),
+                );
+
+                let post_unnest_expr = col(post_unnest_name.clone()).alias(alias_name);
+                let list_unnesting = self
+                    .columns_unnestings
+                    .entry(placeholder_column)
+                    .or_insert(Some(vec![]));
+                let unnesting = ColumnUnnestList {
+                    output_column: Column::from_name(post_unnest_name),
+                    depth: level,
+                };
+                let list_unnestings = list_unnesting.as_mut().unwrap();
+                if !list_unnestings.contains(&unnesting) {
+                    list_unnestings.push(unnesting);
+                }
+                Ok(vec![post_unnest_expr])
+            }
+            _ => {
+                internal_err!("unnest on non-list or struct type is not supported")
+            }
+        }
+    }
+}
+
+impl TreeNodeRewriter for RecursiveUnnestRewriter<'_> {
+    type Node = Expr;
+
+    /// This downward traversal needs to keep track of:
+    /// - Whether or not some unnest expr has been visited from the top util the current node
+    /// - If some unnest expr has been visited, maintain a stack of such information, this
+    ///   is used to detect if some recursive unnest expr exists (e.g **unnest(unnest(unnest(3d column))))**
+    fn f_down(&mut self, expr: Expr) -> Result<Transformed<Expr>> {
+        if let Expr::Unnest(ref unnest_expr) = expr {
+            let (data_type, _) =
+                unnest_expr.expr.data_type_and_nullable(self.input_schema)?;
+            self.consecutive_unnest.push(Some(unnest_expr.clone()));
+            // if expr inside unnest is a struct, do not consider
+            // the next unnest as consecutive unnest (if any)
+            // meaning unnest(unnest(struct_arr_col)) can't
+            // be interpreted as unnest(struct_arr_col, depth:=2)
+            // but has to be split into multiple unnest logical plan instead
+            // a.k.a:
+            // - unnest(struct_col)
+            //      unnest(struct_arr_col) as struct_col
+
+            if let DataType::Struct(_) = data_type {
+                self.consecutive_unnest.push(None);
+            }
+            if self.top_most_unnest.is_none() {
+                self.top_most_unnest = Some(unnest_expr.clone());
+            }
+
+            Ok(Transformed::no(expr))
+        } else {
+            self.consecutive_unnest.push(None);
+            Ok(Transformed::no(expr))
+        }
+    }
+
+    /// The rewriting only happens when the traversal has reached the top-most unnest expr
+    /// within a sequence of consecutive unnest exprs node
+    ///
+    /// For example an expr of **unnest(unnest(column1)) + unnest(unnest(unnest(column2)))**
+    /// ```text
+    ///                         ┌──────────────────┐           
+    ///                         │    binaryexpr    │           
+    ///                         │                  │           
+    ///                         └──────────────────┘           
+    ///                f_down  / /            │ │              
+    ///                       / / f_up        │ │              
+    ///                      / /        f_down│ │f_up          
+    ///                  unnest               │ │              
+    ///                                       │ │              
+    ///       f_down  / / f_up(rewriting)     │ │              
+    ///              / /                                       
+    ///             / /                      unnest            
+    ///         unnest                                         
+    ///                           f_down  / / f_up(rewriting)  
+    /// f_down / /f_up                   / /                   
+    ///       / /                       / /                    
+    ///      / /                    unnest                     
+    ///   column1                                              
+    ///                     f_down / /f_up                     
+    ///                           / /                          
+    ///                          / /                           
+    ///                       column2                          
+    /// ```
+    ///         
+    fn f_up(&mut self, expr: Expr) -> Result<Transformed<Expr>> {
+        if let Expr::Unnest(ref traversing_unnest) = expr {
+            if traversing_unnest == self.top_most_unnest.as_ref().unwrap() {
+                self.top_most_unnest = None;
+            }
+            // Find inside consecutive_unnest, the sequence of continuous unnest exprs
+
+            // Get the latest consecutive unnest exprs
+            // and check if current upward traversal is the returning to the root expr
+            // for example given a expr `unnest(unnest(col))` then the traversal happens like:
+            // down(unnest) -> down(unnest) -> down(col) -> up(col) -> up(unnest) -> up(unnest)
+            // the result of such traversal is unnest(col, depth:=2)
+            let unnest_stack = self.get_latest_consecutive_unnest();
+
+            // This traversal has reached the top most unnest again
+            // e.g Unnest(top) -> Unnest(2nd) -> Column(bottom)
+            // -> Unnest(2nd) -> Unnest(top) a.k.a here
+            // Thus
+            // Unnest(Unnest(some_col)) is rewritten into Unnest(some_col, depth:=2)
+            if traversing_unnest == unnest_stack.last().unwrap() {
+                let most_inner = unnest_stack.first().unwrap();
+                let inner_expr = most_inner.expr.as_ref();
+                // unnest(unnest(struct_arr_col)) is not allow to be done recursively
+                // it needs to be splitted into multiple unnest logical plan
+                // unnest(struct_arr)
+                //  unnest(struct_arr_col) as struct_arr
+                // instead of unnest(struct_arr_col, depth = 2)
+
+                let unnest_recursion = unnest_stack.len();
+                let struct_allowed = (&expr == self.root_expr) && unnest_recursion == 1;
+
+                let mut transformed_exprs = self.transform(
+                    unnest_recursion,
+                    expr.schema_name().to_string(),
+                    inner_expr,
+                    struct_allowed,
+                )?;
+                if struct_allowed {
+                    self.transformed_root_exprs = Some(transformed_exprs.clone());
+                }
+                return Ok(Transformed::new(
+                    transformed_exprs.swap_remove(0),
+                    true,
+                    TreeNodeRecursion::Continue,
+                ));
+            }
+        } else {
+            self.consecutive_unnest.push(None);
+        }
+
+        // For column exprs that are not descendants of any unnest node
+        // retain their projection
+        // e.g given expr tree unnest(col_a) + col_b, we have to retain projection of col_b
+        // this condition can be checked by maintaining an Option<top most unnest>
+        if matches!(&expr, Expr::Column(_)) && self.top_most_unnest.is_none() {
+            push_projection_dedupl(self.inner_projection_exprs, expr.clone());
+        }
+
+        Ok(Transformed::no(expr))
+    }
+}
+
+fn push_projection_dedupl(projection: &mut Vec<Expr>, expr: Expr) {
+    let schema_name = expr.schema_name().to_string();
+    if !projection
+        .iter()
+        .any(|e| e.schema_name().to_string() == schema_name)
+    {
+        projection.push(expr);
+    }
+}
+/// The context is we want to rewrite unnest() into InnerProjection->Unnest->OuterProjection
+/// Given an expression which contains unnest expr as one of its children,
+/// Try transform depends on unnest type
+/// - For list column: unnest(col) with type list -> unnest(col) with type list::item
+/// - For struct column: unnest(struct(field1, field2)) -> unnest(struct).field1, unnest(struct).field2
+///
+/// The transformed exprs will be used in the outer projection
+/// If along the path from root to bottom, there are multiple unnest expressions, the transformation
+/// is done only for the bottom expression
+pub(crate) fn rewrite_recursive_unnest_bottom_up(
+    input: &LogicalPlan,
+    unnest_placeholder_columns: &mut IndexMap<Column, Option<Vec<ColumnUnnestList>>>,
+    inner_projection_exprs: &mut Vec<Expr>,
+    original_expr: &Expr,
+) -> Result<Vec<Expr>> {
+    let mut rewriter = RecursiveUnnestRewriter {
+        input_schema: input.schema(),
+        root_expr: original_expr,
+        top_most_unnest: None,
+        consecutive_unnest: vec![],
+        inner_projection_exprs,
+        columns_unnestings: unnest_placeholder_columns,
+        transformed_root_exprs: None,
+    };
+
+    // This transformation is only done for list unnest
+    // struct unnest is done at the root level, and at the later stage
+    // because the syntax of TreeNode only support transform into 1 Expr, while
+    // Unnest struct will be transformed into multiple Exprs
+    // TODO: This can be resolved after this issue is resolved: https://github.com/apache/datafusion/issues/10102
+    //
+    // The transformation looks like:
+    // - unnest(array_col) will be transformed into Column("unnest_place_holder(array_col)")
+    // - unnest(array_col) + 1 will be transformed into Column("unnest_place_holder(array_col) + 1")
+    let Transformed {
+        data: transformed_expr,
+        transformed,
+        tnr: _,
+    } = original_expr.clone().rewrite(&mut rewriter)?;
+
+    if !transformed {
+        if matches!(&transformed_expr, Expr::Column(_))
+            || matches!(&transformed_expr, Expr::Wildcard { .. })
+        {
+            push_projection_dedupl(inner_projection_exprs, transformed_expr.clone());
+            Ok(vec![transformed_expr])
+        } else {
+            // We need to evaluate the expr in the inner projection,
+            // outer projection just select its name
+            let column_name = transformed_expr.schema_name().to_string();
+            push_projection_dedupl(inner_projection_exprs, transformed_expr);
+            Ok(vec![Expr::Column(Column::from_name(column_name))])
+        }
+    } else {
+        if let Some(transformed_root_exprs) = rewriter.transformed_root_exprs {
+            return Ok(transformed_root_exprs);
+        }
+        Ok(vec![transformed_expr])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ops::Add, sync::Arc};
+
+    use arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema};
+    use datafusion_common::{Column, DFSchema, Result};
+    use datafusion_expr::{
+        col, lit, unnest, ColumnUnnestList, EmptyRelation, LogicalPlan,
+    };
+    use datafusion_functions::core::expr_ext::FieldAccessor;
+    use datafusion_functions_aggregate::expr_fn::count;
+
+    use crate::utils::{resolve_positions_to_exprs, rewrite_recursive_unnest_bottom_up};
+    use indexmap::IndexMap;
+
+    fn column_unnests_eq(
+        l: Vec<&str>,
+        r: &IndexMap<Column, Option<Vec<ColumnUnnestList>>>,
+    ) {
+        let r_formatted: Vec<String> = r
+            .iter()
+            .map(|i| match i.1 {
+                None => format!("{}", i.0),
+                Some(vec) => format!(
+                    "{}=>[{}]",
+                    i.0,
+                    vec.iter()
+                        .map(|i| format!("{}", i))
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                ),
+            })
+            .collect();
+        let l_formatted: Vec<String> = l.iter().map(|i| i.to_string()).collect();
+        assert_eq!(l_formatted, r_formatted);
+    }
+
+    #[test]
+    fn test_transform_bottom_unnest_recursive() -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new(
+                "3d_col",
+                ArrowDataType::List(Arc::new(Field::new(
+                    "2d_col",
+                    ArrowDataType::List(Arc::new(Field::new(
+                        "elements",
+                        ArrowDataType::Int64,
+                        true,
+                    ))),
+                    true,
+                ))),
+                true,
+            ),
+            Field::new("i64_col", ArrowDataType::Int64, true),
+        ]);
+
+        let dfschema = DFSchema::try_from(schema)?;
+
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(dfschema),
+        });
+
+        let mut unnest_placeholder_columns = IndexMap::new();
+        let mut inner_projection_exprs = vec![];
+
+        // unnest(unnest(3d_col)) + unnest(unnest(3d_col))
+        let original_expr = unnest(unnest(col("3d_col")))
+            .add(unnest(unnest(col("3d_col"))))
+            .add(col("i64_col"));
+        let transformed_exprs = rewrite_recursive_unnest_bottom_up(
+            &input,
+            &mut unnest_placeholder_columns,
+            &mut inner_projection_exprs,
+            &original_expr,
+        )?;
+        // Only the bottom most unnest exprs are transformed
+        assert_eq!(
+            transformed_exprs,
+            vec![col("__unnest_placeholder(3d_col,depth=2)")
+                .alias("UNNEST(UNNEST(3d_col))")
+                .add(
+                    col("__unnest_placeholder(3d_col,depth=2)")
+                        .alias("UNNEST(UNNEST(3d_col))")
+                )
+                .add(col("i64_col"))]
+        );
+        column_unnests_eq(
+            vec![
+                "__unnest_placeholder(3d_col)=>[__unnest_placeholder(3d_col,depth=2)|depth=2]",
+            ],
+            &unnest_placeholder_columns,
+        );
+
+        // Still reference struct_col in original schema but with alias,
+        // to avoid colliding with the projection on the column itself if any
+        assert_eq!(
+            inner_projection_exprs,
+            vec![
+                col("3d_col").alias("__unnest_placeholder(3d_col)"),
+                col("i64_col")
+            ]
+        );
+
+        // unnest(3d_col) as 2d_col
+        let original_expr_2 = unnest(col("3d_col")).alias("2d_col");
+        let transformed_exprs = rewrite_recursive_unnest_bottom_up(
+            &input,
+            &mut unnest_placeholder_columns,
+            &mut inner_projection_exprs,
+            &original_expr_2,
+        )?;
+
+        assert_eq!(
+            transformed_exprs,
+            vec![
+                (col("__unnest_placeholder(3d_col,depth=1)").alias("UNNEST(3d_col)"))
+                    .alias("2d_col")
+            ]
+        );
+        column_unnests_eq(
+            vec!["__unnest_placeholder(3d_col)=>[__unnest_placeholder(3d_col,depth=2)|depth=2, __unnest_placeholder(3d_col,depth=1)|depth=1]"],
+            &unnest_placeholder_columns,
+        );
+        // Still reference struct_col in original schema but with alias,
+        // to avoid colliding with the projection on the column itself if any
+        assert_eq!(
+            inner_projection_exprs,
+            vec![
+                col("3d_col").alias("__unnest_placeholder(3d_col)"),
+                col("i64_col")
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_transform_bottom_unnest() -> Result<()> {
+        let schema = Schema::new(vec![
+            Field::new(
+                "struct_col",
+                ArrowDataType::Struct(Fields::from(vec![
+                    Field::new("field1", ArrowDataType::Int32, false),
+                    Field::new("field2", ArrowDataType::Int32, false),
+                ])),
+                false,
+            ),
+            Field::new(
+                "array_col",
+                ArrowDataType::List(Arc::new(Field::new_list_field(
+                    ArrowDataType::Int64,
+                    true,
+                ))),
+                true,
+            ),
+            Field::new("int_col", ArrowDataType::Int32, false),
+        ]);
+
+        let dfschema = DFSchema::try_from(schema)?;
+
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(dfschema),
+        });
+
+        let mut unnest_placeholder_columns = IndexMap::new();
+        let mut inner_projection_exprs = vec![];
+
+        // unnest(struct_col)
+        let original_expr = unnest(col("struct_col"));
+        let transformed_exprs = rewrite_recursive_unnest_bottom_up(
+            &input,
+            &mut unnest_placeholder_columns,
+            &mut inner_projection_exprs,
+            &original_expr,
+        )?;
+        assert_eq!(
+            transformed_exprs,
+            vec![
+                col("__unnest_placeholder(struct_col).field1"),
+                col("__unnest_placeholder(struct_col).field2"),
+            ]
+        );
+        column_unnests_eq(
+            vec!["__unnest_placeholder(struct_col)"],
+            &unnest_placeholder_columns,
+        );
+        // Still reference struct_col in original schema but with alias,
+        // to avoid colliding with the projection on the column itself if any
+        assert_eq!(
+            inner_projection_exprs,
+            vec![col("struct_col").alias("__unnest_placeholder(struct_col)"),]
+        );
+
+        // unnest(array_col) + 1
+        let original_expr = unnest(col("array_col")).add(lit(1i64));
+        let transformed_exprs = rewrite_recursive_unnest_bottom_up(
+            &input,
+            &mut unnest_placeholder_columns,
+            &mut inner_projection_exprs,
+            &original_expr,
+        )?;
+        column_unnests_eq(
+            vec![
+                "__unnest_placeholder(struct_col)",
+                "__unnest_placeholder(array_col)=>[__unnest_placeholder(array_col,depth=1)|depth=1]",
+            ],
+            &unnest_placeholder_columns,
+        );
+        // Only transform the unnest children
+        assert_eq!(
+            transformed_exprs,
+            vec![col("__unnest_placeholder(array_col,depth=1)")
+                .alias("UNNEST(array_col)")
+                .add(lit(1i64))]
+        );
+
+        // Keep appending to the current vector
+        // Still reference array_col in original schema but with alias,
+        // to avoid colliding with the projection on the column itself if any
+        assert_eq!(
+            inner_projection_exprs,
+            vec![
+                col("struct_col").alias("__unnest_placeholder(struct_col)"),
+                col("array_col").alias("__unnest_placeholder(array_col)")
+            ]
+        );
+
+        Ok(())
+    }
+
+    // Unnest -> field access -> unnest
+    #[test]
+    fn test_transform_non_consecutive_unnests() -> Result<()> {
+        // List of struct
+        // [struct{'subfield1':list(i64), 'subfield2':list(utf8)}]
+        let schema = Schema::new(vec![
+            Field::new(
+                "struct_list",
+                ArrowDataType::List(Arc::new(Field::new(
+                    "element",
+                    ArrowDataType::Struct(Fields::from(vec![
+                        Field::new(
+                            // list of i64
+                            "subfield1",
+                            ArrowDataType::List(Arc::new(Field::new(
+                                "i64_element",
+                                ArrowDataType::Int64,
+                                true,
+                            ))),
+                            true,
+                        ),
+                        Field::new(
+                            // list of utf8
+                            "subfield2",
+                            ArrowDataType::List(Arc::new(Field::new(
+                                "utf8_element",
+                                ArrowDataType::Utf8,
+                                true,
+                            ))),
+                            true,
+                        ),
+                    ])),
+                    true,
+                ))),
+                true,
+            ),
+            Field::new("int_col", ArrowDataType::Int32, false),
+        ]);
+
+        let dfschema = DFSchema::try_from(schema)?;
+
+        let input = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(dfschema),
+        });
+
+        let mut unnest_placeholder_columns = IndexMap::new();
+        let mut inner_projection_exprs = vec![];
+
+        // An expr with multiple unnest
+        let select_expr1 = unnest(unnest(col("struct_list")).field("subfield1"));
+        let transformed_exprs = rewrite_recursive_unnest_bottom_up(
+            &input,
+            &mut unnest_placeholder_columns,
+            &mut inner_projection_exprs,
+            &select_expr1,
+        )?;
+        // Only the inner most/ bottom most unnest is transformed
+        assert_eq!(
+            transformed_exprs,
+            vec![unnest(
+                col("__unnest_placeholder(struct_list,depth=1)")
+                    .alias("UNNEST(struct_list)")
+                    .field("subfield1")
+            )]
+        );
+
+        column_unnests_eq(
+            vec![
+                "__unnest_placeholder(struct_list)=>[__unnest_placeholder(struct_list,depth=1)|depth=1]",
+            ],
+            &unnest_placeholder_columns,
+        );
+
+        assert_eq!(
+            inner_projection_exprs,
+            vec![col("struct_list").alias("__unnest_placeholder(struct_list)")]
+        );
+
+        // continue rewrite another expr in select
+        let select_expr2 = unnest(unnest(col("struct_list")).field("subfield2"));
+        let transformed_exprs = rewrite_recursive_unnest_bottom_up(
+            &input,
+            &mut unnest_placeholder_columns,
+            &mut inner_projection_exprs,
+            &select_expr2,
+        )?;
+        // Only the inner most/ bottom most unnest is transformed
+        assert_eq!(
+            transformed_exprs,
+            vec![unnest(
+                col("__unnest_placeholder(struct_list,depth=1)")
+                    .alias("UNNEST(struct_list)")
+                    .field("subfield2")
+            )]
+        );
+
+        // unnest place holder columns remain the same
+        // because expr1 and expr2 derive from the same unnest result
+        column_unnests_eq(
+            vec![
+                "__unnest_placeholder(struct_list)=>[__unnest_placeholder(struct_list,depth=1)|depth=1]",
+            ],
+            &unnest_placeholder_columns,
+        );
+
+        assert_eq!(
+            inner_projection_exprs,
+            vec![col("struct_list").alias("__unnest_placeholder(struct_list)")]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_positions_to_exprs() -> Result<()> {
+        let select_exprs = vec![col("c1"), col("c2"), count(lit(1))];
+
+        // Assert 1 resolved as first column in select list
+        let resolved = resolve_positions_to_exprs(lit(1i64), &select_exprs)?;
+        assert_eq!(resolved, col("c1"));
+
+        // Assert error if index out of select clause bounds
+        let resolved = resolve_positions_to_exprs(lit(-1i64), &select_exprs);
+        assert!(resolved.is_err_and(|e| e.message().contains(
+            "Cannot find column with position -1 in SELECT clause. Valid columns: 1 to 3"
+        )));
+
+        let resolved = resolve_positions_to_exprs(lit(5i64), &select_exprs);
+        assert!(resolved.is_err_and(|e| e.message().contains(
+            "Cannot find column with position 5 in SELECT clause. Valid columns: 1 to 3"
+        )));
+
+        // Assert expression returned as-is
+        let resolved = resolve_positions_to_exprs(lit("text"), &select_exprs)?;
+        assert_eq!(resolved, lit("text"));
+
+        let resolved = resolve_positions_to_exprs(col("fake"), &select_exprs)?;
+        assert_eq!(resolved, col("fake"));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
