### PR TITLE
refactor: refactor HyperKZG compute_commitments_impl

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -114,15 +114,15 @@ fn compute_commitments_impl<T: Into<BNScalar> + Clone>(
     offset: usize,
     scalars: &[T],
 ) -> HyperKZGCommitment {
-    let commitment = CommitmentEngine::commit(
-        setup,
-        &itertools::repeat_n(BNScalar::ZERO, offset)
-            .chain(scalars.iter().map(Into::into))
-            .map(Into::into)
-            .collect_vec(),
-        &NovaScalar::ZERO,
-    );
-    HyperKZGCommitment { commitment }
+    assert!(offset + scalars.len() <= setup.ck().len());
+    let product = scalars
+        .iter()
+        .zip(&setup.ck()[offset..offset + scalars.len()])
+        .map(|(t, s)| *s * Into::<NovaScalar>::into(Into::<BNScalar>::into(t)))
+        .sum();
+    HyperKZGCommitment {
+        commitment: NovaCommitment::new(product),
+    }
 }
 impl Commitment for HyperKZGCommitment {
     type Scalar = BNScalar;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

We don't want the naive implementation of `compute_commitments_impl` padding the scalars with zeroes

# What changes are included in this PR?

Refactoring `compute_commitments_impl` to not pad the scalars with zeroes

# Are these changes tested?
Yes
