### PR TITLE
feat: add `logical_plans::LogicalPlan`

### DIFF
--- a/crates/proof-of-sql/src/sql/logical_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/mod.rs
@@ -3,3 +3,5 @@ mod error;
 pub use error::LogicalPlanError;
 mod expr;
 pub use expr::Expr;
+mod plan;
+pub use plan::LogicalPlan;

--- a/crates/proof-of-sql/src/sql/logical_plans/plan.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/plan.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum LogicalPlan {
     /// Empty
-    Empty,
+    Empty(Empty),
     /// Table scan
-    TableScan(TableRef),
+    TableScan(TableScan),
     /// Projection
     Projection(Projection),
     /// Filter
@@ -26,8 +26,22 @@ pub enum LogicalPlan {
     Union(Union),
 }
 
+/// Empty
+/// e.g. SELECT 1
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Empty {}
+
+/// Table scan
+///
+/// e.g. SELECT * FROM t
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct TableScan {
+    /// Table reference
+    pub table_ref: TableRef,
+}
+
 /// Projection
-/// e.g. SELECT a, b FROM t
+/// e.g. SELECT a, b FROM <input>
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Projection {
     /// Input plan
@@ -93,6 +107,7 @@ pub struct Slice {
 
 /// Join
 /// e.g. SELECT t1.a, t1.b, t2.c FROM t1 JOIN t2 ON t1.a = t2.a
+/// Note that we only support inner joins for now
 #[allow(clippy::struct_field_names)]
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Join {
@@ -102,19 +117,8 @@ pub struct Join {
     pub right: Box<LogicalPlan>,
     /// Equijoin condition
     pub on: Vec<(Expr, Expr)>,
-    /// Join type
-    pub join_type: JoinType,
     /// Output schema
     pub schema: Vec<ColumnField>,
-}
-
-/// Join type
-///
-/// Currently only supports inner join
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
-pub enum JoinType {
-    /// Inner join
-    Inner,
 }
 
 /// Union
@@ -123,6 +127,4 @@ pub enum JoinType {
 pub struct Union {
     /// Input plans
     pub inputs: Vec<LogicalPlan>,
-    /// Schema of the output
-    pub schema: Vec<ColumnField>,
 }

--- a/crates/proof-of-sql/src/sql/logical_plans/plan.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/plan.rs
@@ -1,0 +1,128 @@
+use super::Expr;
+use crate::base::database::{ColumnField, TableRef};
+use alloc::{boxed::Box, vec::Vec};
+use serde::{Deserialize, Serialize};
+
+/// Enum of logical plans that are either provable or supported in postprocessing
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub enum LogicalPlan {
+    /// Empty
+    Empty,
+    /// Table scan
+    TableScan(TableRef),
+    /// Projection
+    Projection(Projection),
+    /// Filter
+    Filter(Filter),
+    /// Aggregate
+    Aggregate(Aggregate),
+    /// Sort
+    Sort(Sort),
+    /// Slice
+    Slice(Slice),
+    /// Join
+    Join(Join),
+    /// Union
+    Union(Union),
+}
+
+/// Projection
+/// e.g. SELECT a, b FROM t
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Projection {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Projection expressions
+    pub expr: Vec<Expr>,
+}
+
+/// Filter
+/// e.g. WHERE a > 5
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Filter {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Filter expression
+    pub filter: Expr,
+}
+
+/// Aggregate
+/// e.g. SELECT a, COUNT(b) FROM t GROUP BY a
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Aggregate {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Group by
+    pub group_by: Vec<Expr>,
+    /// Aggregate expressions
+    pub aggr_expr: Vec<Expr>,
+    /// Output schema
+    pub schema: Vec<ColumnField>,
+}
+
+/// Sort
+/// e.g. ORDER BY a ASC, b DESC
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Sort {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Sort expressions
+    pub expr: Vec<SortExpr>,
+}
+
+/// Sort expression
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct SortExpr {
+    /// Expression
+    pub expr: Expr,
+    /// Direction
+    pub asc: bool,
+}
+
+/// Slice
+/// e.g. LIMIT 5 OFFSET 10
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Slice {
+    /// Input plan
+    pub input: Box<LogicalPlan>,
+    /// Maximum number of rows to return. None = no limit
+    pub limit: Option<u64>,
+    /// Offset value
+    pub offset: i64,
+}
+
+/// Join
+/// e.g. SELECT t1.a, t1.b, t2.c FROM t1 JOIN t2 ON t1.a = t2.a
+#[allow(clippy::struct_field_names)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Join {
+    /// Left input plan
+    pub left: Box<LogicalPlan>,
+    /// Right input plan
+    pub right: Box<LogicalPlan>,
+    /// Equijoin condition
+    pub on: Vec<(Expr, Expr)>,
+    /// Join type
+    pub join_type: JoinType,
+    /// Output schema
+    pub schema: Vec<ColumnField>,
+}
+
+/// Join type
+///
+/// Currently only supports inner join
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub enum JoinType {
+    /// Inner join
+    Inner,
+}
+
+/// Union
+/// e.g. SELECT a, b FROM t1 UNION ALL SELECT a, b FROM t2
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+pub struct Union {
+    /// Input plans
+    pub inputs: Vec<LogicalPlan>,
+    /// Schema of the output
+    pub schema: Vec<ColumnField>,
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

Depends on the following PRs
- [x] #556 
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
Depends on #556
# Rationale for this change
Add `LogicalPlan`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `LogicalPlan`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Will be.