### PR TITLE
fix: convert arrow's Binary column to VarBinary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ opentelemetry-jaeger = { version = "0.20.0" }
 postcard = { version = "1.0" }
 proof-of-sql = { path = "crates/proof-of-sql" } # We automatically update this line during release. So do not modify it!
 proof-of-sql-parser = { path = "crates/proof-of-sql-parser" } # We automatically update this line during release. So do not modify it!
+proptest = { version = "1.6.0" }
+proptest-derive = { version = "0.5.1" }
 rand = { version = "0.8", default-features = false }
 rand_chacha = { version = "0.3.1" }
 rand_core = { version = "0.6", default-features = false }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -75,6 +75,8 @@ tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 flexbuffers = { workspace = true }
+proptest = { workspace = true }
+proptest-derive = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 development = ["arrow-csv", "opentelemetry", "opentelemetry-jaeger", "tracing-opentelemetry", "tracing-subscriber"]

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -293,7 +293,6 @@ impl ArrayRefExt for ArrayRef {
 }
 
 #[cfg(test)]
-#[cfg(feature = "blitzar")]
 mod tests {
 
     use super::*;

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -66,6 +66,7 @@ impl TryFrom<DataType> for ColumnType {
                 ))
             }
             DataType::Utf8 => Ok(ColumnType::VarChar),
+            DataType::Binary => Ok(ColumnType::VarBinary),
             _ => Err(format!("Unsupported arrow data type {data_type:?}")),
         }
     }

--- a/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/column_arrow_conversions.rs
@@ -81,3 +81,19 @@ impl From<&ColumnField> for Field {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn we_can_roundtrip_arbitrary_column_type(column_type: ColumnType) {
+            let arrow = DataType::from(&column_type);
+            let actual = ColumnType::try_from(arrow).unwrap();
+
+            prop_assert_eq!(actual, column_type);
+        }
+    }
+}

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions_test.rs
@@ -12,6 +12,7 @@ use arrow::{
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
+use proptest::prelude::*;
 
 fn we_can_convert_between_owned_column_and_array_ref_impl(
     owned_column: &OwnedColumn<TestScalar>,
@@ -196,4 +197,14 @@ fn we_can_convert_between_owned_table_and_record_batch() {
 fn we_panic_when_converting_an_owned_table_with_a_scalar_column() {
     let owned_table = owned_table::<TestScalar>([scalar("a", [0; 0])]);
     let _ = RecordBatch::try_from(owned_table);
+}
+
+proptest! {
+    #[test]
+    fn we_can_roundtrip_arbitrary_owned_column(owned_column: OwnedColumn<TestScalar>) {
+        let arrow = ArrayRef::from(owned_column.clone());
+        let actual = OwnedColumn::try_from(arrow).unwrap();
+
+        prop_assert_eq!(actual, owned_column);
+    }
 }

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -338,6 +338,7 @@ impl<'a, S: Scalar> Column<'a, S> {
 /// See `<https://ignite.apache.org/docs/latest/sql-reference/data-types>` for
 /// a description of the native types used by Apache Ignite.
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Deserialize, Copy)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum ColumnType {
     /// Mapped to bool
     #[serde(alias = "BOOLEAN", alias = "boolean")]
@@ -368,9 +369,11 @@ pub enum ColumnType {
     Decimal75(Precision, i8),
     /// Mapped to i64
     #[serde(alias = "TIMESTAMP", alias = "timestamp")]
+    #[cfg_attr(test, proptest(skip))]
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone),
     /// Mapped to `S`
     #[serde(alias = "SCALAR", alias = "scalar")]
+    #[cfg_attr(test, proptest(skip))]
     Scalar,
     /// Mapped to [u8]
     #[serde(alias = "BINARY", alias = "BINARY")]

--- a/crates/proof-of-sql/src/base/database/owned_column.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Clone, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 /// Supported types for [`OwnedColumn`]
 pub enum OwnedColumn<S: Scalar> {
     /// Boolean columns
@@ -42,10 +43,13 @@ pub enum OwnedColumn<S: Scalar> {
     /// i128 columns
     Int128(Vec<i128>),
     /// Decimal columns
+    #[cfg_attr(test, proptest(skip))]
     Decimal75(Precision, i8, Vec<S>),
     /// Scalar columns
+    #[cfg_attr(test, proptest(skip))]
     Scalar(Vec<S>),
     /// Timestamp columns
+    #[cfg_attr(test, proptest(skip))]
     TimestampTZ(PoSQLTimeUnit, PoSQLTimeZone, Vec<i64>),
 }
 

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -88,7 +88,8 @@ impl From<DecimalError> for String {
 
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Serialize, Copy)]
 /// limit-enforced precision
-pub struct Precision(u8);
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub struct Precision(#[cfg_attr(test, proptest(strategy = "1..76u8"))] u8);
 pub(crate) const MAX_SUPPORTED_PRECISION: u8 = 75;
 
 impl Precision {


### PR DESCRIPTION
# Rationale for this change
One missing piece of proof-of-sql's VarBinary column support is conversion from arrow's binary data type.

Unfortunately this is easy to miss as adding new columns without adding this conversion does not trigger any compilation issues. A couple new roundtrip tests have been added that should help developers catch this in the future. I figured that the best way to write these tests was with proptest.

Let me know if there are any objections to introducing this dev-dependency. I intentionally put it and the associated tests in a separate commit so I can remove it easily.

# What changes are included in this PR?
- **fix: remove blitzar requirement for arrow_array_to_column_conversion tests**
- **fix: convert arrow's Binary column to VarBinary**
- **test: add proptests for column type and arrow conversions**

# Are these changes tested?
Yes.
