### PR TITLE
test(sol): fix flaky tests

### DIFF
--- a/solidity/test/base/ECPrecompiles.t.pre.sol
+++ b/solidity/test/base/ECPrecompiles.t.pre.sol
@@ -208,7 +208,7 @@ contract ECPrecompilesTest is Test {
     }
 
     function testFuzzECPairingX2WithValidInputsThatDoNotSumToZero(uint256 a, uint256 b) public view {
-        vm.assume(a != 0 || b != 0);
+        vm.assume(addmod(a, b, MODULUS) != 0);
         (uint256 ax, uint256 ay) = ECPrecompilesTestHelper.ecBasePower(a);
         (uint256 bx, uint256 by) = ECPrecompilesTestHelper.ecBasePower(b);
         uint256[12] memory argsPtr = [

--- a/solidity/test/hyperkzg/HyperKZGHelpers.t.pre.sol
+++ b/solidity/test/hyperkzg/HyperKZGHelpers.t.pre.sol
@@ -171,7 +171,13 @@ contract HyperKZGHelpersTest is Test {
     /// forge-config: default.fuzz.max-test-rejects = 100000
     function testFuzzRevertsVConsistency(uint256[3][] calldata v, uint256 r, uint256[] memory x, uint256 y) public {
         vm.assume(x.length > 0);
-        vm.assume(v.length == x.length);
+        uint256 xLength = x.length;
+        vm.assume(v.length == xLength);
+        bool xrAllZero = r == 0;
+        for (uint256 i = 0; i < xLength; ++i) {
+            xrAllZero = xrAllZero && (x[i] == 0);
+        }
+        vm.assume(!xrAllZero);
         vm.expectRevert(Errors.HyperKZGInconsistentV.selector);
         HyperKZGHelpers.__checkVConsistency(v, r, x, y);
     }


### PR DESCRIPTION
# Rationale for this change

Some of the fuzz tests rely on random sampling not choosing very low probability samples. However, the foundry fuzz tests are not fully random, so some edge cases need to be filtered out. Some tests do not filter enough.

# What changes are included in this PR?

* Fixed flakiness in `testFuzzECPairingX2WithValidInputsThatDoNotSumToZero`: if a+b = 0 as field elements, the test will/should fail. This is now filtered out.
* Fixed flakiness in `testFuzzRevertsVConsistency`. If r = 0 and x[i] = 0, the test will/should fail. This is now filtered out.

# Are these changes tested?
NA