### PR TITLE
fix: address many no_std compatibility issues

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run cargo check (proof-of-sql-parser) with no_std target.
         run: |
           rustup target add thumbv7em-none-eabi
-          cargo check -p proof-of-sql-parser --target thumbv7em-none-eabi
+          cargo check --target thumbv7em-none-eabi --no-default-features
 
   test:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ enum_dispatch = { version = "0.3.13" }
 ff = { version = "0.13.0"}
 flexbuffers = { version = "2.0.0" }
 indexmap = { version = "2.1", default-features = false }
-indicatif = "0.17.8"
+indicatif = { version = "0.17.8", default-features = false }
 itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }
 lalrpop = { version = "0.22.0" }
 lalrpop-util = { version = "0.22.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ rand_core = { version = "0.6", default-features = false }
 rayon = { version = "1.5" }
 serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
-sha2 = "0.10.8"
+sha2 = { version = "0.10.8", default-features = false }
 snafu = { version = "0.8.4", default-features = false }
 sqlparser = { version = "0.45.0", default-features = false }
 sysinfo = { version = "0.33" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ snafu = { version = "0.8.4", default-features = false }
 sqlparser = { version = "0.45.0", default-features = false }
 sysinfo = { version = "0.33" }
 tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
-tempfile = "3.13.0"
+tempfile = { version = "3.13.0", default-features = false }
 tracing = { version = "0.1.36", default-features = false }
 tracing-opentelemetry = { version = "0.22.0" }
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,8 @@ missing_docs = "warn"
 [workspace.lints.clippy]
 missing_errors_doc = "allow"
 pedantic = { level = "warn", priority = -1 }
+
+[patch.crates-io]
+# patch for sqlparser no_std compatibility with the serde feature enabled.
+# required until sqlparser releases a similar update and proof-of-sql upgrades to it.
+sqlparser = { git = "https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git", rev = "a828cbea22cf19bb6b4596f902bdd6f4d14a00b8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ark-std = { version = "0.5.0", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
 arrow = { version = "51.0.0" }
 arrow-csv = { version = "51.0.0" }
-bincode = { version = "1.3.3" }
+bincode = { version = "2.0.0-rc.3", default-features = false }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3", default-features = false }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -24,7 +24,7 @@ ark-poly = { workspace = true }
 ark-serialize = { workspace = true }
 ark-std = { workspace = true }
 arrow = { workspace = true, optional = true }
-bincode = { workspace = true }
+bincode = { workspace = true, features = ["serde", "alloc"] }
 bit-iter = { workspace = true }
 bigdecimal = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -49,7 +49,7 @@ num-bigint = { workspace = true, default-features = false }
 postcard = { workspace = true, features = ["alloc"] }
 proof-of-sql-parser = { workspace = true }
 rand = { workspace = true, default-features = false, optional = true }
-rand_chacha = { workspace = true}
+rand_chacha = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
@@ -81,7 +81,7 @@ development = ["arrow-csv"]
 
 [features]
 default = ["arrow", "perf"]
-utils = ["dep:indicatif"]
+utils = ["dep:indicatif", "dep:rand_chacha"]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
 hyperkzg = ["dep:nova-snark", "std", "dep:ff"]

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -53,7 +53,7 @@ rand_chacha = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
+sha2 = { workspace = true, optional = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true, features = ["serde"]  }
 sysinfo = {workspace = true, optional = true }
@@ -67,7 +67,7 @@ criterion = { workspace = true, features = ["html_reports"] }
 merlin = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-jaeger = { workspace = true }
-rand = { workspace = true, default-features = false }
+rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
@@ -81,7 +81,7 @@ development = ["arrow-csv", "opentelemetry", "opentelemetry-jaeger", "tracing-op
 
 [features]
 default = ["arrow", "perf"]
-utils = ["dep:indicatif", "dep:rand_chacha"]
+utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2" ]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
 hyperkzg = ["dep:nova-snark", "std", "dep:ff"]

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -40,7 +40,7 @@ derive_more = { workspace = true }
 enum_dispatch = { workspace = true }
 ff = { workspace = true, optional = true }
 indexmap = { workspace = true, features = ["serde"] }
-indicatif = { workspace = true }
+indicatif = { workspace = true, optional = true }
 itertools = { workspace = true }
 merlin = { workspace = true, optional = true }
 nova-snark = { workspace = true, optional = true }
@@ -81,6 +81,7 @@ development = ["arrow-csv"]
 
 [features]
 default = ["arrow", "perf"]
+utils = ["dep:indicatif"]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
 hyperkzg = ["dep:nova-snark", "std", "dep:ff"]
@@ -96,12 +97,12 @@ workspace = true
 [[bin]]
 name = "generate-parameters"
 path = "utils/generate-parameters/main.rs"
-required-features = [ "std", "blitzar"]
+required-features = [ "std", "blitzar", "utils" ]
 
 [[bin]]
 name = "commitment-utility"
 path = "utils/commitment-utility/main.rs"
-required-features = [ "std", "blitzar"]
+required-features = [ "std", "blitzar", "utils" ]
 
 [[example]]
 name = "hello_world"
@@ -109,7 +110,7 @@ required-features = ["test"]
 
 [[example]]
 name = "posql_db"
-required-features = ["arrow"]
+required-features = ["arrow", "utils"]
 
 [[example]]
 name = "space"

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -33,7 +33,7 @@ bnum = { workspace = true }
 bumpalo = { workspace = true, features = ["collections"] }
 bytemuck = { workspace = true }
 byte-slice-cast = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive"], optional = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true }
@@ -81,7 +81,7 @@ development = ["arrow-csv", "opentelemetry", "opentelemetry-jaeger", "tracing-op
 
 [features]
 default = ["arrow", "perf"]
-utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2" ]
+utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2", "dep:clap" ]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
 hyperkzg = ["dep:nova-snark", "std", "dep:ff"]

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true, features = ["serde"]  }
-sysinfo = {workspace = true }
+sysinfo = {workspace = true, optional = true }
 tiny-keccak = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 zerocopy = { workspace = true }
@@ -77,7 +77,7 @@ tracing-subscriber = { workspace = true }
 flexbuffers = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
-development = ["arrow-csv"]
+development = ["arrow-csv", "opentelemetry", "opentelemetry-jaeger", "tracing-opentelemetry", "tracing-subscriber"]
 
 [features]
 default = ["arrow", "perf"]
@@ -89,7 +89,7 @@ test = ["dep:rand", "std"]
 perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
 rayon = ["dep:rayon", "std"]
-std = ["snafu/std", "ark-serialize/std"]
+std = ["snafu/std", "ark-serialize/std", "dep:sysinfo" ]
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -57,6 +57,7 @@ sha2 = { workspace = true, optional = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true, features = ["serde"]  }
 sysinfo = {workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
 tiny-keccak = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 zerocopy = { workspace = true }
@@ -70,7 +71,6 @@ opentelemetry-jaeger = { workspace = true }
 rand = { workspace = true, default-features = false, features = ["std"] }
 rand_core = { workspace = true, default-features = false }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -81,7 +81,7 @@ development = ["arrow-csv", "opentelemetry", "opentelemetry-jaeger", "tracing-op
 
 [features]
 default = ["arrow", "perf"]
-utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2", "dep:clap" ]
+utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2", "dep:clap", "dep:tempfile"]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
 hyperkzg = ["dep:nova-snark", "std", "dep:ff"]

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -38,12 +38,12 @@ curve25519-dalek = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true }
 enum_dispatch = { workspace = true }
-ff = { workspace = true }
+ff = { workspace = true, optional = true }
 indexmap = { workspace = true, features = ["serde"] }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 merlin = { workspace = true, optional = true }
-nova-snark = { workspace = true }
+nova-snark = { workspace = true, optional = true }
 num-traits = { workspace = true }
 num-bigint = { workspace = true, default-features = false }
 postcard = { workspace = true, features = ["alloc"] }
@@ -83,6 +83,7 @@ development = ["arrow-csv"]
 default = ["arrow", "perf"]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
+hyperkzg = ["dep:nova-snark", "std", "dep:ff"]
 test = ["dep:rand", "std"]
 perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]
@@ -192,4 +193,4 @@ required-features = ["test"]
 [[bench]]
 name = "jaeger_benches"
 harness = false
-required-features = ["blitzar"]
+required-features = ["blitzar", "hyperkzg"]

--- a/crates/proof-of-sql/examples/posql_db/run_example.sh
+++ b/crates/proof-of-sql/examples/posql_db/run_example.sh
@@ -1,5 +1,5 @@
 cd crates/proof-of-sql/examples/posql_db
-cargo run  --features="arrow" "$@" --example posql_db create -t sxt.table -c a,b -d BIGINT,VARCHAR
-cargo run  --features="arrow" "$@" --example posql_db append -t sxt.table -f hello_world.csv
-cargo run  --features="arrow" "$@" --example posql_db prove -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
-cargo run  --features="arrow" "$@" --example posql_db verify -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
+cargo run  --features="arrow,utils" "$@" --example posql_db create -t sxt.table -c a,b -d BIGINT,VARCHAR
+cargo run  --features="arrow,utils" "$@" --example posql_db append -t sxt.table -f hello_world.csv
+cargo run  --features="arrow,utils" "$@" --example posql_db prove -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof
+cargo run  --features="arrow,utils" "$@" --example posql_db verify -q "SELECT b FROM sxt.table WHERE a = 2" -f hello.proof

--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -1,6 +1,5 @@
 use crate::base::scalar::Scalar;
 use alloc::vec::Vec;
-use bincode::Options;
 use zerocopy::{AsBytes, FromBytes};
 
 /// A public-coin transcript.
@@ -43,12 +42,14 @@ pub trait Transcript {
     /// # Panics
     /// - Panics if `postcard::to_allocvec(message)` fails to serialize the message.
     fn extend_serialize_as_le(&mut self, message: &(impl serde::Serialize + ?Sized)) {
-        self.extend_as_le_from_refs([bincode::DefaultOptions::new()
-            .with_fixint_encoding()
-            .with_big_endian()
-            .serialize(message)
-            .unwrap()
-            .as_slice()]);
+        self.extend_as_le_from_refs([bincode::serde::encode_to_vec(
+            message,
+            bincode::config::legacy()
+                .with_fixed_int_encoding()
+                .with_big_endian(),
+        )
+        .unwrap()
+        .as_slice()]);
     }
     /// Appends a type that implements [`ark_serialize::CanonicalSerialize`] by appending the raw bytes (i.e. assuming the message is littleendian)
     ///

--- a/crates/proof-of-sql/src/proof_primitive/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/mod.rs
@@ -6,4 +6,5 @@ pub(super) mod dynamic_matrix_utils;
 pub(crate) mod sumcheck;
 
 /// An implementation of hyper-kzg PCS. This is a wrapper around nova's hyper-kzg implementation.
+#[cfg(feature = "hyperkzg")]
 pub mod hyperkzg;

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -8,18 +8,19 @@ use crate::{
         proof_plans::{DynProofPlan, EmptyExec, FilterExec},
     },
 };
-use bincode::Options;
 use core::iter;
 
 #[test]
 fn we_cannot_generate_serialized_proof_plan_for_unsupported_plan() {
     let plan = DynProofPlan::Empty(EmptyExec::new());
 
-    bincode::DefaultOptions::new()
-        .with_fixint_encoding()
-        .with_big_endian()
-        .serialize(&EVMProofPlan::new(plan))
-        .unwrap_err();
+    bincode::serde::encode_to_vec(
+        EVMProofPlan::new(plan),
+        bincode::config::legacy()
+            .with_fixed_int_encoding()
+            .with_big_endian(),
+    )
+    .unwrap_err();
 }
 
 #[test]
@@ -46,11 +47,13 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
         )),
     ));
 
-    let bytes = bincode::DefaultOptions::new()
-        .with_fixint_encoding()
-        .with_big_endian()
-        .serialize(&EVMProofPlan::new(plan))
-        .unwrap();
+    let bytes = bincode::serde::encode_to_vec(
+        EVMProofPlan::new(plan),
+        bincode::config::legacy()
+            .with_fixed_int_encoding()
+            .with_big_endian(),
+    )
+    .unwrap();
 
     let expected_bytes: Vec<_> = iter::empty()
         .chain(&1_usize.to_be_bytes())

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "std")]
 use sysinfo::System;
 use tracing::{trace, Level};
 
@@ -11,6 +12,7 @@ use tracing::{trace, Level};
 /// * `name` - A string slice that holds the name to be included in the log message.
 #[allow(clippy::cast_precision_loss)]
 pub fn log_memory_usage(name: &str) {
+    #[cfg(feature = "std")]
     if tracing::level_enabled!(Level::TRACE) {
         let mut system = System::new_all();
         system.refresh_memory();

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -4,6 +4,8 @@
 use ark_std::test_rng;
 #[cfg(feature = "blitzar")]
 use proof_of_sql::base::commitment::InnerProductProof;
+#[cfg(feature = "hyperkzg")]
+use proof_of_sql::proof_primitive::hyperkzg::HyperKZGCommitmentEvaluationProof;
 use proof_of_sql::{
     base::{
         database::{
@@ -11,12 +13,9 @@ use proof_of_sql::{
         },
         scalar::Curve25519Scalar,
     },
-    proof_primitive::{
-        dory::{
-            DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup,
-            DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
-        },
-        hyperkzg::HyperKZGCommitmentEvaluationProof,
+    proof_primitive::dory::{
+        DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup,
+        DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
     },
     sql::{
         parse::{ConversionError, QueryExpr},
@@ -176,6 +175,7 @@ fn we_can_prove_a_basic_equality_query_with_dory() {
 }
 
 #[test]
+#[cfg(feature = "hyperkzg")]
 fn we_can_prove_a_basic_equality_query_with_hyperkzg() {
     use nova_snark::{
         provider::hyperkzg::{CommitmentEngine, CommitmentKey, EvaluationEngine},


### PR DESCRIPTION
There is a bug in our CI that checks for no_std compatibility. In the meantime, many incompatibilities have been let through. This PR fixes *most* of them. The exception is `sqlparser`, whose `serde` flag enables `serde/std`. We cannot address this one officially until a version of `sqlparser` is released without this issue, and we upgrade to it. In the meantime, complete no_std can be achieved with the following fork:

```toml
[patch.crates-io]
# patch for sqlparser no_std compatibility with the serde feature enabled.
# required until sqlparser releases a similar update and proof-of-sql upgrades to it.
sqlparser = { git = "https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git", rev = "a828cbea22cf19bb6b4596f902bdd6f4d14a00b8" }
```

The commits provide a decent summary of what has changed:
- **fix: put nova-snark dependency and hyperkzg module behind feature flag**
- **fix: use bincode 2.0.0 release candidate for no_std compatibility**
- **fix: disable default features on tempfile dependency**
- **fix: disable default features on indicatif**
- **fix: make indicatif optional behind new utils flag**
- **fix: make rand_chacha dependency optional**
- **fix: make sysinfo optional and only enable related tracing with std flag**
- **fix: make sha2 dependency optional behind utils flag**
- **fix: make clap dependency optional behind utils flag**
- **fix: add patch for sqlparser for no_std compatibility**
- **fix: check for no_std incompatibility in both crates**
