### PR TITLE
feat: add `logical_plans::Expr`

### DIFF
--- a/crates/proof-of-sql/src/sql/logical_plans/error.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/error.rs
@@ -1,13 +1,12 @@
-use alloc::string::String;
 use snafu::Snafu;
 
 /// Errors encountered during the process of converting `sqlparser::ast::Statement` to `LogicalPlan`
 #[derive(Debug, Snafu)]
 pub enum LogicalPlanError {
-    #[snafu(display("Unsupported feature: {:?}", message))]
-    /// Used when a feature parseable in `sqlparser` is not supported
-    Unsupported {
-        /// The unsupported feature
-        message: String,
+    #[snafu(display("Unsupported binary operator: {:?}", op))]
+    /// Used when a binary operator is not supported
+    UnsupportedBinaryOperator {
+        /// The unsupported binary operator
+        op: sqlparser::ast::BinaryOperator,
     },
 }

--- a/crates/proof-of-sql/src/sql/logical_plans/error.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/error.rs
@@ -1,0 +1,13 @@
+use alloc::string::String;
+use snafu::Snafu;
+
+/// Errors encountered during the process of converting `sqlparser::ast::Statement` to `LogicalPlan`
+#[derive(Debug, Snafu)]
+pub enum LogicalPlanError {
+    #[snafu(display("Unsupported feature: {:?}", message))]
+    /// Used when a feature parseable in `sqlparser` is not supported
+    Unsupported {
+        /// The unsupported feature
+        message: String,
+    },
+}

--- a/crates/proof-of-sql/src/sql/logical_plans/expr.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/expr.rs
@@ -1,0 +1,116 @@
+use super::LogicalPlanError;
+use crate::base::database::{ColumnRef, LiteralValue};
+use alloc::{boxed::Box, format};
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::BinaryOperator as SqlBinaryOperator;
+
+/// Enum of column expressions that are either provable or supported in postprocessing
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Expr {
+    /// Column
+    Column(ColumnRef),
+    /// Provable CONST expression
+    Literal(LiteralValue),
+    /// Binary operation
+    Binary {
+        /// Left hand side of the binary operation
+        left: Box<Expr>,
+        /// Right hand side of the binary operation
+        right: Box<Expr>,
+        /// Binary operator
+        op: BinaryOperator,
+    },
+    /// NOT expression
+    Not(Box<Expr>),
+}
+
+/// Enum of binary operators we support
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum BinaryOperator {
+    /// Equals
+    Eq,
+    /// Not equals
+    Neq,
+    /// Greater than
+    Gt,
+    /// Less than
+    Lt,
+    /// Greater than or equals
+    Gte,
+    /// Less than or equals
+    Lte,
+    /// Logical AND
+    And,
+    /// Logical OR
+    Or,
+    /// Add
+    Add,
+    /// Subtract
+    Sub,
+    /// Multiply
+    Mul,
+    /// Divide
+    Div,
+}
+
+impl TryFrom<SqlBinaryOperator> for BinaryOperator {
+    type Error = LogicalPlanError;
+
+    fn try_from(op: SqlBinaryOperator) -> Result<Self, Self::Error> {
+        match op {
+            SqlBinaryOperator::Eq => Ok(Self::Eq),
+            SqlBinaryOperator::NotEq => Ok(Self::Neq),
+            SqlBinaryOperator::Gt => Ok(Self::Gt),
+            SqlBinaryOperator::Lt => Ok(Self::Lt),
+            SqlBinaryOperator::GtEq => Ok(Self::Gte),
+            SqlBinaryOperator::LtEq => Ok(Self::Lte),
+            SqlBinaryOperator::And => Ok(Self::And),
+            SqlBinaryOperator::Or => Ok(Self::Or),
+            SqlBinaryOperator::Plus => Ok(Self::Add),
+            SqlBinaryOperator::Minus => Ok(Self::Sub),
+            SqlBinaryOperator::Multiply => Ok(Self::Mul),
+            SqlBinaryOperator::Divide => Ok(Self::Div),
+            _ => Err(LogicalPlanError::Unsupported {
+                message: format!("Unsupported binary operator: {op:?}"),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Binary operators
+    #[test]
+    fn we_can_convert_supported_sqlparser_binary_operators() {
+        // Let's test all our supported binary operators.
+        let test_cases = vec![
+            (SqlBinaryOperator::Eq, BinaryOperator::Eq),
+            (SqlBinaryOperator::NotEq, BinaryOperator::Neq),
+            (SqlBinaryOperator::Gt, BinaryOperator::Gt),
+            (SqlBinaryOperator::Lt, BinaryOperator::Lt),
+            (SqlBinaryOperator::GtEq, BinaryOperator::Gte),
+            (SqlBinaryOperator::LtEq, BinaryOperator::Lte),
+            (SqlBinaryOperator::And, BinaryOperator::And),
+            (SqlBinaryOperator::Or, BinaryOperator::Or),
+            (SqlBinaryOperator::Plus, BinaryOperator::Add),
+            (SqlBinaryOperator::Minus, BinaryOperator::Sub),
+            (SqlBinaryOperator::Multiply, BinaryOperator::Mul),
+            (SqlBinaryOperator::Divide, BinaryOperator::Div),
+        ];
+
+        for (sql_op, expected) in test_cases {
+            let result = BinaryOperator::try_from(sql_op).unwrap();
+            assert_eq!(result, expected,);
+        }
+    }
+
+    #[test]
+    fn we_cannot_convert_unsupported_sqlparser_binary_operators() {
+        // Let's test an unsupported operator.
+        let unsupported_op = SqlBinaryOperator::Spaceship;
+        let result = BinaryOperator::try_from(unsupported_op);
+        assert!(matches!(result, Err(LogicalPlanError::Unsupported { .. })));
+    }
+}

--- a/crates/proof-of-sql/src/sql/logical_plans/expr.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/expr.rs
@@ -1,15 +1,15 @@
 use super::LogicalPlanError;
 use crate::base::database::{ColumnRef, LiteralValue};
-use alloc::{boxed::Box, format};
+use alloc::boxed::Box;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::BinaryOperator as SqlBinaryOperator;
+use sqlparser::ast;
 
 /// Enum of column expressions that are either provable or supported in postprocessing
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Expr {
     /// Column
     Column(ColumnRef),
-    /// Provable CONST expression
+    /// A constant expression
     Literal(LiteralValue),
     /// Binary operation
     Binary {
@@ -30,49 +30,47 @@ pub enum BinaryOperator {
     /// Equals
     Eq,
     /// Not equals
-    Neq,
+    NotEq,
     /// Greater than
     Gt,
     /// Less than
     Lt,
     /// Greater than or equals
-    Gte,
+    GtEq,
     /// Less than or equals
-    Lte,
+    LtEq,
     /// Logical AND
     And,
     /// Logical OR
     Or,
-    /// Add
-    Add,
-    /// Subtract
-    Sub,
+    /// Plus
+    Plus,
+    /// Minus
+    Minus,
     /// Multiply
-    Mul,
+    Multiply,
     /// Divide
-    Div,
+    Divide,
 }
 
-impl TryFrom<SqlBinaryOperator> for BinaryOperator {
+impl TryFrom<ast::BinaryOperator> for BinaryOperator {
     type Error = LogicalPlanError;
 
-    fn try_from(op: SqlBinaryOperator) -> Result<Self, Self::Error> {
+    fn try_from(op: ast::BinaryOperator) -> Result<Self, Self::Error> {
         match op {
-            SqlBinaryOperator::Eq => Ok(Self::Eq),
-            SqlBinaryOperator::NotEq => Ok(Self::Neq),
-            SqlBinaryOperator::Gt => Ok(Self::Gt),
-            SqlBinaryOperator::Lt => Ok(Self::Lt),
-            SqlBinaryOperator::GtEq => Ok(Self::Gte),
-            SqlBinaryOperator::LtEq => Ok(Self::Lte),
-            SqlBinaryOperator::And => Ok(Self::And),
-            SqlBinaryOperator::Or => Ok(Self::Or),
-            SqlBinaryOperator::Plus => Ok(Self::Add),
-            SqlBinaryOperator::Minus => Ok(Self::Sub),
-            SqlBinaryOperator::Multiply => Ok(Self::Mul),
-            SqlBinaryOperator::Divide => Ok(Self::Div),
-            _ => Err(LogicalPlanError::Unsupported {
-                message: format!("Unsupported binary operator: {op:?}"),
-            }),
+            ast::BinaryOperator::Eq => Ok(BinaryOperator::Eq),
+            ast::BinaryOperator::NotEq => Ok(BinaryOperator::NotEq),
+            ast::BinaryOperator::Gt => Ok(BinaryOperator::Gt),
+            ast::BinaryOperator::Lt => Ok(BinaryOperator::Lt),
+            ast::BinaryOperator::GtEq => Ok(BinaryOperator::GtEq),
+            ast::BinaryOperator::LtEq => Ok(BinaryOperator::LtEq),
+            ast::BinaryOperator::And => Ok(BinaryOperator::And),
+            ast::BinaryOperator::Or => Ok(BinaryOperator::Or),
+            ast::BinaryOperator::Plus => Ok(BinaryOperator::Plus),
+            ast::BinaryOperator::Minus => Ok(BinaryOperator::Minus),
+            ast::BinaryOperator::Multiply => Ok(BinaryOperator::Multiply),
+            ast::BinaryOperator::Divide => Ok(BinaryOperator::Divide),
+            _ => Err(LogicalPlanError::UnsupportedBinaryOperator { op }),
         }
     }
 }
@@ -86,31 +84,34 @@ mod tests {
     fn we_can_convert_supported_sqlparser_binary_operators() {
         // Let's test all our supported binary operators.
         let test_cases = vec![
-            (SqlBinaryOperator::Eq, BinaryOperator::Eq),
-            (SqlBinaryOperator::NotEq, BinaryOperator::Neq),
-            (SqlBinaryOperator::Gt, BinaryOperator::Gt),
-            (SqlBinaryOperator::Lt, BinaryOperator::Lt),
-            (SqlBinaryOperator::GtEq, BinaryOperator::Gte),
-            (SqlBinaryOperator::LtEq, BinaryOperator::Lte),
-            (SqlBinaryOperator::And, BinaryOperator::And),
-            (SqlBinaryOperator::Or, BinaryOperator::Or),
-            (SqlBinaryOperator::Plus, BinaryOperator::Add),
-            (SqlBinaryOperator::Minus, BinaryOperator::Sub),
-            (SqlBinaryOperator::Multiply, BinaryOperator::Mul),
-            (SqlBinaryOperator::Divide, BinaryOperator::Div),
+            (ast::BinaryOperator::Eq, BinaryOperator::Eq),
+            (ast::BinaryOperator::NotEq, BinaryOperator::NotEq),
+            (ast::BinaryOperator::Gt, BinaryOperator::Gt),
+            (ast::BinaryOperator::Lt, BinaryOperator::Lt),
+            (ast::BinaryOperator::GtEq, BinaryOperator::GtEq),
+            (ast::BinaryOperator::LtEq, BinaryOperator::LtEq),
+            (ast::BinaryOperator::And, BinaryOperator::And),
+            (ast::BinaryOperator::Or, BinaryOperator::Or),
+            (ast::BinaryOperator::Plus, BinaryOperator::Plus),
+            (ast::BinaryOperator::Minus, BinaryOperator::Minus),
+            (ast::BinaryOperator::Multiply, BinaryOperator::Multiply),
+            (ast::BinaryOperator::Divide, BinaryOperator::Divide),
         ];
 
         for (sql_op, expected) in test_cases {
             let result = BinaryOperator::try_from(sql_op).unwrap();
-            assert_eq!(result, expected,);
+            assert_eq!(result, expected);
         }
     }
 
     #[test]
     fn we_cannot_convert_unsupported_sqlparser_binary_operators() {
         // Let's test an unsupported operator.
-        let unsupported_op = SqlBinaryOperator::Spaceship;
+        let unsupported_op = ast::BinaryOperator::Spaceship;
         let result = BinaryOperator::try_from(unsupported_op);
-        assert!(matches!(result, Err(LogicalPlanError::Unsupported { .. })));
+        assert!(matches!(
+            result,
+            Err(LogicalPlanError::UnsupportedBinaryOperator { .. })
+        ));
     }
 }

--- a/crates/proof-of-sql/src/sql/logical_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/mod.rs
@@ -1,0 +1,5 @@
+//! This module contains the logical plan representation used in both proof generation and postprocessing.
+mod error;
+pub use error::LogicalPlanError;
+mod expr;
+pub use expr::Expr;

--- a/crates/proof-of-sql/src/sql/mod.rs
+++ b/crates/proof-of-sql/src/sql/mod.rs
@@ -2,6 +2,7 @@
 
 /// This module holds the [`EVMProofPlan`] struct and its implementation, which allows for EVM compatible serialization.
 pub mod evm_proof_plan;
+pub mod logical_plans;
 pub mod parse;
 pub mod postprocessing;
 pub mod proof;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
This PR is inspired by `DataFusion`.

We do expect to have proof and postprocessing nodes coexisting for a long time. Hence it is necessary to introduce `Expr` and `LogicalPlan` to make it easier to detect schema errors (e.g. `select not_a_column from tab` and `select * from tab where not_a_bool_col`) and separate the process of processing a query into logical nodes from routing them to proof and postprocessing nodes. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `sql/logical_plans` directory
- add `logical_plans::Expr`
- add `LogicalPlanError`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Will be.