### PR TITLE
feat: add `aggregate_function_to_proof_expr`

### DIFF
--- a/crates/proof-of-sql-planner/Cargo.toml
+++ b/crates/proof-of-sql-planner/Cargo.toml
@@ -11,6 +11,7 @@ arrow = { workspace = true }
 datafusion = '38.0.0'
 indexmap = { workspace = true }
 proof-of-sql = { path = "../proof-of-sql", features = ["arrow"] }
+proof-of-sql-parser = { path = "../proof-of-sql-parser" }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
 

--- a/crates/proof-of-sql-planner/src/aggregate.rs
+++ b/crates/proof-of-sql-planner/src/aggregate.rs
@@ -1,0 +1,193 @@
+use super::{PlannerError, PlannerResult};
+use crate::expr_to_proof_expr;
+use datafusion::{
+    common::DFSchema,
+    logical_expr::expr::{AggregateFunction, AggregateFunctionDefinition},
+    physical_plan,
+};
+use proof_of_sql::sql::proof_exprs::DynProofExpr;
+use proof_of_sql_parser::intermediate_ast::AggregationOperator;
+
+/// Convert an [`AggregateFunction`] to a [`DynProofExpr`]
+///
+/// TODO: Some moderate changes are necessary once we upgrade `DataFusion` to 46.0.0
+pub(crate) fn aggregate_function_to_proof_expr(
+    function: &AggregateFunction,
+    schema: &DFSchema,
+) -> PlannerResult<DynProofExpr> {
+    if !matches!(
+        (
+            function.distinct,
+            &function.filter,
+            &function.order_by,
+            function.args.len()
+        ),
+        (false, &None, &None, 1)
+    ) {
+        return Err(PlannerError::UnsupportedAggregateFunction {
+            function: function.clone(),
+        });
+    }
+    let aggregation_operator = match function.func_def {
+        AggregateFunctionDefinition::BuiltIn(
+            physical_plan::aggregates::AggregateFunction::Count,
+        ) => AggregationOperator::Count,
+        AggregateFunctionDefinition::BuiltIn(physical_plan::aggregates::AggregateFunction::Sum) => {
+            AggregationOperator::Sum
+        }
+        _ => {
+            return Err(PlannerError::UnsupportedAggregateFunction {
+                function: function.clone(),
+            });
+        }
+    };
+    Ok(DynProofExpr::new_aggregate(
+        aggregation_operator,
+        expr_to_proof_expr(&function.args[0], schema)?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::df_util::*;
+    use arrow::datatypes::DataType;
+    use proof_of_sql::base::database::{ColumnRef, ColumnType, TableRef};
+
+    // AggregateFunction to DynProofExpr
+    #[test]
+    fn we_can_convert_an_aggregate_function_to_proof_expr() {
+        let expr = df_column("table", "a");
+        let schema = df_schema("table", vec![("a", DataType::Int64)]);
+        for (function, operator) in &[
+            (
+                physical_plan::aggregates::AggregateFunction::Sum,
+                AggregationOperator::Sum,
+            ),
+            (
+                physical_plan::aggregates::AggregateFunction::Count,
+                AggregationOperator::Count,
+            ),
+        ] {
+            let function = AggregateFunction::new(
+                function.clone(),
+                vec![expr.clone()],
+                false,
+                None,
+                None,
+                None,
+            );
+            assert_eq!(
+                aggregate_function_to_proof_expr(&function, &schema).unwrap(),
+                DynProofExpr::new_aggregate(
+                    *operator,
+                    DynProofExpr::new_column(ColumnRef::new(
+                        TableRef::from_names(None, "table"),
+                        "a".into(),
+                        ColumnType::BigInt
+                    ))
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn we_cannot_convert_an_aggregate_function_to_pair_if_unsupported() {
+        let expr = df_column("table", "a");
+        let schema = df_schema("table", vec![("a", DataType::Int64)]);
+        let function = AggregateFunction::new(
+            physical_plan::aggregates::AggregateFunction::RegrIntercept,
+            vec![expr.clone()],
+            false,
+            None,
+            None,
+            None,
+        );
+        assert!(matches!(
+            aggregate_function_to_proof_expr(&function, &schema),
+            Err(PlannerError::UnsupportedAggregateFunction { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_convert_an_aggregate_function_to_pair_if_too_many_or_no_exprs() {
+        let expr = df_column("table", "a");
+        let schema = df_schema("table", vec![("a", DataType::Int64)]);
+        // Too many exprs
+        let function = AggregateFunction::new(
+            physical_plan::aggregates::AggregateFunction::Sum,
+            vec![expr.clone(); 2],
+            false,
+            None,
+            None,
+            None,
+        );
+        assert!(matches!(
+            aggregate_function_to_proof_expr(&function, &schema),
+            Err(PlannerError::UnsupportedAggregateFunction { .. })
+        ));
+
+        // No exprs
+        let function = AggregateFunction::new(
+            physical_plan::aggregates::AggregateFunction::Sum,
+            Vec::<_>::new(),
+            false,
+            None,
+            None,
+            None,
+        );
+        assert!(matches!(
+            aggregate_function_to_proof_expr(&function, &schema),
+            Err(PlannerError::UnsupportedAggregateFunction { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_convert_an_aggregate_function_to_pair_if_unsupported_options() {
+        // No distinct, filter, or order_by
+
+        // Distinct
+        let expr = df_column("table", "a");
+        let schema = df_schema("table", vec![("a", DataType::Int64)]);
+        let function = AggregateFunction::new(
+            physical_plan::aggregates::AggregateFunction::Count,
+            vec![expr.clone()],
+            true,
+            None,
+            None,
+            None,
+        );
+        assert!(matches!(
+            aggregate_function_to_proof_expr(&function, &schema),
+            Err(PlannerError::UnsupportedAggregateFunction { .. })
+        ));
+
+        // Filter
+        let function = AggregateFunction::new(
+            physical_plan::aggregates::AggregateFunction::Count,
+            vec![expr.clone()],
+            false,
+            Some(Box::new(expr.clone())),
+            None,
+            None,
+        );
+        assert!(matches!(
+            aggregate_function_to_proof_expr(&function, &schema),
+            Err(PlannerError::UnsupportedAggregateFunction { .. })
+        ));
+
+        // OrderBy
+        let function = AggregateFunction::new(
+            physical_plan::aggregates::AggregateFunction::Count,
+            vec![expr.clone()],
+            false,
+            None,
+            Some(vec![expr.clone()]),
+            None,
+        );
+        assert!(matches!(
+            aggregate_function_to_proof_expr(&function, &schema),
+            Err(PlannerError::UnsupportedAggregateFunction { .. })
+        ));
+    }
+}

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -2,6 +2,7 @@ use arrow::datatypes::DataType;
 use datafusion::{
     common::DataFusionError,
     logical_expr::{expr::AggregateFunction, Expr, LogicalPlan, Operator},
+    physical_plan,
 };
 use proof_of_sql::{base::math::decimal::DecimalError, sql::AnalyzeError};
 use snafu::Snafu;
@@ -51,6 +52,12 @@ pub enum PlannerError {
     UnsupportedBinaryOperator {
         /// Unsupported binary operation
         op: Operator,
+    },
+    /// Returned when the aggregate opetation is not supported
+    #[snafu(display("Aggregate operation {op:?} is not supported"))]
+    UnsupportedAggregateOperation {
+        /// Unsupported aggregate operation
+        op: physical_plan::aggregates::AggregateFunction,
     },
     /// Returned when the `AggregateFunction` is not supported
     #[snafu(display("AggregateFunction {function:?} is not supported"))]

--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -1,7 +1,7 @@
 use arrow::datatypes::DataType;
 use datafusion::{
     common::DataFusionError,
-    logical_expr::{Expr, LogicalPlan, Operator},
+    logical_expr::{expr::AggregateFunction, Expr, LogicalPlan, Operator},
 };
 use proof_of_sql::{base::math::decimal::DecimalError, sql::AnalyzeError};
 use snafu::Snafu;
@@ -51,6 +51,12 @@ pub enum PlannerError {
     UnsupportedBinaryOperator {
         /// Unsupported binary operation
         op: Operator,
+    },
+    /// Returned when the `AggregateFunction` is not supported
+    #[snafu(display("AggregateFunction {function:?} is not supported"))]
+    UnsupportedAggregateFunction {
+        /// Unsupported `AggregateFunction`
+        function: AggregateFunction,
     },
     /// Returned when a logical expression is not resolved
     #[snafu(display("Logical expression {:?} is not supported", expr))]

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -1,7 +1,8 @@
 //! This crate converts a `DataFusion` `LogicalPlan` to a `ProofPlan` and `Postprocessing`
-//#![cfg_attr(not(test), expect(dead_code))] // TODO: remove this when initial development work is done
+#![cfg_attr(not(test), expect(dead_code))] // TODO: remove this when initial development work is done
 #![cfg_attr(test, expect(clippy::missing_panics_doc))]
 extern crate alloc;
+mod aggregate;
 mod context;
 pub use context::PoSqlContextProvider;
 #[cfg(test)]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
This PR exists to prepare for adding support for `GROUP BY` in the planner.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `aggregate_function_to_proof_expr`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.