### PR TITLE
fix: typo fixes

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -625,7 +625,7 @@ mod tests {
     }
 
     #[test]
-    fn we_can_we_can_convert_boolean_array_normal_range() {
+    fn we_can_convert_boolean_array_normal_range() {
         let alloc = Bump::new();
         let array: ArrayRef = Arc::new(BooleanArray::from(vec![
             Some(true),

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -1,4 +1,4 @@
-//! This module provide `From` and `TryFrom` implementations to go between arrow and owned types
+//! This module provides `From` and `TryFrom` implementations to go between arrow and owned types
 //! The mapping is as follows:
 //! `OwnedType` <-> `Array/ArrayRef`
 //! `OwnedTable` <-> `RecordBatch`
@@ -39,7 +39,7 @@ use sqlparser::ast::Ident;
 
 #[derive(Snafu, Debug)]
 #[non_exhaustive]
-/// Errors cause by conversions between Arrow and owned types.
+/// Errors caused by conversions between Arrow and owned types.
 pub enum OwnedArrowConversionError {
     /// This error occurs when trying to convert from an unsupported arrow type.
     #[snafu(display(


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
