### PR TITLE
refactor!: remove unused error variants

### DIFF
--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -30,10 +30,7 @@ use arrow::{
     error::ArrowError,
     record_batch::RecordBatch,
 };
-use proof_of_sql_parser::{
-    posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError},
-    ParseError,
-};
+use proof_of_sql_parser::posql_time::{PoSQLTimeUnit, PoSQLTimeZone, PoSQLTimestampError};
 use snafu::Snafu;
 use sqlparser::ast::Ident;
 
@@ -52,12 +49,6 @@ pub enum OwnedArrowConversionError {
     /// This error occurs when trying to convert from a record batch with duplicate idents(e.g. `"a"` and `"A"`).
     #[snafu(display("conversion resulted in duplicate idents"))]
     DuplicateIdents,
-    /// This error occurs when converting from a record batch name to an idents fails. (Which may be impossible.)
-    #[snafu(transparent)]
-    FieldParseFail {
-        /// The underlying source error
-        source: ParseError,
-    },
     /// This error occurs when creating an owned table fails, which should only occur when there are zero columns.
     #[snafu(transparent)]
     InvalidTable {

--- a/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_errors.rs
@@ -1,6 +1,5 @@
 use super::arrow_array_to_column_conversion::ArrowArrayToColumnConversionError;
 use crate::base::commitment::ColumnCommitmentsMismatch;
-use proof_of_sql_parser::ParseError;
 use snafu::Snafu;
 
 /// Errors that can occur when trying to create or extend a [`TableCommitment`] from a record batch.
@@ -11,12 +10,6 @@ pub enum RecordBatchToColumnsError {
     ArrowArrayToColumnConversionError {
         /// The underlying source error
         source: ArrowArrayToColumnConversionError,
-    },
-    #[snafu(transparent)]
-    /// This error occurs when converting from a record batch name to an identifier fails. (Which may be impossible.)
-    FieldParseFail {
-        /// The underlying source error
-        source: ParseError,
     },
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
This is a part of the process of removal of the parser crate. There are useless error variants referring to `proof_of_sql_parser` and they need to be removed.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.