### PR TITLE
test(sol): add `FieldUtils`

### DIFF
--- a/solidity/test/base/FieldUtil.sol
+++ b/solidity/test/base/FieldUtil.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import "../../src/base/Constants.sol";
+
+using {F.into, _add as +, _mul as *, _sub as -, _neg as -} for FF global;
+
+type FF is uint256;
+
+function _add(FF a, FF b) pure returns (FF c) {
+    c = FF.wrap(addmod(a.into(), b.into(), MODULUS));
+}
+
+function _mul(FF a, FF b) pure returns (FF c) {
+    c = FF.wrap(mulmod(FF.unwrap(a), FF.unwrap(b), MODULUS));
+}
+
+function _sub(FF a, FF b) pure returns (FF c) {
+    c = a + (-b);
+}
+
+function _neg(FF a) pure returns (FF c) {
+    c = FF.wrap(MODULUS_MINUS_ONE) * a;
+}
+
+library F {
+    FF public constant ZERO = FF.wrap(0);
+    FF public constant ONE = FF.wrap(1);
+    FF public constant TWO = FF.wrap(2);
+
+    function from(int64 a) internal pure returns (FF c) {
+        if (a < 0) {
+            c = -FF.wrap(uint256(-int256(a)));
+        } else {
+            c = FF.wrap(uint256(int256(a)));
+        }
+    }
+
+    function from(uint256 a) internal pure returns (FF c) {
+        c = FF.wrap(a);
+    }
+
+    function into(FF a) internal pure returns (uint256 c) {
+        c = FF.unwrap(a) % MODULUS;
+    }
+}

--- a/solidity/test/base/FieldUtil.t.sol
+++ b/solidity/test/base/FieldUtil.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {F, FF} from "./FieldUtil.sol";
+
+contract FieldUtilTest is Test {
+    function testFromPositive() public pure {
+        int64 input = 23;
+        FF result = F.from(input);
+        assert(result.into() == 23);
+    }
+
+    function testFromNegative() public pure {
+        int64 input = -23;
+        FF result = F.from(input);
+        assert(result.into() == MODULUS - 23);
+    }
+
+    function testAdd() public pure {
+        FF a = FF.wrap(5);
+        FF b = FF.wrap(3);
+        FF result = a + b;
+        assert(result.into() == 8);
+    }
+
+    function testAddOverflow() public pure {
+        FF a = FF.wrap(MODULUS - 1);
+        FF b = FF.wrap(2);
+        FF result = a + b;
+        assert(result.into() == 1);
+    }
+
+    function testMul() public pure {
+        FF a = FF.wrap(5);
+        FF b = FF.wrap(3);
+        FF result = a * b;
+        assert(result.into() == 15);
+    }
+
+    function testMulOverflow() public pure {
+        FF a = FF.wrap(MODULUS - 1);
+        FF b = FF.wrap(2);
+        FF result = a * b;
+        assert(result.into() == MODULUS - 2);
+    }
+
+    function testSub() public pure {
+        FF a = FF.wrap(5);
+        FF b = FF.wrap(3);
+        FF result = a - b;
+        assert(result.into() == 2);
+    }
+
+    function testSubUnderflow() public pure {
+        FF a = FF.wrap(3);
+        FF b = FF.wrap(5);
+        FF result = a - b;
+        assert(result.into() == MODULUS - 2);
+    }
+
+    function testNeg() public pure {
+        FF a = FF.wrap(23);
+        FF result = -a;
+        assert(result.into() == MODULUS - 23);
+    }
+
+    function testNegZero() public pure {
+        FF a = FF.wrap(0);
+        FF result = -a;
+        assert(result.into() == 0);
+    }
+
+    function testFuzzField(uint256 a, uint256 b) public pure {
+        FF fa = FF.wrap(a);
+        FF fb = FF.wrap(b);
+
+        // Test addition
+        FF sum = fa + fb;
+        assert(sum.into() == addmod(a, b, MODULUS));
+
+        // Test multiplication
+        FF product = fa * fb;
+        assert(product.into() == mulmod(a, b, MODULUS));
+
+        // Test subtraction
+        FF diff = fa - fb;
+        assert(diff.into() == addmod(a, mulmod(MODULUS_MINUS_ONE, b, MODULUS), MODULUS));
+
+        // Test negation
+        FF neg = -fa;
+        assert(neg.into() == mulmod(MODULUS_MINUS_ONE, a, MODULUS));
+    }
+
+    function testFuzzFromInt64(int64 value) public pure {
+        FF field = F.from(value);
+        if (value < 0) {
+            assert(field.into() == MODULUS - uint256(-int256(value)));
+        } else {
+            assert(field.into() == uint256(int256(value)));
+        }
+    }
+
+    function testFuzzFromUint256(uint256 value) public pure {
+        assert(FF.unwrap(F.from(value)) == value);
+    }
+
+    function testInto() public pure {
+        assert(FF.wrap(23).into() == 23);
+        assert(FF.wrap(MODULUS).into() == 0);
+        assert(FF.wrap(MODULUS + 5).into() == 5);
+    }
+
+    function testFuzzInto(uint256 value) public pure {
+        assert(FF.wrap(value).into() == value % MODULUS);
+    }
+
+    function testConstants() public pure {
+        assert(F.ZERO.into() == 0);
+        assert(F.ONE.into() == 1);
+        assert(F.TWO.into() == 2);
+    }
+}

--- a/solidity/test/proof_exprs/LiteralExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/LiteralExpr.t.pre.sol
@@ -6,6 +6,7 @@ import {Test} from "forge-std/Test.sol";
 import "../../src/base/Constants.sol";
 import "../../src/base/Errors.sol";
 import {LiteralExpr} from "../../src/proof_exprs/LiteralExpr.pre.sol";
+import {F} from "../base/FieldUtil.sol";
 
 contract LiteralExprTest is Test {
     function testLiteralExpr() public pure {
@@ -23,13 +24,7 @@ contract LiteralExprTest is Test {
     function testFuzzBigIntLiteralExpr(int64 literalValue, uint256 chiInEval, bytes memory trailingExpr) public pure {
         bytes memory exprIn = abi.encodePacked(LITERAL_BIGINT_VARIANT, literalValue, trailingExpr);
         (bytes memory exprOut, uint256 eval) = LiteralExpr.__literalExprEvaluate(exprIn, chiInEval);
-        uint256 literalValueAsScalar;
-        if (literalValue < 0) {
-            literalValueAsScalar = MODULUS - uint256(-int256(literalValue));
-        } else {
-            literalValueAsScalar = uint256(int256(literalValue));
-        }
-        assert(eval == mulmod(literalValueAsScalar, chiInEval, MODULUS));
+        assert(eval == (F.from(literalValue) * F.from(chiInEval)).into());
         assert(exprOut.length == trailingExpr.length);
         uint256 exprOutLength = exprOut.length;
         for (uint256 i = 0; i < exprOutLength; ++i) {


### PR DESCRIPTION
# Rationale for this change

Working with `mulmod` and `addmod` is tedious and unclear. While it is needed for efficient execution, we should have more clarity around tests.

# What changes are included in this PR?

* The `FF` type is added in `tests` that acts as a field type with modulus `MODULUS`.
* Several methods are implemented in the `F` module. In particular, `F.from` and `F.into` allow for conversions to and from the `FF` type.
* Existing tests are refactored to use this type.

# Are these changes tested?
Yes