### PR TITLE
docs: correct spelling errors

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
@@ -64,7 +64,7 @@ impl DoryMessages {
     /// # Panics
     ///
     /// Will panic if there are no messages in the queue (i.e., `F_messages` is empty), indicating that the prover attempted to receive a message that was never sent.
-    pub(super) fn prover_recieve_F_message(&mut self, transcript: &mut impl Transcript) -> F {
+    pub(super) fn prover_receive_F_message(&mut self, transcript: &mut impl Transcript) -> F {
         let message = self.F_messages.pop().unwrap();
         transcript.extend_canonical_serialize_as_le(&message);
         message
@@ -74,7 +74,7 @@ impl DoryMessages {
     /// # Panics
     ///
     /// Will panic if there are no messages in the queue (i.e., `G1_messages` is empty), indicating
-    pub(super) fn prover_recieve_G1_message(
+    pub(super) fn prover_receive_G1_message(
         &mut self,
         transcript: &mut impl Transcript,
     ) -> G1Affine {
@@ -87,7 +87,7 @@ impl DoryMessages {
     /// # Panics
     ///
     /// Will panic if there are no messages in the queue (i.e., `G2_messages` is empty), indicating that the prover attempted to receive a message that was never sent.
-    pub(super) fn prover_recieve_G2_message(
+    pub(super) fn prover_receive_G2_message(
         &mut self,
         transcript: &mut impl Transcript,
     ) -> G2Affine {
@@ -100,7 +100,7 @@ impl DoryMessages {
     /// # Panics
     ///
     /// Will panic if there are no messages in the queue (i.e., `GT_messages` is empty), indicating that the prover attempted to receive a message that was never sent.
-    pub(super) fn prover_recieve_GT_message(&mut self, transcript: &mut impl Transcript) -> GT {
+    pub(super) fn prover_receive_GT_message(&mut self, transcript: &mut impl Transcript) -> GT {
         let message = self.GT_messages.pop().unwrap();
         transcript.extend_canonical_serialize_as_le(&message);
         message

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages_test.rs
@@ -34,42 +34,42 @@ fn we_can_send_and_receive_the_correct_messages_in_the_same_order() {
     // Verifier side
     let mut transcript = Transcript::new(b"test");
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage1
     );
     assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage1);
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage2
     );
     assert_eq!(
-        messages.prover_recieve_G2_message(&mut transcript),
+        messages.prover_receive_G2_message(&mut transcript),
         Pmessage3
     );
     assert_eq!(
-        messages.prover_recieve_GT_message(&mut transcript),
+        messages.prover_receive_GT_message(&mut transcript),
         Pmessage4
     );
     assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage2);
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage5
     );
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage6
     );
     assert_eq!(
-        messages.prover_recieve_G2_message(&mut transcript),
+        messages.prover_receive_G2_message(&mut transcript),
         Pmessage7
     );
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage8
     );
     assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage3);
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage9
     );
 }
@@ -106,42 +106,42 @@ fn verifier_messages_fail_when_the_transcript_is_wrong() {
     // Verifier side
     let mut transcript = Transcript::new(b"test_wrong");
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage1
     );
     assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage1);
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage2
     );
     assert_eq!(
-        messages.prover_recieve_G2_message(&mut transcript),
+        messages.prover_receive_G2_message(&mut transcript),
         Pmessage3
     );
     assert_eq!(
-        messages.prover_recieve_GT_message(&mut transcript),
+        messages.prover_receive_GT_message(&mut transcript),
         Pmessage4
     );
     assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage2);
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage5
     );
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage6
     );
     assert_eq!(
-        messages.prover_recieve_G2_message(&mut transcript),
+        messages.prover_receive_G2_message(&mut transcript),
         Pmessage7
     );
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage8
     );
     assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage3);
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage9
     );
 }
@@ -178,42 +178,42 @@ fn verifier_messages_fail_when_a_verifier_message_is_in_the_wrong_order() {
     // Verifier side
     let mut transcript = Transcript::new(b"test");
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage1
     );
     assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage1);
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage2
     );
     assert_eq!(
-        messages.prover_recieve_G2_message(&mut transcript),
+        messages.prover_receive_G2_message(&mut transcript),
         Pmessage3
     );
     assert_eq!(
-        messages.prover_recieve_GT_message(&mut transcript),
+        messages.prover_receive_GT_message(&mut transcript),
         Pmessage4
     );
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage5
     );
     assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage2);
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage6
     );
     assert_eq!(
-        messages.prover_recieve_G2_message(&mut transcript),
+        messages.prover_receive_G2_message(&mut transcript),
         Pmessage7
     );
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage8
     );
     assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage3);
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage9
     );
 }
@@ -250,42 +250,42 @@ fn verifier_messages_fail_when_prover_messages_are_out_of_order() {
     // Verifier side
     let mut transcript = Transcript::new(b"test");
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage1
     );
     assert_eq!(messages.verifier_F_message(&mut transcript), Vmessage1);
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage2
     );
     assert_eq!(
-        messages.prover_recieve_GT_message(&mut transcript),
+        messages.prover_receive_GT_message(&mut transcript),
         Pmessage4
     );
     assert_eq!(
-        messages.prover_recieve_G2_message(&mut transcript),
+        messages.prover_receive_G2_message(&mut transcript),
         Pmessage3
     );
     assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage2);
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage5
     );
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage6
     );
     assert_eq!(
-        messages.prover_recieve_G2_message(&mut transcript),
+        messages.prover_receive_G2_message(&mut transcript),
         Pmessage7
     );
     assert_eq!(
-        messages.prover_recieve_G1_message(&mut transcript),
+        messages.prover_receive_G1_message(&mut transcript),
         Pmessage8
     );
     assert_ne!(messages.verifier_F_message(&mut transcript), Vmessage3);
     assert_eq!(
-        messages.prover_recieve_F_message(&mut transcript),
+        messages.prover_receive_F_message(&mut transcript),
         Pmessage9
     );
 }

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_reduce.rs
@@ -40,13 +40,13 @@ pub fn dory_reduce_verify(
     if messages.GT_messages.len() < 6 {
         return false;
     }
-    let D_1L = messages.prover_recieve_GT_message(transcript);
-    let D_1R = messages.prover_recieve_GT_message(transcript);
-    let D_2L = messages.prover_recieve_GT_message(transcript);
-    let D_2R = messages.prover_recieve_GT_message(transcript);
+    let D_1L = messages.prover_receive_GT_message(transcript);
+    let D_1R = messages.prover_receive_GT_message(transcript);
+    let D_2L = messages.prover_receive_GT_message(transcript);
+    let D_2R = messages.prover_receive_GT_message(transcript);
     let betas = messages.verifier_F_message(transcript);
-    let C_plus = messages.prover_recieve_GT_message(transcript);
-    let C_minus = messages.prover_recieve_GT_message(transcript);
+    let C_plus = messages.prover_receive_GT_message(transcript);
+    let C_minus = messages.prover_receive_GT_message(transcript);
     let alphas = messages.verifier_F_message(transcript);
     dory_reduce_verify_update_C(state, setup, (C_plus, C_minus), alphas, betas);
     dory_reduce_verify_update_Ds(state, setup, (D_1L, D_1R, D_2L, D_2R), alphas, betas);

--- a/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/eval_vmv_re.rs
@@ -68,9 +68,9 @@ pub fn eval_vmv_re_verify(
     if messages.GT_messages.len() < 2 || messages.G1_messages.is_empty() {
         return None;
     }
-    let C = messages.prover_recieve_GT_message(transcript).into();
-    let D_2 = messages.prover_recieve_GT_message(transcript).into();
-    let E_1 = messages.prover_recieve_G1_message(transcript).into();
+    let C = messages.prover_receive_GT_message(transcript).into();
+    let D_2 = messages.prover_receive_GT_message(transcript).into();
+    let E_1 = messages.prover_receive_G1_message(transcript).into();
     let D_1 = state.T;
     let E_2 = DeferredG2::from(setup.Gamma_2_fin) * state.y;
     let s1_tensor = state.r_tensor;

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_dory_reduce.rs
@@ -68,19 +68,19 @@ pub fn extended_dory_reduce_verify(
     {
         return false;
     }
-    let D_1L = messages.prover_recieve_GT_message(transcript);
-    let D_1R = messages.prover_recieve_GT_message(transcript);
-    let D_2L = messages.prover_recieve_GT_message(transcript);
-    let D_2R = messages.prover_recieve_GT_message(transcript);
-    let E_1beta = messages.prover_recieve_G1_message(transcript);
-    let E_2beta = messages.prover_recieve_G2_message(transcript);
+    let D_1L = messages.prover_receive_GT_message(transcript);
+    let D_1R = messages.prover_receive_GT_message(transcript);
+    let D_2L = messages.prover_receive_GT_message(transcript);
+    let D_2R = messages.prover_receive_GT_message(transcript);
+    let E_1beta = messages.prover_receive_G1_message(transcript);
+    let E_2beta = messages.prover_receive_G2_message(transcript);
     let betas = messages.verifier_F_message(transcript);
-    let C_plus = messages.prover_recieve_GT_message(transcript);
-    let C_minus = messages.prover_recieve_GT_message(transcript);
-    let E_1plus = messages.prover_recieve_G1_message(transcript);
-    let E_1minus = messages.prover_recieve_G1_message(transcript);
-    let E_2plus = messages.prover_recieve_G2_message(transcript);
-    let E_2minus = messages.prover_recieve_G2_message(transcript);
+    let C_plus = messages.prover_receive_GT_message(transcript);
+    let C_minus = messages.prover_receive_GT_message(transcript);
+    let E_1plus = messages.prover_receive_G1_message(transcript);
+    let E_1minus = messages.prover_receive_G1_message(transcript);
+    let E_2plus = messages.prover_receive_G2_message(transcript);
+    let E_2minus = messages.prover_receive_G2_message(transcript);
     let alphas = messages.verifier_F_message(transcript);
     dory_reduce_verify_update_C(
         &mut state.base_state,

--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
@@ -70,8 +70,8 @@ pub fn scalar_product_verify(
     {
         return false;
     }
-    let E_1 = messages.prover_recieve_G1_message(transcript);
-    let E_2 = messages.prover_recieve_G2_message(transcript);
+    let E_1 = messages.prover_receive_G1_message(transcript);
+    let E_2 = messages.prover_receive_G2_message(transcript);
     let (d, d_inv) = messages.verifier_F_message(transcript);
     let res = pairings::pairing(E_1 + setup.Gamma_1_0 * d, E_2 + setup.Gamma_2_0 * d_inv)
         == (state.C + setup.chi[0] + state.D_2 * d + state.D_1 * d_inv).compute();


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

Corrected `recieve` to `receive` spelling error all around the documentation. Now it looks clear. 

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
