### PR TITLE
feat: add methods to `DynProofPlan` and make `AliasedDynProofExpr` && `ProofExpr` && `TableExpr` public

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/aliased_dyn_proof_expr.rs
@@ -5,6 +5,8 @@ use sqlparser::ast::Ident;
 /// A `DynProofExpr` with an alias.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AliasedDynProofExpr {
+    /// The `DynProofExpr` to alias.
     pub expr: DynProofExpr,
+    /// The alias for the expression.
     pub alias: Ident,
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -1,11 +1,11 @@
 //! This module proves provable expressions.
 mod proof_expr;
-pub(crate) use proof_expr::ProofExpr;
+pub use proof_expr::ProofExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod proof_expr_test;
 
 mod aliased_dyn_proof_expr;
-pub(crate) use aliased_dyn_proof_expr::AliasedDynProofExpr;
+pub use aliased_dyn_proof_expr::AliasedDynProofExpr;
 
 mod add_subtract_expr;
 pub(crate) use add_subtract_expr::AddSubtractExpr;
@@ -62,7 +62,7 @@ pub(crate) use equals_expr::EqualsExpr;
 mod equals_expr_test;
 
 mod table_expr;
-pub(crate) use table_expr::TableExpr;
+pub use table_expr::TableExpr;
 
 #[cfg(test)]
 pub(crate) mod test_utility;

--- a/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/table_expr.rs
@@ -4,5 +4,6 @@ use serde::{Deserialize, Serialize};
 /// Expression for an SQL table
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct TableExpr {
+    /// The `TableRef` for the table
     pub table_ref: TableRef,
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
We do not want to expose everything in `proof_of_sql::sql::proof_plans` to the new `proof_of_sql_planner` crate but do have to expose `ProofPlan`s so that it is possible to convert `datafusion` `LogicalPlan`s to them. Hence we have to indirectly expose most of them by adding methods to `DynProofPlan` which is already public.
<!-- 
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add methods to `DynProofPlan`
- make `AliasedDynProofExpr` && `ProofExpr` && `TableExpr` pub
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.