### PR TITLE
feat: add `sqlparser::ast::Expr` -> `proof_of_sql::sql::logical_plans::Expr` conversion

### DIFF
--- a/crates/proof-of-sql/src/sql/logical_plans/error.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/error.rs
@@ -1,4 +1,6 @@
+use crate::base::math::decimal::DecimalError;
 use snafu::Snafu;
+use sqlparser::ast::{BinaryOperator, Value};
 
 /// Errors encountered during the process of converting `sqlparser::ast::Statement` to `LogicalPlan`
 #[derive(Debug, Snafu)]
@@ -7,6 +9,18 @@ pub enum LogicalPlanError {
     /// Used when a binary operator is not supported
     UnsupportedBinaryOperator {
         /// The unsupported binary operator
-        op: sqlparser::ast::BinaryOperator,
+        op: BinaryOperator,
+    },
+    #[snafu(display("Unsupported Value: {:?}", value))]
+    /// Used when a value is not supported
+    UnsupportedValue {
+        /// The unsupported value
+        value: Value,
+    },
+    /// Used when a value can not be parsed as a decimal
+    #[snafu(transparent)]
+    DecimalParseError {
+        /// The underlying error
+        source: DecimalError,
     },
 }

--- a/crates/proof-of-sql/src/sql/logical_plans/expr.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/expr.rs
@@ -1,8 +1,6 @@
-use super::LogicalPlanError;
 use crate::base::database::{ColumnRef, LiteralValue};
 use alloc::boxed::Box;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast;
 
 /// Enum of column expressions that are either provable or supported in postprocessing
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -51,67 +49,4 @@ pub enum BinaryOperator {
     Multiply,
     /// Divide
     Divide,
-}
-
-impl TryFrom<ast::BinaryOperator> for BinaryOperator {
-    type Error = LogicalPlanError;
-
-    fn try_from(op: ast::BinaryOperator) -> Result<Self, Self::Error> {
-        match op {
-            ast::BinaryOperator::Eq => Ok(BinaryOperator::Eq),
-            ast::BinaryOperator::NotEq => Ok(BinaryOperator::NotEq),
-            ast::BinaryOperator::Gt => Ok(BinaryOperator::Gt),
-            ast::BinaryOperator::Lt => Ok(BinaryOperator::Lt),
-            ast::BinaryOperator::GtEq => Ok(BinaryOperator::GtEq),
-            ast::BinaryOperator::LtEq => Ok(BinaryOperator::LtEq),
-            ast::BinaryOperator::And => Ok(BinaryOperator::And),
-            ast::BinaryOperator::Or => Ok(BinaryOperator::Or),
-            ast::BinaryOperator::Plus => Ok(BinaryOperator::Plus),
-            ast::BinaryOperator::Minus => Ok(BinaryOperator::Minus),
-            ast::BinaryOperator::Multiply => Ok(BinaryOperator::Multiply),
-            ast::BinaryOperator::Divide => Ok(BinaryOperator::Divide),
-            _ => Err(LogicalPlanError::UnsupportedBinaryOperator { op }),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Binary operators
-    #[test]
-    fn we_can_convert_supported_sqlparser_binary_operators() {
-        // Let's test all our supported binary operators.
-        let test_cases = vec![
-            (ast::BinaryOperator::Eq, BinaryOperator::Eq),
-            (ast::BinaryOperator::NotEq, BinaryOperator::NotEq),
-            (ast::BinaryOperator::Gt, BinaryOperator::Gt),
-            (ast::BinaryOperator::Lt, BinaryOperator::Lt),
-            (ast::BinaryOperator::GtEq, BinaryOperator::GtEq),
-            (ast::BinaryOperator::LtEq, BinaryOperator::LtEq),
-            (ast::BinaryOperator::And, BinaryOperator::And),
-            (ast::BinaryOperator::Or, BinaryOperator::Or),
-            (ast::BinaryOperator::Plus, BinaryOperator::Plus),
-            (ast::BinaryOperator::Minus, BinaryOperator::Minus),
-            (ast::BinaryOperator::Multiply, BinaryOperator::Multiply),
-            (ast::BinaryOperator::Divide, BinaryOperator::Divide),
-        ];
-
-        for (sql_op, expected) in test_cases {
-            let result = BinaryOperator::try_from(sql_op).unwrap();
-            assert_eq!(result, expected);
-        }
-    }
-
-    #[test]
-    fn we_cannot_convert_unsupported_sqlparser_binary_operators() {
-        // Let's test an unsupported operator.
-        let unsupported_op = ast::BinaryOperator::Spaceship;
-        let result = BinaryOperator::try_from(unsupported_op);
-        assert!(matches!(
-            result,
-            Err(LogicalPlanError::UnsupportedBinaryOperator { .. })
-        ));
-    }
 }

--- a/crates/proof-of-sql/src/sql/logical_plans/mod.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/mod.rs
@@ -2,6 +2,7 @@
 mod error;
 pub use error::LogicalPlanError;
 mod expr;
-pub use expr::Expr;
+pub use expr::{BinaryOperator, Expr};
 mod plan;
 pub use plan::LogicalPlan;
+mod sqlparser;

--- a/crates/proof-of-sql/src/sql/logical_plans/sqlparser.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/sqlparser.rs
@@ -1,0 +1,66 @@
+//! This module contains the conversion functions for converting sqlparser types to our own Logical Plan.
+use super::{BinaryOperator, LogicalPlanError};
+use sqlparser::ast;
+
+impl TryFrom<ast::BinaryOperator> for BinaryOperator {
+    type Error = LogicalPlanError;
+
+    fn try_from(op: ast::BinaryOperator) -> Result<Self, Self::Error> {
+        match op {
+            ast::BinaryOperator::Eq => Ok(BinaryOperator::Eq),
+            ast::BinaryOperator::NotEq => Ok(BinaryOperator::NotEq),
+            ast::BinaryOperator::Gt => Ok(BinaryOperator::Gt),
+            ast::BinaryOperator::Lt => Ok(BinaryOperator::Lt),
+            ast::BinaryOperator::GtEq => Ok(BinaryOperator::GtEq),
+            ast::BinaryOperator::LtEq => Ok(BinaryOperator::LtEq),
+            ast::BinaryOperator::And => Ok(BinaryOperator::And),
+            ast::BinaryOperator::Or => Ok(BinaryOperator::Or),
+            ast::BinaryOperator::Plus => Ok(BinaryOperator::Plus),
+            ast::BinaryOperator::Minus => Ok(BinaryOperator::Minus),
+            ast::BinaryOperator::Multiply => Ok(BinaryOperator::Multiply),
+            ast::BinaryOperator::Divide => Ok(BinaryOperator::Divide),
+            _ => Err(LogicalPlanError::UnsupportedBinaryOperator { op }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Binary operators
+    #[test]
+    fn we_can_convert_supported_sqlparser_binary_operators() {
+        // Let's test all our supported binary operators.
+        let test_cases = vec![
+            (ast::BinaryOperator::Eq, BinaryOperator::Eq),
+            (ast::BinaryOperator::NotEq, BinaryOperator::NotEq),
+            (ast::BinaryOperator::Gt, BinaryOperator::Gt),
+            (ast::BinaryOperator::Lt, BinaryOperator::Lt),
+            (ast::BinaryOperator::GtEq, BinaryOperator::GtEq),
+            (ast::BinaryOperator::LtEq, BinaryOperator::LtEq),
+            (ast::BinaryOperator::And, BinaryOperator::And),
+            (ast::BinaryOperator::Or, BinaryOperator::Or),
+            (ast::BinaryOperator::Plus, BinaryOperator::Plus),
+            (ast::BinaryOperator::Minus, BinaryOperator::Minus),
+            (ast::BinaryOperator::Multiply, BinaryOperator::Multiply),
+            (ast::BinaryOperator::Divide, BinaryOperator::Divide),
+        ];
+
+        for (sql_op, expected) in test_cases {
+            let result = BinaryOperator::try_from(sql_op).unwrap();
+            assert_eq!(result, expected);
+        }
+    }
+
+    #[test]
+    fn we_cannot_convert_unsupported_sqlparser_binary_operators() {
+        // Let's test an unsupported operator.
+        let unsupported_op = ast::BinaryOperator::Spaceship;
+        let result = BinaryOperator::try_from(unsupported_op);
+        assert!(matches!(
+            result,
+            Err(LogicalPlanError::UnsupportedBinaryOperator { .. })
+        ));
+    }
+}

--- a/crates/proof-of-sql/src/sql/logical_plans/sqlparser.rs
+++ b/crates/proof-of-sql/src/sql/logical_plans/sqlparser.rs
@@ -1,6 +1,61 @@
 //! This module contains the conversion functions for converting sqlparser types to our own Logical Plan.
 use super::{BinaryOperator, LogicalPlanError};
+use crate::base::{
+    database::LiteralValue,
+    math::{
+        decimal::{DecimalError, DecimalResult, IntermediateDecimalError, Precision},
+        i256::I256,
+        BigDecimalExt,
+    },
+};
+use bigdecimal::BigDecimal;
+use num_bigint::BigInt;
 use sqlparser::ast;
+
+/// Parse a decimal value from a string
+fn parse_decimal(value: &str) -> DecimalResult<LiteralValue> {
+    let dec: BigDecimal =
+        value
+            .parse()
+            .map_err(|e| DecimalError::IntermediateDecimalConversionError {
+                source: IntermediateDecimalError::ParseError { error: e },
+            })?;
+    let precision = u8::try_from(dec.precision()).map_err(|_| DecimalError::InvalidPrecision {
+        error: format!("Precision {} is too large", dec.precision()),
+    })?;
+    let scale = i8::try_from(dec.scale()).map_err(|_| DecimalError::InvalidScale {
+        scale: format!("Scale {} is too large", dec.scale()),
+    })?;
+    let bigint = dec
+        .try_into_bigint_with_precision_and_scale(precision, scale)
+        .map_err(|source| DecimalError::IntermediateDecimalConversionError { source })?;
+    // Since I256::from_num_bigint() doesn't error out on numbers out of range we need to check here
+    if bigint.bits() > 255 || (bigint.clone() + BigInt::from(1_i64)).bits() > 255 {
+        return Err(DecimalError::InvalidPrecision {
+            error: format!("{bigint} is out of range for I256"),
+        });
+    }
+    let i256 = I256::from_num_bigint(&bigint);
+    let real_precision = Precision::new(precision).map_err(|e| DecimalError::InvalidPrecision {
+        error: format!("Precision {e} is too large"),
+    })?;
+    Ok(LiteralValue::Decimal75(real_precision, scale, i256))
+}
+
+impl TryFrom<ast::Value> for LiteralValue {
+    type Error = LogicalPlanError;
+
+    fn try_from(value: ast::Value) -> Result<Self, Self::Error> {
+        match value {
+            ast::Value::Number(n, _) => {
+                parse_decimal(&n).map_err(|source| LogicalPlanError::DecimalParseError { source })
+            }
+            ast::Value::SingleQuotedString(s) => Ok(LiteralValue::VarChar(s)),
+            ast::Value::Boolean(b) => Ok(LiteralValue::Boolean(b)),
+            _ => Err(LogicalPlanError::UnsupportedValue { value }),
+        }
+    }
+}
 
 impl TryFrom<ast::BinaryOperator> for BinaryOperator {
     type Error = LogicalPlanError;
@@ -27,6 +82,17 @@ impl TryFrom<ast::BinaryOperator> for BinaryOperator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Decimal parsing
+    #[test]
+    fn we_can_parse_a_decimal() {
+        let decimal_str = "123.45";
+        let result = parse_decimal(decimal_str).unwrap();
+        assert_eq!(
+            result,
+            LiteralValue::Decimal75(Precision::new(5).unwrap(), 2, I256::from(12345))
+        );
+    }
 
     // Binary operators
     #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
