### PR TITLE
feat!: remove restrictions that at least one non-empty input table exists from `sql/proof`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -103,7 +103,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         log::log_memory_usage("Start");
 
         let (min_row_num, max_row_num) = get_index_range(accessor, &expr.get_table_references());
-        let initial_range_length = max_row_num - min_row_num;
+        let initial_range_length = (max_row_num - min_row_num).max(1);
         let alloc = Bump::new();
 
         let total_col_refs = expr.get_column_references();
@@ -129,7 +129,6 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let rho_evaluation_lengths = first_round_builder.rho_evaluation_lengths();
 
         let range_length = first_round_builder.range_length();
-
         let num_sumcheck_variables = cmp::max(log2_up(range_length), 1);
         assert!(num_sumcheck_variables > 0);
         let post_result_challenge_count = first_round_builder.num_post_result_challenges();

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -2,15 +2,10 @@ use super::{ProofPlan, QueryData, QueryProof, QueryResult};
 use crate::{
     base::{
         commitment::CommitmentEvaluationProof,
-        database::{
-            ColumnField, ColumnType, CommitmentAccessor, DataAccessor, OwnedColumn, OwnedTable,
-        },
-        proof::ProofError,
-        scalar::Scalar,
+        database::{CommitmentAccessor, DataAccessor, OwnedTable},
     },
     utils::log,
 };
-use alloc::vec;
 use serde::{Deserialize, Serialize};
 
 /// The result of an sql query along with a proof that the query is valid. The
@@ -69,12 +64,12 @@ use serde::{Deserialize, Serialize};
 /// Note: Because the class is deserialized from untrusted data, it
 /// cannot maintain any invariant on its data members; hence, they are
 /// all public so as to allow for easy manipulation for testing.
-#[derive(Default, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct VerifiableQueryResult<CP: CommitmentEvaluationProof> {
     /// The result of the query in intermediate form.
-    pub(super) result: Option<OwnedTable<CP::Scalar>>,
+    pub(super) result: OwnedTable<CP::Scalar>,
     /// The proof that the query result is valid.
-    pub(super) proof: Option<QueryProof<CP>>,
+    pub(super) proof: QueryProof<CP>,
 }
 
 impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
@@ -89,30 +84,9 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         setup: &CP::ProverPublicSetup<'_>,
     ) -> Self {
         log::log_memory_usage("Start");
-
-        // a query must have at least one result column; if not, it should
-        // have been rejected at the parsing stage.
-
-        // handle the empty case
-        let table_refs = expr.get_table_references();
-        if table_refs
-            .into_iter()
-            .all(|table_ref| accessor.get_length(&table_ref) == 0)
-        {
-            return VerifiableQueryResult {
-                result: None,
-                proof: None,
-            };
-        }
-
         let (proof, res) = QueryProof::new(expr, accessor, setup);
-
         log::log_memory_usage("End");
-
-        Self {
-            result: Some(res),
-            proof: Some(proof),
-        }
+        Self { result: res, proof }
     }
 
     /// Verify a `VerifiableQueryResult`. Upon success, this function returns the finalized form of
@@ -130,63 +104,13 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         setup: &CP::VerifierPublicSetup<'_>,
     ) -> QueryResult<CP::Scalar> {
         log::log_memory_usage("Start");
-
-        match (self.result, self.proof) {
-            (Some(result), Some(proof)) => {
-                let QueryData {
-                    table,
-                    verification_hash,
-                } = proof.verify(expr, accessor, result, setup)?;
-                Ok(QueryData {
-                    table: table.try_coerce_with_fields(expr.get_column_result_fields())?,
-                    verification_hash,
-                })
-            }
-            (None, None)
-                if expr
-                    .get_table_references()
-                    .into_iter()
-                    .all(|table_ref| accessor.get_length(&table_ref) == 0) =>
-            {
-                let result_fields = expr.get_column_result_fields();
-                make_empty_query_result(&result_fields)
-            }
-            _ => Err(ProofError::VerificationError {
-                error: "Proof does not match result: at least one is missing",
-            })?,
-        }
+        let QueryData {
+            table,
+            verification_hash,
+        } = self.proof.verify(expr, accessor, self.result, setup)?;
+        Ok(QueryData {
+            table: table.try_coerce_with_fields(expr.get_column_result_fields())?,
+            verification_hash,
+        })
     }
-}
-
-fn make_empty_query_result<S: Scalar>(result_fields: &[ColumnField]) -> QueryResult<S> {
-    let table = OwnedTable::try_new(
-        result_fields
-            .iter()
-            .map(|field| {
-                (
-                    field.name(),
-                    match field.data_type() {
-                        ColumnType::Boolean => OwnedColumn::Boolean(vec![]),
-                        ColumnType::Uint8 => OwnedColumn::Uint8(vec![]),
-                        ColumnType::TinyInt => OwnedColumn::TinyInt(vec![]),
-                        ColumnType::SmallInt => OwnedColumn::SmallInt(vec![]),
-                        ColumnType::Int => OwnedColumn::Int(vec![]),
-                        ColumnType::BigInt => OwnedColumn::BigInt(vec![]),
-                        ColumnType::Int128 => OwnedColumn::Int128(vec![]),
-                        ColumnType::Decimal75(precision, scale) => {
-                            OwnedColumn::Decimal75(precision, scale, vec![])
-                        }
-                        ColumnType::Scalar => OwnedColumn::Scalar(vec![]),
-                        ColumnType::VarChar => OwnedColumn::VarChar(vec![]),
-                        ColumnType::VarBinary => OwnedColumn::VarBinary(vec![]),
-                        ColumnType::TimestampTZ(tu, tz) => OwnedColumn::TimestampTZ(tu, tz, vec![]),
-                    },
-                )
-            })
-            .collect(),
-    )?;
-    Ok(QueryData {
-        table,
-        verification_hash: Default::default(),
-    })
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -111,22 +111,3 @@ fn we_can_verify_queries_on_an_empty_table() {
     let expected_res = owned_table([bigint("a1", [0; 0])]);
     assert_eq!(table, expected_res);
 }
-
-#[test]
-fn empty_verification_fails_if_the_result_contains_non_null_members() {
-    let expr = EmptyTestQueryExpr {
-        columns: 1,
-        ..Default::default()
-    };
-    let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
-        TableRef::new("sxt", "test"),
-        owned_table([bigint("a1", [0_i64; 0])]),
-        0,
-        (),
-    );
-    let res = VerifiableQueryResult::<InnerProductProof> {
-        result: Some(owned_table([])),
-        proof: None,
-    };
-    assert!(res.verify(&expr, &accessor, &()).is_err());
-}

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -21,8 +21,6 @@ use serde::Serialize;
 ///
 /// Will panic if:
 /// - The verification of `res` does not succeed, causing the assertion `assert!(res.verify(...).is_ok())` to fail.
-/// - `res.proof` is `None`, causing `res.proof.as_ref().unwrap()` to panic.
-/// - Attempting to modify `final_round_pcs_proof_evaluations` or `commitments` if `res_p.proof` is `None`, leading to a panic on `unwrap()`.
 /// - `fake_accessor.update_offset` fails, causing a panic if it is designed to do so in the implementation.
 pub fn exercise_verification(
     res: &VerifiableQueryResult<InnerProductProof>,
@@ -34,26 +32,15 @@ pub fn exercise_verification(
         .verify(expr, accessor, &())
         .expect("Verification failed");
 
-    let (result, proof) = match (&res.result, &res.proof) {
-        (Some(result), Some(proof)) => (result, proof),
-        (None, None) => return,
-        _ => panic!("verification did not catch a proof/result mismatch"),
-    };
-
     // try changing the result
     let mut res_p = res.clone();
-    res_p.result = Some(tampered_table(result));
+    res_p.result = tampered_table(&res.result);
     assert!(res_p.verify(expr, accessor, &()).is_err());
 
     // try changing MLE evaluations
-    for i in 0..proof.pcs_proof_evaluations.final_round.len() {
+    for i in 0..res.proof.pcs_proof_evaluations.final_round.len() {
         let mut res_p = res.clone();
-        res_p
-            .proof
-            .as_mut()
-            .unwrap()
-            .pcs_proof_evaluations
-            .final_round[i] += Curve25519Scalar::one();
+        res_p.proof.pcs_proof_evaluations.final_round[i] += Curve25519Scalar::one();
         assert!(res_p.verify(expr, accessor, &()).is_err());
     }
 
@@ -67,14 +54,9 @@ pub fn exercise_verification(
         &(),
     )[0];
 
-    for i in 0..proof.final_round_message.round_commitments.len() {
+    for i in 0..res.proof.final_round_message.round_commitments.len() {
         let mut res_p = res.clone();
-        res_p
-            .proof
-            .as_mut()
-            .unwrap()
-            .final_round_message
-            .round_commitments[i] = commit_p;
+        res_p.proof.final_round_message.round_commitments[i] = commit_p;
         assert!(res_p.verify(expr, accessor, &()).is_err());
     }
 
@@ -84,7 +66,8 @@ pub fn exercise_verification(
     // the inner product proof isn't dependent on the generators since it simply sends the input
     // vector; hence, changing the offset would have no effect.
     if accessor.get_length(table_ref) > 1
-        || proof
+        || res
+            .proof
             .final_round_message
             .round_commitments
             .iter()

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -38,8 +38,7 @@ fn we_can_prove_an_equality_query_with_no_rows() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("a", [0; 0]), varchar("d", [""; 0])]);
     assert_eq!(res, expected_res);
@@ -61,8 +60,7 @@ fn we_can_prove_another_equality_query_with_no_rows() {
         tab(&t),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("a", [0; 0]), varchar("d", [""; 0])]);
     assert_eq!(res, expected_res);
@@ -88,8 +86,7 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("b", [1; 0]),

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -419,9 +419,9 @@ mod tests {
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
     }
 
-    // This one doesn't panic since it is an empty query
     #[test]
-    fn we_can_do_membership_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
+    #[should_panic(expected = "The number of source columns should be greater than 0")]
+    fn we_cannot_do_membership_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
         let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
@@ -447,10 +447,8 @@ mod tests {
             source_columns: vec![],
             candidate_columns: vec![],
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        let actual = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
-        let expected = owned_table([int128("multiplicities", [0_i128; 0])]);
-        assert_eq!(actual, expected);
+        let _verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -381,9 +381,9 @@ mod tests {
             VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
     }
 
-    // This one doesn't panic since it is an empty query
     #[test]
-    fn we_can_do_permutation_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
+    #[should_panic(expected = "The number of source columns should be greater than 0")]
+    fn we_cannot_do_permutation_check_if_there_are_neither_rows_nor_columns_in_the_tables() {
         let source_table = Table::<'_, Curve25519Scalar>::try_new_with_options(
             IndexMap::default(),
             TableOptions { row_count: Some(0) },
@@ -409,8 +409,8 @@ mod tests {
             source_columns: vec![],
             candidate_columns: vec![],
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+        let _verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -368,8 +368,7 @@ fn we_can_prove_a_filter_on_an_empty_table() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
     let res = res.verify(&expr, &accessor, &()).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -407,8 +407,7 @@ fn we_can_prove_a_projection_on_an_empty_table() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
     let res = res.verify(&expr, &accessor, &()).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -524,11 +524,9 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
 #[test]
 fn we_can_create_and_prove_a_slice_exec_on_top_of_an_empty_exec() {
     let empty_table = owned_table([]);
-    let t = TableRef::new("sxt", "t");
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let expr = slice_exec(empty_exec(), 3, Some(2));
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
-    exercise_verification(&res, &expr, &accessor, &t);
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
     let res = res.verify(&expr, &accessor, &()).unwrap().table;
     assert_eq!(res, empty_table);
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -436,7 +436,6 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
         VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([
         bigint("id", [0_i64; 0]),

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -23,8 +23,7 @@ fn we_can_create_and_prove_an_empty_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &());
-    exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
     let res = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
     let expected = owned_table([bigint("a", [0_i64; 0])]);
     assert_eq!(res, expected);

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -82,8 +82,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
         ],
         vec![column_field("a", ColumnType::BigInt)],
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
-    exercise_verification(&verifiable_res, &ast, &accessor, &t0);
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
     let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
     let expected_res = owned_table([bigint("a", [0_i64; 0])]);
     assert_eq!(res, expected_res);


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
Tableless queries such as `select 'not_a_column', 0 as def_int;` are legitimate and can have non-trivial results. However we currently force the results to be empty since we currently don't allow tableless queries in `sql/parse` any way. Now this needs to be fixed in order for such queries to be allowed and return correct results. Note that we aren't going to enable it in `sql/parse` since it is legacy code that will be removed very soon but we will in the planner.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- remove restriction that at least one non-empty input table exists
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Existing tests should pass.