### PR TITLE
fix: typo fix `base::bit::BitDistrubutionError` to `BitDistributionError`

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -21,7 +21,7 @@ pub struct BitDistribution {
 
 /// Errors associated with `BitDistribution`
 #[derive(Debug)]
-pub enum BitDistrubutionError {
+pub enum BitDistributionError {
     /// No lead bit was provided when the lead bit is variable
     NoLeadBit,
     /// Failed to verify bit decomposition
@@ -81,11 +81,11 @@ impl BitDistribution {
         &self,
         bit_evals: &[S],
         chi_eval: S,
-    ) -> Result<S, BitDistrubutionError> {
+    ) -> Result<S, BitDistributionError> {
         if U256::from(self.vary_mask) & (U256::ONE.shl(255)) != U256::ZERO {
             bit_evals
                 .last()
-                .ok_or(BitDistrubutionError::NoLeadBit)
+                .ok_or(BitDistributionError::NoLeadBit)
                 .copied()
         } else if U256::from(self.leading_bit_mask) & U256::ONE.shl(255) == U256::ZERO {
             Ok(S::ZERO)


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
