### PR TITLE
feat: add `sql_to_proof_plans`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ output/
 solidity/lcov.info
 solidity/coverage-report
 solidity/docs
+autogen_logs/
+_autocoder/

--- a/crates/proof-of-sql-planner/Cargo.toml
+++ b/crates/proof-of-sql-planner/Cargo.toml
@@ -16,6 +16,8 @@ snafu = { workspace = true }
 sqlparser = { workspace = true }
 
 [dev-dependencies]
+ark-std = { workspace = true }
+blitzar = { workspace = true }
 bumpalo = { workspace = true }
 
 [lints]

--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -1,0 +1,48 @@
+use crate::{logical_plan_to_proof_plan, PlannerResult};
+use datafusion::{
+    catalog::TableReference,
+    common::DFSchema,
+    config::ConfigOptions,
+    optimizer::{Analyzer, Optimizer, OptimizerContext},
+    sql::planner::{ContextProvider, SqlToRel},
+};
+use indexmap::IndexMap;
+use proof_of_sql::sql::proof_plans::DynProofPlan;
+use sqlparser::{dialect::GenericDialect, parser::Parser};
+
+/// Convert a SQL query to a `DynProofPlan` using schema from provided tables
+///
+/// This function does the following
+/// 1. Parse the SQL query into AST using sqlparser
+/// 2. Convert the AST into a `LogicalPlan` using `SqlToRel`
+/// 3. Analyze the `LogicalPlan` using `Analyzer`
+/// 4. Optimize the `LogicalPlan` using `Optimizer`
+/// 5. Convert the optimized `LogicalPlan` into a `DynProofPlan`
+pub fn sql_to_proof_plans<S: ContextProvider>(
+    sql: &str,
+    context_provider: &S,
+    schemas: &IndexMap<TableReference, DFSchema>,
+    config: &ConfigOptions,
+) -> PlannerResult<Vec<DynProofPlan>> {
+    // 1. Parse the SQL query into AST using sqlparser
+    let dialect = GenericDialect {};
+    let asts = Parser::parse_sql(&dialect, sql)?;
+    asts.iter()
+        .map(|ast| -> PlannerResult<DynProofPlan> {
+            // 2. Convert the AST into a `LogicalPlan` using `SqlToRel`
+            let raw_logical_plan =
+                SqlToRel::new(context_provider).sql_statement_to_plan(ast.clone())?;
+            // 3. Analyze the `LogicalPlan` using `Analyzer`
+            let analyzer = Analyzer::new();
+            let analyzed_logical_plan =
+                analyzer.execute_and_check(raw_logical_plan, config, |_, _| {})?;
+            // 4. Optimize the `LogicalPlan` using `Optimizer`
+            let optimizer = Optimizer::new();
+            let optimizer_context = OptimizerContext::default();
+            let optimized_logical_plan =
+                optimizer.optimize(analyzed_logical_plan, &optimizer_context, |_, _| {})?;
+            // 5. Convert the optimized `LogicalPlan` into a `DynProofPlan`
+            logical_plan_to_proof_plan(&optimized_logical_plan, schemas)
+        })
+        .collect::<PlannerResult<Vec<_>>>()
+}

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -6,6 +6,8 @@ mod context;
 pub use context::PoSqlContextProvider;
 #[cfg(test)]
 pub(crate) use context::PoSqlTableSource;
+mod conversion;
+pub use conversion::sql_to_proof_plans;
 #[cfg(test)]
 mod df_util;
 mod expr;
@@ -15,7 +17,8 @@ pub use error::{PlannerError, PlannerResult};
 mod plan;
 pub use plan::logical_plan_to_proof_plan;
 mod util;
+pub use util::column_fields_to_schema;
 pub(crate) use util::{
-    column_fields_to_schema, column_to_column_ref, df_schema_to_column_fields,
-    scalar_value_to_literal_value, table_reference_to_table_ref,
+    column_to_column_ref, df_schema_to_column_fields, scalar_value_to_literal_value,
+    table_reference_to_table_ref,
 };

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -82,7 +82,8 @@ pub(crate) fn column_to_column_ref(column: &Column, schema: &DFSchema) -> Planne
 }
 
 /// Convert a Vec<ColumnField> to a Schema
-pub(crate) fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
+#[must_use]
+pub fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
     Schema::new(
         column_fields
             .into_iter()

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -1,0 +1,207 @@
+//! In this file we run end-to-end tests for Proof of SQL.
+#![cfg_attr(test, allow(clippy::missing_panics_doc))]
+use ark_std::test_rng;
+use bumpalo::Bump;
+use datafusion::{catalog::TableReference, common::DFSchema, config::ConfigOptions};
+use indexmap::{indexmap, IndexMap};
+use proof_of_sql::{
+    base::{
+        commitment::CommitmentEvaluationProof,
+        database::{
+            owned_table_utility::*, table_utility::*, OwnedTable, Table, TableRef,
+            TableTestAccessor, TestAccessor,
+        },
+    },
+    proof_primitive::dory::{
+        DoryScalar, DynamicDoryEvaluationProof, ProverSetup, PublicParameters, VerifierSetup,
+    },
+    sql::proof::VerifiableQueryResult,
+};
+use proof_of_sql_planner::{
+    column_fields_to_schema, sql_to_proof_plans, PlannerResult, PoSqlContextProvider,
+};
+
+/// Get a new `TableTestAccessor` with the provided tables
+fn new_test_accessor<'a, CP: CommitmentEvaluationProof>(
+    tables: &IndexMap<TableRef, Table<'a, CP::Scalar>>,
+    prover_setup: CP::ProverPublicSetup<'a>,
+) -> TableTestAccessor<'a, CP> {
+    let mut accessor = TableTestAccessor::<CP>::new_empty_with_setup(prover_setup);
+    for (table_ref, table) in tables {
+        accessor.add_table(table_ref.clone(), table.clone(), 0);
+    }
+    accessor
+}
+
+/// Get the schemas of the provided tables
+fn get_schemas<CP: CommitmentEvaluationProof>(
+    tables: &IndexMap<TableRef, Table<'_, CP::Scalar>>,
+) -> PlannerResult<IndexMap<TableReference, DFSchema>> {
+    tables
+        .iter()
+        .map(
+            |(table_ref, table)| -> PlannerResult<(TableReference, DFSchema)> {
+                let table_reference = TableReference::from(table_ref.to_string().as_str());
+                let schema = column_fields_to_schema(table.schema());
+                let df_schema =
+                    DFSchema::try_from_qualified_schema(table_reference.clone(), &schema)?;
+                Ok((table_reference, df_schema))
+            },
+        )
+        .collect::<PlannerResult<IndexMap<_, _>>>()
+}
+
+/// Test setup
+///
+/// # Panics
+/// This function will panic if anything goes wrong
+fn posql_end_to_end_test<'a, CP: CommitmentEvaluationProof>(
+    sql: &str,
+    tables: IndexMap<TableRef, Table<'a, CP::Scalar>>,
+    expected_results: &[OwnedTable<CP::Scalar>],
+    prover_setup: CP::ProverPublicSetup<'a>,
+    verifier_setup: CP::VerifierPublicSetup<'_>,
+) {
+    // Get accessor
+    let accessor: TableTestAccessor<'a, CP> = new_test_accessor(&tables, prover_setup);
+    let schemas = get_schemas::<CP>(&tables).unwrap();
+    let context_provider = PoSqlContextProvider::new(tables);
+    let config = ConfigOptions::default();
+    let plans = sql_to_proof_plans(sql, &context_provider, &schemas, &config).unwrap();
+    // Prove and verify the plans
+    for (plan, expected) in plans.iter().zip(expected_results.iter()) {
+        let res = VerifiableQueryResult::<CP>::new(plan, &accessor, &prover_setup);
+        let res = res.verify(plan, &accessor, &verifier_setup).unwrap().table;
+        assert_eq!(res, expected.clone());
+    }
+}
+
+/// Empty SQL should return no plans
+#[test]
+fn test_empty_sql() {
+    // Create public parameters for DynamicDoryEvaluationProof
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        "",
+        indexmap! {},
+        &[],
+        &prover_setup,
+        &verifier_setup,
+    );
+}
+
+/// Test a simple SQL query
+#[test]
+fn test_simple_filter_queries() {
+    let alloc = Bump::new();
+    let sql = "select id, name from cats where age > 2;
+    select * from cats;";
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "cats") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4, 5], &alloc),
+                borrowed_varchar("name", ["Chloe", "Margaret", "Katy", "Lucy", "Prudence"], &alloc),
+                borrowed_tinyint("age", [13_i8, 2, 0, 4, 4], &alloc),
+            ]
+        )
+    };
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![
+        owned_table([
+            int("id", [1, 4, 5]),
+            varchar("name", ["Chloe", "Lucy", "Prudence"]),
+        ]),
+        owned_table([
+            int("id", [1, 2, 3, 4, 5]),
+            varchar("name", ["Chloe", "Margaret", "Katy", "Lucy", "Prudence"]),
+            tinyint("age", [13_i8, 2, 0, 4, 4]),
+        ]),
+    ];
+
+    // Create public parameters for DynamicDoryEvaluationProof
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+    );
+}
+
+/// Test projection operation - selecting only specific columns
+#[test]
+fn test_projection() {
+    let alloc = Bump::new();
+    let sql = "SELECT name, age FROM pets;";
+
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "pets") => table(
+            vec![
+                borrowed_int("id", [1, 2, 3, 4], &alloc),
+                borrowed_varchar("name", ["Rex", "Whiskers", "Fido", "Fluffy"], &alloc),
+                borrowed_tinyint("age", [3_i8, 5, 2, 7], &alloc),
+                borrowed_varchar("type", ["Dog", "Cat", "Dog", "Cat"], &alloc),
+            ]
+        )
+    };
+
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![owned_table([
+        varchar("name", ["Rex", "Whiskers", "Fido", "Fluffy"]),
+        tinyint("age", [3_i8, 5, 2, 7]),
+    ])];
+
+    // Create public parameters for DynamicDoryEvaluationProof
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+    );
+}
+
+/// Test slicing/limit operation - retrieving only a subset of rows
+#[test]
+fn test_slicing_limit() {
+    let alloc = Bump::new();
+    let sql = "SELECT * FROM products LIMIT 2;";
+
+    let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
+        TableRef::from_names(None, "products") => table(
+            vec![
+                borrowed_int("id", [101, 102, 103, 104, 105], &alloc),
+                borrowed_varchar("name", ["Laptop", "Phone", "Tablet", "Monitor", "Keyboard"], &alloc),
+                borrowed_int("price", [1200, 800, 500, 300, 100], &alloc),
+            ]
+        )
+    };
+
+    let expected_results: Vec<OwnedTable<DoryScalar>> = vec![owned_table([
+        int("id", [101, 102]),
+        varchar("name", ["Laptop", "Phone"]),
+        int("price", [1200, 800]),
+    ])];
+
+    // Create public parameters for DynamicDoryEvaluationProof
+    let public_parameters = PublicParameters::test_rand(5, &mut test_rng());
+    let prover_setup = ProverSetup::from(&public_parameters);
+    let verifier_setup = VerifierSetup::from(&public_parameters);
+
+    posql_end_to_end_test::<DynamicDoryEvaluationProof>(
+        sql,
+        tables,
+        &expected_results,
+        &prover_setup,
+        &verifier_setup,
+    );
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to take advantage of name resolution and logical plan from datafusion we would like to add a new planner crate.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `sql_to_proof_plans`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Will be.