### PR TITLE
feat(sol): add table chi evaluations

### DIFF
--- a/solidity/src/base/Array.pre.sol
+++ b/solidity/src/base/Array.pre.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "./Constants.sol";
+import "./Errors.sol";
+
+/// @title Array
+/// @dev Library providing array utility functions with bounds checking.
+library Array {
+    /// @notice Gets an element from an array with bounds checking
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// get_array_element(arr_ptr, index) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `arr_ptr` - pointer to the array in memory. In Solidity memory layout,
+    ///   this points to where the array length is stored, followed by the array elements
+    /// * `index` - the index of the element to retrieve
+    /// ##### Return Values
+    /// * `value` - the element at the specified index
+    /// @dev Retrieves an element at the specified index with bounds checking.
+    /// Reverts with Errors.InvalidIndex if the index is out of bounds.
+    /// @param __array Single-element array containing the array to get element from
+    /// @param __index The index of the element to retrieve
+    /// @return __value The element at the specified index
+    function __getArrayElement(uint256[][1] memory __array, uint256 __index) internal pure returns (uint256 __value) {
+        assembly {
+            // IMPORT-YUL Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            function get_array_element(arr_ptr, index) -> value {
+                let arr := mload(arr_ptr)
+                let length := mload(arr)
+                if iszero(lt(index, length)) { err(ERR_INVALID_INDEX) }
+                value := mload(add(add(arr, WORD_SIZE), mul(index, WORD_SIZE)))
+            }
+            __value := get_array_element(__array, __index)
+        }
+    }
+}

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -89,7 +89,7 @@ uint256 constant G2_NEG_GEN_Y_REAL = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285
 uint256 constant G2_NEG_GEN_Y_IMAG = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
 
 /// @dev Size of the verification builder in bytes.
-uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 10;
+uint256 constant VERIFICATION_BUILDER_SIZE = 0x20 * 11;
 /// @dev Offset of the pointer to the challenge queue in the verification builder.
 uint256 constant BUILDER_CHALLENGES_OFFSET = 0x20 * 0;
 /// @dev Offset of the pointer to the first round MLEs in the verification builder.
@@ -110,3 +110,5 @@ uint256 constant BUILDER_AGGREGATE_EVALUATION_OFFSET = 0x20 * 7;
 uint256 constant BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET = 0x20 * 8;
 /// @dev Offset of the pointer to the column evaluations in the verification builder.
 uint256 constant BUILDER_COLUMN_EVALUATIONS_OFFSET = 0x20 * 9;
+/// @dev Offset of the pointer to the table chi evaluations in the verification builder.
+uint256 constant BUILDER_TABLE_CHI_EVALUATIONS_OFFSET = 0x20 * 10;

--- a/solidity/src/base/Errors.sol
+++ b/solidity/src/base/Errors.sol
@@ -20,8 +20,8 @@ uint32 constant ERR_CONSTRAINT_DEGREE_TOO_HIGH = 0x8568ae69;
 uint32 constant ERR_INCORRECT_CASE_CONST = 0x9324fb03;
 /// @dev Error code for when a literal variant is unsupported.
 uint32 constant ERR_UNSUPPORTED_LITERAL_VARIANT = 0xed9d5b00;
-/// @dev Error code for when a column index is invalid.
-uint32 constant ERR_INVALID_COLUMN_INDEX = 0xb9c4d54d;
+/// @dev Error code for when an index is invalid.
+uint32 constant ERR_INVALID_INDEX = 0x63df8171;
 
 library Errors {
     /// @notice Error thrown when the inputs to the ECADD precompile are invalid.
@@ -42,8 +42,8 @@ library Errors {
     error IncorrectCaseConst();
     /// @notice Error thrown when a literal variant is unsupported.
     error UnsupportedLiteralVariant();
-    /// @notice Error thrown when a column index is invalid.
-    error InvalidColumnIndex();
+    /// @notice Error thrown when an index is invalid.
+    error InvalidIndex();
 
     function __err(uint32 __code) internal pure {
         assembly {

--- a/solidity/src/proof/VerificationBuilder.pre.sol
+++ b/solidity/src/proof/VerificationBuilder.pre.sol
@@ -512,10 +512,12 @@ library VerificationBuilder {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/Array.pre.sol
+            function get_array_element(arr_ptr, index) -> value {
+                revert(0, 0)
+            }
             function builder_get_column_evaluation(builder_ptr, column_num) -> value {
-                let arr_ptr := mload(add(builder_ptr, BUILDER_COLUMN_EVALUATIONS_OFFSET))
-                if iszero(lt(column_num, mload(arr_ptr))) { err(ERR_INVALID_COLUMN_INDEX) }
-                value := mload(add(add(arr_ptr, WORD_SIZE), mul(column_num, WORD_SIZE)))
+                value := get_array_element(add(builder_ptr, BUILDER_COLUMN_EVALUATIONS_OFFSET), column_num)
             }
             __value := builder_get_column_evaluation(__builder, __columnNum)
         }

--- a/solidity/src/proof/VerificationBuilder.pre.sol
+++ b/solidity/src/proof/VerificationBuilder.pre.sol
@@ -20,6 +20,7 @@ library VerificationBuilder {
         uint256 aggregateEvaluation;
         uint256 rowMultipliersEvaluation;
         uint256[] columnEvaluations;
+        uint256[] tableChiEvaluations;
     }
 
     /// @notice Allocates and reserves a block of memory for a verification builder
@@ -520,6 +521,63 @@ library VerificationBuilder {
                 value := get_array_element(add(builder_ptr, BUILDER_COLUMN_EVALUATIONS_OFFSET), column_num)
             }
             __value := builder_get_column_evaluation(__builder, __columnNum)
+        }
+    }
+
+    /// @notice Sets the table chi evaluations in the verification builder
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_set_table_chi_evaluations(builder_ptr, values_ptr)
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `values_ptr` - pointer to the array in memory
+    /// @param __builder The builder struct
+    /// @param __values The table chi evaluation values array
+    function __setTableChiEvaluations(Builder memory __builder, uint256[] memory __values) internal pure {
+        assembly {
+            function builder_set_table_chi_evaluations(builder_ptr, values_ptr) {
+                mstore(add(builder_ptr, BUILDER_TABLE_CHI_EVALUATIONS_OFFSET), values_ptr)
+            }
+            builder_set_table_chi_evaluations(__builder, __values)
+        }
+    }
+
+    /// @notice Gets a table chi evaluation by table number
+    /// @custom:as-yul-wrapper
+    /// #### Wrapped Yul Function
+    /// ##### Signature
+    /// ```yul
+    /// builder_get_table_chi_evaluation(builder_ptr, table_num) -> value
+    /// ```
+    /// ##### Parameters
+    /// * `builder_ptr` - memory pointer to the builder struct region
+    /// * `table_num` - the table number to get evaluation for
+    /// ##### Return Values
+    /// * `value` - the table chi evaluation
+    /// @param __builder The builder struct
+    /// @param __tableNum The table number
+    /// @return __value The table chi evaluation value
+    function __getTableChiEvaluation(Builder memory __builder, uint256 __tableNum)
+        internal
+        pure
+        returns (uint256 __value)
+    {
+        assembly {
+            // IMPORT-YUL ../base/Errors.sol
+            function err(code) {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../base/Array.pre.sol
+            function get_array_element(arr_ptr, index) -> value {
+                revert(0, 0)
+            }
+            function builder_get_table_chi_evaluation(builder_ptr, table_num) -> value {
+                value := get_array_element(add(builder_ptr, BUILDER_TABLE_CHI_EVALUATIONS_OFFSET), table_num)
+            }
+            __value := builder_get_table_chi_evaluation(__builder, __tableNum)
         }
     }
 }

--- a/solidity/src/proof_exprs/ColumnExpr.pre.sol
+++ b/solidity/src/proof_exprs/ColumnExpr.pre.sol
@@ -38,6 +38,10 @@ library ColumnExpr {
             function err(code) {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../base/Array.pre.sol
+            function get_array_element(arr_ptr, index) -> value {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof/VerificationBuilder.pre.sol
             function builder_get_column_evaluation(builder_ptr, column_num) -> eval {
                 revert(0, 0)

--- a/solidity/test/base/Array.t.pre.sol
+++ b/solidity/test/base/Array.t.pre.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {Array} from "../../src/base/Array.pre.sol";
+import {Errors} from "../../src/base/Errors.sol";
+
+contract ArrayTest is Test {
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testGetArrayElementEmptyArray() public {
+        uint256[][1] memory array = [new uint256[](0)];
+
+        vm.expectRevert(Errors.InvalidIndex.selector);
+        Array.__getArrayElement(array, 0);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testGetArrayElementOutOfBounds() public {
+        uint256[][1] memory array = [new uint256[](3)];
+        array[0][0] = 0x12345678;
+        array[0][1] = 0x23456789;
+        array[0][2] = 0x3456789A;
+
+        vm.expectRevert(Errors.InvalidIndex.selector);
+        Array.__getArrayElement(array, 3);
+    }
+
+    function testGetArrayElement() public pure {
+        uint256[][1] memory array = [new uint256[](3)];
+        array[0][0] = 0x12345678;
+        array[0][1] = 0x23456789;
+        array[0][2] = 0x3456789A;
+
+        assert(Array.__getArrayElement(array, 0) == 0x12345678);
+        assert(Array.__getArrayElement(array, 1) == 0x23456789);
+        assert(Array.__getArrayElement(array, 2) == 0x3456789A);
+    }
+
+    function testFuzzGetArrayElement(uint256[] memory values) public pure {
+        vm.assume(values.length > 0);
+
+        uint256[][1] memory array = [values];
+
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(Array.__getArrayElement(array, i) == values[i]);
+        }
+    }
+}

--- a/solidity/test/base/Constants.t.sol
+++ b/solidity/test/base/Constants.t.sol
@@ -49,7 +49,7 @@ contract ConstantsTest is Test {
     }
 
     function testVerificationBuilderOffsetsAreValid() public pure {
-        uint256[10] memory offsets = [
+        uint256[11] memory offsets = [
             BUILDER_CHALLENGES_OFFSET,
             BUILDER_FIRST_ROUND_MLES_OFFSET,
             BUILDER_FINAL_ROUND_MLES_OFFSET,
@@ -59,7 +59,8 @@ contract ConstantsTest is Test {
             BUILDER_MAX_DEGREE_OFFSET,
             BUILDER_AGGREGATE_EVALUATION_OFFSET,
             BUILDER_ROW_MULTIPLIERS_EVALUATION_OFFSET,
-            BUILDER_COLUMN_EVALUATIONS_OFFSET
+            BUILDER_COLUMN_EVALUATIONS_OFFSET,
+            BUILDER_TABLE_CHI_EVALUATIONS_OFFSET
         ];
         uint256 offsetsLength = offsets.length;
         assert(VERIFICATION_BUILDER_SIZE == offsetsLength * WORD_SIZE);

--- a/solidity/test/base/Errors.t.sol
+++ b/solidity/test/base/Errors.t.sol
@@ -17,7 +17,7 @@ contract ErrorsTest is Test {
             Errors.ConstraintDegreeTooHigh.selector,
             Errors.IncorrectCaseConst.selector,
             Errors.UnsupportedLiteralVariant.selector,
-            Errors.InvalidColumnIndex.selector
+            Errors.InvalidIndex.selector
         ];
         uint32[10] memory selectorConstants = [
             ERR_INVALID_EC_ADD_INPUTS,
@@ -29,7 +29,7 @@ contract ErrorsTest is Test {
             ERR_CONSTRAINT_DEGREE_TOO_HIGH,
             ERR_INCORRECT_CASE_CONST,
             ERR_UNSUPPORTED_LITERAL_VARIANT,
-            ERR_INVALID_COLUMN_INDEX
+            ERR_INVALID_INDEX
         ];
         assert(selectors.length == selectorConstants.length);
         uint256 length = selectors.length;
@@ -93,8 +93,8 @@ contract ErrorsTest is Test {
     }
 
     /// forge-config: default.allow_internal_expect_revert = true
-    function testErrorFailedInvalidColumnIndex() public {
-        vm.expectRevert(Errors.InvalidColumnIndex.selector);
-        Errors.__err(ERR_INVALID_COLUMN_INDEX);
+    function testErrorFailedInvalidIndex() public {
+        vm.expectRevert(Errors.InvalidIndex.selector);
+        Errors.__err(ERR_INVALID_INDEX);
     }
 }

--- a/solidity/test/proof/VerificationBuilder.t.pre.sol
+++ b/solidity/test/proof/VerificationBuilder.t.pre.sol
@@ -659,4 +659,61 @@ contract VerificationBuilderTest is Test {
             assert(VerificationBuilder.__getColumnEvaluation(builder, i) == values[i]);
         }
     }
+
+    function testSetTableChiEvaluations() public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        VerificationBuilder.__setTableChiEvaluations(builder, values);
+        assert(builder.tableChiEvaluations.length == 3);
+        assert(builder.tableChiEvaluations[0] == 0x12345678);
+        assert(builder.tableChiEvaluations[1] == 0x23456789);
+        assert(builder.tableChiEvaluations[2] == 0x3456789A);
+    }
+
+    function testFuzzSetTableChiEvaluations(uint256[] memory values) public pure {
+        VerificationBuilder.Builder memory builder = VerificationBuilder.__builderNew();
+        VerificationBuilder.__setTableChiEvaluations(builder, values);
+        assert(builder.tableChiEvaluations.length == values.length);
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(builder.tableChiEvaluations[i] == values[i]);
+        }
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function testGetTableChiEvaluationInvalidIndex() public {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](2);
+        builder.tableChiEvaluations = values;
+        vm.expectRevert(Errors.InvalidIndex.selector);
+        VerificationBuilder.__getTableChiEvaluation(builder, 2);
+    }
+
+    function testGetTableChiEvaluation() public pure {
+        VerificationBuilder.Builder memory builder;
+        uint256[] memory values = new uint256[](3);
+        values[0] = 0x12345678;
+        values[1] = 0x23456789;
+        values[2] = 0x3456789A;
+        builder.tableChiEvaluations = values;
+        assert(VerificationBuilder.__getTableChiEvaluation(builder, 0) == 0x12345678);
+        assert(VerificationBuilder.__getTableChiEvaluation(builder, 1) == 0x23456789);
+        assert(VerificationBuilder.__getTableChiEvaluation(builder, 2) == 0x3456789A);
+        assert(VerificationBuilder.__getTableChiEvaluation(builder, 2) == 0x3456789A);
+        assert(VerificationBuilder.__getTableChiEvaluation(builder, 0) == 0x12345678);
+        assert(VerificationBuilder.__getTableChiEvaluation(builder, 1) == 0x23456789);
+    }
+
+    function testFuzzGetTableChiEvaluation(uint256[] memory values) public pure {
+        vm.assume(values.length > 0);
+        VerificationBuilder.Builder memory builder;
+        builder.tableChiEvaluations = values;
+        uint256 valuesLength = values.length;
+        for (uint256 i = 0; i < valuesLength; ++i) {
+            assert(VerificationBuilder.__getTableChiEvaluation(builder, i) == values[i]);
+        }
+    }
 }

--- a/solidity/test/proof/VerificationBuilder.t.pre.sol
+++ b/solidity/test/proof/VerificationBuilder.t.pre.sol
@@ -631,7 +631,7 @@ contract VerificationBuilderTest is Test {
         VerificationBuilder.Builder memory builder;
         uint256[] memory values = new uint256[](2);
         builder.columnEvaluations = values;
-        vm.expectRevert(Errors.InvalidColumnIndex.selector);
+        vm.expectRevert(Errors.InvalidIndex.selector);
         VerificationBuilder.__getColumnEvaluation(builder, 2);
     }
 

--- a/solidity/test/proof_exprs/ColumnExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/ColumnExpr.t.pre.sol
@@ -56,7 +56,7 @@ contract ColumnExprTest is Test {
         builder.columnEvaluations = values;
 
         bytes memory exprIn = abi.encodePacked(uint64(2), hex"abcdef");
-        vm.expectRevert(Errors.InvalidColumnIndex.selector);
+        vm.expectRevert(Errors.InvalidIndex.selector);
         ColumnExpr.__columnExprEvaluate(exprIn, builder);
     }
 }


### PR DESCRIPTION
# Rationale for this change

We need to port the verifier to the EVM. This is one part of it.

# What changes are included in this PR?

Added `get_array_element` and `builder_get_table_chi_evaluation` methods.

# Are these changes tested?
Yes