### PR TITLE
fix: pin chrono to avoid build errors with arrow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bytemuck = {version = "1.16.3", features = ["derive"]}
 byte-slice-cast = { version = "1.2.1", default-features = false }
 clap = { version = "4.5.4" }
 criterion = { version = "0.5.1" }
-chrono = { version = "0.4.38", default-features = false }
+chrono = { version = "=0.4.39", default-features = false }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
 derive_more = { version = "0.99" }
 enum_dispatch = { version = "0.3.13" }


### PR DESCRIPTION
# Rationale for this change
chrono `v0.4.40` implemented a `quarter` method that causes build errors when building with arrow. See bug https://github.com/apache/arrow-rs/issues/7196 and this commit https://github.com/apache/arrow-rs/pull/7210. The suggested workaround is to pin chrono to `v0.4.39`.

# What changes are included in this PR?
- Pins chrono to the latest version that works with arrow, `v0.4.39`

# Are these changes tested?
Yes