### PR TITLE
feat: add `datafusion::logical_expr::Expr` -> `ProofExpr`

### DIFF
--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -1,0 +1,27 @@
+use arrow::datatypes::{DataType, Field, Schema};
+use datafusion::{
+    catalog::TableReference,
+    common::{Column, DFSchema},
+    logical_expr::Expr,
+};
+
+/// Create a `Expr::Column` from full table name and column
+pub(crate) fn df_column(table_name: &str, column: &str) -> Expr {
+    Expr::Column(Column::new(
+        Some(TableReference::from(table_name)),
+        column.to_string(),
+    ))
+}
+
+/// Create a `DFSchema` from table name, column name and data type pairs
+///
+/// Note that nulls are not allowed in the schema
+pub(crate) fn df_schema(table_name: &str, pairs: Vec<(&str, DataType)>) -> DFSchema {
+    let arrow_schema = Schema::new(
+        pairs
+            .into_iter()
+            .map(|(name, data_type)| Field::new(name, data_type, false))
+            .collect::<Vec<_>>(),
+    );
+    DFSchema::try_from_qualified_schema(table_name, &arrow_schema).unwrap()
+}

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -1,5 +1,8 @@
 use arrow::datatypes::DataType;
-use datafusion::common::DataFusionError;
+use datafusion::{
+    common::DataFusionError,
+    logical_expr::{Expr, Operator},
+};
 use proof_of_sql::sql::parse::ConversionError;
 use snafu::Snafu;
 use sqlparser::parser::ParserError;
@@ -30,6 +33,18 @@ pub enum PlannerError {
     UnsupportedDataType {
         /// Unsupported datatype
         data_type: DataType,
+    },
+    /// Returned when a binary operator is not supported
+    #[snafu(display("Binary operator {} is not supported", op))]
+    UnsupportedBinaryOperator {
+        /// Unsupported binary operation
+        op: Operator,
+    },
+    /// Returned when a logical expression is not resolved
+    #[snafu(display("Logical expression {:?} is not supported", expr))]
+    UnsupportedLogicalExpression {
+        /// Unsupported logical expression
+        expr: Expr,
     },
     /// Returned when the `LogicalPlan` is not resolved
     #[snafu(display("LogicalPlan is not resolved"))]

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -1,0 +1,318 @@
+use super::{column_to_column_ref, scalar_value_to_literal_value, PlannerError, PlannerResult};
+use datafusion::{
+    common::DFSchema,
+    logical_expr::{BinaryExpr, Expr, Operator},
+};
+use proof_of_sql::sql::proof_exprs::DynProofExpr;
+
+/// Convert an [`datafusion::expr::Expr`] to [`DynProofExpr`]
+///
+/// # Panics
+/// The function should not panic if Proof of SQL is working correctly
+pub fn expr_to_proof_expr(expr: &Expr, schema: &DFSchema) -> PlannerResult<DynProofExpr> {
+    match expr {
+        Expr::Column(col) => Ok(DynProofExpr::new_column(column_to_column_ref(col, schema)?)),
+        Expr::BinaryExpr(BinaryExpr { left, right, op }) => {
+            let left_proof_expr = expr_to_proof_expr(left, schema)?;
+            let right_proof_expr = expr_to_proof_expr(right, schema)?;
+            match op {
+                Operator::Eq => Ok(DynProofExpr::try_new_equals(
+                    left_proof_expr,
+                    right_proof_expr,
+                )?),
+                Operator::Lt => Ok(DynProofExpr::try_new_inequality(
+                    left_proof_expr,
+                    right_proof_expr,
+                    true,
+                )?),
+                Operator::Gt => Ok(DynProofExpr::try_new_inequality(
+                    left_proof_expr,
+                    right_proof_expr,
+                    false,
+                )?),
+                Operator::LtEq => Ok(DynProofExpr::try_new_not(
+                    DynProofExpr::try_new_inequality(left_proof_expr, right_proof_expr, false)?,
+                ).expect("an inequality expression must have a boolean data type, and try_new_not only fails when the datatype is non-boolean.")),
+                Operator::GtEq => Ok(DynProofExpr::try_new_not(
+                    DynProofExpr::try_new_inequality(left_proof_expr, right_proof_expr, true)?,
+                ).expect("an inequality expression must have a boolean data type, and try_new_not only fails when the datatype is non-boolean.")),
+                Operator::Plus => Ok(DynProofExpr::try_new_add(
+                    left_proof_expr,
+                    right_proof_expr,
+                )?),
+                Operator::Minus => Ok(DynProofExpr::try_new_subtract(
+                    left_proof_expr,
+                    right_proof_expr,
+                )?),
+                Operator::Multiply => Ok(DynProofExpr::try_new_multiply(
+                    left_proof_expr,
+                    right_proof_expr,
+                )?),
+                Operator::And => Ok(DynProofExpr::try_new_and(
+                    left_proof_expr,
+                    right_proof_expr,
+                )?),
+                Operator::Or => Ok(DynProofExpr::try_new_or(left_proof_expr, right_proof_expr)?),
+                _ => Err(PlannerError::UnsupportedBinaryOperator { op: *op }),
+            }
+        }
+        Expr::Literal(val) => Ok(DynProofExpr::new_literal(scalar_value_to_literal_value(
+            val.clone(),
+        )?)),
+        Expr::Not(expr) => {
+            let proof_expr = expr_to_proof_expr(expr, schema)?;
+            Ok(DynProofExpr::try_new_not(proof_expr)?)
+        }
+        _ => Err(PlannerError::UnsupportedLogicalExpression { expr: expr.clone() }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::df_util::*;
+    use arrow::datatypes::DataType;
+    use datafusion::{common::ScalarValue, logical_expr::expr::Placeholder};
+    use proof_of_sql::base::database::{ColumnRef, ColumnType, LiteralValue, TableRef};
+
+    #[expect(non_snake_case)]
+    fn COLUMN_INT() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column".into(),
+            ColumnType::Int,
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN1_SMALLINT() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::SmallInt,
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN2_BIGINT() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column2".into(),
+            ColumnType::BigInt,
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN1_BOOLEAN() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::Boolean,
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN2_BOOLEAN() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column2".into(),
+            ColumnType::Boolean,
+        ))
+    }
+
+    // Column
+    #[test]
+    fn we_can_convert_column_expr_to_proof_expr() {
+        // Column
+        let expr = df_column("namespace.table_name", "column");
+        let schema = df_schema("namespace.table_name", vec![("column", DataType::Int32)]);
+        assert_eq!(expr_to_proof_expr(&expr, &schema).unwrap(), COLUMN_INT());
+    }
+
+    // BinaryExpr
+    #[test]
+    fn we_can_convert_comparison_binary_expr_to_proof_expr() {
+        let schema = df_schema(
+            "namespace.table_name",
+            vec![("column1", DataType::Int16), ("column2", DataType::Int64)],
+        );
+
+        // Eq
+        let expr = df_column("namespace.table_name", "column1")
+            .eq(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_equals(COLUMN1_SMALLINT(), COLUMN2_BIGINT()).unwrap()
+        );
+
+        // Lt
+        let expr = df_column("namespace.table_name", "column1")
+            .lt(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_inequality(COLUMN1_SMALLINT(), COLUMN2_BIGINT(), true).unwrap()
+        );
+
+        // Gt
+        let expr = df_column("namespace.table_name", "column1")
+            .gt(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_inequality(COLUMN1_SMALLINT(), COLUMN2_BIGINT(), false).unwrap()
+        );
+
+        // LtEq
+        let expr = df_column("namespace.table_name", "column1")
+            .lt_eq(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_not(
+                DynProofExpr::try_new_inequality(COLUMN1_SMALLINT(), COLUMN2_BIGINT(), false)
+                    .unwrap()
+            )
+            .unwrap()
+        );
+
+        // GtEq
+        let expr = df_column("namespace.table_name", "column1")
+            .gt_eq(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_not(
+                DynProofExpr::try_new_inequality(COLUMN1_SMALLINT(), COLUMN2_BIGINT(), true)
+                    .unwrap()
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_arithmetic_binary_expr_to_proof_expr() {
+        let schema = df_schema(
+            "namespace.table_name",
+            vec![("column1", DataType::Int16), ("column2", DataType::Int64)],
+        );
+
+        // Plus
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(df_column("namespace.table_name", "column1")),
+            right: Box::new(df_column("namespace.table_name", "column2")),
+            op: Operator::Plus,
+        });
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_add(COLUMN1_SMALLINT(), COLUMN2_BIGINT(),).unwrap()
+        );
+
+        // Minus
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(df_column("namespace.table_name", "column1")),
+            right: Box::new(df_column("namespace.table_name", "column2")),
+            op: Operator::Minus,
+        });
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_subtract(COLUMN1_SMALLINT(), COLUMN2_BIGINT(),).unwrap()
+        );
+
+        // Multiply
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(df_column("namespace.table_name", "column1")),
+            right: Box::new(df_column("namespace.table_name", "column2")),
+            op: Operator::Multiply,
+        });
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_multiply(COLUMN1_SMALLINT(), COLUMN2_BIGINT(),).unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_logical_binary_expr_to_proof_expr() {
+        let schema = df_schema(
+            "namespace.table_name",
+            vec![
+                ("column1", DataType::Boolean),
+                ("column2", DataType::Boolean),
+            ],
+        );
+
+        // And
+        let expr = df_column("namespace.table_name", "column1")
+            .and(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_and(COLUMN1_BOOLEAN(), COLUMN2_BOOLEAN()).unwrap()
+        );
+
+        // Or
+        let expr = df_column("namespace.table_name", "column1")
+            .or(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_or(COLUMN1_BOOLEAN(), COLUMN2_BOOLEAN()).unwrap()
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_unsupported_binary_expr_to_proof_expr() {
+        // Unsupported binary operator
+        let expr = Expr::BinaryExpr(BinaryExpr {
+            left: Box::new(df_column("namespace.table_name", "column1")),
+            right: Box::new(df_column("namespace.table_name", "column2")),
+            op: Operator::AtArrow,
+        });
+        let schema = df_schema(
+            "namespace.table_name",
+            vec![
+                ("column1", DataType::Boolean),
+                ("column2", DataType::Boolean),
+            ],
+        );
+        assert!(matches!(
+            expr_to_proof_expr(&expr, &schema),
+            Err(PlannerError::UnsupportedBinaryOperator { .. })
+        ));
+    }
+
+    // Literal
+    #[test]
+    fn we_can_convert_literal_expr_to_proof_expr() {
+        let expr = Expr::Literal(ScalarValue::Int32(Some(1)));
+        let schema = df_schema("namespace.table_name", vec![]);
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::new_literal(LiteralValue::Int(1))
+        );
+    }
+
+    // Not
+    #[test]
+    fn we_can_convert_not_expr_to_proof_expr() {
+        let expr = Expr::Not(Box::new(df_column("table_name", "column")));
+        let schema = df_schema("table_name", vec![("column", DataType::Boolean)]);
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_not(DynProofExpr::new_column(ColumnRef::new(
+                TableRef::from_names(None, "table_name"),
+                "column".into(),
+                ColumnType::Boolean
+            )))
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_unsupported_logical_expr_to_proof_expr() {
+        // Unsupported logical expression
+        let expr = Expr::Placeholder(Placeholder {
+            id: "$1".to_string(),
+            data_type: None,
+        });
+        let schema = df_schema("namespace.table_name", vec![]);
+        assert!(matches!(
+            expr_to_proof_expr(&expr, &schema),
+            Err(PlannerError::UnsupportedLogicalExpression { .. })
+        ));
+    }
+}

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -1,10 +1,17 @@
 //! This crate converts a `DataFusion` `LogicalPlan` to a `ProofPlan` and `Postprocessing`
-#![cfg_attr(not(test), expect(dead_code))] // TODO: remove this when initial development work is done
+//#![cfg_attr(not(test), expect(dead_code))] // TODO: remove this when initial development work is done
 #![cfg_attr(test, expect(clippy::missing_panics_doc))]
 extern crate alloc;
 mod context;
 pub use context::PoSqlContextProvider;
+#[cfg(test)]
+mod df_util;
+mod expr;
+pub use expr::expr_to_proof_expr;
 mod error;
 pub use error::{PlannerError, PlannerResult};
 mod util;
-pub(crate) use util::{column_fields_to_schema, table_reference_to_table_ref};
+pub(crate) use util::{
+    column_fields_to_schema, column_to_column_ref, scalar_value_to_literal_value,
+    table_reference_to_table_ref,
+};

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -48,6 +48,7 @@ pub enum DynProofExpr {
 }
 impl DynProofExpr {
     /// Create column expression
+    #[must_use]
     pub fn new_column(column_ref: ColumnRef) -> Self {
         Self::Column(ColumnExpr::new(column_ref))
     }
@@ -69,6 +70,7 @@ impl DynProofExpr {
         Ok(Self::Not(NotExpr::new(Box::new(expr))))
     }
     /// Create CONST expression
+    #[must_use]
     pub fn new_literal(value: LiteralValue) -> Self {
         Self::Literal(LiteralExpr::new(value))
     }
@@ -161,6 +163,7 @@ impl DynProofExpr {
     }
 
     /// Create a new aggregate expression
+    #[must_use]
     pub fn new_aggregate(op: AggregationOperator, expr: DynProofExpr) -> Self {
         Self::Aggregate(AggregateExpr::new(op, Box::new(expr)))
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -21,7 +21,7 @@ use multiply_expr::MultiplyExpr;
 mod multiply_expr_test;
 
 mod dyn_proof_expr;
-pub(crate) use dyn_proof_expr::DynProofExpr;
+pub use dyn_proof_expr::DynProofExpr;
 
 mod literal_expr;
 pub(crate) use literal_expr::LiteralExpr;


### PR DESCRIPTION
Depends on #596.
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
Following #596 now we need to add conversion of `datafusion::logical_expr::Expr` to `DynProofExpr`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add conversion of `datafusion::logical_expr::Expr` to `DynProofExpr`
- add a few more error variants in `ProofExpr`
- add `df_util.rs` for datafusion-related helper functions
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.