### PR TITLE
feat: add basic support for `sqlparser::ast::Statement`

### DIFF
--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -7,7 +7,7 @@ use core::{
 };
 use indexmap::Equivalent;
 use proof_of_sql_parser::{impl_serde_from_str, ResourceId};
-use sqlparser::ast::Ident;
+use sqlparser::ast::{Ident, ObjectName};
 
 /// Expression for an SQL table
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -82,6 +82,24 @@ impl TableRef {
                     .collect::<Vec<_>>()
                     .join(","),
             }),
+        }
+    }
+}
+
+/// Creates a [`TableRef`] from an [`sqlparser::ast::ObjectName`].
+impl TryFrom<ObjectName> for TableRef {
+    type Error = ParseError;
+
+    fn try_from(object_name: sqlparser::ast::ObjectName) -> Result<Self, Self::Error> {
+        let schema_name = object_name.0;
+        let table_name = object_name.1;
+
+        match schema_name {
+            Some(schema) => Ok(Self::from_names(
+                Some(schema.value.as_str()),
+                table_name.value.as_str(),
+            )),
+            None => Ok(Self::from_names(None, table_name.value.as_str())),
         }
     }
 }

--- a/crates/proof-of-sql/src/sql/logical_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/mod.rs
@@ -5,3 +5,4 @@ mod expr;
 pub use expr::Expr;
 mod plan;
 pub use plan::LogicalPlan;
+mod sqlparser;

--- a/crates/proof-of-sql/src/sql/logical_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/mod.rs
@@ -3,3 +3,5 @@ mod error;
 pub use error::LogicalPlanError;
 mod expr;
 pub use expr::Expr;
+mod plan;
+pub use plan::LogicalPlan;

--- a/crates/proof-of-sql/src/sql/logical_plans/plan.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/plan.rs
@@ -1,0 +1,128 @@
+use super::Expr;
+use crate::base::database::{ColumnField, TableRef};
+use alloc::{boxed::Box, vec::Vec};
+use serde::{Deserialize, Serialize};
+
+/// Enum of logical plans that are either provable or supported in postprocessing
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub enum LogicalPlan {
+    /// Empty
+    Empty,
+    /// Table scan
+    TableScan(TableRef),
+    /// Projection
+    Projection(Projection),
+    /// Filter
+    Filter(Filter),
+    /// Aggregate
+    Aggregate(Aggregate),
+    /// Sort
+    Sort(Sort),
+    /// Slice
+    Slice(Slice),
+    /// Join
+    Join(Join),
+    /// Union
+    Union(Union),
+}
+
+/// Projection
+/// e.g. SELECT a, b FROM t
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Projection {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Projection expressions
+    pub expr: Vec<Expr>,
+}
+
+/// Filter
+/// e.g. WHERE a > 5
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Filter {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Filter expression
+    pub filter: Expr,
+}
+
+/// Aggregate
+/// e.g. SELECT a, COUNT(b) FROM t GROUP BY a
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Aggregate {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Group by
+    pub group_by: Vec<Expr>,
+    /// Aggregate expressions
+    pub aggr_expr: Vec<Expr>,
+    /// Output schema
+    pub schema: Vec<ColumnField>,
+}
+
+/// Sort
+/// e.g. ORDER BY a ASC, b DESC
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Sort {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Sort expressions
+    pub expr: Vec<SortExpr>,
+}
+
+/// Sort expression
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct SortExpr {
+    /// Expression
+    pub expr: Expr,
+    /// Direction
+    pub asc: bool,
+}
+
+/// Slice
+/// e.g. LIMIT 5 OFFSET 10
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Slice {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Maximum number of rows to return. None = no limit
+    pub limit: Option<u64>,
+    /// Offset value
+    pub offset: i64,
+}
+
+/// Join
+/// e.g. SELECT t1.a, t1.b, t2.c FROM t1 JOIN t2 ON t1.a = t2.a
+#[allow(clippy::struct_field_names)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Join {
+    /// Left input plan
+    pub left: Box<LogicalPlan>,
+    /// Right input plan
+    pub right: Box<LogicalPlan>,
+    /// Equijoin condition
+    pub on: Vec<(Expr, Expr)>,
+    /// Join type
+    pub join_type: JoinType,
+    /// Output schema
+    pub schema: Vec<ColumnField>,
+}
+
+/// Join type
+///
+/// Currently only supports inner join
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub enum JoinType {
+    /// Inner join
+    Inner,
+}
+
+/// Union
+/// e.g. SELECT a, b FROM t1 UNION ALL SELECT a, b FROM t2
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Union {
+    /// Input plans
+    pub inputs: Vec<LogicalPlan>,
+    /// Schema of the output
+    pub schema: Vec<ColumnField>,
+}

--- a/crates/proof-of-sql/src/sql/logical_plans/sqlparser.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/sqlparser.rs
@@ -1,0 +1,207 @@
+use super::{unsupported, LogicalPlanError, LogicalPlanResult, SortExpr};
+use crate::{base::database::table_ref::TableRef, sql::logical_plans::LogicalPlan};
+use sqlparser::ast::{
+    Expr, Ident, ObjectName, Offset, OffsetRows, OrderBy, Query, Select, SetExpr, SetOperator,
+    SetQuantifier, Statement, TableFactor, TableWithJoins, Value,
+};
+
+pub fn sql_statement_to_plan(statement: &Statement) -> LogicalPlanResult<LogicalPlan> {
+    match statement {
+        // We do not support anything other than Query yet
+        Statement::Query(query) => query_to_plan(*query),
+        _ => Err(unsupported(
+            "We don't support any Statement other than Query",
+        )),
+    }
+}
+
+/// Convert a [`sqlparser::ast::Query`] to a [`LogicalPlan`].
+///
+/// Note that we only support a `Query` with `body`, `order_by`, `limit` and `offset`.
+fn query_to_plan(query: &Query) -> LogicalPlanResult<LogicalPlan> {
+    // First exclude what we don't support
+    match (
+        query.with,
+        query.limit_by,
+        query.fetch,
+        query.locks,
+        query.for_clause,
+        query.settings,
+        query.format_clause,
+    ) {
+        (None, None, None, None, None, None, None) => {}
+        _ => {
+            return Err(unsupported(
+                "We only support `body`, `order_by`, `limit` and `offset` in Query",
+            ))
+        }
+    }
+
+    // We only support
+    // `body`, `order_by`, `limit` and `offset` in the query
+    let opt_offset = query.offset.map(|o| offset_to_int(o));
+    let opt_limit = query.limit.map(|l| expr_to_int(l));
+    let sort_exprs: Vec<SortExpr> = query
+        .order_by
+        .map(order_by_to_sort_expr)
+        .collect::<LogicalPlanResult<_>>()?;
+    let core_plan = set_expr_to_plan(&query.body)?;
+    Ok(LogicalPlan::Slice(Slice {
+        input: Box::new(LogicalPlan::Sort(Sort {
+            input: Box::new(core_plan),
+            expr: sort_exprs,
+        })),
+        offset: opt_offset,
+        limit: opt_limit,
+    }))
+}
+
+/// Convert a [`sqlparser::ast::OrderBy`] to a [`LogicalPlan`].
+fn set_expr_to_plan(set_expr: &SetExpr) -> LogicalPlanResult<LogicalPlan> {
+    match set_expr {
+        SetExpr::Select(select) => select_to_plan(*select),
+        SetExpr::SetOperation {
+            op,
+            left,
+            right,
+            set_quantifier,
+        } => {
+            if !matches!(
+                (op, set_quantifier),
+                (SetOperator::Union, SetQuantifier::All)
+            ) {
+                return Err(unsupported("We only support UNION ALL"));
+            }
+            LogicalPlan::Union(Union {
+                left: Box::new(set_expr_to_plan(left)?),
+                right: Box::new(set_expr_to_plan(right)?),
+            })
+        }
+        _ => Err(unsupported("Other SetExpr not supported")),
+    }
+}
+
+/// Convert a [`sqlparser::ast::Select`] to a [`LogicalPlan`].
+fn select_to_plan(select: &Select) -> LogicalPlanResult<LogicalPlan> {
+    // First exclude what we don't support
+    if select.distinct.is_some() {
+        return Err(unsupported("We don't support DISTINCT"));
+    }
+    if select.top.is_some() {
+        return Err(unsupported("We don't support TOP"));
+    }
+    if select.into.is_some() {
+        return Err(unsupported("We don't support INTO"));
+    }
+    if !select.lateral_views.is_empty() {
+        return Err(unsupported("We don't support LATERAL VIEWs"));
+    }
+    if !select.cluster_by.is_empty() {
+        return Err(unsupported("We don't support CLUSTER BY"));
+    }
+    if !select.distribute_by.is_empty() {
+        return Err(unsupported("We don't support DISTRIBUTE BY"));
+    }
+    if !select.sort_by.is_empty() {
+        return Err(unsupported("We don't support SORT BY"));
+    }
+    //TODO: Support HAVING
+    if select.having.is_some() {
+        return Err(unsupported("We don't support HAVING"));
+    }
+    if !self.named_window.is_empty() {
+        return Err(unsupported("We don't support WINDOW AS"));
+    }
+    if self.qualify.is_some() {
+        return Err(unsupported("We don't support QUALIFY"));
+    }
+    if self.value_table_mode.is_some() {
+        return Err(unsupported("We don't support VALUES"));
+    }
+    // We only support `projection`, `from`, `selection` and `group_by`
+}
+
+/// Convert a [`sqlparser::ast::TableWithJoins`] to joins.
+///
+/// TODO: Support JOINs
+fn table_with_joins_to_table_ref(table_with_joins: &TableWithJoins) -> LogicalPlanResult<TableRef> {
+    if !table_with_joins.joins.is_empty() {
+        return Err(unsupported("We don't support JOINs"));
+    }
+    table_factor_to_table_ref(table_with_joins.relation)
+}
+
+/// Convert a [`sqlparser::ast::TableFactor`] to a [`TableRef`].
+fn table_factor_to_table_ref(table_factor: &TableFactor) -> LogicalPlanResult<TableRef> {
+    match table_factor {
+        TableFactor::Table { name, .. } => {
+            //TODO: Support alias and filter out args we don't support
+            name.try_into()
+        }
+        //TODO: Support Nested Join
+        TableFactor::NestedJoin {
+            table_with_joins,
+            alias,
+        } => {
+            todo!("Support Nested Join")
+        }
+        _ => Err(unsupported("We only support `TableFactor::Table`")),
+    }
+}
+
+/// Convert a [`sqlparser::ast::OrderBy`] to a vector of [`SortExpr`]s.
+///
+/// TODO: Support position-based ordering.
+fn order_by_to_sort_expr(order_by: &OrderBy) -> LogicalPlanResult<SortExpr> {
+    if order_by.interpolate.is_some() {
+        return Err(unsupported("We don't support INTERPOLATE"));
+    }
+    // No ASC/DESC is equivalent to ASC
+    let asc = match order_by_expr.asc {
+        Some(true) => true,
+        Some(false) => false,
+        None => true,
+    };
+    let sort_expr = SortExpr {
+        expr: expr_to_ident(&order_by_expr.expr)?,
+        asc,
+    };
+    Ok((expr_to_ident(order_by_expr.expr)?, asc))
+}
+
+/// Convert a [`sqlparser::ast::Offset`] to an integer.
+fn offset_to_int(offset: &Offset) -> LogicalPlanResult<i64> {
+    if offset.rows != OffsetRows::None {
+        return Err(unsupported(
+            "We do not support keywords after OFFSET <num_rows>",
+        ));
+    }
+    expr_to_int(&offset.value)
+}
+
+/// Convert a [`sqlparser::ast::Expr`] to an integer.
+///
+/// We only support some SQL expressions being integers.
+/// If the expression is not supported, an error is returned.
+fn expr_to_int(expr: &Expr) -> LogicalPlanResult<i64> {
+    match expr {
+        Expr::Value(value) => match value {
+            Value::Number(n) => n
+                .parse()
+                .map_err(|_e| unsupported("Invalid integer format")),
+            _ => Err(unsupported("We only support integer values")),
+        },
+        _ => Err(unsupported("We only support integer values")),
+    }
+}
+
+/// Convert an [`sqlparser::ast::Expr`] to an [`sqlparser::ast::Ident`].
+///
+/// We only support some [`sqlparser::ast::Expr`]s being [`sqlparser::ast::Ident`]s.
+/// If the expression is not supported, an error is returned.
+fn expr_to_ident(expr: &Expr) -> LogicalPlanResult<Ident> {
+    match expr {
+        Expr::Identifier(ident) => Ok(ident.clone()),
+        _ => Err(unsupported("We only support Idents")),
+    }
+}

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -195,4 +195,11 @@ impl ConversionError {
     }
 }
 
+/// Create a `ConversionError::UnsupportedOperation` error.
+pub(crate) fn unsupported(message: &str) -> ConversionError {
+    ConversionError::UnsupportedOperation {
+        message: message.to_string(),
+    }
+}
+
 pub type ConversionResult<T> = Result<T, ConversionError>;

--- a/crates/proof-of-sql/src/sql/parse/mod.rs
+++ b/crates/proof-of-sql/src/sql/parse/mod.rs
@@ -2,7 +2,7 @@
 mod error;
 
 pub use error::ConversionError;
-pub(crate) use error::ConversionResult;
+pub(crate) use error::{unsupported, ConversionResult};
 
 mod enriched_expr;
 pub(crate) use enriched_expr::EnrichedExpr;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

Depends on the following PRs:
- [ ] #556 
- [ ] #562
# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
Add basic support for `sqlparser::ast::Statement` so that we can use `sqlparser` and convert intermediate AST it generates into proof AST. Note that we don't add support for unions and joins yet but leave them as `todo!` for easy extension.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
