### PR TITLE
refactor!: add `AnalyzeError` and make `sql/proof_exprs` no longer dependent on `sql/parse`

### DIFF
--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -3,18 +3,18 @@ use datafusion::{
     common::DataFusionError,
     logical_expr::{Expr, LogicalPlan, Operator},
 };
-use proof_of_sql::{base::math::decimal::DecimalError, sql::parse::ConversionError};
+use proof_of_sql::{base::math::decimal::DecimalError, sql::AnalyzeError};
 use snafu::Snafu;
 use sqlparser::parser::ParserError;
 
 /// Proof of SQL Planner error
 #[derive(Debug, Snafu)]
 pub enum PlannerError {
-    /// Returned when a conversion fails
+    /// Returned when the internal analyze process fails
     #[snafu(transparent)]
-    ConversionError {
-        /// Underlying conversion error
-        source: ConversionError,
+    AnalyzeError {
+        /// Underlying analyze error
+        source: AnalyzeError,
     },
     /// Returned when a decimal error occurs
     #[snafu(transparent)]

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -1,0 +1,63 @@
+use crate::base::{
+    database::ColumnType,
+    math::decimal::{DecimalError, IntermediateDecimalError},
+};
+use alloc::string::{String, ToString};
+use core::result::Result;
+use snafu::Snafu;
+
+/// Errors related to queries that can not be run due to invalid column references, data types, etc.
+/// Will be replaced once we fully switch to the planner.
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum AnalyzeError {
+    #[snafu(display("Expected '{expected}' but found '{actual}'"))]
+    /// Invalid data type received
+    InvalidDataType {
+        /// Expected data type
+        expected: ColumnType,
+        /// Actual data type found
+        actual: ColumnType,
+    },
+
+    #[snafu(display("Left side has '{left_type}' type but right side has '{right_type}' type"))]
+    /// Data types do not match
+    DataTypeMismatch {
+        /// The left side datatype
+        left_type: String,
+        /// The right side datatype
+        right_type: String,
+    },
+
+    #[snafu(display("Columns have different lengths: {len_a} != {len_b}"))]
+    /// Two columns do not have the same length
+    DifferentColumnLength {
+        /// The length of the first column
+        len_a: usize,
+        /// The length of the second column
+        len_b: usize,
+    },
+
+    #[snafu(transparent)]
+    /// Errors related to decimal operations
+    DecimalConversionError {
+        /// The underlying source error
+        source: DecimalError,
+    },
+}
+
+impl From<AnalyzeError> for String {
+    fn from(error: AnalyzeError) -> Self {
+        error.to_string()
+    }
+}
+
+impl From<IntermediateDecimalError> for AnalyzeError {
+    fn from(err: IntermediateDecimalError) -> AnalyzeError {
+        AnalyzeError::DecimalConversionError {
+            source: DecimalError::IntermediateDecimalConversionError { source: err },
+        }
+    }
+}
+
+/// Result type for analyze errors
+pub type AnalyzeResult<T> = Result<T, AnalyzeError>;

--- a/crates/proof-of-sql/src/sql/mod.rs
+++ b/crates/proof-of-sql/src/sql/mod.rs
@@ -11,3 +11,4 @@ pub mod proof;
 pub mod proof_exprs;
 pub mod proof_gadgets;
 pub mod proof_plans;
+pub(crate) mod util;

--- a/crates/proof-of-sql/src/sql/mod.rs
+++ b/crates/proof-of-sql/src/sql/mod.rs
@@ -1,8 +1,11 @@
 //! This module contains the main logic for Proof of SQL.
 
+mod error;
 /// This module holds the [`EVMProofPlan`] struct and its implementation, which allows for EVM compatible serialization.
 pub mod evm_proof_plan;
 pub mod parse;
+/// This temporarily exists until we switch to using Datafusion Analyzer to handle type checking.
+pub use error::{AnalyzeError, AnalyzeResult};
 pub mod postprocessing;
 pub mod proof;
 pub mod proof_exprs;

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -141,7 +141,7 @@ impl DynProofExprBuilder<'_> {
     ) -> Result<DynProofExpr, ConversionError> {
         let expr = self.visit_expr(expr);
         match op {
-            UnaryOperator::Not => DynProofExpr::try_new_not(expr?),
+            UnaryOperator::Not => Ok(DynProofExpr::try_new_not(expr?)?),
             // Handle unsupported operators
             _ => Err(ConversionError::UnsupportedOperation {
                 message: format!("{op:?}"),
@@ -159,42 +159,42 @@ impl DynProofExprBuilder<'_> {
             BinaryOperator::And => {
                 let left = self.visit_expr(left);
                 let right = self.visit_expr(right);
-                DynProofExpr::try_new_and(left?, right?)
+                Ok(DynProofExpr::try_new_and(left?, right?)?)
             }
             BinaryOperator::Or => {
                 let left = self.visit_expr(left);
                 let right = self.visit_expr(right);
-                DynProofExpr::try_new_or(left?, right?)
+                Ok(DynProofExpr::try_new_or(left?, right?)?)
             }
             BinaryOperator::Eq => {
                 let left = self.visit_expr(left);
                 let right = self.visit_expr(right);
-                DynProofExpr::try_new_equals(left?, right?)
+                Ok(DynProofExpr::try_new_equals(left?, right?)?)
             }
             BinaryOperator::Gt => {
                 let left = self.visit_expr(left);
                 let right = self.visit_expr(right);
-                DynProofExpr::try_new_inequality(left?, right?, false)
+                Ok(DynProofExpr::try_new_inequality(left?, right?, false)?)
             }
             BinaryOperator::Lt => {
                 let left = self.visit_expr(left);
                 let right = self.visit_expr(right);
-                DynProofExpr::try_new_inequality(left?, right?, true)
+                Ok(DynProofExpr::try_new_inequality(left?, right?, true)?)
             }
             BinaryOperator::Plus => {
                 let left = self.visit_expr(left);
                 let right = self.visit_expr(right);
-                DynProofExpr::try_new_add(left?, right?)
+                Ok(DynProofExpr::try_new_add(left?, right?)?)
             }
             BinaryOperator::Minus => {
                 let left = self.visit_expr(left);
                 let right = self.visit_expr(right);
-                DynProofExpr::try_new_subtract(left?, right?)
+                Ok(DynProofExpr::try_new_subtract(left?, right?)?)
             }
             BinaryOperator::Multiply => {
                 let left = self.visit_expr(left);
                 let right = self.visit_expr(right);
-                DynProofExpr::try_new_multiply(left?, right?)
+                Ok(DynProofExpr::try_new_multiply(left?, right?)?)
             }
             BinaryOperator::Divide => Err(ConversionError::Unprovable {
                 error: format!("Binary operator {op:?} is not supported at this location"),

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -1,6 +1,9 @@
-use crate::base::{
-    database::{ColumnOperationError, ColumnType, TableRef},
-    math::decimal::{DecimalError, IntermediateDecimalError},
+use crate::{
+    base::{
+        database::{ColumnOperationError, ColumnType, TableRef},
+        math::decimal::{DecimalError, IntermediateDecimalError},
+    },
+    sql::AnalyzeError,
 };
 use alloc::{
     boxed::Box,
@@ -159,6 +162,12 @@ pub enum ConversionError {
     IdentifierConversionError {
         /// The underlying error message
         error: String,
+    },
+    /// Errors in the native analyze process
+    #[snafu(transparent)]
+    AnalyzeError {
+        /// The underlying source error
+        source: AnalyzeError,
     },
 }
 

--- a/crates/proof-of-sql/src/sql/parse/mod.rs
+++ b/crates/proof-of-sql/src/sql/parse/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod query_context;
 pub(crate) use query_context::QueryContext;
 
 mod query_context_builder;
-pub(crate) use query_context_builder::{type_check_binary_operation, QueryContextBuilder};
+pub(crate) use query_context_builder::QueryContextBuilder;
 
 mod dyn_proof_expr_builder;
 pub(crate) use dyn_proof_expr_builder::DynProofExprBuilder;

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -1,14 +1,14 @@
 use super::{ConversionError, ConversionResult, QueryContext};
-use crate::base::{
-    database::{
-        try_add_subtract_column_types, try_multiply_column_types, ColumnRef, ColumnType,
-        SchemaAccessor, TableRef,
+use crate::{
+    base::{
+        database::{ColumnRef, ColumnType, SchemaAccessor, TableRef},
+        map::IndexSet,
+        math::{
+            decimal::{DecimalError, Precision},
+            BigDecimalExt,
+        },
     },
-    map::IndexSet,
-    math::{
-        decimal::{DecimalError, Precision},
-        BigDecimalExt,
-    },
+    sql::util::check_dtypes,
 };
 use alloc::{boxed::Box, format, string::ToString, vec::Vec};
 use proof_of_sql_parser::{
@@ -322,88 +322,5 @@ impl QueryContextBuilder<'_> {
         self.context.push_column_ref(column_name.clone(), column);
 
         Ok(column_type)
-    }
-}
-
-/// Checks if the binary operation between the left and right data types is valid.
-///
-/// # Arguments
-///
-/// * `left_dtype` - The data type of the left operand.
-/// * `right_dtype` - The data type of the right operand.
-/// * `binary_operator` - The binary operator to be applied.
-///
-/// # Returns
-///
-/// * `true` if the operation is valid, `false` otherwise.
-pub(crate) fn type_check_binary_operation(
-    left_dtype: ColumnType,
-    right_dtype: ColumnType,
-    binary_operator: &BinaryOperator,
-) -> bool {
-    match binary_operator {
-        BinaryOperator::And | BinaryOperator::Or => {
-            matches!(
-                (left_dtype, right_dtype),
-                (ColumnType::Boolean, ColumnType::Boolean)
-            )
-        }
-        BinaryOperator::Eq => {
-            matches!(
-                (left_dtype, right_dtype),
-                (ColumnType::VarChar, ColumnType::VarChar)
-                    | (ColumnType::VarBinary, ColumnType::VarBinary)
-                    | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
-                    | (ColumnType::Boolean, ColumnType::Boolean)
-                    | (_, ColumnType::Scalar)
-                    | (ColumnType::Scalar, _)
-            ) || (left_dtype.is_numeric() && right_dtype.is_numeric())
-        }
-        BinaryOperator::Gt | BinaryOperator::Lt => {
-            if left_dtype == ColumnType::VarChar || right_dtype == ColumnType::VarChar {
-                return false;
-            }
-            // Due to constraints in bitwise_verification we limit the precision of decimal types to 38
-            if let ColumnType::Decimal75(precision, _) = left_dtype {
-                if precision.value() > 38 {
-                    return false;
-                }
-            }
-            if let ColumnType::Decimal75(precision, _) = right_dtype {
-                if precision.value() > 38 {
-                    return false;
-                }
-            }
-            left_dtype.is_numeric() && right_dtype.is_numeric()
-                || matches!(
-                    (left_dtype, right_dtype),
-                    (ColumnType::Boolean, ColumnType::Boolean)
-                        | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
-                )
-        }
-        BinaryOperator::Plus | BinaryOperator::Minus => {
-            try_add_subtract_column_types(left_dtype, right_dtype).is_ok()
-        }
-        BinaryOperator::Multiply => try_multiply_column_types(left_dtype, right_dtype).is_ok(),
-        BinaryOperator::Divide => left_dtype.is_numeric() && right_dtype.is_numeric(),
-        _ => {
-            // Handle unsupported binary operations
-            false
-        }
-    }
-}
-
-fn check_dtypes(
-    left_dtype: ColumnType,
-    right_dtype: ColumnType,
-    binary_operator: &BinaryOperator,
-) -> ConversionResult<()> {
-    if type_check_binary_operation(left_dtype, right_dtype, binary_operator) {
-        Ok(())
-    } else {
-        Err(ConversionError::DataTypeMismatch {
-            left_type: left_dtype.to_string(),
-            right_type: right_dtype.to_string(),
-        })
     }
 }

--- a/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_expr_tests.rs
@@ -9,6 +9,7 @@ use crate::{
         postprocessing::{test_utility::*, PostprocessingError},
         proof_exprs::test_utility::*,
         proof_plans::{test_utility::*, DynProofPlan},
+        AnalyzeError,
     },
 };
 use itertools::Itertools;
@@ -1655,13 +1656,12 @@ fn varchar_column_is_not_compatible_with_integer_column() {
         let result =
             QueryExpr::try_new(intermediate_ast, t.schema_id().cloned().unwrap(), &accessor);
 
-        assert_eq!(
+        assert!(matches!(
             result,
-            Err(ConversionError::DataTypeMismatch {
-                left_type: ColumnType::BigInt.to_string(),
-                right_type: ColumnType::VarChar.to_string(),
+            Err(ConversionError::AnalyzeError {
+                source: AnalyzeError::DataTypeMismatch { .. }
             })
-        );
+        ));
     }
 
     for query_text in &varchar_to_bigint_queries {
@@ -1669,13 +1669,12 @@ fn varchar_column_is_not_compatible_with_integer_column() {
         let result =
             QueryExpr::try_new(intermediate_ast, t.schema_id().cloned().unwrap(), &accessor);
 
-        assert_eq!(
+        assert!(matches!(
             result,
-            Err(ConversionError::DataTypeMismatch {
-                left_type: ColumnType::VarChar.to_string(),
-                right_type: ColumnType::BigInt.to_string(),
+            Err(ConversionError::AnalyzeError {
+                source: AnalyzeError::DataTypeMismatch { .. }
             })
-        );
+        ));
     }
 }
 
@@ -1694,13 +1693,12 @@ fn arithmetic_operations_are_not_allowed_with_varchar_column() {
     let intermediate_ast = SelectStatementParser::new().parse(query_text).unwrap();
     let result = QueryExpr::try_new(intermediate_ast, t.schema_id().cloned().unwrap(), &accessor);
 
-    assert_eq!(
+    assert!(matches!(
         result,
-        Err(ConversionError::DataTypeMismatch {
-            left_type: ColumnType::VarChar.to_string(),
-            right_type: ColumnType::VarChar.to_string(),
+        Err(ConversionError::AnalyzeError {
+            source: AnalyzeError::DataTypeMismatch { .. }
         })
-    );
+    ));
 }
 
 #[test]

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder_tests.rs
@@ -7,6 +7,7 @@ use crate::{
     sql::{
         parse::{ConversionError, QueryExpr, WhereExprBuilder},
         proof_exprs::{ColumnExpr, DynProofExpr, LiteralExpr},
+        AnalyzeError,
     },
 };
 use bigdecimal::BigDecimal;
@@ -336,7 +337,9 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_eq_decimal() {
             t.schema_id().cloned().unwrap(),
             &accessor,
         ),
-        Err(ConversionError::DataTypeMismatch { .. })
+        Err(ConversionError::AnalyzeError {
+            source: AnalyzeError::DataTypeMismatch { .. }
+        })
     ));
 }
 
@@ -355,7 +358,9 @@ fn we_expect_an_error_while_trying_to_check_varchar_column_ge_decimal() {
             t.schema_id().cloned().unwrap(),
             &accessor,
         ),
-        Err(ConversionError::DataTypeMismatch { .. })
+        Err(ConversionError::AnalyzeError {
+            source: AnalyzeError::DataTypeMismatch { .. }
+        })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -9,10 +9,10 @@ use crate::{
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        parse::ConversionError,
         proof::{exercise_verification, QueryError, VerifiableQueryResult},
         proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
         proof_plans::{test_utility::*, DynProofPlan},
+        AnalyzeError,
     },
 };
 use bumpalo::Bump;
@@ -113,7 +113,7 @@ fn decimal_column_type_issues_error_out_when_producing_provable_ast() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     assert!(matches!(
         DynProofExpr::try_new_add(column(&t, "a", &accessor), const_bigint(1)),
-        Err(ConversionError::DataTypeMismatch { .. })
+        Err(AnalyzeError::DataTypeMismatch { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -5,7 +5,7 @@ use crate::{
         scalar::{Scalar, ScalarExt},
         slice_ops,
     },
-    sql::parse::{type_check_binary_operation, ConversionError, ConversionResult},
+    sql::{util::type_check_binary_operation, AnalyzeError, AnalyzeResult},
 };
 use alloc::string::ToString;
 use bumpalo::Bump;
@@ -25,7 +25,7 @@ pub fn scale_and_subtract_literal<S: Scalar>(
     lhs_scale: i8,
     rhs_scale: i8,
     is_equal: bool,
-) -> ConversionResult<S> {
+) -> AnalyzeResult<S> {
     let lhs_type = lhs.column_type();
     let rhs_type = rhs.column_type();
     let operator = if is_equal {
@@ -34,7 +34,7 @@ pub fn scale_and_subtract_literal<S: Scalar>(
         BinaryOperator::Lt
     };
     if !type_check_binary_operation(lhs_type, rhs_type, &operator) {
-        return Err(ConversionError::DataTypeMismatch {
+        return Err(AnalyzeError::DataTypeMismatch {
             left_type: lhs_type.to_string(),
             right_type: rhs_type.to_string(),
         });
@@ -56,7 +56,7 @@ pub fn scale_and_subtract_literal<S: Scalar>(
         );
         // Check if the precision is valid
         let _max_precision = Precision::new(max_precision_value).map_err(|_| {
-            ConversionError::DecimalConversionError {
+            AnalyzeError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision {
                     error: max_precision_value.to_string(),
                 },
@@ -90,11 +90,11 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
     lhs_scale: i8,
     rhs_scale: i8,
     is_equal: bool,
-) -> ConversionResult<&'a [S]> {
+) -> AnalyzeResult<&'a [S]> {
     let lhs_len = lhs.len();
     let rhs_len = rhs.len();
     if lhs_len != rhs_len {
-        return Err(ConversionError::DifferentColumnLength {
+        return Err(AnalyzeError::DifferentColumnLength {
             len_a: lhs_len,
             len_b: rhs_len,
         });
@@ -107,7 +107,7 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
         BinaryOperator::Lt
     };
     if !type_check_binary_operation(lhs_type, rhs_type, &operator) {
-        return Err(ConversionError::DataTypeMismatch {
+        return Err(AnalyzeError::DataTypeMismatch {
             left_type: lhs_type.to_string(),
             right_type: rhs_type.to_string(),
         });
@@ -129,7 +129,7 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
         );
         // Check if the precision is valid
         let _max_precision = Precision::new(max_precision_value).map_err(|_| {
-            ConversionError::DecimalConversionError {
+            AnalyzeError::DecimalConversionError {
                 source: DecimalError::InvalidPrecision {
                     error: max_precision_value.to_string(),
                 },
@@ -155,7 +155,7 @@ pub(crate) fn scale_and_subtract_columnar_value<'a, S: Scalar>(
     lhs_scale: i8,
     rhs_scale: i8,
     is_equal: bool,
-) -> ConversionResult<ColumnarValue<'a, S>> {
+) -> AnalyzeResult<ColumnarValue<'a, S>> {
     match (lhs, rhs) {
         (ColumnarValue::Column(lhs), ColumnarValue::Column(rhs)) => {
             Ok(ColumnarValue::Column(Column::Scalar(scale_and_subtract(

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -10,8 +10,9 @@ use crate::{
         scalar::Scalar,
     },
     sql::{
-        parse::{type_check_binary_operation, ConversionError, ConversionResult},
         proof::{FinalRoundBuilder, VerificationBuilder},
+        util::type_check_binary_operation,
+        AnalyzeError, AnalyzeResult,
     },
 };
 use alloc::{boxed::Box, string::ToString};
@@ -53,19 +54,19 @@ impl DynProofExpr {
         Self::Column(ColumnExpr::new(column_ref))
     }
     /// Create logical AND expression
-    pub fn try_new_and(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
+    pub fn try_new_and(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         lhs.check_data_type(ColumnType::Boolean)?;
         rhs.check_data_type(ColumnType::Boolean)?;
         Ok(Self::And(AndExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical OR expression
-    pub fn try_new_or(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
+    pub fn try_new_or(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         lhs.check_data_type(ColumnType::Boolean)?;
         rhs.check_data_type(ColumnType::Boolean)?;
         Ok(Self::Or(OrExpr::new(Box::new(lhs), Box::new(rhs))))
     }
     /// Create logical NOT expression
-    pub fn try_new_not(expr: DynProofExpr) -> ConversionResult<Self> {
+    pub fn try_new_not(expr: DynProofExpr) -> AnalyzeResult<Self> {
         expr.check_data_type(ColumnType::Boolean)?;
         Ok(Self::Not(NotExpr::new(Box::new(expr))))
     }
@@ -75,13 +76,13 @@ impl DynProofExpr {
         Self::Literal(LiteralExpr::new(value))
     }
     /// Create a new equals expression
-    pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
+    pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Eq) {
             Ok(Self::Equals(EqualsExpr::new(Box::new(lhs), Box::new(rhs))))
         } else {
-            Err(ConversionError::DataTypeMismatch {
+            Err(AnalyzeError::DataTypeMismatch {
                 left_type: lhs_datatype.to_string(),
                 right_type: rhs_datatype.to_string(),
             })
@@ -92,7 +93,7 @@ impl DynProofExpr {
         lhs: DynProofExpr,
         rhs: DynProofExpr,
         is_lt: bool,
-    ) -> ConversionResult<Self> {
+    ) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Lt) {
@@ -102,7 +103,7 @@ impl DynProofExpr {
                 is_lt,
             )))
         } else {
-            Err(ConversionError::DataTypeMismatch {
+            Err(AnalyzeError::DataTypeMismatch {
                 left_type: lhs_datatype.to_string(),
                 right_type: rhs_datatype.to_string(),
             })
@@ -110,7 +111,7 @@ impl DynProofExpr {
     }
 
     /// Create a new add expression
-    pub fn try_new_add(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
+    pub fn try_new_add(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Plus) {
@@ -120,7 +121,7 @@ impl DynProofExpr {
                 false,
             )))
         } else {
-            Err(ConversionError::DataTypeMismatch {
+            Err(AnalyzeError::DataTypeMismatch {
                 left_type: lhs_datatype.to_string(),
                 right_type: rhs_datatype.to_string(),
             })
@@ -128,7 +129,7 @@ impl DynProofExpr {
     }
 
     /// Create a new subtract expression
-    pub fn try_new_subtract(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
+    pub fn try_new_subtract(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Minus) {
@@ -138,7 +139,7 @@ impl DynProofExpr {
                 true,
             )))
         } else {
-            Err(ConversionError::DataTypeMismatch {
+            Err(AnalyzeError::DataTypeMismatch {
                 left_type: lhs_datatype.to_string(),
                 right_type: rhs_datatype.to_string(),
             })
@@ -146,7 +147,7 @@ impl DynProofExpr {
     }
 
     /// Create a new multiply expression
-    pub fn try_new_multiply(lhs: DynProofExpr, rhs: DynProofExpr) -> ConversionResult<Self> {
+    pub fn try_new_multiply(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Multiply) {
@@ -155,7 +156,7 @@ impl DynProofExpr {
                 Box::new(rhs),
             )))
         } else {
-            Err(ConversionError::DataTypeMismatch {
+            Err(AnalyzeError::DataTypeMismatch {
                 left_type: lhs_datatype.to_string(),
                 right_type: rhs_datatype.to_string(),
             })
@@ -169,11 +170,11 @@ impl DynProofExpr {
     }
 
     /// Check that the plan has the correct data type
-    fn check_data_type(&self, data_type: ColumnType) -> ConversionResult<()> {
+    fn check_data_type(&self, data_type: ColumnType) -> AnalyzeResult<()> {
         if self.data_type() == data_type {
             Ok(())
         } else {
-            Err(ConversionError::InvalidDataType {
+            Err(AnalyzeError::InvalidDataType {
                 actual: self.data_type(),
                 expected: data_type,
             })

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -10,10 +10,10 @@ use crate::{
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        parse::ConversionError,
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
+        AnalyzeError,
     },
 };
 use bumpalo::Bump;
@@ -313,7 +313,7 @@ fn we_cannot_compare_columns_filtering_on_extreme_decimal_values() {
             const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ONE),
             false
         ),
-        Err(ConversionError::DataTypeMismatch { .. })
+        Err(AnalyzeError::DataTypeMismatch { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -9,10 +9,10 @@ use crate::{
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
     sql::{
-        parse::ConversionError,
         proof::{exercise_verification, QueryError, VerifiableQueryResult},
         proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
         proof_plans::{test_utility::*, DynProofPlan},
+        AnalyzeError,
     },
 };
 use bumpalo::Bump;
@@ -81,7 +81,7 @@ fn decimal_column_type_issues_error_out_when_producing_provable_ast() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     assert!(matches!(
         DynProofExpr::try_new_multiply(column(&t, "a", &accessor), const_bigint(1)),
-        Err(ConversionError::DataTypeMismatch { .. })
+        Err(AnalyzeError::DataTypeMismatch { .. })
     ));
 }
 

--- a/crates/proof-of-sql/src/sql/util.rs
+++ b/crates/proof-of-sql/src/sql/util.rs
@@ -1,0 +1,87 @@
+use crate::base::database::{try_add_subtract_column_types, try_multiply_column_types, ColumnType};
+use crate::sql::parse::{ConversionError, ConversionResult};
+use alloc::string::ToString;
+use sqlparser::ast::BinaryOperator;
+
+/// Checks if the binary operation between the left and right data types is valid.
+///
+/// # Arguments
+///
+/// * `left_dtype` - The data type of the left operand.
+/// * `right_dtype` - The data type of the right operand.
+/// * `binary_operator` - The binary operator to be applied.
+///
+/// # Returns
+///
+/// * `true` if the operation is valid, `false` otherwise.
+pub(crate) fn type_check_binary_operation(
+    left_dtype: ColumnType,
+    right_dtype: ColumnType,
+    binary_operator: &BinaryOperator,
+) -> bool {
+    match binary_operator {
+        BinaryOperator::And | BinaryOperator::Or => {
+            matches!(
+                (left_dtype, right_dtype),
+                (ColumnType::Boolean, ColumnType::Boolean)
+            )
+        }
+        BinaryOperator::Eq => {
+            matches!(
+                (left_dtype, right_dtype),
+                (ColumnType::VarChar, ColumnType::VarChar)
+                    | (ColumnType::VarBinary, ColumnType::VarBinary)
+                    | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
+                    | (ColumnType::Boolean, ColumnType::Boolean)
+                    | (_, ColumnType::Scalar)
+                    | (ColumnType::Scalar, _)
+            ) || (left_dtype.is_numeric() && right_dtype.is_numeric())
+        }
+        BinaryOperator::Gt | BinaryOperator::Lt => {
+            if left_dtype == ColumnType::VarChar || right_dtype == ColumnType::VarChar {
+                return false;
+            }
+            // Due to constraints in bitwise_verification we limit the precision of decimal types to 38
+            if let ColumnType::Decimal75(precision, _) = left_dtype {
+                if precision.value() > 38 {
+                    return false;
+                }
+            }
+            if let ColumnType::Decimal75(precision, _) = right_dtype {
+                if precision.value() > 38 {
+                    return false;
+                }
+            }
+            left_dtype.is_numeric() && right_dtype.is_numeric()
+                || matches!(
+                    (left_dtype, right_dtype),
+                    (ColumnType::Boolean, ColumnType::Boolean)
+                        | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
+                )
+        }
+        BinaryOperator::Plus | BinaryOperator::Minus => {
+            try_add_subtract_column_types(left_dtype, right_dtype).is_ok()
+        }
+        BinaryOperator::Multiply => try_multiply_column_types(left_dtype, right_dtype).is_ok(),
+        BinaryOperator::Divide => left_dtype.is_numeric() && right_dtype.is_numeric(),
+        _ => {
+            // Handle unsupported binary operations
+            false
+        }
+    }
+}
+
+pub(crate) fn check_dtypes(
+    left_dtype: ColumnType,
+    right_dtype: ColumnType,
+    binary_operator: &BinaryOperator,
+) -> ConversionResult<()> {
+    if type_check_binary_operation(left_dtype, right_dtype, binary_operator) {
+        Ok(())
+    } else {
+        Err(ConversionError::DataTypeMismatch {
+            left_type: left_dtype.to_string(),
+            right_type: right_dtype.to_string(),
+        })
+    }
+}

--- a/crates/proof-of-sql/src/sql/util.rs
+++ b/crates/proof-of-sql/src/sql/util.rs
@@ -1,5 +1,5 @@
+use super::{AnalyzeError, AnalyzeResult};
 use crate::base::database::{try_add_subtract_column_types, try_multiply_column_types, ColumnType};
-use crate::sql::parse::{ConversionError, ConversionResult};
 use alloc::string::ToString;
 use sqlparser::ast::BinaryOperator;
 
@@ -75,11 +75,11 @@ pub(crate) fn check_dtypes(
     left_dtype: ColumnType,
     right_dtype: ColumnType,
     binary_operator: &BinaryOperator,
-) -> ConversionResult<()> {
+) -> AnalyzeResult<()> {
     if type_check_binary_operation(left_dtype, right_dtype, binary_operator) {
         Ok(())
     } else {
-        Err(ConversionError::DataTypeMismatch {
+        Err(AnalyzeError::DataTypeMismatch {
             left_type: left_dtype.to_string(),
             right_type: right_dtype.to_string(),
         })

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -21,6 +21,7 @@ use proof_of_sql::{
         parse::{ConversionError, QueryExpr},
         postprocessing::apply_postprocessing_steps,
         proof::{QueryError, VerifiableQueryResult},
+        AnalyzeError,
     },
 };
 
@@ -454,7 +455,9 @@ fn decimal_type_issues_should_cause_provable_ast_to_fail() {
     let query_string = format!("SELECT d0 + {large_decimal} as res FROM table;");
     assert!(matches!(
         QueryExpr::try_new(query_string.parse().unwrap(), "sxt".into(), &accessor,),
-        Err(ConversionError::DataTypeMismatch { .. })
+        Err(ConversionError::AnalyzeError {
+            source: AnalyzeError::DataTypeMismatch { .. }
+        })
     ));
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
In order to drop `sql/parse` it is necessary to make sure `proof-of-sql-planner` and `sql/proof-exprs` are not dependent on it. Hence we split out functionalities we expect to retain after the dropping.  
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `AnalyzeError`
- move type checks out of `sql/parse`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.