### PR TITLE
feat: add decimal support to `I256` and `scalar_value_to_literal_value`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,4 @@ solidity/coverage-report
 solidity/docs
 autogen_logs/
 _autocoder/
-_autocoder/tasks/*/bash_cmd.*
 prompts/

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ solidity/coverage-report
 solidity/docs
 autogen_logs/
 _autocoder/
+_autocoder/tasks/*/bash_cmd.*
+prompts/

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -3,7 +3,7 @@ use datafusion::{
     common::DataFusionError,
     logical_expr::{Expr, LogicalPlan, Operator},
 };
-use proof_of_sql::sql::parse::ConversionError;
+use proof_of_sql::{base::math::decimal::DecimalError, sql::parse::ConversionError};
 use snafu::Snafu;
 use sqlparser::parser::ParserError;
 
@@ -15,6 +15,12 @@ pub enum PlannerError {
     ConversionError {
         /// Underlying conversion error
         source: ConversionError,
+    },
+    /// Returned when a decimal error occurs
+    #[snafu(transparent)]
+    DecimalError {
+        /// Underlying decimal error
+        source: DecimalError,
     },
     /// Returned when sqlparser fails to parse a query
     #[snafu(transparent)]

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -6,7 +6,7 @@ use datafusion::{
 };
 use proof_of_sql::base::{
     database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
-    math::{decimal::Precision, i256::I256},
+    math::decimal::Precision,
 };
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use sqlparser::ast::Ident;
@@ -58,7 +58,7 @@ pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult
         ScalarValue::Decimal128(Some(v), precision, scale) => Ok(LiteralValue::Decimal75(
             Precision::new(precision)?,
             scale,
-            I256::from(v),
+            v.into(),
         )),
         ScalarValue::Decimal256(Some(v), precision, scale) => Ok(LiteralValue::Decimal75(
             Precision::new(precision)?,
@@ -130,7 +130,7 @@ pub(crate) fn df_schema_to_column_fields(schema: &DFSchema) -> PlannerResult<Vec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::{i256 as ArrowI256, DataType};
+    use arrow::datatypes::DataType;
 
     // TableReference to TableRef
     #[test]
@@ -271,58 +271,87 @@ mod tests {
         let value = ScalarValue::Decimal128(Some(123), 38, 0);
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
-            LiteralValue::Decimal75(Precision::new(38).unwrap(), 0, I256::from(123i128))
+            LiteralValue::Decimal75(
+                Precision::new(38).unwrap(),
+                0,
+                proof_of_sql::base::math::i256::I256::from(123i128)
+            )
         );
 
         // Test edge cases for Decimal128
         let value = ScalarValue::Decimal128(Some(i128::MIN), 38, 10);
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
-            LiteralValue::Decimal75(Precision::new(38).unwrap(), 10, I256::from(i128::MIN))
+            LiteralValue::Decimal75(
+                Precision::new(38).unwrap(),
+                10,
+                proof_of_sql::base::math::i256::I256::from(i128::MIN)
+            )
         );
 
         let value = ScalarValue::Decimal128(Some(i128::MAX), 28, -5);
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
-            LiteralValue::Decimal75(Precision::new(28).unwrap(), -5, I256::from(i128::MAX))
+            LiteralValue::Decimal75(
+                Precision::new(28).unwrap(),
+                -5,
+                proof_of_sql::base::math::i256::I256::from(i128::MAX)
+            )
         );
 
         let value = ScalarValue::Decimal128(Some(0), 38, 0);
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
-            LiteralValue::Decimal75(Precision::new(38).unwrap(), 0, I256::from(0i128))
+            LiteralValue::Decimal75(
+                Precision::new(38).unwrap(),
+                0,
+                proof_of_sql::base::math::i256::I256::from(0i128)
+            )
         );
 
         // Decimal256
-        let value = ScalarValue::Decimal256(Some(ArrowI256::from_i128(-456)), 75, 120);
+        let value = ScalarValue::Decimal256(Some(arrow::datatypes::i256::from_i128(-456)), 75, 120);
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
-            LiteralValue::Decimal75(Precision::new(75).unwrap(), 120, I256::from(-456i128))
+            LiteralValue::Decimal75(
+                Precision::new(75).unwrap(),
+                120,
+                proof_of_sql::base::math::i256::I256::from(-456i128)
+            )
         );
 
         // Test edge cases for Decimal256
-        let value = ScalarValue::Decimal256(Some(ArrowI256::MIN), 75, 127);
+        let value = ScalarValue::Decimal256(Some(arrow::datatypes::i256::MIN), 75, 127);
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::Decimal75(
                 Precision::new(75).unwrap(),
                 127,
-                I256::new([0, 0, 0, i64::MIN as u64])
+                proof_of_sql::base::math::i256::I256::new([0, 0, 0, i64::MIN as u64])
             )
         );
-        let value = ScalarValue::Decimal256(Some(ArrowI256::MAX), 75, -128);
+        let value = ScalarValue::Decimal256(Some(arrow::datatypes::i256::MAX), 75, -128);
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
             LiteralValue::Decimal75(
                 Precision::new(75).unwrap(),
                 -128,
-                I256::new([u64::MAX, u64::MAX, u64::MAX, i64::MAX as u64])
+                proof_of_sql::base::math::i256::I256::new([
+                    u64::MAX,
+                    u64::MAX,
+                    u64::MAX,
+                    i64::MAX as u64
+                ])
             )
         );
-        let value = ScalarValue::Decimal256(Some(ArrowI256::ZERO), 75, 0);
+        let value = ScalarValue::Decimal256(Some(arrow::datatypes::i256::ZERO), 75, 0);
         assert_eq!(
             scalar_value_to_literal_value(value).unwrap(),
-            LiteralValue::Decimal75(Precision::new(75).unwrap(), 0, I256::from(0i128))
+            LiteralValue::Decimal75(
+                Precision::new(75).unwrap(),
+                0,
+                proof_of_sql::base::math::i256::I256::from(0i128)
+            )
         );
     }
 

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -4,7 +4,10 @@ use datafusion::{
     catalog::TableReference,
     common::{Column, DFSchema, ScalarValue},
 };
-use proof_of_sql::base::database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef};
+use proof_of_sql::base::{
+    database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
+    math::{decimal::Precision, i256::I256},
+};
 use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone};
 use sqlparser::ast::Ident;
 
@@ -51,6 +54,16 @@ pub(crate) fn scalar_value_to_literal_value(value: ScalarValue) -> PlannerResult
             PoSQLTimeUnit::Nanosecond,
             PoSQLTimeZone::utc(),
             v,
+        )),
+        ScalarValue::Decimal128(Some(v), precision, scale) => Ok(LiteralValue::Decimal75(
+            Precision::new(precision)?,
+            scale,
+            I256::from(v),
+        )),
+        ScalarValue::Decimal256(Some(v), precision, scale) => Ok(LiteralValue::Decimal75(
+            Precision::new(precision)?,
+            scale,
+            v.into(),
         )),
         _ => Err(PlannerError::UnsupportedDataType {
             data_type: value.data_type().clone(),
@@ -117,7 +130,7 @@ pub(crate) fn df_schema_to_column_fields(schema: &DFSchema) -> PlannerResult<Vec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::DataType;
+    use arrow::datatypes::{i256 as ArrowI256, DataType};
 
     // TableReference to TableRef
     #[test]
@@ -249,7 +262,72 @@ mod tests {
                 1_741_236_192_123_456_789_i64
             )
         );
+    }
 
+    #[expect(clippy::cast_sign_loss)]
+    #[test]
+    fn we_can_convert_scalar_value_to_literal_value_for_decimals() {
+        // Decimal128
+        let value = ScalarValue::Decimal128(Some(123), 38, 0);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::Decimal75(Precision::new(38).unwrap(), 0, I256::from(123i128))
+        );
+
+        // Test edge cases for Decimal128
+        let value = ScalarValue::Decimal128(Some(i128::MIN), 38, 10);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::Decimal75(Precision::new(38).unwrap(), 10, I256::from(i128::MIN))
+        );
+
+        let value = ScalarValue::Decimal128(Some(i128::MAX), 28, -5);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::Decimal75(Precision::new(28).unwrap(), -5, I256::from(i128::MAX))
+        );
+
+        let value = ScalarValue::Decimal128(Some(0), 38, 0);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::Decimal75(Precision::new(38).unwrap(), 0, I256::from(0i128))
+        );
+
+        // Decimal256
+        let value = ScalarValue::Decimal256(Some(ArrowI256::from_i128(-456)), 75, 120);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::Decimal75(Precision::new(75).unwrap(), 120, I256::from(-456i128))
+        );
+
+        // Test edge cases for Decimal256
+        let value = ScalarValue::Decimal256(Some(ArrowI256::MIN), 75, 127);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::Decimal75(
+                Precision::new(75).unwrap(),
+                127,
+                I256::new([0, 0, 0, i64::MIN as u64])
+            )
+        );
+        let value = ScalarValue::Decimal256(Some(ArrowI256::MAX), 75, -128);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::Decimal75(
+                Precision::new(75).unwrap(),
+                -128,
+                I256::new([u64::MAX, u64::MAX, u64::MAX, i64::MAX as u64])
+            )
+        );
+        let value = ScalarValue::Decimal256(Some(ArrowI256::ZERO), 75, 0);
+        assert_eq!(
+            scalar_value_to_literal_value(value).unwrap(),
+            LiteralValue::Decimal75(Precision::new(75).unwrap(), 0, I256::from(0i128))
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_scalar_value_to_literal_value_if_unsupported() {
         // Unsupported
         let value = ScalarValue::Float32(Some(1.0));
         assert!(matches!(

--- a/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
@@ -1,6 +1,5 @@
-use crate::base::{math::i256::I256 as PoSqlI256, scalar::Scalar};
+use crate::base::{math, scalar::Scalar};
 use arrow::datatypes::i256;
-use core::ops::Neg;
 
 const MIN_SUPPORTED_I256: i256 = i256::from_parts(
     326_411_208_032_252_286_695_448_638_536_326_387_210,
@@ -54,26 +53,15 @@ pub fn convert_i256_to_scalar<S: Scalar>(value: &i256) -> Option<S> {
 }
 
 #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-impl From<i256> for PoSqlI256 {
+impl From<i256> for math::i256::I256 {
     fn from(value: i256) -> Self {
-        if value == i256::MIN {
-            PoSqlI256::new([0, 0, 0, i64::MIN as u64])
-        } else {
-            // Prepare the absolute value for conversion
-            let abs_value = if value.is_negative() { -value } else { value };
-            let (low, high) = abs_value.to_parts();
-            let abs_posql = PoSqlI256::new([
-                low as u64,
-                (low >> 64) as u64,
-                high as u64,
-                (high >> 64) as u64,
-            ]);
-            if value.is_negative() {
-                abs_posql.neg()
-            } else {
-                abs_posql
-            }
-        }
+        let (low, high) = value.to_parts();
+        Self::new([
+            low as u64,
+            (low >> 64) as u64,
+            high as u64,
+            (high >> 64) as u64,
+        ])
     }
 }
 
@@ -82,7 +70,6 @@ mod tests {
 
     use super::*;
     use crate::base::scalar::{test_scalar::TestScalar, Scalar};
-    use arrow::datatypes::i256;
     use num_traits::Zero;
     use rand::RngCore;
 
@@ -220,40 +207,49 @@ mod tests {
     #[test]
     fn test_arrow_i256_to_posql_i256_conversion() {
         // Test zero
-        assert_eq!(PoSqlI256::from(i256::ZERO), PoSqlI256::new([0, 0, 0, 0]));
+        assert_eq!(
+            math::i256::I256::from(i256::ZERO),
+            math::i256::I256::new([0, 0, 0, 0])
+        );
 
         // Test positive values
-        assert_eq!(PoSqlI256::from(i256::from(1)), PoSqlI256::new([1, 0, 0, 0]));
-        assert_eq!(PoSqlI256::from(i256::from(2)), PoSqlI256::new([2, 0, 0, 0]));
+        assert_eq!(
+            math::i256::I256::from(i256::from(1)),
+            math::i256::I256::new([1, 0, 0, 0])
+        );
+        assert_eq!(
+            math::i256::I256::from(i256::from(2)),
+            math::i256::I256::new([2, 0, 0, 0])
+        );
 
         // Test negative values
         assert_eq!(
-            PoSqlI256::from(i256::from(-1)),
-            PoSqlI256::new([u64::MAX; 4])
+            math::i256::I256::from(i256::from(-1)),
+            math::i256::I256::new([u64::MAX; 4])
         );
         assert_eq!(
-            PoSqlI256::from(i256::from(-2)),
-            PoSqlI256::new([u64::MAX - 1, u64::MAX, u64::MAX, u64::MAX])
+            math::i256::I256::from(i256::from(-2)),
+            math::i256::I256::new([u64::MAX - 1, u64::MAX, u64::MAX, u64::MAX])
         );
 
         // Test some boundary values
         assert_eq!(
-            PoSqlI256::from(i256::MAX),
-            PoSqlI256::new([u64::MAX, u64::MAX, u64::MAX, i64::MAX as u64])
+            math::i256::I256::from(i256::MAX),
+            math::i256::I256::new([u64::MAX, u64::MAX, u64::MAX, i64::MAX as u64])
         );
         assert_eq!(
-            PoSqlI256::from(i256::MIN),
-            PoSqlI256::new([0, 0, 0, i64::MIN as u64])
+            math::i256::I256::from(i256::MIN),
+            math::i256::I256::new([0, 0, 0, i64::MIN as u64])
         );
 
         // Test other values
         assert_eq!(
-            PoSqlI256::from(i256::from_parts(40, 20)),
-            PoSqlI256::new([40, 0, 20, 0])
+            math::i256::I256::from(i256::from_parts(40, 20)),
+            math::i256::I256::new([40, 0, 20, 0])
         );
         assert_eq!(
-            PoSqlI256::from(i256::from_parts(20, -20)),
-            PoSqlI256::new([20, 0, u64::MAX - 19, u64::MAX])
+            math::i256::I256::from(i256::from_parts(20, -20)),
+            math::i256::I256::new([20, 0, u64::MAX - 19, u64::MAX])
         );
     }
 }

--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -67,18 +67,15 @@ impl From<i32> for I256 {
     }
 }
 
-#[expect(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 impl From<i128> for I256 {
     fn from(value: i128) -> Self {
-        let abs_u128 = value.unsigned_abs();
-        let low = abs_u128 as u64;
-        let high = (abs_u128 >> 64) as u64;
-        let abs = Self([low, high, 0, 0]);
-        if value >= 0 {
-            abs
-        } else {
-            abs.neg()
-        }
+        Self([
+            value as u64,
+            (value >> 64) as u64,
+            (value >> 127) as u64,
+            (value >> 127) as u64,
+        ])
     }
 }
 

--- a/crates/proof-of-sql/src/base/math/i256.rs
+++ b/crates/proof-of-sql/src/base/math/i256.rs
@@ -1,5 +1,6 @@
 use crate::base::scalar::Scalar;
 use ark_ff::BigInteger;
+use core::ops::Neg;
 use serde::{Deserialize, Serialize};
 
 /// A 256-bit data type with some conversions implemented that interpret it as a signed integer.
@@ -7,12 +8,22 @@ use serde::{Deserialize, Serialize};
 /// This should only implement conversions. If anything else is needed, we should strongly consider an alternative design.
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Copy)]
 pub struct I256([u64; 4]);
-impl I256 {
+
+impl Neg for I256 {
+    type Output = Self;
     /// Computes the wrapping negative of the value. This could perhaps be more efficient.
-    fn neg(self) -> Self {
+    fn neg(self) -> Self::Output {
         let mut res = ark_ff::BigInt([0; 4]);
         res.sub_with_borrow(&ark_ff::BigInt(self.0));
         Self(res.0)
+    }
+}
+
+impl I256 {
+    /// Make an `I256` from its limbs.
+    #[must_use]
+    pub fn new(limbs: [u64; 4]) -> Self {
+        Self(limbs)
     }
     #[must_use]
     /// Conversion into a [Scalar] type. The conversion handles negative values. In other words, `-1` maps to `-S::ONE`.
@@ -56,9 +67,24 @@ impl From<i32> for I256 {
     }
 }
 
+#[expect(clippy::cast_possible_truncation)]
+impl From<i128> for I256 {
+    fn from(value: i128) -> Self {
+        let abs_u128 = value.unsigned_abs();
+        let low = abs_u128 as u64;
+        let high = (abs_u128 >> 64) as u64;
+        let abs = Self([low, high, 0, 0]);
+        if value >= 0 {
+            abs
+        } else {
+            abs.neg()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::I256;
+    use super::*;
     use crate::base::scalar::{test_scalar::TestScalar, MontScalar, Scalar};
     use ark_ff::MontFp;
     use num_bigint::BigInt;
@@ -263,6 +289,67 @@ mod tests {
             assert_eq!(neg_int256_from_i32, int256_from_i32.neg());
             assert_eq!(int256_from_i32.into_scalar::<TestScalar>(), scalar);
             assert_eq!(neg_int256_from_i32.into_scalar::<TestScalar>(), neg_scalar);
+        }
+    }
+
+    #[expect(clippy::cast_sign_loss)]
+    #[test]
+    fn test_i128_to_i256_conversion() {
+        // Test zero
+        assert_eq!(I256::from(0i128), ZERO);
+
+        // Test positive values
+        assert_eq!(I256::from(1i128), ONE);
+        assert_eq!(I256::from(2i128), TWO);
+
+        // Test negative values
+        assert_eq!(I256::from(-1i128), NEG_ONE);
+        assert_eq!(I256::from(-2i128), NEG_TWO);
+
+        // Test boundary values
+        assert_eq!(
+            I256::from(i128::MIN),
+            I256([0, 0x8000_0000_0000_0000, 0, 0]).neg()
+        );
+        assert_eq!(
+            I256::from(i128::MAX),
+            I256([0xFFFF_FFFF_FFFF_FFFF, 0x7FFF_FFFF_FFFF_FFFF, 0, 0])
+        );
+
+        // Test some random values
+        let test_values = [
+            42i128,
+            -42i128,
+            1_234_567_890i128,
+            -1_234_567_890i128,
+            i128::from(i64::MAX),
+            i128::from(i64::MIN),
+        ];
+
+        for &value in &test_values {
+            let converted = I256::from(value);
+            if value >= 0 {
+                assert_eq!(
+                    converted.0[0],
+                    (value as u128 & 0xFFFF_FFFF_FFFF_FFFF) as u64
+                );
+                assert_eq!(
+                    converted.0[1],
+                    ((value as u128 >> 64) & 0xFFFF_FFFF_FFFF_FFFF) as u64
+                );
+                assert_eq!(converted.0[2], 0);
+                assert_eq!(converted.0[3], 0);
+            } else {
+                let abs_value = value.unsigned_abs();
+                let expected = I256([
+                    (abs_value & 0xFFFF_FFFF_FFFF_FFFF) as u64,
+                    ((abs_value >> 64) & 0xFFFF_FFFF_FFFF_FFFF) as u64,
+                    0,
+                    0,
+                ])
+                .neg();
+                assert_eq!(converted, expected);
+            }
         }
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
We need to fully support decimal literals in the planner hence the PR.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- Add `From<i128>` and `From<arrow::datatypes::i256>` implementation for `I256` with unit tests
- Add `Decimal128` and `Decimal256` conversion in `scalar_value_to_literal_value`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.