### PR TITLE
feat: equality between varbianry columns

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -54,6 +54,7 @@ impl ColumnCommitmentMetadata {
             | (
                 ColumnType::Boolean
                 | ColumnType::VarChar
+                | ColumnType::VarBinary
                 | ColumnType::Scalar
                 | ColumnType::Decimal75(..),
                 ColumnBounds::NoOrder,

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -201,8 +201,11 @@ pub(crate) fn max_aggregate_column_by_index_counts<'a, S: Scalar>(
             max_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => max_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
+        Column::VarBinary(_) => {
+            unreachable!("MAX can not be applied to varbinary")
+        }
         // The following should never be reached because the `MAX` function can't be applied to varchar.
-        Column::VarChar(_) | Column::VarBinary(_) => {
+        Column::VarChar(_) => {
             unreachable!("MAX can not be applied to varchar")
         }
     }
@@ -235,7 +238,7 @@ pub(crate) fn min_aggregate_column_by_index_counts<'a, S: Scalar>(
             min_aggregate_slice_by_index_counts(alloc, col, counts, indexes)
         }
         Column::Scalar(col) => min_aggregate_slice_by_index_counts(alloc, col, counts, indexes),
-        Column::VarBinary(_) => unreachable!("MIN can not be applied to varchar"),
+        Column::VarBinary(_) => unreachable!("MIN can not be applied to varbinary"),
         // The following should never be reached because the `MIN` function can't be applied to varchar.
         Column::VarChar(_) => {
             unreachable!("MIN can not be applied to varchar")

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -8,6 +8,46 @@ use crate::{
 use bumpalo::Bump;
 
 #[test]
+#[should_panic(expected = "MAX can not be applied to varbinary")]
+fn we_cannot_apply_max_to_varbinary() {
+    let col: Column<'_, TestScalar> = Column::VarBinary((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = max_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "MIN can not be applied to varbinary")]
+fn we_cannot_apply_min_to_varbinary() {
+    let col: Column<'_, TestScalar> = Column::VarBinary((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = min_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "MAX can not be applied to varchar")]
+fn we_cannot_apply_max_to_varchar() {
+    let col: Column<'_, TestScalar> = Column::VarChar((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = max_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
+#[should_panic(expected = "MIN can not be applied to varchar")]
+fn we_cannot_apply_min_to_varchar() {
+    let col: Column<'_, TestScalar> = Column::VarChar((&[], &[]));
+    let indexes = &[];
+    let counts = &[];
+    let alloc = bumpalo::Bump::new();
+    let _ = min_aggregate_column_by_index_counts(&alloc, &col, counts, indexes);
+}
+
+#[test]
 fn we_can_aggregate_empty_columns() {
     let column_a = Column::BigInt::<TestScalar>(&[]);
     let column_b = Column::VarChar((&[], &[]));

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -348,6 +348,7 @@ pub(crate) fn type_check_binary_operation(
             matches!(
                 (left_dtype, right_dtype),
                 (ColumnType::VarChar, ColumnType::VarChar)
+                    | (ColumnType::VarBinary, ColumnType::VarBinary)
                     | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
                     | (ColumnType::Boolean, ColumnType::Boolean)
                     | (_, ColumnType::Scalar)

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -919,6 +919,7 @@ fn we_can_perform_equality_checks_on_var_binary() {
 
 #[test]
 #[cfg(feature = "blitzar")]
+#[allow(clippy::too_many_lines)]
 fn we_can_perform_rich_equality_checks_on_var_binary() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
@@ -1036,6 +1037,7 @@ fn we_can_perform_rich_equality_checks_on_var_binary() {
 
 #[test]
 #[cfg(feature = "blitzar")]
+#[allow(clippy::too_many_lines)]
 fn we_can_perform_equality_checks_on_rich_var_binary_data() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     // We'll create multiple columns to have richer data,


### PR DESCRIPTION
# Rationale for this change

Enables queries of the form:

```sql
"SELECT * FROM table WHERE a=b AND c=d AND e=f"
```
for the varbinary type.

# What changes are included in this PR?

Simple update to PoSQL to update the binary check operation to enable var binary support

# Are these changes tested?

- [x]  test equality queries
