### PR TITLE
fix: minor typos in code

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -170,7 +170,7 @@ impl Commitment for NaiveCommitment {
 
 #[allow(clippy::similar_names)]
 #[test]
-fn we_can_compute_commitments_from_commitable_columns() {
+fn we_can_compute_commitments_from_committable_columns() {
     let column_a = [1i64, 10, -5, 0, 10];
     let column_b = vec![
         [1, 0, 0, 0],
@@ -183,40 +183,40 @@ fn we_can_compute_commitments_from_commitable_columns() {
         column_a.iter().map(core::convert::Into::into).collect();
     let column_b_scalars: Vec<TestScalar> =
         column_b.iter().map(core::convert::Into::into).collect();
-    let commitable_column_a = CommittableColumn::BigInt(&column_a);
-    let commitable_column_b = CommittableColumn::VarChar(column_b);
-    let committable_columns: &[CommittableColumn] = &[commitable_column_a, commitable_column_b];
+    let committable_column_a = CommittableColumn::BigInt(&column_a);
+    let committable_column_b = CommittableColumn::VarChar(column_b);
+    let committable_columns: &[CommittableColumn] = &[committable_column_a, committable_column_b];
     let commitments = NaiveCommitment::compute_commitments(committable_columns, 0, &());
     assert_eq!(commitments[0].0, column_a_scalars);
     assert_eq!(commitments[1].0, column_b_scalars);
 }
 
 #[test]
-fn we_can_compute_commitments_from_commitable_columns_with_offset() {
+fn we_can_compute_commitments_from_committable_columns_with_offset() {
     let column_a = [0i64, 1, 10, -5, 0, 10];
     let column_a_scalars: Vec<TestScalar> =
         column_a.iter().map(core::convert::Into::into).collect();
-    let commitable_column_a = CommittableColumn::BigInt(&column_a[1..]);
-    let committable_columns: &[CommittableColumn] = &[commitable_column_a];
+    let committable_column_a = CommittableColumn::BigInt(&column_a[1..]);
+    let committable_columns: &[CommittableColumn] = &[committable_column_a];
     let commitments = NaiveCommitment::compute_commitments(committable_columns, 1, &());
     assert_eq!(commitments[0].0, column_a_scalars);
 }
 
 #[test]
-fn we_can_compute_commitments_from_commitable_varbinary_column() {
+fn we_can_compute_commitments_from_committable_varbinary_column() {
     let varbinary_data = vec![[1u64, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]];
     let varbinary_scalars: Vec<TestScalar> = varbinary_data.iter().map(Into::into).collect();
-    let commitable_column_varbinary = CommittableColumn::VarBinary(varbinary_data);
-    let commitments = NaiveCommitment::compute_commitments(&[commitable_column_varbinary], 0, &());
+    let committable_column_varbinary = CommittableColumn::VarBinary(varbinary_data);
+    let commitments = NaiveCommitment::compute_commitments(&[committable_column_varbinary], 0, &());
     assert_eq!(commitments[0].0, varbinary_scalars);
 }
 
 #[test]
-fn we_can_compute_commitments_from_commitable_varbinary_column_with_offset() {
+fn we_can_compute_commitments_from_committable_varbinary_column_with_offset() {
     let raw_limb_data = [[100u64, 101, 102, 103], [1, 2, 3, 4], [5, 6, 7, 8]];
     let trimmed_data = &raw_limb_data[1..];
-    let commitable_column = CommittableColumn::VarBinary(trimmed_data.to_vec());
-    let commitments = NaiveCommitment::compute_commitments(&[commitable_column], 1, &());
+    let committable_column = CommittableColumn::VarBinary(trimmed_data.to_vec());
+    let commitments = NaiveCommitment::compute_commitments(&[committable_column], 1, &());
     let expected: Vec<TestScalar> = core::iter::once(TestScalar::ZERO)
         .chain(trimmed_data.iter().map(Into::into))
         .collect();

--- a/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
+++ b/crates/proof-of-sql/src/base/commitment/vec_commitment_ext.rs
@@ -26,7 +26,7 @@ pub trait VecCommitmentExt {
         C: Into<CommittableColumn<'a>>;
 
     /// Returns a collection of commitments to the provided slice of `CommittableColumn`s using the given generator offset.
-    fn from_commitable_columns_with_offset(
+    fn from_committable_columns_with_offset(
         committable_columns: &[CommittableColumn],
         offset: usize,
         setup: &Self::CommitmentPublicSetup<'_>,
@@ -94,10 +94,10 @@ impl<C: Commitment> VecCommitmentExt for Vec<C> {
         let committable_columns: Vec<CommittableColumn<'a>> =
             columns.into_iter().map(Into::into).collect::<Vec<_>>();
 
-        Self::from_commitable_columns_with_offset(&committable_columns, offset, setup)
+        Self::from_committable_columns_with_offset(&committable_columns, offset, setup)
     }
 
-    fn from_commitable_columns_with_offset(
+    fn from_committable_columns_with_offset(
         committable_columns: &[CommittableColumn],
         offset: usize,
         setup: &Self::CommitmentPublicSetup<'_>,

--- a/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/final_round_builder.rs
@@ -100,7 +100,7 @@ impl<'a, S: Scalar> FinalRoundBuilder<'a, S> {
     ) -> Vec<C> {
         log::log_memory_usage("Start");
 
-        let res = Vec::from_commitable_columns_with_offset(
+        let res = Vec::from_committable_columns_with_offset(
             &self.commitment_descriptor,
             offset_generators,
             setup,

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
@@ -97,7 +97,7 @@ impl<'a, S: Scalar> FirstRoundBuilder<'a, S> {
         offset_generators: usize,
         setup: &C::PublicSetup<'_>,
     ) -> Vec<C> {
-        Vec::from_commitable_columns_with_offset(
+        Vec::from_committable_columns_with_offset(
             &self.commitment_descriptor,
             offset_generators,
             setup,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
