### PR TITLE
fix: minor typos in code

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -113,7 +113,7 @@ pub fn try_multiply_column_types(
 }
 
 /// Determine the output type of a division operation if it is possible
-/// to multiply the two input types. If the types are not compatible, return
+/// to divide the two input types. If the types are not compatible, return
 /// an error.
 ///
 /// # Panics

--- a/crates/proof-of-sql/src/base/database/literal_value.rs
+++ b/crates/proof-of-sql/src/base/database/literal_value.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 pub enum LiteralValue {
     /// Boolean literals
     Boolean(bool),
-    /// i8 literals
+    /// u8 literals
     Uint8(u8),
     /// i8 literals
     TinyInt(i8),


### PR DESCRIPTION


# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

