### PR TITLE
feat(sol): add literal expression

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -23,6 +23,22 @@ uint256 constant WORDX6_SIZE = 0x20 * 6;
 /// @dev Size of twelve words in bytes.
 uint256 constant WORDX12_SIZE = 0x20 * 12;
 
+/// @dev Size of uint32 in bytes
+uint256 constant UINT32_SIZE = 0x04;
+/// @dev Number of bits needed to pad uint32 to 256 bits
+/// @dev This is useful for shifting a uint256 to the right to extract a uint32
+uint256 constant UINT32_PADDING_BITS = 0xE0;
+/// @dev Size of int64 in bytes
+uint256 constant INT64_SIZE = 0x08;
+/// @dev Number of bits needed to pad int64 to 256 bits
+/// @dev This is useful for shifting a uint256 to the right to extract a int64
+uint256 constant INT64_PADDING_BITS = 0xC0;
+/// @dev Size of int64 minus one byte
+uint256 constant INT64_SIZE_MINUS_ONE = 0x07;
+
+/// @dev BigInt variant constant for literal expressions
+uint32 constant LITERAL_BIGINT_VARIANT = 0;
+
 /// @dev Position of the free memory pointer in the context of the EVM memory.
 uint256 constant FREE_PTR = 0x40;
 

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -14,6 +14,8 @@ uint32 constant ERR_ROUND_EVALUATION_MISMATCH = 0x741f5c3f;
 uint32 constant ERR_EMPTY_QUEUE = 0x31dcf2b5;
 /// @dev Error code for when the HyperKZG proof has an inconsistent v.
 uint32 constant ERR_HYPER_KZG_INCONSISTENT_V = 0x6a5ae827;
+/// @dev Error code for when the case literal in a switch statement is incorrect.
+uint32 constant ERR_INCORRECT_CASE_CONST = 0x9324fb03;
 /// @dev Error code for when the produces constraint degree is higher than the provided proof.
 uint32 constant ERR_CONSTRAINT_DEGREE_TOO_HIGH = 0x8568ae69;
 
@@ -30,6 +32,8 @@ library Errors {
     error EmptyQueue();
     /// @notice Error thrown when the HyperKZG proof has an inconsistent v.
     error HyperKZGInconsistentV();
+    /// @notice Error thrown when the case literal in a switch statement is incorrect.
+    error IncorrectCaseConst();
     /// @notice Error thrown when the produces constraint degree is higher than the provided proof.
     error ConstraintDegreeTooHigh();
 

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -14,10 +14,12 @@ uint32 constant ERR_ROUND_EVALUATION_MISMATCH = 0x741f5c3f;
 uint32 constant ERR_EMPTY_QUEUE = 0x31dcf2b5;
 /// @dev Error code for when the HyperKZG proof has an inconsistent v.
 uint32 constant ERR_HYPER_KZG_INCONSISTENT_V = 0x6a5ae827;
-/// @dev Error code for when the case literal in a switch statement is incorrect.
-uint32 constant ERR_INCORRECT_CASE_CONST = 0x9324fb03;
 /// @dev Error code for when the produces constraint degree is higher than the provided proof.
 uint32 constant ERR_CONSTRAINT_DEGREE_TOO_HIGH = 0x8568ae69;
+/// @dev Error code for when the case literal in a switch statement is incorrect.
+uint32 constant ERR_INCORRECT_CASE_CONST = 0x9324fb03;
+/// @dev Error code for when a literal variant is unsupported.
+uint32 constant ERR_UNSUPPORTED_LITERAL_VARIANT = 0xed9d5b00;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -32,10 +34,12 @@ library Errors {
     error EmptyQueue();
     /// @notice Error thrown when the HyperKZG proof has an inconsistent v.
     error HyperKZGInconsistentV();
-    /// @notice Error thrown when the case literal in a switch statement is incorrect.
-    error IncorrectCaseConst();
     /// @notice Error thrown when the produces constraint degree is higher than the provided proof.
     error ConstraintDegreeTooHigh();
+    /// @notice Error thrown when the case literal in a switch statement is incorrect.
+    error IncorrectCaseConst();
+    /// @notice Error thrown when a literal variant is unsupported.
+    error UnsupportedLiteralVariant();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/src/base/SwitchUtil.pre.sol
+++ b/solidity/src/base/SwitchUtil.pre.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "./Errors.sol";
+
+/// @title SwitchUtil
+/// @dev Library providing helper functions for switch statement validation.
+library SwitchUtil {
+    /// @notice Validates that two values in a switch case statement match
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// case_const(lhs, rhs)
+    /// ```
+    /// ##### Parameters
+    /// * `lhs` - the left-hand side value to compare
+    /// * `rhs` - the right-hand side value to compare
+    /// @dev This function reverts with ERR_INCORRECT_CASE_CONST if the values don't match
+    /// @dev Note: This function is designed to be used with constant values. When both lhs and rhs
+    /// @dev are constants and the --optimize flag is used, the entire function call will be eliminated
+    /// @dev at compile time. The compiler will either:
+    /// @dev 1. Remove the call entirely if the constants match
+    /// @dev 2. Replace it with a direct revert if they don't match
+    /// @dev This means there is zero runtime overhead for switch statement validation in the intended usage.
+    /// @param __lhs The left-hand side value
+    /// @param __rhs The right-hand side value
+    function __caseConst(uint256 __lhs, uint256 __rhs) internal pure {
+        assembly {
+            // IMPORT-YUL Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            function case_const(lhs, rhs) {
+                if sub(lhs, rhs) { err(ERR_INCORRECT_CASE_CONST) }
+            }
+            case_const(__lhs, __rhs)
+        }
+    }
+}

--- a/solidity/src/proof_exprs/LiteralExpr.pre.sol
+++ b/solidity/src/proof_exprs/LiteralExpr.pre.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+
+/// @title LiteralExpr
+/// @dev Library for handling literal expressions
+library LiteralExpr {
+    enum LiteralVariant {
+        BigInt
+    }
+
+    /// @notice Evaluates a literal expression
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval
+    /// ```
+    /// ##### Parameters
+    /// * `expr_ptr` - the calldata pointer to the beginning of the expression data
+    /// * `chi_eval` - the chi value for evaluation
+    /// ##### Return Values
+    /// * `expr_ptr_out` - the pointer to the remaining expression after consuming the literal expression
+    /// * `eval` - the evaluated result
+    /// @dev This function evaluates a literal expression by multiplying the literal value by chi_eval.
+    /// This is because `chi_eval` is the evaluation of a column of ones of the appropriate length.
+    /// @param __expr The literal expression data
+    /// @param __chiEval The chi value for evaluation
+    /// @return __exprOut The remaining expression data after processing
+    /// @return __eval The evaluated result
+    function __literalExprEvaluate(bytes calldata __expr, uint256 __chiEval)
+        external
+        pure
+        returns (bytes calldata __exprOut, uint256 __eval)
+    {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/SwitchUtil.pre.sol
+            function case_const(lhs, rhs) {
+                revert(0, 0)
+            }
+
+            function literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval {
+                let literal_variant := shr(UINT32_PADDING_BITS, calldataload(expr_ptr))
+                expr_ptr := add(expr_ptr, UINT32_SIZE)
+
+                switch literal_variant
+                case 0 {
+                    case_const(0, LITERAL_BIGINT_VARIANT)
+                    eval :=
+                        add(signextend(INT64_SIZE_MINUS_ONE, shr(INT64_PADDING_BITS, calldataload(expr_ptr))), MODULUS)
+                    expr_ptr := add(expr_ptr, INT64_SIZE)
+                }
+                default { err(ERR_UNSUPPORTED_LITERAL_VARIANT) }
+                eval := mulmod(eval, chi_eval, MODULUS)
+
+                expr_ptr_out := expr_ptr
+            }
+            let __exprOutOffset
+            __exprOutOffset, __eval := literal_expr_evaluate(__expr.offset, __chiEval)
+            __exprOut.offset := __exprOutOffset
+            // slither-disable-next-line write-after-write
+            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+        }
+    }
+}

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -32,6 +32,17 @@ contract ConstantsTest is Test {
         assert(WORDX12_SIZE == 12 * WORD_SIZE);
     }
 
+    function testUint32SizesAreCorrect() public pure {
+        assert(UINT32_SIZE * 8 == 32);
+        assert(UINT32_PADDING_BITS == 256 - 32);
+    }
+
+    function testInt64SizesAreCorrect() public pure {
+        assert(INT64_SIZE * 8 == 64);
+        assert(INT64_PADDING_BITS == 256 - 64);
+        assert(INT64_SIZE_MINUS_ONE == INT64_SIZE - 1);
+    }
+
     function testVerificationBuilderOffsetsAreValid() public pure {
         uint256[9] memory offsets = [
             BUILDER_CHALLENGES_OFFSET,

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -7,23 +7,25 @@ import "../../src/base/Errors.sol";
 
 contract ErrorsTest is Test {
     function testErrorConstantsMatchSelectors() public pure {
-        bytes4[7] memory selectors = [
+        bytes4[8] memory selectors = [
             Errors.InvalidECAddInputs.selector,
             Errors.InvalidECMulInputs.selector,
             Errors.InvalidECPairingInputs.selector,
             Errors.RoundEvaluationMismatch.selector,
             Errors.EmptyQueue.selector,
             Errors.HyperKZGInconsistentV.selector,
-            Errors.ConstraintDegreeTooHigh.selector
+            Errors.ConstraintDegreeTooHigh.selector,
+            Errors.IncorrectCaseConst.selector
         ];
-        uint32[7] memory selectorConstants = [
+        uint32[8] memory selectorConstants = [
             ERR_INVALID_EC_ADD_INPUTS,
             ERR_INVALID_EC_MUL_INPUTS,
             ERR_INVALID_EC_PAIRING_INPUTS,
             ERR_ROUND_EVALUATION_MISMATCH,
             ERR_EMPTY_QUEUE,
             ERR_HYPER_KZG_INCONSISTENT_V,
-            ERR_CONSTRAINT_DEGREE_TOO_HIGH
+            ERR_CONSTRAINT_DEGREE_TOO_HIGH,
+            ERR_INCORRECT_CASE_CONST
         ];
         assert(selectors.length == selectorConstants.length);
         uint256 length = selectors.length;
@@ -66,6 +68,12 @@ contract ErrorsTest is Test {
     function testErrorFailedHyperKZGInconsistentV() public {
         vm.expectRevert(Errors.HyperKZGInconsistentV.selector);
         Errors.__err(ERR_HYPER_KZG_INCONSISTENT_V);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorFailedIncorrectCaseConst() public {
+        vm.expectRevert(Errors.IncorrectCaseConst.selector);
+        Errors.__err(ERR_INCORRECT_CASE_CONST);
     }
 
     /// forge-config: default.allow_internal_expect_revert = true

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -7,7 +7,7 @@ import "../../src/base/Errors.sol";
 
 contract ErrorsTest is Test {
     function testErrorConstantsMatchSelectors() public pure {
-        bytes4[8] memory selectors = [
+        bytes4[9] memory selectors = [
             Errors.InvalidECAddInputs.selector,
             Errors.InvalidECMulInputs.selector,
             Errors.InvalidECPairingInputs.selector,
@@ -15,9 +15,10 @@ contract ErrorsTest is Test {
             Errors.EmptyQueue.selector,
             Errors.HyperKZGInconsistentV.selector,
             Errors.ConstraintDegreeTooHigh.selector,
-            Errors.IncorrectCaseConst.selector
+            Errors.IncorrectCaseConst.selector,
+            Errors.UnsupportedLiteralVariant.selector
         ];
-        uint32[8] memory selectorConstants = [
+        uint32[9] memory selectorConstants = [
             ERR_INVALID_EC_ADD_INPUTS,
             ERR_INVALID_EC_MUL_INPUTS,
             ERR_INVALID_EC_PAIRING_INPUTS,
@@ -25,7 +26,8 @@ contract ErrorsTest is Test {
             ERR_EMPTY_QUEUE,
             ERR_HYPER_KZG_INCONSISTENT_V,
             ERR_CONSTRAINT_DEGREE_TOO_HIGH,
-            ERR_INCORRECT_CASE_CONST
+            ERR_INCORRECT_CASE_CONST,
+            ERR_UNSUPPORTED_LITERAL_VARIANT
         ];
         assert(selectors.length == selectorConstants.length);
         uint256 length = selectors.length;
@@ -71,14 +73,20 @@ contract ErrorsTest is Test {
     }
 
     /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorFailedConstraintDegreeTooHigh() public {
+        vm.expectRevert(Errors.ConstraintDegreeTooHigh.selector);
+        Errors.__err(ERR_CONSTRAINT_DEGREE_TOO_HIGH);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
     function testErrorFailedIncorrectCaseConst() public {
         vm.expectRevert(Errors.IncorrectCaseConst.selector);
         Errors.__err(ERR_INCORRECT_CASE_CONST);
     }
 
     /// forge-config: default.allow_internal_expect_revert = true
-    function testErrorFailedConstraintDegreeTooHigh() public {
-        vm.expectRevert(Errors.ConstraintDegreeTooHigh.selector);
-        Errors.__err(ERR_CONSTRAINT_DEGREE_TOO_HIGH);
+    function testErrorFailedUnsupportedLiteralVariant() public {
+        vm.expectRevert(Errors.UnsupportedLiteralVariant.selector);
+        Errors.__err(ERR_UNSUPPORTED_LITERAL_VARIANT);
     }
 }

--- a/solidity/test/base/SwitchUtil.t.pre.sol
+++ b/solidity/test/base/SwitchUtil.t.pre.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Errors.sol";
+import {SwitchUtil} from "../../src/base/SwitchUtil.pre.sol";
+
+contract SwitchUtilTest is Test {
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testFuzzCaseConst(uint256 lhs, uint256 rhs) public {
+        if (lhs != rhs) {
+            vm.expectRevert(Errors.IncorrectCaseConst.selector);
+        }
+        SwitchUtil.__caseConst(lhs, rhs);
+    }
+}

--- a/solidity/test/proof_exprs/LiteralExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/LiteralExpr.t.pre.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import "../../src/base/Errors.sol";
+import {LiteralExpr} from "../../src/proof_exprs/LiteralExpr.pre.sol";
+
+contract LiteralExprTest is Test {
+    function testLiteralExpr() public pure {
+        bytes memory exprIn = abi.encodePacked(LITERAL_BIGINT_VARIANT, int64(2), hex"abcdef");
+        bytes memory expectedExprOut = hex"abcdef";
+        (bytes memory exprOut, uint256 eval) = LiteralExpr.__literalExprEvaluate(exprIn, 3);
+        assert(eval == 6);
+        assert(exprOut.length == expectedExprOut.length);
+        uint256 exprOutLength = exprOut.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(exprOut[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testFuzzBigIntLiteralExpr(int64 literalValue, uint256 chiInEval, bytes memory trailingExpr) public pure {
+        bytes memory exprIn = abi.encodePacked(LITERAL_BIGINT_VARIANT, literalValue, trailingExpr);
+        (bytes memory exprOut, uint256 eval) = LiteralExpr.__literalExprEvaluate(exprIn, chiInEval);
+        uint256 literalValueAsScalar;
+        if (literalValue < 0) {
+            literalValueAsScalar = MODULUS - uint256(-int256(literalValue));
+        } else {
+            literalValueAsScalar = uint256(int256(literalValue));
+        }
+        assert(eval == mulmod(literalValueAsScalar, chiInEval, MODULUS));
+        assert(exprOut.length == trailingExpr.length);
+        uint256 exprOutLength = exprOut.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(exprOut[i] == trailingExpr[i]);
+        }
+    }
+
+    function testFuzzInvalidLiteralVariant(uint32 variant) public {
+        vm.assume(variant > 0);
+        bytes memory exprIn = abi.encodePacked(variant, int64(2), hex"abcdef");
+        vm.expectRevert(Errors.UnsupportedLiteralVariant.selector);
+        LiteralExpr.__literalExprEvaluate(exprIn, 3);
+    }
+
+    function testVariantsMatchEnum() public pure {
+        assert(uint32(LiteralExpr.LiteralVariant.BigInt) == LITERAL_BIGINT_VARIANT);
+    }
+}


### PR DESCRIPTION
# Rationale for this change

We need to add the SQL nodes to the solidity verifier.

# What changes are included in this PR?


* Added a `case_const` function to "compile-time" assert that two constants are equal. This is because Yul does not support constants in case statements.
* Added `literal_expr_evaluate` function.

# Are these changes tested?
Yes