### PR TITLE
feat(sol): add column expression

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -84,7 +84,7 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 9;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 10;
 /// @dev Offset of the pointer to the challenge queue in the verification builder.
 uint256 constant BUILDER_CHALLENGES_OFFSET = 0x20 * 0;
 /// @dev Offset of the pointer to the first round MLEs in the verification builder.
@@ -103,3 +103,5 @@ uint256 constant BUILDER_MAX_DEGREE_OFFSET = 0x20 * 6;
 uint256 constant BUILDER_AGGREGATE_EVALUATION_OFFSET = 0x20 * 7;
 /// @dev Offset of the row multipliers evaluation in the verification builder.
 uint256 constant BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET = 0x20 * 8;
+/// @dev Offset of the pointer to the column evaluations in the verification builder.
+uint256 constant BUILDER_COLUMN_EVALUATIONS_OFFSET = 0x20 * 9;

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -28,6 +28,11 @@ uint256 constant UINT32_SIZE = 0x04;
 /// @dev Number of bits needed to pad uint32 to 256 bits
 /// @dev This is useful for shifting a uint256 to the right to extract a uint32
 uint256 constant UINT32_PADDING_BITS = 0xE0;
+/// @dev Size of uint64 in bytes
+uint256 constant UINT64_SIZE = 0x08;
+/// @dev Number of bits needed to pad uint64 to 256 bits
+/// @dev This is useful for shifting a uint256 to the right to extract a uint64
+uint256 constant UINT64_PADDING_BITS = 0xC0;
 /// @dev Size of int64 in bytes
 uint256 constant INT64_SIZE = 0x08;
 /// @dev Number of bits needed to pad int64 to 256 bits

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -20,6 +20,8 @@ uint32 constant ERR_CONSTRAINT_DEGREE_TOO_HIGH = 0x8568ae69;
 uint32 constant ERR_INCORRECT_CASE_CONST = 0x9324fb03;
 /// @dev Error code for when a literal variant is unsupported.
 uint32 constant ERR_UNSUPPORTED_LITERAL_VARIANT = 0xed9d5b00;
+/// @dev Error code for when a column index is invalid.
+uint32 constant ERR_INVALID_COLUMN_INDEX = 0xb9c4d54d;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -40,6 +42,8 @@ library Errors {
     error IncorrectCaseConst();
     /// @notice Error thrown when a literal variant is unsupported.
     error UnsupportedLiteralVariant();
+    /// @notice Error thrown when a column index is invalid.
+    error InvalidColumnIndex();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/src/proof/VerificationBuilder.pre.sol
+++ b/solidity/src/proof/VerificationBuilder.pre.sol
@@ -19,6 +19,7 @@ library VerificationBuilder {
         uint256 maxDegree;
         uint256 aggregateEvaluation;
         uint256 rowMultipliersEvaluation;
+        uint256[] columnEvaluations;
     }
 
     /// @notice Allocates and reserves a block of memory for a verification builder
@@ -462,6 +463,61 @@ library VerificationBuilder {
                 )
             }
             builder_produce_identity_constraint(__builder, __evaluation, __degree)
+        }
+    }
+
+    /// @notice Sets the column evaluations in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_column_evaluations(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - pointer to the array in memory
+    /// @param __builder The builder struct
+    /// @param __values The column evaluation values array
+    function __setColumnEvaluations(Builder memory __builder, uint256[] memory __values) internal pure {
+        assembly {
+            function builder_set_column_evaluations(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_COLUMN_EVALUATIONS_OFFSET), values_ptr)
+            }
+            builder_set_column_evaluations(__builder, __values)
+        }
+    }
+
+    /// @notice Gets a column evaluation by column number
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_column_evaluation(builder_ptr, column_num) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `column_num` - the column number to get evaluation for
+    /// ##### Return Values
+    /// * `value` - the column evaluation
+    /// @param __builder The builder struct
+    /// @param __columnNum The column number
+    /// @return __value The column evaluation value
+    function __getColumnEvaluation(Builder memory __builder, uint256 __columnNum)
+        internal
+        pure
+        returns (uint256 __value)
+    {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            function builder_get_column_evaluation(builder_ptr, column_num) -> value {
+                let arr_ptr := mload(add(builder_ptr, BUILDER_COLUMN_EVALUATIONS_OFFSET))
+                if iszero(lt(column_num, mload(arr_ptr))) { err(ERR_INVALID_COLUMN_INDEX) }
+                value := mload(add(add(arr_ptr, WORD_SIZE), mul(column_num, WORD_SIZE)))
+            }
+            __value := builder_get_column_evaluation(__builder, __columnNum)
         }
     }
 }

--- a/solidity/src/proof_exprs/ColumnExpr.pre.sol
+++ b/solidity/src/proof_exprs/ColumnExpr.pre.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../base/Constants.sol";
+import "../base/Errors.sol";
+import {VerificationBuilder} from "../proof/VerificationBuilder.pre.sol";
+
+/// @title ColumnExpr
+/// @dev Library for handling column expressions
+library ColumnExpr {
+    /// @notice Evaluates a column expression
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// column_expr_evaluate(expr_ptr, builder_ptr) -> expr_ptr_out, eval
+    /// ```
+    /// ##### Parameters
+    /// * `expr_ptr` - calldata pointer to the column expression
+    /// * `builder_ptr` - memory pointer to the verification builder
+    /// ##### Return Values
+    /// * `expr_ptr_out` - pointer to the remaining expression after consuming the column expression
+    /// * `eval` - the evaluation result from looking up the column value
+    /// @dev Reads a uint64 column index from the expression and looks up its evaluation
+    /// @param __expr The input column expression
+    /// @param __builder The verification builder containing column evaluations
+    /// @return __exprOut The remaining expression after consuming the column index
+    /// @return __eval The evaluation result for the column
+    function __columnExprEvaluate( // solhint-disable-line gas-calldata-parameters
+    bytes calldata __expr, VerificationBuilder.Builder memory __builder)
+        external
+        pure
+        returns (bytes calldata __exprOut, uint256 __eval)
+    {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof/VerificationBuilder.pre.sol
+            function builder_get_column_evaluation(builder_ptr, column_num) -> eval {
+                revert(0, 0)
+            }
+
+            function column_expr_evaluate(expr_ptr, builder_ptr) -> expr_ptr_out, eval {
+                let column_num := shr(UINT64_PADDING_BITS, calldataload(expr_ptr))
+                expr_ptr := add(expr_ptr, UINT64_SIZE)
+
+                eval := builder_get_column_evaluation(builder_ptr, column_num)
+
+                expr_ptr_out := expr_ptr
+            }
+            let __exprOutOffset
+            __exprOutOffset, __eval := column_expr_evaluate(__expr.offset, __builder)
+            __exprOut.offset := __exprOutOffset
+            // slither-disable-next-line write-after-write
+            __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))
+        }
+    }
+}

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -44,7 +44,7 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[9] memory offsets = [
+        uint256[10] memory offsets = [
             BUILDER_CHALLENGES_OFFSET,
             BUILDER_FIRST_ROUND_MLES_OFFSET,
             BUILDER_FINAL_ROUND_MLES_OFFSET,
@@ -53,7 +53,8 @@ contract ConstantsTest is Test {
             BUILDER_CONSTRAINT_MULTIPLIERS_OFFSET,
             BUILDER_MAX_DEGREE_OFFSET,
             BUILDER_AGGREGATE_EVALUATION_OFFSET,
-            BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET
+            BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET,
+            BUILDER_COLUMN_EVALUATIONS_OFFSET
         ];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -37,6 +37,11 @@ contract ConstantsTest is Test {
         assert(UINT32_PADDING_BITS == 256 - 32);
     }
 
+    function testUint64SizesAreCorrect() public pure {
+        assert(UINT64_SIZE * 8 == 64);
+        assert(UINT64_PADDING_BITS == 256 - 64);
+    }
+
     function testInt64SizesAreCorrect() public pure {
         assert(INT64_SIZE * 8 == 64);
         assert(INT64_PADDING_BITS == 256 - 64);

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -7,7 +7,7 @@ import "../../src/base/Errors.sol";
 
 contract ErrorsTest is Test {
     function testErrorConstantsMatchSelectors() public pure {
-        bytes4[9] memory selectors = [
+        bytes4[10] memory selectors = [
             Errors.InvalidECAddInputs.selector,
             Errors.InvalidECMulInputs.selector,
             Errors.InvalidECPairingInputs.selector,
@@ -16,9 +16,10 @@ contract ErrorsTest is Test {
             Errors.HyperKZGInconsistentV.selector,
             Errors.ConstraintDegreeTooHigh.selector,
             Errors.IncorrectCaseConst.selector,
-            Errors.UnsupportedLiteralVariant.selector
+            Errors.UnsupportedLiteralVariant.selector,
+            Errors.InvalidColumnIndex.selector
         ];
-        uint32[9] memory selectorConstants = [
+        uint32[10] memory selectorConstants = [
             ERR_INVALID_EC_ADD_INPUTS,
             ERR_INVALID_EC_MUL_INPUTS,
             ERR_INVALID_EC_PAIRING_INPUTS,
@@ -27,7 +28,8 @@ contract ErrorsTest is Test {
             ERR_HYPER_KZG_INCONSISTENT_V,
             ERR_CONSTRAINT_DEGREE_TOO_HIGH,
             ERR_INCORRECT_CASE_CONST,
-            ERR_UNSUPPORTED_LITERAL_VARIANT
+            ERR_UNSUPPORTED_LITERAL_VARIANT,
+            ERR_INVALID_COLUMN_INDEX
         ];
         assert(selectors.length == selectorConstants.length);
         uint256 length = selectors.length;
@@ -88,5 +90,11 @@ contract ErrorsTest is Test {
     function testErrorFailedUnsupportedLiteralVariant() public {
         vm.expectRevert(Errors.UnsupportedLiteralVariant.selector);
         Errors.__err(ERR_UNSUPPORTED_LITERAL_VARIANT);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testErrorFailedInvalidColumnIndex() public {
+        vm.expectRevert(Errors.InvalidColumnIndex.selector);
+        Errors.__err(ERR_INVALID_COLUMN_INDEX);
     }
 }

--- a/solidity/test/proof/VerificationBuilder.t.pre.sol
+++ b/solidity/test/proof/VerificationBuilder.t.pre.sol
@@ -602,4 +602,61 @@ contract VerificationBuilderTest is Test {
             VerificationBuilder.__produceIdentityConstraint(builder, values[length], 2);
         }
     }
+
+    function testSetColumnEvaluations() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        VerificationBuilder.__setColumnEvaluations(builder, values);
+        assert(builder.columnEvaluations.length == 3);
+        assert(builder.columnEvaluations[0] == 0x12345678);
+        assert(builder.columnEvaluations[1] == 0x23456789);
+        assert(builder.columnEvaluations[2] == 0x3456789A);
+    }
+
+    function testFuzzSetColumnEvaluations(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setColumnEvaluations(builder, values);
+        assert(builder.columnEvaluations.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(builder.columnEvaluations[i] == values[i]);
+        }
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testGetColumnEvaluationInvalidIndex() public {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](2);
+        builder.columnEvaluations = values;
+        vm.expectRevert(Errors.InvalidColumnIndex.selector);
+        VerificationBuilder.__getColumnEvaluation(builder, 2);
+    }
+
+    function testGetColumnEvaluation() public pure {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        builder.columnEvaluations = values;
+        assert(VerificationBuilder.__getColumnEvaluation(builder, 0) == 0x12345678);
+        assert(VerificationBuilder.__getColumnEvaluation(builder, 1) == 0x23456789);
+        assert(VerificationBuilder.__getColumnEvaluation(builder, 2) == 0x3456789A);
+        assert(VerificationBuilder.__getColumnEvaluation(builder, 2) == 0x3456789A);
+        assert(VerificationBuilder.__getColumnEvaluation(builder, 0) == 0x12345678);
+        assert(VerificationBuilder.__getColumnEvaluation(builder, 1) == 0x23456789);
+    }
+
+    function testFuzzGetColumnEvaluation(uint256[] memory values) public pure {
+        vm.assume(values.length > 0);
+        VerificationBuilder.Builder memory builder;
+        builder.columnEvaluations = values;
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(VerificationBuilder.__getColumnEvaluation(builder, i) == values[i]);
+        }
+    }
 }

--- a/solidity/test/proof_exprs/ColumnExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/ColumnExpr.t.pre.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {Errors} from "../../src/base/Errors.sol";
+import {ColumnExpr} from "../../src/proof_exprs/ColumnExpr.pre.sol";
+import {VerificationBuilder} from "../../src/proof/VerificationBuilder.pre.sol";
+
+contract ColumnExprTest is Test {
+    function testColumnExpr() public pure {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x11111111;
+        values[1] = 0x22222222;
+        values[2] = 0x33333333;
+        builder.columnEvaluations = values;
+
+        bytes memory exprIn = abi.encodePacked(uint64(1), hex"abcdef");
+        bytes memory expectedExprOut = hex"abcdef";
+
+        (bytes memory exprOut, uint256 eval) = ColumnExpr.__columnExprEvaluate(exprIn, builder);
+        assert(eval == 0x22222222);
+        assert(exprOut.length == expectedExprOut.length);
+        uint256 exprOutLength = exprOut.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(exprOut[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testFuzzColumnExpr(uint64 columnNum, bytes memory trailingExpr, uint256[] memory columnValues)
+        public
+        pure
+    {
+        vm.assume(columnNum < columnValues.length);
+
+        VerificationBuilder.Builder memory builder;
+        builder.columnEvaluations = columnValues;
+
+        bytes memory exprIn = abi.encodePacked(columnNum, trailingExpr);
+        (bytes memory exprOut, uint256 eval) = ColumnExpr.__columnExprEvaluate(exprIn, builder);
+
+        assert(eval == columnValues[columnNum]);
+        assert(exprOut.length == trailingExpr.length);
+        uint256 exprOutLength = exprOut.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(exprOut[i] == trailingExpr[i]);
+        }
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testInvalidColumnIndex() public {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](2);
+        builder.columnEvaluations = values;
+
+        bytes memory exprIn = abi.encodePacked(uint64(2), hex"abcdef");
+        vm.expectRevert(Errors.InvalidColumnIndex.selector);
+        ColumnExpr.__columnExprEvaluate(exprIn, builder);
+    }
+}


### PR DESCRIPTION
# Rationale for this change

We need to add the SQL nodes to the solidity verifier.

# What changes are included in this PR?

* Added column evaluations to the verification builder. This diverges slightly from the Rust code, but reduces the stack size, which is critical in the EVM.
* Added `column_expr_evaluate`.

# Are these changes tested?
Yes