### PR TITLE
feat: enforce conventional commit guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,8 @@ Please be sure to look over the pull request guidelines here: https://github.com
 # Please go through the following checklist
 - [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
 - [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
+- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
+- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.
 
 # Rationale for this change
 

--- a/COMMIT_GUIDELINES.md
+++ b/COMMIT_GUIDELINES.md
@@ -1,0 +1,106 @@
+We follow conventional commits as defined [here](https://www.conventionalcommits.org/en/v1.0.0/#summary). We (and most major projects) will not merge your PR unless your commit history aligns to these guidelines.
+
+This document explains how to clean up your commit history, squash commits into a single commit if needed, and ensure you adhere to our conventional commit style. We use the following standard prefixes:
+
+- feat
+- fix
+- test
+- docs
+- refactor
+- perf
+
+## Example of a Messy Commit History
+
+Consider a history like this:
+```
+9ec71a4 partial fix for issue #22 
+4a8d2b6 correct typo in logging 
+a19b75c Merge branch 'main' into feature-branch 
+3b22d10 update docs again
+```
+
+We want to transform these into a single clean commit or a small number of commits with proper messages. At the end, we want only this:
+
+```
+9ec71a4 fix: partial fix for issue #22 
+```
+
+## Step-by-Step: Squashing and Cleaning Up Commits
+
+1. **Update your local branch**  
+
+```
+git checkout feature-branch 
+git fetch origin 
+git rebase origin/main
+```
+
+2. **Start interactive rebase**  
+Identify how many commits need adjusting (in this example, 4). Then run:  
+
+```
+git rebase -i HEAD~4
+```
+
+A text editor opens with a list of commits.
+
+3. **Choose your actions**  
+In the editor, specify one commit as `pick` (the first commit you want to keep) and mark the others as `squash` or `fixup`:
+
+```
+pick 9ec71a4 partial fix for issue #22 
+squash 4a8d2b6 correct typo in logging 
+squash a19b75c Merge branch 'main' into feature-branch 
+squash 3b22d10 update docs again
+```
+
+- `pick`: Keep the commit as is.
+- `squash`: Combine this commit with the previous commit and let you edit the commit message.
+- `fixup`: Combine this commit with the previous commit but use the previous commit’s message.
+
+4. **Reword the commit**  
+After saving the rebase file, a new editor window will appear if you used `squash`. Enter a new commit message that follows our style:
+
+```
+feat: add documentation and fix logging
+```
+
+(Detailed description about what was changed and why.)
+
+
+5. **Resolve Conflicts if Needed**  
+If there are merge conflicts, edit the files to fix them, then do:
+
+```
+git add <file1> <file2> ... git rebase --continue
+```
+
+6. **Force push your changes**  
+After the rebase completes:
+
+```
+git push -f origin feature-branch
+```
+
+**Note**: This overwrites the remote history for your branch, so be cautious when others are working on the same branch.
+
+## Final Commit Message Examples
+
+Here are some acceptable final commit messages:
+
+- `feat: implement new user login`
+- `fix: resolve null pointer exception`
+- `test: add tests for new user login`
+- `docs: update README with usage instructions`
+- `refactor: simplify database query logic`
+- `perf: improve caching mechanism for faster responses`
+
+Always keep your commit message clear and concise. You should add an exclamation mark `!` after the type if it’s a breaking change, for example:
+
+```
+feat!: remove deprecated authentication method
+```
+
+By following these steps, you’ll ensure that your commit history is clean, meaningful, and easy to review.
+
+This is a highly simplified guide to clean commits. The full docs for this can be found in our contributing guidelines [here](https://github.com/angular/angular/blob/main/CONTRIBUTING.md).

--- a/scripts/check_commits.sh
+++ b/scripts/check_commits.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+CONVENTIONAL_REGEX="^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\(.+\))?: .+$"
+COMMITS=$(git log origin/main..HEAD --pretty=format:"%s")
+
+count=0
+failed=0
+
+while IFS= read -r COMMIT_MSG; do
+  count=$((count + 1))
+  echo "[$count] Checking commit message: $COMMIT_MSG"
+  if [[ ! $COMMIT_MSG =~ $CONVENTIONAL_REGEX ]]; then
+    echo "    -> Does NOT match conventional commit format"
+    failed=$((failed + 1))
+  else
+    echo "    -> Matches conventional commit format"
+  fi
+  echo
+done <<< "$COMMITS"
+
+echo "Summary of the conventional commit check:"
+echo "  Total commits: $count"
+echo "  Failed commits: $failed"
+
+if [ "$failed" -gt 0 ]; then
+  echo "Some commits failed the check. Make sure your commit messages match the conventional commit format. 
+  Check https://www.conventionalcommits.org/en/v1.0.0/#summary for more details."
+else
+  echo "All commits match the conventional commit format!"
+fi


### PR DESCRIPTION
# Rationale for this change

Most of our contributors do not read or follow the conventional commit guidelines outlined [here](https://www.conventionalcommits.org/en/v1.0.0/#summary). This causes slowdowns and frictions in the review process when asking the contributors to reword or squash their commits to ensure they are clean enough to meet our standards.

This PR adds a required checkbox to the PR template that provides a simple and concise example of what the resulting commit history should look like before the PR is ready to merge.

# What changes are included in this PR?

- [x] introduce a new required checkbox item in the PR template that ensures the contributor has followed the conventional commit guidelines.
- [x] introduces a more detailed COMMIT_GUIDELINES.md document at the head of the repo that provides the needed steps and details to ensure commits are clean and compliant with our standards.
- [x] enforces clean commits by way of another script which applies a regex to the local commit history

# Are these changes tested?
- [x] verified script detects dirty commits, and succeeds on commits adhering to conventional commit guidelines