### PR TITLE
chore: increase test optimization level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,6 @@ pedantic = { level = "warn", priority = -1 }
 # patch for sqlparser no_std compatibility with the serde feature enabled.
 # required until sqlparser releases a similar update and proof-of-sql upgrades to it.
 sqlparser = { git = "https://github.com/tlovell-sxt/datafusion-sqlparser-rs.git", rev = "a828cbea22cf19bb6b4596f902bdd6f4d14a00b8" }
+
+[profile.test]
+opt-level = 3


### PR DESCRIPTION
# Rationale for this change
To improve test run time by using rust's aggressive compiler optimizations. This is generally done by testing multiple settings and levels, 1-2 could be done as well but the most improvement we get with this codebase is with 3. LTO and codegen unit numbers being 1 do not provide enough justification for build time increase, as they do not give good runtime improvements compared to this.

# What changes are included in this PR?

Set the optimization level for test profile to 3 to improve test performance and potentially catch more optimization-related issues.

# Are these changes tested?

Yes, manually.

/claim #557