### PR TITLE
feat: add minimal `proof-of-sql-planner` crate && relevant CI change

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -72,10 +72,11 @@ jobs:
         run: |
           cargo check -p proof-of-sql --no-default-features --features="std"
           cargo check -p proof-of-sql --all-targets --no-default-features --features="std"
-      - name: Run cargo check (proof-of-sql-parser) with no_std target.
+      - name: Run cargo check (proof-of-sql-parser & proof-of-sql) with no_std target.
         run: |
           rustup target add thumbv7em-none-eabi
-          cargo check --target thumbv7em-none-eabi --no-default-features
+          cargo check -p proof-of-sql-parser --target thumbv7em-none-eabi --no-default-features
+          cargo check -p proof-of-sql --target thumbv7em-none-eabi --no-default-features
 
   test:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/proof-of-sql", "crates/proof-of-sql-parser"]
+members = ["crates/proof-of-sql", "crates/proof-of-sql-parser", "crates/proof-of-sql-planner"]
 
 [workspace.package]
 edition = "2021"

--- a/crates/proof-of-sql-planner/Cargo.toml
+++ b/crates/proof-of-sql-planner/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "proof-of-sql-planner"
+edition.workspace = true
+exclude.workspace = true
+repository.workspace = true
+version.workspace = true
+license-file.workspace = true
+
+[dependencies]
+arrow = { workspace = true }
+bumpalo = { workspace = true }
+datafusion = '38.0.0'
+indexmap = { workspace = true }
+proof-of-sql = { path = "../proof-of-sql", features = ["arrow"] }
+snafu = { workspace = true }
+sqlparser = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/proof-of-sql-planner/Cargo.toml
+++ b/crates/proof-of-sql-planner/Cargo.toml
@@ -8,12 +8,14 @@ license-file.workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-bumpalo = { workspace = true }
 datafusion = '38.0.0'
 indexmap = { workspace = true }
 proof-of-sql = { path = "../proof-of-sql", features = ["arrow"] }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
+
+[dev-dependencies]
+bumpalo = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -1,0 +1,264 @@
+use super::{column_fields_to_schema, table_reference_to_table_ref, PlannerResult};
+use alloc::{format, sync::Arc};
+use arrow::datatypes::{Field, Schema};
+use core::any::Any;
+use datafusion::{
+    common::{
+        arrow::datatypes::{DataType, SchemaRef},
+        DFSchema, DataFusionError,
+    },
+    config::ConfigOptions,
+    logical_expr::{
+        AggregateUDF, Expr, ScalarUDF, TableProviderFilterPushDown, TableSource, WindowUDF,
+    },
+    sql::{planner::ContextProvider, TableReference},
+};
+use indexmap::IndexMap;
+use proof_of_sql::base::{
+    database::{ColumnField, Table, TableRef},
+    scalar::Scalar,
+};
+
+/// A [`ContextProvider`] implementation for Proof of SQL
+///
+/// This provider is used to provide tables to the Proof of SQL planner
+pub struct PoSqlContextProvider<'a, S: Scalar> {
+    tables: IndexMap<TableRef, Table<'a, S>>,
+    options: ConfigOptions,
+}
+
+impl<S: Scalar> Default for PoSqlContextProvider<'_, S> {
+    fn default() -> Self {
+        Self::new(IndexMap::new())
+    }
+}
+
+impl<'a, S: Scalar> PoSqlContextProvider<'a, S> {
+    /// Create a new `PoSqlContextProvider`
+    #[must_use]
+    pub fn new(tables: IndexMap<TableRef, Table<'a, S>>) -> Self {
+        Self {
+            tables,
+            options: ConfigOptions::default(),
+        }
+    }
+
+    /// Get the [`DFSchemas`] of the tables in this provider
+    pub fn try_get_df_schemas(&self) -> PlannerResult<IndexMap<TableReference, DFSchema>> {
+        self.tables
+            .iter()
+            .map(|(table_ref, table)| {
+                let table_reference = TableReference::from(table_ref.to_string());
+                Ok((
+                    table_reference.clone(),
+                    DFSchema::try_from_qualified_schema(
+                        table_reference.clone(),
+                        &column_fields_to_schema(table.schema()),
+                    )?,
+                ))
+            })
+            .collect::<PlannerResult<IndexMap<_, _>>>()
+    }
+}
+
+impl<S: Scalar> ContextProvider for PoSqlContextProvider<'_, S> {
+    fn get_table_source(
+        &self,
+        name: TableReference,
+    ) -> Result<Arc<dyn TableSource>, DataFusionError> {
+        let table_ref = table_reference_to_table_ref(&name);
+        self.tables
+            .get(&table_ref)
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!("Table {} not found", name.to_quoted_string()))
+            })
+            .map(|table| Arc::new(PoSqlTableSource::new(table.schema())) as Arc<dyn TableSource>)
+    }
+    fn get_function_meta(&self, _name: &str) -> Option<Arc<ScalarUDF>> {
+        None
+    }
+    //TODO: add count and sum
+    fn get_aggregate_meta(&self, _name: &str) -> Option<Arc<AggregateUDF>> {
+        None
+    }
+    fn get_window_meta(&self, _name: &str) -> Option<Arc<WindowUDF>> {
+        None
+    }
+    fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
+        None
+    }
+    fn options(&self) -> &ConfigOptions {
+        &self.options
+    }
+    fn udfs_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+    fn udafs_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+    fn udwfs_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+/// A [`TableSource`] implementation for Proof of SQL
+struct PoSqlTableSource {
+    schema: SchemaRef,
+}
+
+impl PoSqlTableSource {
+    /// Create a new `PoSqlTableSource`
+    fn new(column_fields: Vec<ColumnField>) -> Self {
+        let arrow_schema = Schema::new(
+            column_fields
+                .into_iter()
+                .map(|column_field| {
+                    Field::new(
+                        column_field.name().value.as_str(),
+                        (&column_field.data_type()).into(),
+                        false,
+                    )
+                })
+                .collect::<Vec<_>>(),
+        );
+        Self {
+            schema: Arc::new(arrow_schema),
+        }
+    }
+}
+
+impl TableSource for PoSqlTableSource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>, DataFusionError> {
+        Ok(vec![TableProviderFilterPushDown::Exact; filters.len()])
+    }
+}
+
+#[allow(clippy::missing_panics_doc)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use bumpalo::Bump;
+    use core::any::TypeId;
+    use indexmap::indexmap;
+    use proof_of_sql::base::{
+        database::{table_utility::*, ColumnType},
+        scalar::Curve25519Scalar,
+    };
+
+    // PoSqlTableSource
+    #[test]
+    fn we_can_create_a_posql_table_source() {
+        // Empty
+        let table_source = PoSqlTableSource::new(vec![]);
+        assert_eq!(table_source.schema().all_fields(), Vec::<&Field>::new());
+        assert_eq!(
+            table_source.as_any().type_id(),
+            TypeId::of::<PoSqlTableSource>()
+        );
+
+        // Non-empty
+        let column_fields = vec![
+            ColumnField::new("a".into(), ColumnType::SmallInt),
+            ColumnField::new("b".into(), ColumnType::VarChar),
+        ];
+        let table_source = PoSqlTableSource::new(column_fields);
+        assert_eq!(
+            table_source.schema().all_fields(),
+            vec![
+                &Field::new("a", DataType::Int16, false),
+                &Field::new("b", DataType::Utf8, false),
+            ]
+        );
+        assert_eq!(
+            table_source.as_any().type_id(),
+            TypeId::of::<PoSqlTableSource>()
+        );
+    }
+
+    // PoSqlContextProvider
+    #[test]
+    fn we_can_create_a_posql_context_provider() {
+        // Empty
+        let tables = IndexMap::default();
+        let context_provider = PoSqlContextProvider::<Curve25519Scalar>::new(tables);
+        assert_eq!(context_provider.tables, IndexMap::new());
+        assert_eq!(
+            context_provider.try_get_df_schemas().unwrap(),
+            IndexMap::new()
+        );
+        assert_eq!(context_provider.udfs_names(), Vec::<String>::new());
+        assert_eq!(context_provider.udafs_names(), Vec::<String>::new());
+        assert_eq!(context_provider.udwfs_names(), Vec::<String>::new());
+        assert_eq!(context_provider.get_variable_type(&[]), None);
+        assert_eq!(context_provider.get_function_meta(""), None);
+        assert_eq!(context_provider.get_aggregate_meta(""), None);
+        assert_eq!(context_provider.get_window_meta(""), None);
+        assert!(matches!(
+            context_provider.get_table_source(TableReference::from("namespace.table")),
+            Err(DataFusionError::Plan(_))
+        ));
+
+        // Non-empty
+        let alloc = Bump::new();
+        let tables = indexmap! {
+                TableRef::new("namespace", "a") =>
+                table(
+                    vec![
+                        borrowed_smallint("a", [1_i16, 2, 3], &alloc),
+                        borrowed_varchar("b", ["Space", "and", "Time"], &alloc),
+                    ]
+                ),
+                TableRef::new("namespace", "b") =>
+                table(
+                    vec![
+                        borrowed_int("c", [1, 2, 3], &alloc),
+                        borrowed_bigint("d", [1_i64, 2, 3], &alloc),
+                    ]
+                )
+        };
+        let context_provider = PoSqlContextProvider::<Curve25519Scalar>::new(tables.clone());
+        let schema_a = Schema::new(vec![
+            Field::new("a", DataType::Int16, false),
+            Field::new("b", DataType::Utf8, false),
+        ]);
+        let schema_b = Schema::new(vec![
+            Field::new("c", DataType::Int32, false),
+            Field::new("d", DataType::Int64, false),
+        ]);
+        assert_eq!(context_provider.tables, tables);
+        assert_eq!(
+            context_provider.try_get_df_schemas().unwrap(),
+            indexmap! {
+                TableReference::from("namespace.a") => DFSchema::try_from_qualified_schema(
+                    "namespace.a",
+                    &schema_a
+                ).unwrap(),
+                TableReference::from("namespace.b") => DFSchema::try_from_qualified_schema(
+                    "namespace.b",
+                    &schema_b
+                ).unwrap(),
+            }
+        );
+        assert_eq!(context_provider.udfs_names(), Vec::<String>::new());
+        assert_eq!(context_provider.udafs_names(), Vec::<String>::new());
+        assert_eq!(context_provider.udwfs_names(), Vec::<String>::new());
+        assert_eq!(context_provider.get_variable_type(&[]), None);
+        assert_eq!(context_provider.get_function_meta(""), None);
+        assert_eq!(context_provider.get_aggregate_meta(""), None);
+        assert_eq!(context_provider.get_window_meta(""), None);
+        assert!(matches!(
+            context_provider.get_table_source(TableReference::from("namespace.table")),
+            Err(DataFusionError::Plan(_))
+        ));
+    }
+}

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -1,0 +1,40 @@
+use arrow::datatypes::DataType;
+use datafusion::common::DataFusionError;
+use proof_of_sql::sql::parse::ConversionError;
+use snafu::Snafu;
+use sqlparser::parser::ParserError;
+
+/// Proof of SQL Planner error
+#[derive(Debug, Snafu)]
+pub enum PlannerError {
+    /// Returned when a conversion fails
+    #[snafu(transparent)]
+    ConversionError {
+        /// Underlying conversion error
+        source: ConversionError,
+    },
+    /// Returned when sqlparser fails to parse a query
+    #[snafu(transparent)]
+    SqlParserError {
+        /// Underlying sqlparser error
+        source: ParserError,
+    },
+    /// Returned when datafusion fails to plan a query
+    #[snafu(transparent)]
+    DataFusionError {
+        /// Underlying datafusion error
+        source: DataFusionError,
+    },
+    /// Returned when a datatype is not supported
+    #[snafu(display("Unsupported datatype: {}", data_type))]
+    UnsupportedDataType {
+        /// Unsupported datatype
+        data_type: DataType,
+    },
+    /// Returned when the `LogicalPlan` is not resolved
+    #[snafu(display("LogicalPlan is not resolved"))]
+    UnresolvedLogicalPlan,
+}
+
+/// Proof of SQL Planner result
+pub type PlannerResult<T> = Result<T, PlannerError>;

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -34,6 +34,9 @@ pub enum PlannerError {
     /// Returned when the `LogicalPlan` is not resolved
     #[snafu(display("LogicalPlan is not resolved"))]
     UnresolvedLogicalPlan,
+    /// Returned when catalog is provided since it is not supported
+    #[snafu(display("Catalog is not supported"))]
+    CatalogNotSupported,
 }
 
 /// Proof of SQL Planner result

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -1,4 +1,6 @@
 //! This crate converts a `DataFusion` `LogicalPlan` to a `ProofPlan` and `Postprocessing`
+#![cfg_attr(not(test), expect(dead_code))] // TODO: remove this when initial development work is done
+#![cfg_attr(test, expect(clippy::missing_panics_doc))]
 extern crate alloc;
 mod context;
 pub use context::PoSqlContextProvider;

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -1,0 +1,8 @@
+//! This crate converts a `DataFusion` `LogicalPlan` to a `ProofPlan` and `Postprocessing`
+extern crate alloc;
+mod context;
+pub use context::PoSqlContextProvider;
+mod error;
+pub use error::{PlannerError, PlannerResult};
+mod util;
+pub(crate) use util::{column_fields_to_schema, table_reference_to_table_ref};

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -8,29 +8,27 @@ use proof_of_sql::base::database::{ColumnField, ColumnRef, ColumnType, LiteralVa
 
 /// Convert a [`TableReference`] to a [`TableRef`]
 ///
-/// If catalog is provided it is ignored
-pub(crate) fn table_reference_to_table_ref(table: &TableReference) -> TableRef {
+/// If catalog is provided it errors out
+pub(crate) fn table_reference_to_table_ref(table: &TableReference) -> PlannerResult<TableRef> {
     match table {
-        TableReference::Bare { table } => TableRef::from_names(None, table),
-        TableReference::Partial { schema, table } | TableReference::Full { schema, table, .. } => {
-            TableRef::from_names(Some(schema), table)
-        }
+        TableReference::Bare { table } => Ok(TableRef::from_names(None, table)),
+        TableReference::Partial { schema, table } => Ok(TableRef::from_names(Some(schema), table)),
+        TableReference::Full { .. } => Err(PlannerError::CatalogNotSupported),
     }
 }
 
 /// Convert a [`ScalarValue`] to a [`LiteralValue`]
 ///
 /// TODO: add other types supported in `PoSQL`
-#[allow(dead_code)]
-pub(crate) fn scalar_value_to_literal_value(value: &ScalarValue) -> PlannerResult<LiteralValue> {
+pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult<LiteralValue> {
     match value {
-        ScalarValue::Boolean(Some(v)) => Ok(LiteralValue::Boolean(*v)),
-        ScalarValue::Int8(Some(v)) => Ok(LiteralValue::TinyInt(*v)),
-        ScalarValue::Int16(Some(v)) => Ok(LiteralValue::SmallInt(*v)),
-        ScalarValue::Int32(Some(v)) => Ok(LiteralValue::Int(*v)),
-        ScalarValue::Int64(Some(v)) => Ok(LiteralValue::BigInt(*v)),
-        ScalarValue::UInt8(Some(v)) => Ok(LiteralValue::Uint8(*v)),
-        ScalarValue::Utf8(Some(v)) => Ok(LiteralValue::VarChar(v.clone())),
+        ScalarValue::Boolean(Some(v)) => Ok(LiteralValue::Boolean(v)),
+        ScalarValue::Int8(Some(v)) => Ok(LiteralValue::TinyInt(v)),
+        ScalarValue::Int16(Some(v)) => Ok(LiteralValue::SmallInt(v)),
+        ScalarValue::Int32(Some(v)) => Ok(LiteralValue::Int(v)),
+        ScalarValue::Int64(Some(v)) => Ok(LiteralValue::BigInt(v)),
+        ScalarValue::UInt8(Some(v)) => Ok(LiteralValue::Uint8(v)),
+        ScalarValue::Utf8(Some(v)) => Ok(LiteralValue::VarChar(v)),
         _ => Err(PlannerError::UnsupportedDataType {
             data_type: value.data_type().clone(),
         }),
@@ -41,14 +39,13 @@ pub(crate) fn scalar_value_to_literal_value(value: &ScalarValue) -> PlannerResul
 ///
 /// Note that the table name must be provided in the column which resolved logical plans do
 /// Otherwise we error out
-#[allow(dead_code)]
 pub(crate) fn column_to_column_ref(column: &Column, schema: &DFSchema) -> PlannerResult<ColumnRef> {
     let relation = column
         .relation
         .as_ref()
         .ok_or_else(|| PlannerError::UnresolvedLogicalPlan)?;
     let field = schema.field_with_name(Some(relation), &column.name)?;
-    let table_ref = table_reference_to_table_ref(relation);
+    let table_ref = table_reference_to_table_ref(relation)?;
     let column_type = ColumnType::try_from(field.data_type().clone()).map_err(|_e| {
         PlannerError::UnsupportedDataType {
             data_type: field.data_type().clone(),
@@ -75,7 +72,6 @@ pub(crate) fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema
     )
 }
 
-#[allow(clippy::missing_panics_doc)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,23 +83,25 @@ mod tests {
         // Bare
         let table = TableReference::bare("table");
         assert_eq!(
-            table_reference_to_table_ref(&table),
+            table_reference_to_table_ref(&table).unwrap(),
             TableRef::from_names(None, "table")
         );
 
         // Partial
         let table = TableReference::partial("schema", "table");
         assert_eq!(
-            table_reference_to_table_ref(&table),
+            table_reference_to_table_ref(&table).unwrap(),
             TableRef::from_names(Some("schema"), "table")
         );
+    }
 
-        // Full
+    #[test]
+    fn we_cannot_convert_full_table_reference_to_table_ref() {
         let table = TableReference::full("catalog", "schema", "table");
-        assert_eq!(
+        assert!(matches!(
             table_reference_to_table_ref(&table),
-            TableRef::from_names(Some("schema"), "table")
-        );
+            Err(PlannerError::CatalogNotSupported)
+        ));
     }
 
     // ScalarValue to LiteralValue
@@ -112,56 +110,56 @@ mod tests {
         // Boolean
         let value = ScalarValue::Boolean(Some(true));
         assert_eq!(
-            scalar_value_to_literal_value(&value).unwrap(),
+            scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::Boolean(true)
         );
 
         // Int8
         let value = ScalarValue::Int8(Some(1));
         assert_eq!(
-            scalar_value_to_literal_value(&value).unwrap(),
+            scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::TinyInt(1)
         );
 
         // Int16
         let value = ScalarValue::Int16(Some(1));
         assert_eq!(
-            scalar_value_to_literal_value(&value).unwrap(),
+            scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::SmallInt(1)
         );
 
         // Int32
         let value = ScalarValue::Int32(Some(1));
         assert_eq!(
-            scalar_value_to_literal_value(&value).unwrap(),
+            scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::Int(1)
         );
 
         // Int64
         let value = ScalarValue::Int64(Some(1));
         assert_eq!(
-            scalar_value_to_literal_value(&value).unwrap(),
+            scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::BigInt(1)
         );
 
         // UInt8
         let value = ScalarValue::UInt8(Some(1));
         assert_eq!(
-            scalar_value_to_literal_value(&value).unwrap(),
+            scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::Uint8(1)
         );
 
         // Utf8
         let value = ScalarValue::Utf8(Some("value".to_string()));
         assert_eq!(
-            scalar_value_to_literal_value(&value).unwrap(),
+            scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::VarChar("value".to_string())
         );
 
         // Unsupported
         let value = ScalarValue::Float32(Some(1.0));
         assert!(matches!(
-            scalar_value_to_literal_value(&value),
+            scalar_value_to_literal_value(value),
             Err(PlannerError::UnsupportedDataType { .. })
         ));
     }

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -1,0 +1,243 @@
+use super::{PlannerError, PlannerResult};
+use arrow::datatypes::{Field, Schema};
+use datafusion::{
+    catalog::TableReference,
+    common::{Column, DFSchema, ScalarValue},
+};
+use proof_of_sql::base::database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef};
+
+/// Convert a [`TableReference`] to a [`TableRef`]
+///
+/// If catalog is provided it is ignored
+pub(crate) fn table_reference_to_table_ref(table: &TableReference) -> TableRef {
+    match table {
+        TableReference::Bare { table } => TableRef::from_names(None, table),
+        TableReference::Partial { schema, table } | TableReference::Full { schema, table, .. } => {
+            TableRef::from_names(Some(schema), table)
+        }
+    }
+}
+
+/// Convert a [`ScalarValue`] to a [`LiteralValue`]
+///
+/// TODO: add other types supported in `PoSQL`
+#[allow(dead_code)]
+pub(crate) fn scalar_value_to_literal_value(value: &ScalarValue) -> PlannerResult<LiteralValue> {
+    match value {
+        ScalarValue::Boolean(Some(v)) => Ok(LiteralValue::Boolean(*v)),
+        ScalarValue::Int8(Some(v)) => Ok(LiteralValue::TinyInt(*v)),
+        ScalarValue::Int16(Some(v)) => Ok(LiteralValue::SmallInt(*v)),
+        ScalarValue::Int32(Some(v)) => Ok(LiteralValue::Int(*v)),
+        ScalarValue::Int64(Some(v)) => Ok(LiteralValue::BigInt(*v)),
+        ScalarValue::UInt8(Some(v)) => Ok(LiteralValue::Uint8(*v)),
+        ScalarValue::Utf8(Some(v)) => Ok(LiteralValue::VarChar(v.clone())),
+        _ => Err(PlannerError::UnsupportedDataType {
+            data_type: value.data_type().clone(),
+        }),
+    }
+}
+
+/// Find a column in a schema and return its info as a [`ColumnRef`]
+///
+/// Note that the table name must be provided in the column which resolved logical plans do
+/// Otherwise we error out
+#[allow(dead_code)]
+pub(crate) fn column_to_column_ref(column: &Column, schema: &DFSchema) -> PlannerResult<ColumnRef> {
+    let relation = column
+        .relation
+        .as_ref()
+        .ok_or_else(|| PlannerError::UnresolvedLogicalPlan)?;
+    let field = schema.field_with_name(Some(relation), &column.name)?;
+    let table_ref = table_reference_to_table_ref(relation);
+    let column_type = ColumnType::try_from(field.data_type().clone()).map_err(|_e| {
+        PlannerError::UnsupportedDataType {
+            data_type: field.data_type().clone(),
+        }
+    })?;
+    Ok(ColumnRef::new(
+        table_ref,
+        column.name.as_str().into(),
+        column_type,
+    ))
+}
+
+/// Convert a Vec<ColumnField> to a Schema
+pub(crate) fn column_fields_to_schema(column_fields: Vec<ColumnField>) -> Schema {
+    Schema::new(
+        column_fields
+            .into_iter()
+            .map(|column_field| {
+                //TODO: Make columns nullable
+                let data_type = (&column_field.data_type()).into();
+                Field::new(column_field.name().value.as_str(), data_type, false)
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[allow(clippy::missing_panics_doc)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::DataType;
+
+    // TableReference to TableRef
+    #[test]
+    fn we_can_convert_table_reference_to_table_ref() {
+        // Bare
+        let table = TableReference::bare("table");
+        assert_eq!(
+            table_reference_to_table_ref(&table),
+            TableRef::from_names(None, "table")
+        );
+
+        // Partial
+        let table = TableReference::partial("schema", "table");
+        assert_eq!(
+            table_reference_to_table_ref(&table),
+            TableRef::from_names(Some("schema"), "table")
+        );
+
+        // Full
+        let table = TableReference::full("catalog", "schema", "table");
+        assert_eq!(
+            table_reference_to_table_ref(&table),
+            TableRef::from_names(Some("schema"), "table")
+        );
+    }
+
+    // ScalarValue to LiteralValue
+    #[test]
+    fn we_can_convert_scalar_value_to_literal_value() {
+        // Boolean
+        let value = ScalarValue::Boolean(Some(true));
+        assert_eq!(
+            scalar_value_to_literal_value(&value).unwrap(),
+            LiteralValue::Boolean(true)
+        );
+
+        // Int8
+        let value = ScalarValue::Int8(Some(1));
+        assert_eq!(
+            scalar_value_to_literal_value(&value).unwrap(),
+            LiteralValue::TinyInt(1)
+        );
+
+        // Int16
+        let value = ScalarValue::Int16(Some(1));
+        assert_eq!(
+            scalar_value_to_literal_value(&value).unwrap(),
+            LiteralValue::SmallInt(1)
+        );
+
+        // Int32
+        let value = ScalarValue::Int32(Some(1));
+        assert_eq!(
+            scalar_value_to_literal_value(&value).unwrap(),
+            LiteralValue::Int(1)
+        );
+
+        // Int64
+        let value = ScalarValue::Int64(Some(1));
+        assert_eq!(
+            scalar_value_to_literal_value(&value).unwrap(),
+            LiteralValue::BigInt(1)
+        );
+
+        // UInt8
+        let value = ScalarValue::UInt8(Some(1));
+        assert_eq!(
+            scalar_value_to_literal_value(&value).unwrap(),
+            LiteralValue::Uint8(1)
+        );
+
+        // Utf8
+        let value = ScalarValue::Utf8(Some("value".to_string()));
+        assert_eq!(
+            scalar_value_to_literal_value(&value).unwrap(),
+            LiteralValue::VarChar("value".to_string())
+        );
+
+        // Unsupported
+        let value = ScalarValue::Float32(Some(1.0));
+        assert!(matches!(
+            scalar_value_to_literal_value(&value),
+            Err(PlannerError::UnsupportedDataType { .. })
+        ));
+    }
+
+    // Column to ColumnRef
+    #[test]
+    fn we_can_convert_column_to_column_ref() {
+        let column = Column::new(Some("namespace.table"), "a");
+        let arrow_schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let df_schema =
+            DFSchema::try_from_qualified_schema("namespace.table", &arrow_schema).unwrap();
+        assert_eq!(
+            column_to_column_ref(&column, &df_schema).unwrap(),
+            ColumnRef::new(
+                TableRef::from_names(Some("namespace"), "table"),
+                "a".into(),
+                ColumnType::Int
+            )
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_column_to_column_ref_without_relation() {
+        let column = Column::new(None::<&str>, "a");
+        let arrow_schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let df_schema = DFSchema::try_from(arrow_schema).unwrap();
+        assert!(matches!(
+            column_to_column_ref(&column, &df_schema),
+            Err(PlannerError::UnresolvedLogicalPlan)
+        ));
+    }
+
+    #[test]
+    fn we_cannot_convert_column_to_column_ref_with_invalid_column_name() {
+        let column = Column::new(Some("namespace.table"), "b");
+        let arrow_schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let df_schema =
+            DFSchema::try_from_qualified_schema("namespace.table", &arrow_schema).unwrap();
+        assert!(matches!(
+            column_to_column_ref(&column, &df_schema),
+            Err(PlannerError::DataFusionError { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_convert_column_to_column_ref_with_unsupported_data_type() {
+        let column = Column::new(Some("namespace.table"), "a");
+        let arrow_schema = Schema::new(vec![Field::new("a", DataType::Float32, false)]);
+        let df_schema =
+            DFSchema::try_from_qualified_schema("namespace.table", &arrow_schema).unwrap();
+        assert!(matches!(
+            column_to_column_ref(&column, &df_schema),
+            Err(PlannerError::UnsupportedDataType { .. })
+        ));
+    }
+
+    // ColumnFields to Schema
+    #[test]
+    fn we_can_convert_column_fields_to_schema() {
+        // Empty
+        let column_fields = vec![];
+        let schema = column_fields_to_schema(column_fields);
+        assert_eq!(schema.all_fields(), Vec::<&Field>::new());
+
+        // Non-empty
+        let column_fields = vec![
+            ColumnField::new("a".into(), ColumnType::SmallInt),
+            ColumnField::new("b".into(), ColumnType::VarChar),
+        ];
+        let schema = column_fields_to_schema(column_fields);
+        assert_eq!(
+            schema.all_fields(),
+            vec![
+                &Field::new("a", DataType::Int16, false),
+                &Field::new("b", DataType::Utf8, false),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
In order to take advantage of name resolution and logical plan from datafusion we would like to add a new planner crate. This PR is a part of #580 since #580 is getting large.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `proof-of-sql-planner` crate with the following
  - `PlannerError` and `PlannerResult`
  - `PoSqlContextProvider` and `PoSqlTableSource`
  - utils that perform datafusion <-> PoSql conversions
- let CI check for `no_std` for `proof-of-sql` and `proof-of-sql-parser` crates since `proof-of-sql-planner` which uses `datafusion` requires `std`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.