### PR TITLE
feat: implement GPU version or HyperKZG commitment computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bincode = { version = "2.0.0-rc.3", default-features = false }
 bit-iter = { version = "1.1.1" }
 bigdecimal = { version = "0.4.5", default-features = false, features = ["serde"] }
 blake3 = { version = "1.3.3", default-features = false }
-blitzar = { version = "4.0.0" }
+blitzar = { version = "4.3.0" }
 bnum = { version = "0.3.0" }
 bumpalo = { version = "3.11.0" }
 bytemuck = {version = "1.16.3", features = ["derive"]}
@@ -45,7 +45,7 @@ itertools = { version = "0.13.0", default-features = false, features = ["use_all
 lalrpop = { version = "0.22.0" }
 lalrpop-util = { version = "0.22.0", default-features = false }
 merlin = { version = "2" }
-nova-snark = { version = "0.39.0" }
+nova-snark = { version = "0.40.0" }
 num-traits = { version = "0.2", default-features = false }
 num-bigint = { version = "0.4.4", default-features = false }
 opentelemetry = { version = "0.23.0" }

--- a/crates/proof-of-sql/benches/README.md
+++ b/crates/proof-of-sql/benches/README.md
@@ -13,7 +13,7 @@ To run benchmarks with Jaeger, you need to do the following
     cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof
     cargo bench -p proof-of-sql --bench jaeger_benches Dory
     cargo bench -p proof-of-sql --bench jaeger_benches DynamicDory
-    cargo bench -p proof-of-sql --bench jaeger_benches HyperKZG
+    cargo bench -p proof-of-sql --bench jaeger_benches HyperKZG --features="hyperkzg"
     ```
 3. Navigate to http://localhost:16686/ to see the results.
 4. To end the Jaeger service, run

--- a/crates/proof-of-sql/benches/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger_benches.rs
@@ -5,7 +5,7 @@
 //! cargo bench -p proof-of-sql --bench jaeger_benches InnerProductProof
 //! cargo bench -p proof-of-sql --bench jaeger_benches Dory
 //! cargo bench -p proof-of-sql --bench jaeger_benches DynamicDory
-//! cargo bench -p proof-of-sql --bench jaeger_benches HyperKZG
+//! cargo bench -p proof-of-sql --bench jaeger_benches HyperKZG --features="hyperkzg"
 //! ```
 //! Then, navigate to <http://localhost:16686> to view the traces.
 

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -5,22 +5,26 @@ use crate::base::{
     slice_ops,
 };
 use alloc::vec::Vec;
+#[cfg(feature = "blitzar")]
+use ark_bn254::G1Affine;
+#[cfg(feature = "blitzar")]
+use blitzar;
 use core::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 use ff::Field;
+#[cfg(not(feature = "blitzar"))]
 use itertools::Itertools;
 use nova_snark::{
     errors::NovaError,
     provider::{
         bn256_grumpkin::bn256::Scalar as NovaScalar,
-        hyperkzg::{
-            CommitmentEngine, CommitmentKey, EvaluationArgument, EvaluationEngine, VerifierKey,
-        },
+        hyperkzg::{CommitmentKey, EvaluationArgument, EvaluationEngine, VerifierKey},
     },
     traits::{
-        commitment::CommitmentEngineTrait, evaluation::EvaluationEngineTrait, Engine,
-        TranscriptEngineTrait, TranscriptReprTrait,
+        evaluation::EvaluationEngineTrait, Engine, TranscriptEngineTrait, TranscriptReprTrait,
     },
 };
+#[cfg(not(feature = "blitzar"))]
+use nova_snark::{provider::hyperkzg::CommitmentEngine, traits::commitment::CommitmentEngineTrait};
 use serde::{Deserialize, Serialize};
 use tracing::{span, Level};
 
@@ -46,6 +50,16 @@ pub type HyperKZGCommitmentEvaluationProof = EvaluationArgument<HyperKZGEngine>;
 impl AddAssign for HyperKZGCommitment {
     fn add_assign(&mut self, rhs: Self) {
         self.commitment = self.commitment + rhs.commitment;
+    }
+}
+#[cfg(feature = "blitzar")]
+impl From<&G1Affine> for HyperKZGCommitment {
+    fn from(value: &G1Affine) -> Self {
+        Self {
+            commitment: NovaCommitment::new(
+                blitzar::compute::convert_to_halo2_bn256_g1_affine(value).into(),
+            ),
+        }
     }
 }
 impl From<&BNScalar> for NovaScalar {
@@ -93,6 +107,7 @@ impl Sub for HyperKZGCommitment {
     }
 }
 
+#[cfg(not(feature = "blitzar"))]
 #[tracing::instrument(name = "compute_commitments_impl (cpu)", level = "debug", skip_all)]
 fn compute_commitments_impl<T: Into<BNScalar> + Clone>(
     setup: &CommitmentKey<HyperKZGEngine>,
@@ -113,6 +128,7 @@ impl Commitment for HyperKZGCommitment {
     type Scalar = BNScalar;
     type PublicSetup<'a> = &'a CommitmentKey<HyperKZGEngine>;
 
+    #[cfg(not(feature = "blitzar"))]
     #[tracing::instrument(name = "compute_commitments (cpu)", level = "debug", skip_all)]
     fn compute_commitments(
         committable_columns: &[crate::base::commitment::CommittableColumn],
@@ -140,6 +156,39 @@ impl Commitment for HyperKZGCommitment {
             })
             .collect()
     }
+
+    #[cfg(feature = "blitzar")]
+    #[tracing::instrument(name = "compute_commitments (gpu)", level = "debug", skip_all)]
+    fn compute_commitments(
+        committable_columns: &[crate::base::commitment::CommittableColumn],
+        offset: usize,
+        setup: &Self::PublicSetup<'_>,
+    ) -> Vec<Self> {
+        if committable_columns.is_empty() {
+            return Vec::new();
+        }
+
+        // Find the maximum length of the columns to get number of generators to use
+        let max_column_len = committable_columns
+            .iter()
+            .map(CommittableColumn::len)
+            .max()
+            .expect("You must have at least one column");
+
+        let mut blitzar_commitments = vec![G1Affine::default(); committable_columns.len()];
+
+        blitzar::compute::compute_bn254_g1_uncompressed_commitments_with_generators(
+            &mut blitzar_commitments,
+            &slice_ops::slice_cast(committable_columns),
+            &slice_ops::slice_cast_with(
+                &setup.ck()[offset..offset + max_column_len],
+                blitzar::compute::convert_to_ark_bn254_g1_affine,
+            ),
+        );
+
+        slice_ops::slice_cast(&blitzar_commitments)
+    }
+
     fn to_transcript_bytes(&self) -> Vec<u8> {
         self.commitment.to_transcript_bytes()
     }
@@ -268,6 +317,8 @@ impl CommitmentEvaluationProof for HyperKZGCommitmentEvaluationProof {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "blitzar")]
+    use crate::base::math::decimal::Precision;
     use crate::base::{
         commitment::commitment_evaluation_proof_test::{
             test_commitment_evaluation_proof_with_length_1,
@@ -275,8 +326,16 @@ mod tests {
         },
         scalar::test_scalar_constants,
     };
+    #[cfg(feature = "blitzar")]
+    use ark_ec::AffineRepr;
     use ark_std::UniformRand;
-    use nova_snark::provider::hyperkzg::CommitmentEngine;
+    #[cfg(feature = "blitzar")]
+    use itertools::Itertools;
+    use nova_snark::{
+        provider::hyperkzg::CommitmentEngine, traits::commitment::CommitmentEngineTrait,
+    };
+    #[cfg(feature = "blitzar")]
+    use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 
     #[test]
     fn we_have_correct_constants_for_bn_scalar() {
@@ -376,5 +435,210 @@ mod tests {
         test_random_commitment_evaluation_proof::<HyperKZGCommitmentEvaluationProof>(
             128, 0, &&ck, &&vk,
         );
+    }
+
+    #[cfg(feature = "blitzar")]
+    fn compute_commitment_with_hyperkzg_repo<T: Into<BNScalar> + Clone>(
+        setup: &CommitmentKey<HyperKZGEngine>,
+        offset: usize,
+        scalars: &[T],
+    ) -> HyperKZGCommitment {
+        let commitment = CommitmentEngine::commit(
+            setup,
+            &itertools::repeat_n(BNScalar::ZERO, offset)
+                .chain(scalars.iter().map(Into::into))
+                .map(Into::into)
+                .collect_vec(),
+            &NovaScalar::ZERO,
+        );
+        HyperKZGCommitment { commitment }
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_compute_commitment_with_hyperkzg_repo_for_testing() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6);
+
+        let result = compute_commitment_with_hyperkzg_repo(&ck, 0, &[0]);
+
+        assert_eq!(result, (&G1Affine::default()).into());
+    }
+
+    #[cfg(feature = "blitzar")]
+    fn compute_expected_commitments(
+        committable_columns: &[CommittableColumn],
+        offset: usize,
+        ck: &CommitmentKey<HyperKZGEngine>,
+    ) -> Vec<HyperKZGCommitment> {
+        let mut expected: Vec<HyperKZGCommitment> = Vec::with_capacity(committable_columns.len());
+        for column in committable_columns {
+            match column {
+                CommittableColumn::Boolean(vals) => {
+                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
+                }
+                CommittableColumn::Uint8(vals) => {
+                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
+                }
+                CommittableColumn::TinyInt(vals) => {
+                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
+                }
+                CommittableColumn::SmallInt(vals) => {
+                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
+                }
+                CommittableColumn::Int(vals) => {
+                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
+                }
+                CommittableColumn::BigInt(vals) | CommittableColumn::TimestampTZ(_, _, vals) => {
+                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
+                }
+                CommittableColumn::Int128(vals) => {
+                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
+                }
+                CommittableColumn::Decimal75(_, _, vals)
+                | CommittableColumn::Scalar(vals)
+                | CommittableColumn::VarChar(vals)
+                | CommittableColumn::VarBinary(vals) => {
+                    expected.push(compute_commitment_with_hyperkzg_repo(ck, offset, vals));
+                }
+            }
+        }
+        expected
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_compute_expected_commitments_for_testing() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6);
+
+        let committable_columns = vec![CommittableColumn::BigInt(&[0; 0])];
+
+        let offset = 0;
+
+        let result = compute_expected_commitments(&committable_columns, offset, &ck);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].commitment, NovaCommitment::default());
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_compute_a_commitment_with_only_one_column() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 6);
+
+        let committable_columns = vec![CommittableColumn::BigInt(&[0, 1, 2, 3, 4, 5, 6, 7])];
+
+        let offset = 0;
+
+        let res = HyperKZGCommitment::compute_commitments(&committable_columns, offset, &&ck);
+        let expected = compute_expected_commitments(&committable_columns, offset, &ck);
+
+        assert_eq!(res, expected);
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_compute_commitments_with_a_single_empty_column() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32);
+
+        let committable_columns = vec![CommittableColumn::BigInt(&[0; 0])];
+
+        for offset in 0..32 {
+            let res = HyperKZGCommitment::compute_commitments(&committable_columns, offset, &&ck);
+            let expected = compute_expected_commitments(&committable_columns, offset, &ck);
+
+            assert_eq!(res, expected, "Offset: {offset}");
+        }
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_compute_commitments_with_a_multiple_mixed_empty_columns() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 32);
+
+        let committable_columns = vec![
+            CommittableColumn::TinyInt(&[0; 0]),
+            CommittableColumn::SmallInt(&[0; 0]),
+            CommittableColumn::Uint8(&[0; 0]),
+            CommittableColumn::Int(&[0; 0]),
+            CommittableColumn::BigInt(&[0; 0]),
+            CommittableColumn::Int128(&[0; 0]),
+        ];
+
+        for offset in 0..32 {
+            let res = HyperKZGCommitment::compute_commitments(&committable_columns, offset, &&ck);
+            let expected = compute_expected_commitments(&committable_columns, offset, &ck);
+
+            assert_eq!(res, expected, "Offset: {offset}");
+        }
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_compute_a_commitment_with_mixed_columns_of_different_sizes_and_offsets() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128);
+
+        let committable_columns = vec![
+            CommittableColumn::BigInt(&[0, 1]),
+            CommittableColumn::Uint8(&[2, 3]),
+            CommittableColumn::Int(&[4, 5, 10]),
+            CommittableColumn::SmallInt(&[6, 7]),
+            CommittableColumn::Int128(&[8, 9]),
+            CommittableColumn::Boolean(&[true, true]),
+            CommittableColumn::Decimal75(
+                Precision::new(1).unwrap(),
+                0,
+                vec![[10, 0, 0, 0], [11, 0, 0, 0], [12, 0, 0, 0], [13, 0, 0, 0]],
+            ),
+            CommittableColumn::Scalar(vec![[14, 0, 0, 0], [15, 0, 0, 0]]),
+            CommittableColumn::VarChar(vec![[16, 0, 0, 0]]),
+            CommittableColumn::TimestampTZ(
+                PoSQLTimeUnit::Second,
+                PoSQLTimeZone::utc(),
+                &[17, 18, 19, 20],
+            ),
+            CommittableColumn::VarBinary(vec![[21, 0, 0, 0]]),
+        ];
+
+        for offset in 0..64 {
+            let res = HyperKZGCommitment::compute_commitments(&committable_columns, offset, &&ck);
+            let expected = compute_expected_commitments(&committable_columns, offset, &ck);
+
+            assert_eq!(res, expected, "Offset: {offset}");
+        }
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_compute_a_commitment_with_mixed_signed_columns_of_different_sizes_and_offsets() {
+        let ck: CommitmentKey<HyperKZGEngine> = CommitmentEngine::setup(b"test", 128);
+
+        let committable_columns = vec![
+            CommittableColumn::BigInt(&[-1, -2, -3]),
+            CommittableColumn::Int(&[-4, -5, -10]),
+            CommittableColumn::SmallInt(&[-6, -7]),
+            CommittableColumn::Int128(&[-8, -9]),
+        ];
+
+        for offset in 0..60 {
+            let res = HyperKZGCommitment::compute_commitments(&committable_columns, offset, &&ck);
+            let expected = compute_expected_commitments(&committable_columns, offset, &ck);
+
+            assert_eq!(res, expected, "Offset: {offset}");
+        }
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_convert_default_point_to_a_hyperkzg_commitment_from_ark_bn254_g1_affine() {
+        let commitment: HyperKZGCommitment = HyperKZGCommitment::from(&G1Affine::default());
+        assert_eq!(commitment.commitment, NovaCommitment::default());
+    }
+
+    #[cfg(feature = "blitzar")]
+    #[test]
+    fn we_can_convert_generator_to_a_hyperkzg_commitment_from_ark_bn254_g1_affine() {
+        let commitment: HyperKZGCommitment = (&G1Affine::generator()).into();
+        let expected: HyperKZGCommitment = HyperKZGCommitment::from(&G1Affine::generator());
+        assert_eq!(commitment.commitment, expected.commitment);
     }
 }


### PR DESCRIPTION
# Rationale for this change
HyperKZG performance can be improved by doing commitment computation on the GPU. This PR implements a GPU version of the HyperKZG commitment computation.

The HyperKZG commitment computation run on the CPU (from the `main` branch) 
![image](https://github.com/user-attachments/assets/9084008a-1865-4b4b-be99-a385ea629640)

The HyperKZG commitment computation using the GPU implementation from this PR 
![image](https://github.com/user-attachments/assets/241dd6d7-649e-49b1-973a-9fbbdd534589)

The GPU commitment computation shows a `5.1x` performance improvement on the same query.

# What changes are included in this PR?
- HyperKZG GPU commitment computation implementation and tests are added in commit https://github.com/spaceandtimelabs/sxt-proof-of-sql/pull/577/commits/b79c98195347415b610da399a7354dc34ceb986b
- `blitzar` is update to version `4.3.0`
- `nova-snark` is updated to version `0.40.0`

# Are these changes tested?
Yes