### PR TITLE
refactor: replace allow with expect in most cases

### DIFF
--- a/crates/proof-of-sql-parser/src/error.rs
+++ b/crates/proof-of-sql-parser/src/error.rs
@@ -2,7 +2,7 @@ use alloc::string::String;
 use snafu::Snafu;
 
 /// Errors encountered during the parsing process
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions)]
 #[derive(Debug, Snafu, Eq, PartialEq)]
 pub enum ParseError {
     #[snafu(display("Unable to parse query"))]

--- a/crates/proof-of-sql-parser/src/intermediate_ast_tests.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast_tests.rs
@@ -112,7 +112,7 @@ fn we_can_parse_strings_having_control_characters() {
     );
 }
 
-#[allow(clippy::unicode_not_nfc)]
+#[expect(clippy::unicode_not_nfc)]
 #[test]
 fn unnormalized_strings_should_differ() {
     let lhs = StringLiteralParser::new().parse("'á'").unwrap();
@@ -770,7 +770,7 @@ fn we_can_parse_multiple_order_by() {
 // TODO: we should be able to pass this test.
 // But due to some lalrpop restriction, we aren't.
 // This problem will be addressed in a future PR.
-#[allow(clippy::should_panic_without_expect)]
+#[expect(clippy::should_panic_without_expect)]
 #[test]
 #[should_panic]
 fn we_cannot_parse_order_by_referencing_reserved_keywords_yet() {

--- a/crates/proof-of-sql-parser/src/posql_time/error.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/error.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 /// Errors related to time operations, including timezone and timestamp conversions.
-#[allow(clippy::module_name_repetitions)]
 #[derive(Snafu, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PoSQLTimestampError {
     /// Error when the timezone string provided cannot be parsed into a valid timezone.

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -5,7 +5,6 @@ use core::hash::Hash;
 use serde::{Deserialize, Serialize};
 
 /// Represents a fully parsed timestamp with detailed time unit and timezone information
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PoSQLTimestamp {
     /// The datetime representation in UTC.

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -3,7 +3,6 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 /// An intermediate type representing the time units from a parsed query
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PoSQLTimeUnit {
     /// Represents seconds with precision 0: ex "2024-06-20 12:34:56"
@@ -56,7 +55,7 @@ impl fmt::Display for PoSQLTimeUnit {
 // allow(deprecated) for the sole purpose of testing that
 // timestamp precision is parsed correctly.
 #[cfg(test)]
-#[allow(deprecated, clippy::missing_panics_doc)]
+#[expect(deprecated, clippy::missing_panics_doc)]
 mod time_unit_tests {
     use super::*;
     use crate::posql_time::{PoSQLTimestamp, PoSQLTimestampError};

--- a/crates/proof-of-sql/benches/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger_benches.rs
@@ -29,7 +29,7 @@ use std::env;
 
 const SIZE: usize = 1_000_000;
 
-#[allow(clippy::items_after_statements)]
+#[expect(clippy::items_after_statements)]
 fn main() {
     init_backend();
 

--- a/crates/proof-of-sql/benches/scaffold/mod.rs
+++ b/crates/proof-of-sql/benches/scaffold/mod.rs
@@ -71,7 +71,7 @@ pub fn jaeger_scaffold<CP: CommitmentEvaluationProof>(
         .unwrap();
 }
 
-#[allow(dead_code, clippy::module_name_repetitions)]
+#[allow(dead_code)]
 pub fn criterion_scaffold<CP: CommitmentEvaluationProof + Clone>(
     c: &mut Criterion,
     title: &str,

--- a/crates/proof-of-sql/benches/scaffold/queries.rs
+++ b/crates/proof-of-sql/benches/scaffold/queries.rs
@@ -140,7 +140,7 @@ const COMPLEX_CONDITION_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
     ("d", ColumnType::VarChar, None),
 ];
 
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub const QUERIES: &[(&str, &str, &[(&str, ColumnType, OptionalRandBound)])] = &[
     (
         SINGLE_COLUMN_FILTER_TITLE,

--- a/crates/proof-of-sql/benches/scaffold/random_util.rs
+++ b/crates/proof-of-sql/benches/scaffold/random_util.rs
@@ -11,7 +11,7 @@ pub type OptionalRandBound = Option<fn(usize) -> i64>;
 ///
 /// Will panic if:
 /// - An unsupported `ColumnType` is encountered, triggering a panic in the `todo!()` macro.
-#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+#[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 pub fn generate_random_columns<'a, S: Scalar>(
     alloc: &'a Bump,
     rng: &mut impl Rng,

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -148,7 +148,7 @@ fn end_timer(instant: Instant) {
 /// - **Proof Verification Failure**: Panics if the proof verification process fails.
 /// - **Serialization/Deserialization Failure**: Panics if the proof cannot be serialized or deserialized.
 /// - **Record Batch Conversion Failure**: Panics if the query result cannot be converted into a `RecordBatch`.
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn main() {
     let args = CliArgs::parse();
 

--- a/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/arrow_array_to_column_conversion.rs
@@ -101,7 +101,7 @@ impl ArrayRefExt for ArrayRef {
     ///
     /// # Panics
     /// - When any range is OOB, i.e. indexing 3..6 or 5..5 on array of size 2.
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn to_column<'a, S: Scalar>(
         &'a self,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
@@ -136,7 +136,7 @@ impl<S: Scalar> TryFrom<ArrayRef> for OwnedColumn<S> {
 impl<S: Scalar> TryFrom<&ArrayRef> for OwnedColumn<S> {
     type Error = OwnedArrowConversionError;
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     /// # Panics
     ///
     /// Will panic if downcasting fails for the following types:

--- a/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
+++ b/crates/proof-of-sql/src/base/arrow/record_batch_conversion.rs
@@ -40,7 +40,7 @@ impl<C: Commitment> TableCommitment<C> {
     /// The row offset is assumed to be the end of the [`TableCommitment`]'s current range.
     ///
     /// Will error on a variety of mismatches, or if the provided columns have mixed length.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_append_record_batch(
         &mut self,
         batch: &RecordBatch,
@@ -75,7 +75,7 @@ impl<C: Commitment> TableCommitment<C> {
     }
 
     /// Returns a [`TableCommitment`] to the provided arrow [`RecordBatch`] with the given row offset.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_from_record_batch_with_offset(
         batch: &RecordBatch,
         offset: usize,

--- a/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
+++ b/crates/proof-of-sql/src/base/arrow/scalar_and_i256_conversions.rs
@@ -27,7 +27,7 @@ pub fn convert_scalar_to_i256<S: Scalar>(val: &S) -> i256 {
     }
 }
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 /// Converts an arrow i256 into limbed representation and then
 /// into a type implementing [Scalar]
 #[must_use]

--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -116,7 +116,7 @@ impl BitDistribution {
     }
 
     /// Iterate over each varying bit
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn vary_mask_iter(&self) -> impl Iterator<Item = u8> + '_ {
         (0..4).flat_map(|i| {
             BitIter::from(self.vary_mask[i])

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata.rs
@@ -69,7 +69,7 @@ impl ColumnCommitmentMetadata {
         }
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     /// Construct a [`ColumnCommitmentMetadata`] with widest possible bounds for the column type.
     #[must_use]
     pub fn from_column_type_with_max_bounds(column_type: ColumnType) -> Self {
@@ -128,7 +128,7 @@ impl ColumnCommitmentMetadata {
     /// Combine two [`ColumnCommitmentMetadata`] as if their source collections are being unioned.
     ///
     /// Can error if the two metadatas are mismatched.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_union(
         self,
         other: ColumnCommitmentMetadata,
@@ -155,7 +155,7 @@ impl ColumnCommitmentMetadata {
     ///
     /// This should be interpreted as the set difference of the two collections.
     /// The result would be the rows in self that are not also rows in other.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_difference(
         self,
         other: ColumnCommitmentMetadata,
@@ -791,7 +791,7 @@ mod tests {
         );
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_cannot_perform_arithmetic_on_mismatched_metadata() {
         let boolean_metadata = ColumnCommitmentMetadata {

--- a/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitment_metadata_map.rs
@@ -327,7 +327,7 @@ mod tests {
         ));
     }
 
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     #[test]
     fn we_cannot_perform_arithmetic_on_mismatched_metadata_maps_with_same_column_counts() {
         let id_a = "column_a";

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -170,7 +170,7 @@ impl<C: Commitment> ColumnCommitments<C> {
     ///
     /// Will error on a variety of mismatches.
     /// See [`ColumnCommitmentsMismatch`] for an enumeration of these errors.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_append_rows_with_offset<'a, COL>(
         &mut self,
         columns: impl IntoIterator<Item = (&'a Ident, COL)>,
@@ -262,7 +262,7 @@ impl<C: Commitment> ColumnCommitments<C> {
     ///
     /// Will error on a variety of mismatches.
     /// See [`ColumnCommitmentsMismatch`] for an enumeration of these errors.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_add(self, other: Self) -> Result<Self, ColumnCommitmentsMismatch>
     where
         Self: Sized,
@@ -283,7 +283,7 @@ impl<C: Commitment> ColumnCommitments<C> {
     ///
     /// Will error on a variety of mismatches.
     /// See [`ColumnCommitmentsMismatch`] for an enumeration of these errors.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn try_sub(self, other: Self) -> Result<Self, ColumnCommitmentsMismatch>
     where
         Self: Sized,

--- a/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof.rs
+++ b/crates/proof-of-sql/src/base/commitment/commitment_evaluation_proof.rs
@@ -35,7 +35,7 @@ pub trait CommitmentEvaluationProof {
     /// Note: `b_point` must have length `nu`, where `2^nu` is at least the length of `a`.
     /// `b_point` are the values for the variables that are being evaluated.
     /// The resulting evaluation is the inner product of `a` and `b`, where `b` is the expanded vector form of `b_point`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn verify_proof(
         &self,
         transcript: &mut impl Transcript,
@@ -58,7 +58,7 @@ pub trait CommitmentEvaluationProof {
         )
     }
     /// Verify a batch proof. This can be more efficient than verifying individual proofs for some schemes.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn verify_batched_proof(
         &self,
         transcript: &mut impl Transcript,

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment.rs
@@ -168,7 +168,7 @@ impl Commitment for NaiveCommitment {
     }
 }
 
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names)]
 #[test]
 fn we_can_compute_commitments_from_committable_columns() {
     let column_a = [1i64, 10, -5, 0, 10];

--- a/crates/proof-of-sql/src/base/commitment/naive_commitment_test.rs
+++ b/crates/proof-of-sql/src/base/commitment/naive_commitment_test.rs
@@ -184,7 +184,7 @@ fn we_can_subtract_naive_commitments_with_both_empty() {
 
 // AddAssign Tests
 
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names)]
 #[test]
 fn we_can_add_assign_naive_commitments() {
     let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10]
@@ -216,7 +216,7 @@ fn we_can_add_assign_naive_commitments() {
     assert_eq!(commitment_b_mutable, commitment_sum);
 }
 
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names)]
 #[test]
 fn we_can_add_assign_naive_commitments_with_one_empty() {
     let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10]
@@ -283,7 +283,7 @@ fn we_can_sub_assign_naive_commitments() {
     assert_eq!(commitment_a_mutable, commitment_difference);
 }
 
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names)]
 #[test]
 fn we_can_sub_assign_naive_commitments_with_one_empty() {
     let column_a: Vec<TestScalar> = [1i64, 10, -5, 0, 10]

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -202,7 +202,7 @@ mod tests {
         assert_eq!(query_commitments.get_length(&no_rows_id), 0);
     }
 
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     #[test]
     fn we_can_get_commitment_of_a_column() {
         let column_a_id: Ident = "column_a".into();
@@ -256,7 +256,7 @@ mod tests {
         );
     }
 
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     #[test]
     fn we_can_get_schema_of_tables() {
         let column_a_id: Ident = "column_a".into();
@@ -335,7 +335,7 @@ mod tests {
         assert_eq!(query_commitments.lookup_schema(no_columns_id), vec![]);
     }
 
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     #[test]
     fn we_can_get_query_commitments_from_accessor() {
         let public_parameters = PublicParameters::test_rand(4, &mut test_rng());

--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -92,7 +92,7 @@ where
 
 impl<C: Commitment> TableCommitment<C> {
     /// Create a new [`TableCommitment`] for a table from a commitment accessor.
-    #[allow(
+    #[expect(
         clippy::missing_panics_doc,
         reason = "The assertion ensures that from_accessor should not create columns with a negative range"
     )]
@@ -187,7 +187,7 @@ impl<C: Commitment> TableCommitment<C> {
     }
 
     /// Returns a [`TableCommitment`] to the provided table with the given row offset.
-    #[allow(
+    #[expect(
         clippy::missing_panics_doc,
         reason = "since OwnedTables cannot have columns of mixed length or duplicate idents"
     )]
@@ -391,7 +391,7 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    #[allow(clippy::reversed_empty_ranges)]
+    #[expect(clippy::reversed_empty_ranges)]
     fn we_cannot_construct_table_commitment_with_negative_range() {
         let try_new_result =
             TableCommitment::<NaiveCommitment>::try_new(ColumnCommitments::default(), 1..0);
@@ -701,7 +701,7 @@ mod tests {
         assert_eq!(table_commitment.column_commitments(), &column_commitments);
     }
 
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     #[test]
     fn we_cannot_append_columns_of_mixed_length_to_table_commitment() {
         let column_id_a: Ident = "column_a".into();

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -323,7 +323,7 @@ impl<'a, S: Scalar> Column<'a, S> {
     }
 
     /// Convert a column to a vector of Scalar values with scaling
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub(crate) fn to_scalar_with_scaling(self, scale: i8) -> Vec<S> {
         let scale_factor = S::pow10(u8::try_from(scale).expect("Upscale factor is nonnegative"));
         match self {
@@ -545,7 +545,7 @@ impl ColumnType {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     /// Returns the bit size of the column type.
     #[must_use]
     pub fn bit_size(&self) -> u32 {

--- a/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_arithmetic_operation.rs
@@ -34,7 +34,7 @@ pub trait ArithmeticOp {
         T0: Copy + Debug + Into<BigInt>,
         T1: Copy + Debug + Into<BigInt>;
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn owned_column_element_wise_arithmetic<S: Scalar>(
         lhs: &OwnedColumn<S>,
         rhs: &OwnedColumn<S>,

--- a/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_comparison_operation.rs
@@ -44,7 +44,7 @@ pub trait ComparisonOp {
     /// Return an error if op is not implemented for string
     fn string_op(lhs: &[String], rhs: &[String]) -> ColumnOperationResult<Vec<bool>>;
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn owned_column_element_wise_comparison<S: Scalar>(
         lhs: &OwnedColumn<S>,
         rhs: &OwnedColumn<S>,

--- a/crates/proof-of-sql/src/base/database/column_index_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_index_operation.rs
@@ -7,7 +7,6 @@ use bumpalo::Bump;
 ///
 /// # Panics
 /// Panics if any of the indexes are out of bounds.
-#[allow(dead_code)]
 pub(crate) fn apply_column_to_indexes<'a, S>(
     column: &Column<'a, S>,
     alloc: &'a Bump,

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -6,8 +6,7 @@ use crate::base::scalar::Scalar;
 use bumpalo::Bump;
 use core::iter::Iterator;
 
-#[allow(dead_code)]
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub trait RepetitionOp {
     fn op<T: Clone>(column: &[T], n: usize) -> impl Iterator<Item = T>;
 

--- a/crates/proof-of-sql/src/base/database/error.rs
+++ b/crates/proof-of-sql/src/base/database/error.rs
@@ -2,7 +2,6 @@ use alloc::string::String;
 use snafu::Snafu;
 
 /// Errors encountered during the parsing process
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Snafu, Eq, PartialEq)]
 pub enum ParseError {
     #[snafu(display("Invalid table reference: {}", table_reference))]

--- a/crates/proof-of-sql/src/base/database/group_by_util.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util.rs
@@ -38,7 +38,7 @@ pub enum AggregateColumnsError {
     ColumnLengthMismatch,
 }
 
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 /// This is a function that gives the result of a group by query similar to the following:
 /// ```sql
 ///     SELECT <group_by[0]>, <group_by[1]>, ..., SUM(<sum_columns[0]>), SUM(<sum_columns[1]>), ...,

--- a/crates/proof-of-sql/src/base/database/group_by_util_test.rs
+++ b/crates/proof-of-sql/src/base/database/group_by_util_test.rs
@@ -150,7 +150,7 @@ fn we_can_aggregate_columns_with_empty_group_by() {
     assert_eq!(aggregate_result.min_columns, expected_min_result);
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[test]
 fn we_can_aggregate_columns() {
     let slice_a = &[3, 3, 3, 2, 2, 1, 1, 2, 2, 3, 3, 3];

--- a/crates/proof-of-sql/src/base/database/join_util.rs
+++ b/crates/proof-of-sql/src/base/database/join_util.rs
@@ -122,7 +122,6 @@ pub fn cross_join<'a, S: Scalar>(
 /// Get columns from a table with given indexes.
 ///
 /// The function returns an error if any of the indexes are out of bounds.
-#[allow(dead_code)]
 pub(crate) fn get_columns_of_table<'a, S: Scalar>(
     table: &Table<'a, S>,
     indexes: &[usize],
@@ -225,7 +224,6 @@ pub(crate) fn get_sort_merge_join_indexes<'a, S: Scalar>(
 /// 3. Other columns from the right table
 /// # Panics
 /// The function panics if we feed in incorrect data (e.g. Num of rows in `left` and some column of `left_on` being different).
-#[allow(clippy::needless_borrowed_reference)]
 pub fn apply_sort_merge_join_indexes<'a, S: Scalar>(
     left: &Table<'a, S>,
     right: &Table<'a, S>,

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -26,6 +26,7 @@ pub(super) use column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanO
 mod column_index_operation;
 pub(super) use column_index_operation::apply_column_to_indexes;
 
+#[allow(dead_code)]
 mod column_repetition_operation;
 pub(super) use column_repetition_operation::{ColumnRepeatOp, ElementwiseRepeatOp, RepetitionOp};
 

--- a/crates/proof-of-sql/src/base/database/owned_table.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table.rs
@@ -59,7 +59,7 @@ impl<S: Scalar> OwnedTable<S> {
         Self::try_new(IndexMap::from_iter(iter))
     }
 
-    #[allow(
+    #[expect(
         clippy::missing_panics_doc,
         reason = "Mapping from one table to another should not result in column mismatch"
     )]

--- a/crates/proof-of-sql/src/base/database/owned_table_utility.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_utility.rs
@@ -144,7 +144,6 @@ pub fn int<S: Scalar>(
 ///     bigint("a", [1, 2, 3]),
 /// ]);
 /// ```
-#[allow(clippy::missing_panics_doc)]
 pub fn bigint<S: Scalar>(
     name: impl Into<Ident>,
     data: impl IntoIterator<Item = impl Into<i64>>,

--- a/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
+++ b/crates/proof-of-sql/src/base/database/slice_decimal_operation.rs
@@ -414,7 +414,7 @@ where
 /// 4. Precision and scale follow T-SQL rules. That is,
 ///   - `new_scale = max(6, right_precision + left_scale + 1)`
 ///   - `new_precision = left_precision - left_scale + right_scale + new_scale`
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 pub(crate) fn try_divide_decimal_columns<S, T0, T1>(
     lhs: &[T0],
     rhs: &[T1],
@@ -807,7 +807,7 @@ mod test {
         assert_eq!(expected, actual);
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_can_try_add_decimal_columns() {
         // lhs is integer and rhs is decimal with nonnegative scale
@@ -929,7 +929,7 @@ mod test {
         assert_eq!(expected, actual);
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_can_try_subtract_decimal_columns() {
         // lhs is integer and rhs is decimal with nonnegative scale
@@ -1051,7 +1051,7 @@ mod test {
         assert_eq!(expected, actual);
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_can_try_multiply_decimal_columns() {
         // lhs is integer and rhs is decimal with nonnegative scale
@@ -1174,7 +1174,7 @@ mod test {
         assert_eq!(expected, actual);
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_can_try_divide_decimal_columns() {
         // lhs is integer and rhs is decimal with nonnegative scale

--- a/crates/proof-of-sql/src/base/database/table_ref.rs
+++ b/crates/proof-of-sql/src/base/database/table_ref.rs
@@ -36,7 +36,6 @@ impl TableRef {
 
     /// Returns the identifier of the schema
     /// # Panics
-    #[allow(clippy::get_first)]
     #[must_use]
     pub fn schema_id(&self) -> Option<&Ident> {
         self.schema_name.as_ref()

--- a/crates/proof-of-sql/src/base/database/union_util.rs
+++ b/crates/proof-of-sql/src/base/database/union_util.rs
@@ -20,7 +20,7 @@ fn are_schemas_compatible(left: &[ColumnField], right: &[ColumnField]) -> bool {
 ///
 /// # Panics
 /// This function should never panic as long as it is written correctly
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn column_union<'a, S: Scalar>(
     columns: &[&Column<'a, S>],
     alloc: &'a Bump,

--- a/crates/proof-of-sql/src/base/encode/scalar_varint.rs
+++ b/crates/proof-of-sql/src/base/encode/scalar_varint.rs
@@ -18,7 +18,7 @@ pub fn write_scalar_varint<T: MontConfig<4>>(buf: &mut [u8], x: &MontScalar<T>) 
     write_u256_varint(buf, x.zigzag())
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 pub fn write_u256_varint(buf: &mut [u8], mut zig_x: U256) -> usize {
     let mut pos = 0;
 

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -53,7 +53,7 @@ pub trait VarInt: Sized + Copy {
     }
 }
 
-#[allow(clippy::cast_sign_loss)]
+#[expect(clippy::cast_sign_loss)]
 #[inline]
 fn zigzag_encode(from: i64) -> u64 {
     ((from << 1) ^ (from >> 63)) as u64
@@ -62,7 +62,7 @@ fn zigzag_encode(from: i64) -> u64 {
 // see: http://stackoverflow.com/a/2211086/56332
 // casting required because operations like unary negation
 // cannot be performed on unsigned integers
-#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+#[expect(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
 #[inline]
 fn zigzag_decode(from: u64) -> i64 {
     ((from >> 1) ^ (-((from & 1) as i64)) as u64) as i64
@@ -77,7 +77,8 @@ macro_rules! impl_varint {
                 (self as u64).required_space()
             }
 
-            #[allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
+            #[allow(clippy::cast_lossless)]
             fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
                 let (n, s) = u64::decode_var(src)?;
                 // This check is required to ensure that we actually return `None` when `src` has a value that would overflow `Self`.
@@ -101,7 +102,8 @@ macro_rules! impl_varint {
                 (self as i64).required_space()
             }
 
-            #[allow(clippy::cast_lossless, clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
+            #[allow(clippy::cast_lossless)]
             fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
                 let (n, s) = i64::decode_var(src)?;
                 // This check is required to ensure that we actually return `None` when `src` has a value that would overflow `Self`.
@@ -187,7 +189,7 @@ impl VarInt for u64 {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     #[inline]
     fn encode_var(self, dst: &mut [u8]) -> usize {
         assert!(dst.len() >= self.required_space());
@@ -250,7 +252,7 @@ impl VarInt for u128 {
 }
 
 // Adapted from integer-encoding-rs. See third_party/license/integer-encoding.LICENSE
-#[allow(clippy::cast_sign_loss)]
+#[expect(clippy::cast_sign_loss)]
 #[inline]
 fn zigzag_encode_i128(from: i128) -> u128 {
     ((from << 1) ^ (from >> 127)) as u128
@@ -259,7 +261,7 @@ fn zigzag_encode_i128(from: i128) -> u128 {
 // see: http://stackoverflow.com/a/2211086/56332
 // casting required because operations like unary negation
 // cannot be performed on unsigned integers
-#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+#[expect(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
 #[inline]
 fn zigzag_decode_i128(from: u128) -> i128 {
     ((from >> 1) ^ (-((from & 1) as i128)) as u128) as i128

--- a/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait_test.rs
@@ -315,7 +315,6 @@ fn we_can_encode_and_decode_u32_and_u64_the_same() {
 
 #[test]
 fn we_can_encode_and_decode_large_positive_u128() {
-    #[allow(clippy::unusual_byte_groupings)]
     let value: u128 =
         0b110_0010101_1111111_1111111_1111111_1111111_1111111_1111111_1111111_1111111_0011100;
     let expected_result: &[u8] = &[
@@ -340,7 +339,7 @@ fn we_can_encode_and_decode_large_positive_u128() {
 
 #[test]
 fn we_can_encode_and_decode_large_positive_i128() {
-    #[allow(clippy::unusual_byte_groupings)]
+    #[expect(clippy::unusual_byte_groupings)]
     let value: i128 =
         0b110_0010101_1111111_1111111_1111111_1111111_1111111_1111111_1111111_1111111_001110;
     let expected_result: &[u8] = &[
@@ -365,7 +364,7 @@ fn we_can_encode_and_decode_large_positive_i128() {
 
 #[test]
 fn we_can_encode_and_decode_large_negative_i128() {
-    #[allow(clippy::unusual_byte_groupings)]
+    #[expect(clippy::unusual_byte_groupings)]
     let value: i128 =
         -1 - 0b110_0010101_1111111_1111111_1111111_1111111_1111111_1111111_1111111_1111111_001110;
     let expected_result: &[u8] = &[

--- a/crates/proof-of-sql/src/base/math/decimal.rs
+++ b/crates/proof-of-sql/src/base/math/decimal.rs
@@ -245,7 +245,7 @@ mod scale_adjust_test {
         assert_eq!(limbs, -TestScalar::from(expected_limbs));
     }
 
-    #[allow(clippy::cast_possible_wrap)]
+    #[expect(clippy::cast_possible_wrap)]
     #[test]
     fn we_can_match_decimals_at_extrema() {
         // a big decimal cannot scale up past the supported precision

--- a/crates/proof-of-sql/src/base/math/log.rs
+++ b/crates/proof-of-sql/src/base/math/log.rs
@@ -71,7 +71,7 @@ mod tests {
         assert_eq!(log2_up(4u32), 2);
     }
 
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     #[test]
     fn test_log2_bytes_ceil() {
         // 0-1 edge cases

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial.rs
@@ -52,7 +52,7 @@ impl<S: Scalar> CompositePolynomial<S> {
 
     /// Add a list of multilinear extensions that is meant to be multiplied together.
     /// The resulting polynomial will be multiplied by the scalar `coefficient`.
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn add_product(&mut self, product: impl IntoIterator<Item = Rc<Vec<S>>>, coefficient: S) {
         let product: Vec<Rc<Vec<S>>> = product.into_iter().collect();
         let mut indexed_product = Vec::with_capacity(product.len());

--- a/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
+++ b/crates/proof-of-sql/src/base/polynomial/composite_polynomial_test.rs
@@ -39,7 +39,7 @@ fn test_composite_polynomial_evaluation() {
     assert_eq!(prod11, calc11);
 }
 
-#[allow(clippy::identity_op)]
+#[expect(clippy::identity_op)]
 #[test]
 fn test_composite_polynomial_hypercube_sum() {
     let a: Vec<TestScalar> = vec![

--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -14,7 +14,8 @@ use num_traits::{Inv, One, Zero};
 /// `f(x) = sum_{i=0}^{d} (-1)^(d-i) * (f(i) / (i! * (d-i)! * (x-i))) * prod_{i=0}^{d} (x-i)`
 // Allow missing panics documentation because the function should not panic under normal conditions.
 /// unless x is one of 0,1,...,d, in which case, f(x) is already known.
-#[allow(dead_code, clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
+#[allow(dead_code)]
 pub fn interpolate_uni_poly<F>(polynomial: &[F], x: F) -> F
 where
     F: Copy

--- a/crates/proof-of-sql/src/base/polynomial/mod.rs
+++ b/crates/proof-of-sql/src/base/polynomial/mod.rs
@@ -6,7 +6,7 @@ mod composite_polynomial_test;
 mod interpolate;
 #[cfg(test)]
 mod interpolate_test;
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub use interpolate::{interpolate_evaluations_to_reverse_coefficients, interpolate_uni_poly};
 
 mod evaluation_vector;

--- a/crates/proof-of-sql/src/base/proof/keccak256_transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/keccak256_transcript.rs
@@ -2,7 +2,6 @@ use super::{transcript_core::TranscriptCore, Transcript};
 use core::mem::replace;
 use tiny_keccak::{Hasher, Keccak};
 
-#[allow(dead_code)]
 /// Public coin transcript that is easily portable to Solidity.
 ///
 /// Leverages the keccak256 hash function, which has the lowest gas costs on Solidity.

--- a/crates/proof-of-sql/src/base/proof/mod.rs
+++ b/crates/proof-of-sql/src/base/proof/mod.rs
@@ -15,5 +15,4 @@ mod transcript_core;
 mod transcript_core_test;
 
 mod keccak256_transcript;
-#[allow(unused_imports)]
 pub use keccak256_transcript::Keccak256Transcript;

--- a/crates/proof-of-sql/src/base/proof/transcript.rs
+++ b/crates/proof-of-sql/src/base/proof/transcript.rs
@@ -7,7 +7,6 @@ use zerocopy::{AsBytes, FromBytes};
 /// This trait contains several method for adding prover messages and computing verifier challenges.
 ///
 /// Implementation note: this is intended to be implemented via [`super::transcript_core::TranscriptCore`] rather than directly.
-#[allow(dead_code)]
 pub trait Transcript {
     /// Creates a new transcript
     fn new() -> Self;

--- a/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/mont_scalar.rs
@@ -204,7 +204,6 @@ impl<T: MontConfig<4>> MontScalar<T> {
     }
     /// Create a `Vec<u8>` from a `MontScalar<T>`. The array will be in non-montgomery form.
     #[must_use]
-    #[allow(clippy::wrong_self_convention)]
     pub fn to_bytes_le(&self) -> Vec<u8> {
         self.0.into_bigint().to_bytes_le()
     }
@@ -403,7 +402,7 @@ where
             u64::MAX >> (T::MODULUS.0[3].leading_zeros() + 1),
         ])
     };
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     const MAX_BITS: u8 = {
         assert!(
             T::MODULUS.0[3].leading_zeros() < 64,
@@ -574,7 +573,7 @@ where
 {
     type Error = ScalarConversionError;
 
-    #[allow(clippy::cast_possible_wrap)]
+    #[expect(clippy::cast_possible_wrap)]
     fn try_from(value: MontScalar<T>) -> Result<Self, Self::Error> {
         let (sign, abs): (i128, [u64; 4]) = if value > <MontScalar<T>>::MAX_SIGNED {
             (-1, (-value).into())

--- a/crates/proof-of-sql/src/base/slice_ops/mod.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/mod.rs
@@ -24,7 +24,6 @@ pub use add_const::*;
 pub use inner_product::*;
 pub use mul_add_assign::*;
 pub use slice_cast::*;
-#[allow(unused_imports)]
 pub use sub::*;
 
 mod batch_inverse;

--- a/crates/proof-of-sql/src/base/slice_ops/sub.rs
+++ b/crates/proof-of-sql/src/base/slice_ops/sub.rs
@@ -3,7 +3,6 @@ use core::ops::Sub;
 #[cfg(feature = "rayon")]
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
-#[allow(dead_code)]
 /// This operation does `result[i] = lhs[i] - rhs[i]` for `i` in `0..lhs.len()`.
 ///
 /// # Panics

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
@@ -5,7 +5,7 @@ use ark_ff::Field;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use num_traits::Zero;
 
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 #[derive(Default, Clone, CanonicalSerialize, CanonicalDeserialize, PartialEq, Eq, Debug)]
 /// The messages sent from the prover to the verifier in the interactive protocol.
 /// This is, in essence, the proof.
@@ -53,7 +53,7 @@ impl DoryMessages {
         self.G2_messages.insert(0, message);
     }
 
-    #[allow(clippy::large_types_passed_by_value)]
+    #[expect(clippy::large_types_passed_by_value)]
     /// Pushes a GT element from the prover onto the queue, and appends it to the transcript.
     pub(super) fn prover_send_GT_message(&mut self, transcript: &mut impl Transcript, message: GT) {
         transcript.extend_canonical_serialize_as_le(&message);
@@ -106,7 +106,7 @@ impl DoryMessages {
         message
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     /// This is the F message that the verifier sends to the prover.
     /// This message is produces as a challenge from the transcript.
     ///

--- a/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dynamic_dory_commitment_helper_cpu.rs
@@ -19,7 +19,7 @@ use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterato
 /// - `setup.Gamma_1.last()` returns `None`, indicating that `Gamma_1` is empty.
 /// - `setup.Gamma_2.last()` returns `None`, indicating that `Gamma_2` is empty.
 /// - The indexing for `Gamma_2` with `first_row..=last_row` goes out of bounds.
-#[allow(clippy::range_plus_one)]
+#[expect(clippy::range_plus_one)]
 fn compute_dory_commitment_impl<'a, T>(
     column: &'a [T],
     offset: usize,

--- a/crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/extended_state.rs
@@ -111,7 +111,7 @@ pub struct ExtendedVerifierState {
 
 impl ExtendedVerifierState {
     /// Create a new `ExtendedVerifierState` from the commitment to the witness.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_tensor(
         E_1: DeferredG1,
         E_2: DeferredG2,

--- a/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/fold_scalars.rs
@@ -8,7 +8,7 @@ use crate::{base::proof::Transcript, utils::log};
 /// This is the prover side of the Fold-Scalars algorithm in section 4.1 of <https://eprint.iacr.org/2020/1274.pdf>.
 ///
 /// Note: this only works for nu = 0.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 pub fn fold_scalars_0_prove(
     messages: &mut DoryMessages,
     transcript: &mut impl Transcript,

--- a/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/pack_scalars.rs
@@ -173,7 +173,7 @@ fn pack_bit<const LEN: usize, T: OffsetToBytes<LEN>>(
 /// * `offset` - The offset to the data.
 /// * `num_matrix_commitment_columns` - The number of generators used for msm.
 /// * `buffer` - Pre-allocated offset column buffer.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 fn offset_column(
     committable_columns: &[CommittableColumn],
     offset: usize,

--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
@@ -3,7 +3,7 @@ use super::{pairings, DoryMessages, ProverState, VerifierSetup, VerifierState};
 use crate::{base::proof::Transcript, utils::log};
 
 /// This is the prover side of the Scalar-Product algorithm in section 3.1 of <https://eprint.iacr.org/2020/1274.pdf>.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 pub fn scalar_product_prove(
     messages: &mut DoryMessages,
     transcript: &mut impl Transcript,

--- a/crates/proof-of-sql/src/proof_primitive/dory/vmv_state.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/vmv_state.rs
@@ -61,7 +61,7 @@ impl VMVProverState {
 
 /// A struct that holds the matrix and vectors for a vector-matrix-vector product. This is used for testing purposes.
 #[cfg(test)]
-#[allow(clippy::upper_case_acronyms)]
+#[expect(clippy::upper_case_acronyms)]
 pub(super) struct VMV {
     pub(super) M: Vec<Vec<F>>,
     pub(super) l_tensor: Vec<F>,

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg.rs
@@ -83,7 +83,7 @@ impl From<BNScalar> for NovaScalar {
 }
 impl Mul<HyperKZGCommitment> for BNScalar {
     type Output = HyperKZGCommitment;
-    #[allow(clippy::op_ref)]
+    #[expect(clippy::op_ref)]
     fn mul(self, rhs: HyperKZGCommitment) -> Self::Output {
         self * &rhs
     }

--- a/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
+++ b/crates/proof-of-sql/src/proof_primitive/inner_product/curve_25519_tests.rs
@@ -420,7 +420,7 @@ fn strings_of_arbitrary_size_map_to_different_scalars() {
     }
 }
 
-#[allow(clippy::cast_sign_loss)]
+#[expect(clippy::cast_sign_loss)]
 #[test]
 fn byte_arrays_of_arbitrary_size_map_to_different_scalars() {
     let mut prev_scalars = IndexSet::default();

--- a/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
+++ b/crates/proof-of-sql/src/proof_primitive/sumcheck/prover_round.rs
@@ -12,7 +12,7 @@ use alloc::{vec, vec::Vec};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
-#[allow(clippy::ref_option)]
+#[expect(clippy::ref_option)]
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn prove_round<S: Scalar>(prover_state: &mut ProverState<S>, r_maybe: &Option<S>) -> Vec<S> {
     log::log_memory_usage("Start");

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -52,7 +52,7 @@ impl<'a> DynProofExprBuilder<'a> {
     }
 }
 
-#[allow(clippy::match_wildcard_for_single_variants)]
+#[expect(clippy::match_wildcard_for_single_variants)]
 // Private interface
 impl DynProofExprBuilder<'_> {
     fn visit_expr(&self, expr: &Expression) -> Result<DynProofExpr, ConversionError> {
@@ -81,7 +81,7 @@ impl DynProofExprBuilder<'_> {
         )))
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     fn visit_literal(&self, lit: &Literal) -> Result<DynProofExpr, ConversionError> {
         match lit {
             Literal::Boolean(b) => Ok(DynProofExpr::new_literal(LiteralValue::Boolean(*b))),

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -50,7 +50,7 @@ impl EnrichedExpr {
     /// Get the alias of the `EnrichedExpr`.
     ///
     /// Since we plan to support unaliased expressions in the future, this method returns an `Option`.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn get_alias(&self) -> Option<Ident> {
         self.residue_expression
             .try_as_identifier()
@@ -58,7 +58,7 @@ impl EnrichedExpr {
     }
 
     /// Is the `EnrichedExpr` provable
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn is_provable(&self) -> bool {
         self.dyn_proof_expr.is_some()
     }

--- a/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/filter_exec_builder.rs
@@ -76,7 +76,7 @@ impl FilterExecBuilder {
         self
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn build(self) -> FilterExec {
         FilterExec::new(
             self.filter_result_expr_list,

--- a/crates/proof-of-sql/src/sql/parse/query_context.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context.rs
@@ -34,13 +34,13 @@ pub struct QueryContext {
 }
 
 impl QueryContext {
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn set_table_ref(&mut self, table: TableRef) {
         assert!(self.table.is_none());
         self.table = Some(table);
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn get_table_ref(&self) -> &TableRef {
         self.table
             .as_ref()
@@ -51,7 +51,7 @@ impl QueryContext {
         self.where_expr = where_expr;
     }
 
-    #[allow(clippy::ref_option)]
+    #[expect(clippy::ref_option)]
     pub fn get_where_expr(&self) -> &Option<Box<Expression>> {
         &self.where_expr
     }
@@ -68,7 +68,7 @@ impl QueryContext {
         self.in_result_scope
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn set_in_agg_scope(&mut self, in_agg_scope: bool) -> ConversionResult<()> {
         if !in_agg_scope {
             assert!(
@@ -117,7 +117,7 @@ impl QueryContext {
         }
     }
 
-    #[allow(clippy::missing_panics_doc, clippy::unnecessary_wraps)]
+    #[expect(clippy::missing_panics_doc, clippy::unnecessary_wraps)]
     pub fn push_aliased_result_expr(&mut self, expr: AliasedResultExpr) -> ConversionResult<()> {
         assert!(&self.has_visited_group_by, "Group by must be visited first");
         self.res_aliased_exprs.push(expr);
@@ -200,7 +200,7 @@ impl QueryContext {
         &self.order_by_exprs
     }
 
-    #[allow(clippy::ref_option)]
+    #[expect(clippy::ref_option)]
     pub fn get_slice_expr(&self) -> &Option<Slice> {
         &self.slice_expr
     }

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -33,7 +33,7 @@ impl<'a> QueryContextBuilder<'a> {
         }
     }
 
-    #[allow(clippy::vec_box, clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn visit_table_expr(
         mut self,
         table_expr: &[Box<TableExpression>],
@@ -140,7 +140,7 @@ impl<'a> QueryContextBuilder<'a> {
         Ok(self)
     }
 
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     pub fn build(self) -> ConversionResult<QueryContext> {
         Ok(self.context)
     }
@@ -148,7 +148,7 @@ impl<'a> QueryContextBuilder<'a> {
 
 // Private interface
 impl QueryContextBuilder<'_> {
-    #[allow(
+    #[expect(
         clippy::missing_panics_doc,
         reason = "The assertion ensures there is at least one column, and this is a fundamental requirement for schema retrieval."
     )]
@@ -281,7 +281,7 @@ impl QueryContextBuilder<'_> {
         }
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     fn visit_literal(&self, literal: &Literal) -> Result<ColumnType, ConversionError> {
         match literal {
             Literal::Boolean(_) => Ok(ColumnType::Boolean),

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing.rs
@@ -210,7 +210,7 @@ impl GroupByPostprocessing {
 
 impl<S: Scalar> PostprocessingStep<S> for GroupByPostprocessing {
     /// Apply the group by transformation to the given `OwnedTable`.
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn apply(&self, owned_table: OwnedTable<S>) -> PostprocessingResult<OwnedTable<S>> {
         // First evaluate all the aggregated columns
         let alloc = Bump::new();

--- a/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing_test.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/group_by_postprocessing_test.rs
@@ -60,7 +60,7 @@ fn we_can_make_group_by_postprocessing() {
     );
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[test]
 fn we_can_do_simple_group_bys() {
     // SELECT 1 as cons FROM tab
@@ -200,7 +200,6 @@ fn we_can_do_simple_group_bys() {
     assert_eq!(actual_table, expected_table);
 }
 
-#[allow(clippy::too_many_lines)]
 #[test]
 fn we_can_do_complex_group_bys() {
     // SELECT 2 * MAX(2 * a + 1) as max_a, MIN(b + 4) - 2.4 as min_b, SUM(c * 1.4) as sum_c, COUNT(d) + 3 as count_d FROM tab

--- a/crates/proof-of-sql/src/sql/postprocessing/slice_postprocessing_test.rs
+++ b/crates/proof-of-sql/src/sql/postprocessing/slice_postprocessing_test.rs
@@ -20,7 +20,7 @@ fn we_can_slice_an_owned_table_using_only_a_positive_limit_value() {
     assert_eq!(actual_table, expected_table);
 }
 
-#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+#[expect(clippy::cast_sign_loss)]
 #[test]
 fn we_can_slice_an_owned_table_using_only_a_zero_limit_value() {
     let limit = 0;
@@ -37,7 +37,7 @@ fn we_can_slice_an_owned_table_using_only_a_zero_limit_value() {
     assert_eq!(actual_table, expected_table);
 }
 
-#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+#[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
 #[test]
 fn we_can_slice_an_owned_table_using_only_a_positive_offset_value() {
     let offset = 3;
@@ -54,7 +54,7 @@ fn we_can_slice_an_owned_table_using_only_a_positive_offset_value() {
     assert_eq!(actual_table, expected_table);
 }
 
-#[allow(
+#[expect(
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap
@@ -81,7 +81,7 @@ fn we_can_slice_an_owned_table_using_only_a_negative_offset_value() {
     assert_eq!(actual_table, expected_table);
 }
 
-#[allow(
+#[expect(
     clippy::cast_sign_loss,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap

--- a/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/composite_polynomial_builder.rs
@@ -21,7 +21,7 @@ pub struct CompositePolynomialBuilder<S: Scalar> {
 }
 
 impl<S: Scalar> CompositePolynomialBuilder<S> {
-    #[allow(
+    #[expect(
         clippy::missing_panics_doc,
         reason = "The assertion ensures that the length of 'fr' does not exceed the allowable range based on 'num_sumcheck_variables', making the panic clear from context."
     )]
@@ -62,7 +62,7 @@ impl<S: Scalar> CompositePolynomialBuilder<S> {
     }
     /// Produce a polynomial term of the form
     ///    mult * term1(X1, ..., Xr) * ... * termK(X1, ..., Xr)
-    #[allow(
+    #[expect(
         clippy::missing_panics_doc,
         reason = "The assertion guarantees that terms are not empty, which is inherently clear from the context of this function."
     )]

--- a/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/first_round_builder.rs
@@ -69,7 +69,6 @@ impl<'a, S: Scalar> FirstRoundBuilder<'a, S> {
     }
 
     /// Append the length to the list of rho evaluation lengths.
-    #[allow(dead_code)]
     pub(crate) fn produce_rho_evaluation_length(&mut self, length: usize) {
         self.rho_evaluation_lengths.push(length);
     }

--- a/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
+++ b/crates/proof-of-sql/src/sql/proof/make_sumcheck_state.rs
@@ -166,7 +166,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn we_can_make_complex_sumcheck_prover_state() {
         let mle1 = &[0; 0];
         let mle2 = &[1];

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -19,7 +19,7 @@ pub struct ProvableQueryResult {
 
 // TODO: Handle truncation properly. The `allow(clippy::cast_possible_truncation)` is a temporary fix and should be replaced with proper logic to manage possible truncation scenarios.
 impl ProvableQueryResult {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     /// The number of columns in the result
     #[must_use]
     pub fn num_columns(&self) -> usize {
@@ -32,7 +32,7 @@ impl ProvableQueryResult {
         &mut self.num_columns
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     /// The number of rows in the result
     #[must_use]
     pub fn table_length(&self) -> usize {
@@ -81,11 +81,7 @@ impl ProvableQueryResult {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(
-        clippy::missing_panics_doc,
-        reason = "Assertions ensure preconditions are met, eliminating the possibility of panic."
-    )]
+    #[expect(clippy::cast_possible_truncation)]
     /// Given an evaluation vector, compute the evaluation of the intermediate result
     /// columns as spare multilinear extensions
     ///
@@ -144,7 +140,7 @@ impl ProvableQueryResult {
         Ok(res)
     }
 
-    #[allow(
+    #[expect(
         clippy::missing_panics_doc,
         reason = "Assertions ensure preconditions are met, eliminating the possibility of panic."
     )]

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result_test.rs
@@ -46,7 +46,6 @@ fn we_can_evaluate_result_columns_as_mles() {
     let evals = res
         .evaluate(&evaluation_point, 2, &column_fields[..])
         .unwrap();
-    #[allow(clippy::possible_missing_comma)]
     let expected_evals = [
         TestScalar::from(10u64) * evaluation_vec[0] - TestScalar::from(12u64) * evaluation_vec[1]
     ];
@@ -104,7 +103,7 @@ fn we_can_evaluate_multiple_result_columns_as_mles_with_128_bits() {
     assert_eq!(evals, expected_evals);
 }
 
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names)]
 #[test]
 fn we_can_evaluate_multiple_result_columns_as_mles_with_scalar_columns() {
     let col0 = [10, 12]

--- a/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
+++ b/crates/proof-of-sql/src/sql/proof/result_element_serialization.rs
@@ -318,7 +318,7 @@ mod tests {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     #[test]
     fn arbitrary_encoded_buffers_are_correctly_decoded() {
         let mut rng = StdRng::from_seed([0u8; 32]);

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_mle_evaluations.rs
@@ -38,7 +38,7 @@ pub struct SumcheckMleEvaluations<'a, S: Scalar> {
     pub rho_256_evaluation: Option<S>,
 }
 
-#[allow(
+#[expect(
     clippy::missing_panics_doc,
     reason = "Assertions ensure preconditions are met, eliminating the possibility of panic."
 )]

--- a/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
+++ b/crates/proof-of-sql/src/sql/proof/sumcheck_subpolynomial.rs
@@ -58,7 +58,6 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn subpolynomial_type(&self) -> SumcheckSubpolynomialType {
         self.subpolynomial_type
     }
@@ -74,7 +73,6 @@ impl<'a, S: Scalar> SumcheckSubpolynomial<'a, S> {
     ///
     /// An iterator that yields tuples containing the subpolynomial type, the
     /// multiplied coefficient, and a slice of multilinear extensions.
-    #[allow(dead_code)]
     pub(crate) fn iter_mul_by(
         &self,
         multiplier: S,

--- a/crates/proof-of-sql/src/sql/proof/verification_builder.rs
+++ b/crates/proof-of-sql/src/sql/proof/verification_builder.rs
@@ -74,11 +74,6 @@ pub struct VerificationBuilderImpl<'a, S: Scalar> {
 }
 
 impl<'a, S: Scalar> VerificationBuilderImpl<'a, S> {
-    #[allow(
-        clippy::missing_panics_doc,
-        reason = "The only possible panic is from the assertion comparing lengths, which is clear from context."
-    )]
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         mle_evaluations: SumcheckMleEvaluations<'a, S>,
         bit_distributions: &'a [BitDistribution],
@@ -105,7 +100,7 @@ impl<'a, S: Scalar> VerificationBuilderImpl<'a, S> {
         }
     }
 
-    #[allow(
+    #[expect(
         clippy::missing_panics_doc,
         reason = "The panic condition is clear due to the assertion that checks if the computation is completed."
     )]

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -18,7 +18,7 @@ use sqlparser::ast::BinaryOperator;
 /// # Panics
 /// This function will panic if `lhs` and `rhs` have [`ColumnType`]s that are not comparable
 /// or if we have precision overflow issues.
-#[allow(clippy::cast_sign_loss)]
+#[expect(clippy::cast_sign_loss)]
 pub fn scale_and_subtract_literal<S: Scalar>(
     lhs: &LiteralValue,
     rhs: &LiteralValue,
@@ -76,13 +76,13 @@ pub fn scale_and_subtract_literal<S: Scalar>(
     }
 }
 
-#[allow(
+#[expect(
     clippy::missing_panics_doc,
     reason = "precision and scale are validated prior to calling this function, ensuring no panic occurs"
 )]
 /// Scale LHS and RHS to the same scale if at least one of them is decimal
 /// and take the difference. This function is used for comparisons.
-#[allow(clippy::cast_sign_loss)]
+#[expect(clippy::cast_sign_loss)]
 pub(crate) fn scale_and_subtract<'a, S: Scalar>(
     alloc: &'a Bump,
     lhs: Column<'a, S>,
@@ -145,8 +145,7 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
     Ok(result)
 }
 
-#[allow(clippy::cast_sign_loss)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 /// Scale LHS and RHS to the same scale if at least one of them is decimal
 /// and take the difference. This function is used for comparisons.
 pub(crate) fn scale_and_subtract_columnar_value<'a, S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -102,7 +102,7 @@ impl ProofExpr for EqualsExpr {
     }
 }
 
-#[allow(
+#[expect(
     clippy::missing_panics_doc,
     reason = "table_length is guaranteed to match lhs.len()"
 )]

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -7,7 +7,7 @@ use core::{cmp::Ordering, ops::Neg};
 use itertools::izip;
 use num_traits::{NumCast, PrimInt};
 
-#[allow(clippy::cast_sign_loss)]
+#[expect(clippy::cast_sign_loss)]
 /// Add or subtract two literals together.
 pub(crate) fn add_subtract_literals<S: Scalar>(
     lhs: &LiteralValue,
@@ -34,7 +34,7 @@ pub(crate) fn add_subtract_literals<S: Scalar>(
     }
 }
 
-#[allow(
+#[expect(
     clippy::missing_panics_doc,
     reason = "lhs and rhs are guaranteed to have the same length by design, ensuring no panic occurs"
 )]
@@ -67,7 +67,7 @@ pub(crate) fn add_subtract_columns<'a, S: Scalar>(
 }
 
 /// Add or subtract two [`ColumnarValues`] together.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn add_subtract_columnar_values<'a, S: Scalar>(
     lhs: ColumnarValue<'a, S>,
     rhs: ColumnarValue<'a, S>,
@@ -134,7 +134,7 @@ pub(crate) fn multiply_columns<'a, S: Scalar>(
     })
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 /// Multiply two [`ColumnarValues`] together.
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length.
@@ -166,10 +166,6 @@ pub(crate) fn multiply_columnar_values<'a, S: Scalar>(
     }
 }
 
-#[allow(
-    clippy::missing_panics_doc,
-    reason = "scaling factor is guaranteed to not be negative based on input validation prior to calling this function"
-)]
 /// The counterpart of `add_subtract_columns` for evaluating decimal expressions.
 pub(crate) fn scale_and_add_subtract_eval<S: Scalar>(
     lhs_eval: S,
@@ -274,7 +270,7 @@ fn modulo_integer_columns<
 /// For now, only signed integer types are supported.
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length or column type division is unsupported.
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[cfg_attr(not(test), expect(dead_code))]
 pub(crate) fn divide_columns<'a, S: Scalar>(
     lhs: &Column<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -89,7 +89,7 @@ impl ProofExpr for OrExpr {
     }
 }
 
-#[allow(
+#[expect(
     clippy::missing_panics_doc,
     reason = "table_length matches lhs and rhs lengths, ensuring no panic occurs"
 )]
@@ -104,7 +104,7 @@ pub fn result_evaluate_or<'a>(
     alloc.alloc_slice_fill_with(table_length, |i| lhs[i] || rhs[i])
 }
 
-#[allow(
+#[expect(
     clippy::missing_panics_doc,
     reason = "lhs and rhs are guaranteed to have the same length, ensuring no panic occurs"
 )]

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check.rs
@@ -46,8 +46,7 @@ pub(crate) fn first_round_evaluate_membership_check<'a, S: Scalar>(
 /// # Panics
 /// Panics if the number of source and candidate columns are not equal
 /// or if the number of columns is zero.
-#[allow(dead_code)]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn final_round_evaluate_membership_check<'a, S: Scalar>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
@@ -126,7 +125,7 @@ pub(crate) fn final_round_evaluate_membership_check<'a, S: Scalar>(
     multiplicities
 }
 
-#[allow(dead_code, clippy::similar_names)]
+#[expect(clippy::similar_names)]
 pub(crate) fn verify_membership_check<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
     alpha: S,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -154,7 +154,7 @@ impl ProofPlan for MembershipCheckTestPlan {
     }
 
     #[doc = "Form components needed to verify and proof store into `VerificationBuilder`"]
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
 mod membership_check;
 mod monotonic;
+#[allow(dead_code)]
 mod permutation_check;
 mod shift;
 pub(crate) use membership_check::{
@@ -9,7 +10,7 @@ pub(crate) use membership_check::{
 };
 #[cfg(test)]
 mod membership_check_test;
-#[allow(unused_imports, dead_code)]
+#[expect(unused_imports)]
 use permutation_check::{final_round_evaluate_permutation_check, verify_permutation_check};
 #[cfg(test)]
 mod permutation_check_test;
@@ -19,7 +20,7 @@ mod shift_test;
 mod sign_expr;
 pub(crate) use sign_expr::{prover_evaluate_sign, result_evaluate_sign, verifier_evaluate_sign};
 #[cfg(feature = "blitzar")]
-#[allow(unused_imports, dead_code)] // remove this when we use it
+#[allow(dead_code)]
 mod range_check;
 #[cfg(all(test, feature = "blitzar"))]
 mod range_check_test;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -20,7 +20,6 @@ pub(crate) fn first_round_evaluate_monotonic<S: Scalar>(
 }
 
 /// Perform final round evaluation of monotonicity.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn final_round_evaluate_monotonic<'a, S: Scalar, const STRICT: bool, const ASC: bool>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
@@ -14,8 +14,6 @@ use num_traits::{One, Zero};
 /// # Panics
 /// Panics if the number of source and candidate columns are not equal
 /// or if the number of columns is zero.
-#[allow(dead_code)]
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn final_round_evaluate_permutation_check<'a, S: Scalar>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
@@ -87,7 +85,6 @@ pub(crate) fn final_round_evaluate_permutation_check<'a, S: Scalar>(
     );
 }
 
-#[allow(dead_code)]
 pub(crate) fn verify_permutation_check<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
     alpha: S,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -277,7 +277,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cast_sign_loss)]
     fn we_can_prove_a_range_check_with_range_up_to_boundary() {
         // 2^248 - 1
         let big_uint = BigUint::from(2u8).pow(248) - BigUint::from(1u8);

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift.rs
@@ -26,7 +26,6 @@ pub(crate) fn first_round_evaluate_shift<S: Scalar>(
 ///
 /// # Panics
 /// Panics if `column.len() != shifted_column.len() - 1` which should always hold for shifts.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn final_round_evaluate_shift<'a, S: Scalar>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -36,7 +36,6 @@ impl EmptyExec {
 }
 
 impl ProofPlan for EmptyExec {
-    #[allow(unused_variables)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -84,7 +83,6 @@ impl ProverEvaluate for EmptyExec {
     }
 
     #[tracing::instrument(name = "EmptyExec::final_round_evaluate", level = "debug", skip_all)]
-    #[allow(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         _builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -60,7 +60,6 @@ impl<H: ProverHonestyMarker> ProofPlan for OstensibleFilterExec<H>
 where
     OstensibleFilterExec<H>: ProverEvaluate,
 {
-    #[allow(unused_variables)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -187,7 +186,6 @@ impl ProverEvaluate for FilterExec {
     }
 
     #[tracing::instrument(name = "FilterExec::final_round_evaluate", level = "debug", skip_all)]
-    #[allow(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
@@ -249,11 +247,7 @@ impl ProverEvaluate for FilterExec {
     }
 }
 
-#[allow(
-    clippy::unnecessary_wraps,
-    clippy::too_many_arguments,
-    clippy::similar_names
-)]
+#[expect(clippy::too_many_arguments, clippy::similar_names)]
 pub(super) fn verify_filter<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
     alpha: S,
@@ -293,7 +287,7 @@ pub(super) fn verify_filter<S: Scalar>(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments, clippy::many_single_char_names)]
+#[expect(clippy::too_many_arguments, clippy::many_single_char_names)]
 pub(super) fn prove_filter<'a, S: Scalar + 'a>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -82,7 +82,6 @@ impl ProverEvaluate for DishonestFilterExec {
         level = "debug",
         skip_all
     )]
-    #[allow(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -68,7 +68,6 @@ impl GroupByExec {
 }
 
 impl ProofPlan for GroupByExec {
-    #[allow(unused_variables)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -155,7 +154,7 @@ impl ProofPlan for GroupByExec {
         Ok(TableEvaluation::new(column_evals, output_chi_eval))
     }
 
-    #[allow(clippy::redundant_closure_for_method_calls)]
+    #[expect(clippy::redundant_closure_for_method_calls)]
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.group_by_exprs
             .iter()
@@ -251,7 +250,6 @@ impl ProverEvaluate for GroupByExec {
     }
 
     #[tracing::instrument(name = "GroupByExec::final_round_evaluate", level = "debug", skip_all)]
-    #[allow(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
@@ -328,7 +326,6 @@ impl ProverEvaluate for GroupByExec {
     }
 }
 
-#[allow(clippy::unnecessary_wraps)]
 fn verify_group_by<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
     alpha: S,
@@ -374,10 +371,6 @@ fn verify_group_by<S: Scalar>(
     Ok(())
 }
 
-#[allow(
-    clippy::missing_panics_doc,
-    reason = "alpha is guaranteed to not be zero in this context"
-)]
 pub fn prove_group_by<'a, S: Scalar>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
@@ -75,7 +75,7 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
     assert_eq!(res, expected);
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[test]
 fn we_can_prove_a_complex_group_by_query_with_many_columns() {
     let scalar_filter_data: Vec<Curve25519Scalar> = [

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -41,7 +41,6 @@ impl ProjectionExec {
 }
 
 impl ProofPlan for ProjectionExec {
-    #[allow(unused_variables)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -153,7 +152,6 @@ impl ProverEvaluate for ProjectionExec {
         level = "debug",
         skip_all
     )]
-    #[allow(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -45,7 +45,6 @@ fn get_slice_select(num_rows: usize, skip: usize, fetch: Option<usize>) -> Vec<b
 
 impl SliceExec {
     /// Creates a new slice execution plan.
-    #[allow(dead_code)]
     pub fn new(input: Box<DynProofPlan>, skip: usize, fetch: Option<usize>) -> Self {
         Self { input, skip, fetch }
     }
@@ -55,7 +54,6 @@ impl ProofPlan for SliceExec
 where
     SliceExec: ProverEvaluate,
 {
-    #[allow(unused_variables)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -154,7 +152,6 @@ impl ProverEvaluate for SliceExec {
     }
 
     #[tracing::instrument(name = "SliceExec::prover_evaluate", level = "debug", skip_all)]
-    #[allow(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -97,7 +97,7 @@ impl ProofPlan for SortMergeJoinExec
 where
     SortMergeJoinExec: ProverEvaluate,
 {
-    #[allow(clippy::too_many_lines, clippy::similar_names)]
+    #[expect(clippy::too_many_lines, clippy::similar_names)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -422,7 +422,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         level = "debug",
         skip_all
     )]
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -132,7 +132,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_sort_merge_joins() {
     let alloc = Bump::new();
     let mut accessor = TableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
@@ -304,7 +304,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
     assert_eq!(res, expected_res);
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[test]
 fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_or_both_tables_have_no_rows(
 ) {

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -34,7 +34,7 @@ impl TableExec {
 }
 
 impl ProofPlan for TableExec {
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -94,7 +94,7 @@ impl ProverEvaluate for TableExec {
     }
 
     #[tracing::instrument(name = "TableExec::final_round_evaluate", level = "debug", skip_all)]
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -47,7 +47,7 @@ impl ProofPlan for UnionExec
 where
     UnionExec: ProverEvaluate,
 {
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
@@ -125,7 +125,6 @@ impl ProverEvaluate for UnionExec {
     }
 
     #[tracing::instrument(name = "UnionExec::prover_evaluate", level = "debug", skip_all)]
-    #[allow(unused_variables)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
@@ -169,7 +168,6 @@ impl ProverEvaluate for UnionExec {
 ///
 /// # Panics
 /// Should never panic if the code is correct.
-#[allow(clippy::too_many_arguments)]
 fn verify_union<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
     gamma: S,
@@ -223,7 +221,7 @@ fn verify_union<S: Scalar>(
 ///
 /// # Panics
 /// Should never panic if the code is correct.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn prove_union<'a, S: Scalar + 'a>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -140,7 +140,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
     assert_eq!(res, expected_res);
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[test]
 fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
     let alloc = Bump::new();

--- a/crates/proof-of-sql/src/utils/log.rs
+++ b/crates/proof-of-sql/src/utils/log.rs
@@ -10,7 +10,7 @@ use tracing::{trace, Level};
 /// # Arguments
 ///
 /// * `name` - A string slice that holds the name to be included in the log message.
-#[allow(clippy::cast_precision_loss)]
+#[expect(clippy::cast_precision_loss)]
 pub fn log_memory_usage(name: &str) {
     #[cfg(feature = "std")]
     if tracing::level_enabled!(Level::TRACE) {

--- a/crates/proof-of-sql/src/utils/parse.rs
+++ b/crates/proof-of-sql/src/utils/parse.rs
@@ -9,7 +9,7 @@ use sqlparser::{
     parser::Parser,
 };
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 /// Parse a DDL file and return a map of table names to bigdecimal columns
 ///
 /// # Panics

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -949,7 +949,7 @@ fn we_can_perform_equality_checks_on_var_binary() {
 
 #[test]
 #[cfg(feature = "blitzar")]
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn we_can_perform_rich_equality_checks_on_var_binary() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     accessor.add_table(
@@ -1067,7 +1067,7 @@ fn we_can_perform_rich_equality_checks_on_var_binary() {
 
 #[test]
 #[cfg(feature = "blitzar")]
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn we_can_perform_equality_checks_on_rich_var_binary_data() {
     let mut accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     // We'll create multiple columns to have richer data,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Note that this doesn't actually remove `allow` in all cases. In particular in macros `allow` is sometimes necessary since there are cases when lint expectations are warranted and cases where they aren't.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- replace `allow` with `expect` in many cases
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.