### PR TITLE
fix: transition from allow to expect for turning off clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ missing_docs = "warn"
 [workspace.lints.clippy]
 missing_errors_doc = "allow"
 pedantic = { level = "warn", priority = -1 }
+allow_attributes = "warn"
 
 [patch.crates-io]
 # patch for sqlparser no_std compatibility with the serde feature enabled.

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -101,7 +101,7 @@ impl ArrayRefExt for ArrayRef {
     ///
     /// # Panics
     /// - When any range is OOB, i.e. indexing 3..6 or 5..5 on array of size 2.
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn to_column<'a, S: Scalar>(
         &'a self,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -145,7 +145,7 @@ impl<S: Scalar> TryFrom<ArrayRef> for OwnedColumn<S> {
 impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     type Error = OwnedArrowConversionError;
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     /// # Panics
     ///
     /// Will panic if downcasting fails for the following types:

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -40,7 +40,7 @@ impl<C: Commitment> TableCommitment<C> {
     /// The row offset is assumed to be the end of the [`TableCommitment`]'s current range.
     ///
     /// Will error on a variety of mismatches, or if the provided columns have mixed length.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_append_record_batch(
         &mut self,
         batch: &RecordBatch,
@@ -75,7 +75,7 @@ impl<C: Commitment> TableCommitment<C> {
     }
 
     /// Returns a [`TableCommitment`] to the provided arrow [`RecordBatch`] with the given row offset.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_from_record_batch_with_offset(
         batch: &RecordBatch,
         offset: usize,

--- a/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
@@ -27,7 +27,7 @@ pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
     }
 }
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 /// Converts an arrow i256 into limbed representation and then
 /// into a type implementing [Scalar]
 #[must_use]

--- a/crates/proof-of-sql/src/lib.rs
+++ b/crates/proof-of-sql/src/lib.rs
@@ -1,7 +1,7 @@
-#![cfg_attr(test, allow(clippy::missing_panics_doc))]
+#![cfg_attr(test, expect(clippy::missing_panics_doc))]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::module_name_repetitions)]
+#![expect(clippy::module_name_repetitions)]
 
 extern crate alloc;
 

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -68,7 +68,7 @@ impl GroupByExec {
 }
 
 impl ProofPlan for GroupByExec {
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -155,7 +155,7 @@ impl ProofPlan for GroupByExec {
         Ok(TableEvaluation::new(column_evals, output_chi_eval))
     }
 
-    #[allow(clippy::redundant_closure_for_method_calls)]
+    #[expect(clippy::redundant_closure_for_method_calls)]
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.group_by_exprs
             .iter()
@@ -251,7 +251,7 @@ impl ProverEvaluate for GroupByExec {
     }
 
     #[tracing::instrument(name = "GroupByExec::final_round_evaluate", level = "debug", skip_all)]
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
@@ -328,7 +328,7 @@ impl ProverEvaluate for GroupByExec {
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn verify_group_by<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
     alpha: S,
@@ -374,7 +374,7 @@ fn verify_group_by<S: Scalar>(
     Ok(())
 }
 
-#[allow(
+#[expect(
     clippy::missing_panics_doc,
     reason = "alpha is guaranteed to not be zero in this context"
 )]


### PR DESCRIPTION
/claim #545 
This PR implements the transition from `#[allow(clippy::...)]` to `#[expect(clippy::...)]` throughout our codebase, addressing issue #545


## Rationale for this change
To better track temporary lint suppressions and receive notifications when they are no longer needed, following Rust 1.81's introduction of the expect lint level.

## What changes are included in this PR?
- Updated Cargo.toml to enable warnings for any remaining #[allow(...)] attributes
- Systematically converted  #[allow(clippy::...)] to #[expect(clippy::...)] while preserving the specific lint identifiers