### PR TITLE
feat: add group by support in the planner

### DIFF
--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(test, expect(clippy::missing_panics_doc))]
 extern crate alloc;
 mod aggregate;
+pub(crate) use aggregate::{aggregate_function_to_proof_expr, AggregateFunc};
 mod context;
 pub use context::PoSqlContextProvider;
 #[cfg(test)]

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -1,18 +1,20 @@
 use super::{
-    df_schema_to_column_fields, expr_to_proof_expr, table_reference_to_table_ref, PlannerError,
-    PlannerResult,
+    aggregate_function_to_proof_expr, column_to_column_ref, df_schema_to_column_fields,
+    expr_to_proof_expr, table_reference_to_table_ref, AggregateFunc, PlannerError, PlannerResult,
 };
 use alloc::vec::Vec;
 use datafusion::{
     common::DFSchema,
-    logical_expr::{Expr, Limit, LogicalPlan, Projection, TableScan, Union},
+    logical_expr::{
+        expr::Alias, Aggregate, Expr, Limit, LogicalPlan, Projection, TableScan, Union,
+    },
     sql::{sqlparser::ast::Ident, TableReference},
 };
 use indexmap::IndexMap;
 use proof_of_sql::{
-    base::database::{ColumnRef, ColumnType, TableRef},
+    base::database::{ColumnRef, ColumnType, LiteralValue, TableRef},
     sql::{
-        proof_exprs::{AliasedDynProofExpr, DynProofExpr, TableExpr},
+        proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
         proof_plans::DynProofPlan,
     },
 };
@@ -139,6 +141,128 @@ fn projection_to_proof_plan(
     Ok(DynProofPlan::new_projection(aliased_exprs, input_plan))
 }
 
+/// Convert a [`datafusion::logical_plan::LogicalPlan`] to a [`DynProofPlan`] for GROUP BYs
+///
+/// TODO: Improve how we handle GROUP BYs so that all the tech debt is resolved
+///
+/// # Panics
+/// The code should never panic
+fn aggregate_to_proof_plan(
+    input: &LogicalPlan,
+    group_expr: &[Expr],
+    aggr_expr: &[Expr],
+    schemas: &IndexMap<TableReference, DFSchema>,
+    alias_map: &IndexMap<&str, &str>,
+) -> PlannerResult<DynProofPlan> {
+    // Check that all of `group_expr` are columns and get their names
+    let group_columns = group_expr
+        .iter()
+        .map(|e| match e {
+            Expr::Column(c) => Ok(c),
+            _ => Err(PlannerError::UnsupportedLogicalPlan {
+                plan: input.clone(),
+            }),
+        })
+        .collect::<PlannerResult<Vec<_>>>()?;
+    match input {
+        // Only TableScan without fetch is supported
+        LogicalPlan::TableScan(TableScan {
+            table_name,
+            filters,
+            fetch: None,
+            ..
+        }) => {
+            let table_ref = table_reference_to_table_ref(table_name)?;
+            let input_schema =
+                schemas
+                    .get(table_name)
+                    .ok_or_else(|| PlannerError::TableNotFound {
+                        table_name: table_name.to_string(),
+                    })?;
+            let table_expr = TableExpr { table_ref };
+            // Filter
+            let consolidated_filter_proof_expr = filters
+                .iter()
+                .map(|f| expr_to_proof_expr(f, input_schema))
+                .reduce(|a, b| Ok(DynProofExpr::try_new_and(a?, b?)?))
+                .unwrap_or_else(|| Ok(DynProofExpr::new_literal(LiteralValue::Boolean(true))))?;
+            // Aggregate
+            // Prove that the ordering of `aggr_expr` is
+            // 1. All group columns according to `group_columns`
+            // 2. (Optional) All the SUMs
+            // 3. COUNT
+            if aggr_expr.is_empty() {
+                return Err(PlannerError::UnsupportedLogicalPlan {
+                    plan: input.clone(),
+                });
+            }
+            let agg_aliased_proof_exprs: Vec<((AggregateFunc, DynProofExpr), Ident)> = aggr_expr
+                .iter()
+                .map(|e| match e {
+                    Expr::AggregateFunction(agg) => {
+                        let name_string = e.display_name()?;
+                        let name = name_string.as_str();
+                        let alias = alias_map.get(&name).ok_or_else(|| {
+                            PlannerError::UnsupportedLogicalPlan {
+                                plan: input.clone(),
+                            }
+                        })?;
+                        Ok((
+                            aggregate_function_to_proof_expr(agg, input_schema)?,
+                            (*alias).into(),
+                        ))
+                    }
+                    _ => Err(PlannerError::UnsupportedLogicalPlan {
+                        plan: input.clone(),
+                    }),
+                })
+                .collect::<PlannerResult<Vec<_>>>()?;
+            // Check that the last expression is COUNT and the rest are SUMs
+            let (sum_tuples, count_tuple) =
+                agg_aliased_proof_exprs.split_at(agg_aliased_proof_exprs.len() - 1);
+            let sum_is_compliant = sum_tuples
+                .iter()
+                .all(|((op, _), _)| matches!(op, AggregateFunc::Sum));
+            let count_is_compliant = count_tuple
+                .iter()
+                .all(|((op, _), _)| matches!(op, AggregateFunc::Count));
+            if !sum_is_compliant || !count_is_compliant {
+                return Err(PlannerError::UnsupportedLogicalPlan {
+                    plan: input.clone(),
+                });
+            }
+            let count_alias = agg_aliased_proof_exprs
+                .last()
+                .expect("We have already checked that this exists")
+                .1
+                .clone();
+            // `group_by_exprs`
+            let group_by_exprs = group_columns
+                .iter()
+                .map(|column| Ok(ColumnExpr::new(column_to_column_ref(column, input_schema)?)))
+                .collect::<PlannerResult<Vec<_>>>()?;
+            // `sum_expr`
+            let sum_expr = sum_tuples
+                .iter()
+                .map(|((_, expr), alias)| AliasedDynProofExpr {
+                    expr: expr.clone(),
+                    alias: alias.clone(),
+                })
+                .collect::<Vec<_>>();
+            Ok(DynProofPlan::new_group_by(
+                group_by_exprs,
+                sum_expr,
+                count_alias,
+                table_expr,
+                consolidated_filter_proof_expr,
+            ))
+        }
+        _ => Err(PlannerError::UnsupportedLogicalPlan {
+            plan: input.clone(),
+        }),
+    }
+}
+
 /// Visit a [`datafusion::logical_plan::LogicalPlan`] and return a [`DynProofPlan`]
 pub fn logical_plan_to_proof_plan(
     plan: &LogicalPlan,
@@ -172,7 +296,34 @@ pub fn logical_plan_to_proof_plan(
             expr,
             schema,
             ..
-        }) => projection_to_proof_plan(expr, input, schema, schemas),
+        }) => {
+            match &**input {
+                LogicalPlan::Aggregate(Aggregate {
+                    input: agg_input,
+                    group_expr,
+                    aggr_expr,
+                    ..
+                }) => {
+                    // Check whether the last layer is identity
+                    let alias_map = expr
+                        .iter()
+                        .map(|e| match e {
+                            Expr::Column(c) => Ok((c.name.as_str(), c.name.as_str())),
+                            Expr::Alias(Alias { expr, name, .. }) => {
+                                if let Expr::Column(c) = expr.as_ref() {
+                                    Ok((c.name.as_str(), name.as_str()))
+                                } else {
+                                    Err(PlannerError::UnsupportedLogicalPlan { plan: plan.clone() })
+                                }
+                            }
+                            _ => Err(PlannerError::UnsupportedLogicalPlan { plan: plan.clone() }),
+                        })
+                        .collect::<PlannerResult<IndexMap<_, _>>>()?;
+                    aggregate_to_proof_plan(agg_input, group_expr, aggr_expr, schemas, &alias_map)
+                }
+                _ => projection_to_proof_plan(expr, input, schema, schemas),
+            }
+        }
         // Limit
         LogicalPlan::Limit(Limit { input, fetch, skip }) => {
             let input_plan = logical_plan_to_proof_plan(input, schemas)?;
@@ -197,11 +348,24 @@ mod tests {
     use crate::{df_util::*, PoSqlTableSource};
     use alloc::{sync::Arc, vec};
     use arrow::datatypes::DataType;
-    use datafusion::logical_expr::{
-        not, BinaryExpr, EmptyRelation, Operator, Prepare, TableScan, TableSource,
+    use core::ops::Add;
+    use datafusion::{
+        common::{Column, ScalarValue},
+        logical_expr::{
+            expr::{AggregateFunction, AggregateFunctionDefinition},
+            not, BinaryExpr, EmptyRelation, Operator, Prepare, TableScan, TableSource,
+        },
+        physical_plan,
     };
     use indexmap::indexmap;
     use proof_of_sql::base::database::ColumnField;
+
+    const SUM: AggregateFunctionDefinition =
+        AggregateFunctionDefinition::BuiltIn(physical_plan::aggregates::AggregateFunction::Sum);
+    const COUNT: AggregateFunctionDefinition =
+        AggregateFunctionDefinition::BuiltIn(physical_plan::aggregates::AggregateFunction::Count);
+    const AVG: AggregateFunctionDefinition =
+        AggregateFunctionDefinition::BuiltIn(physical_plan::aggregates::AggregateFunction::Avg);
 
     #[expect(non_snake_case)]
     fn TABLE_REF_TABLE() -> TableRef {
@@ -313,6 +477,42 @@ mod tests {
         }
     }
 
+    #[expect(non_snake_case)]
+    fn COUNT_1() -> Expr {
+        Expr::AggregateFunction(AggregateFunction {
+            func_def: COUNT,
+            args: vec![Expr::Literal(ScalarValue::Int8(Some(1)))],
+            distinct: false,
+            filter: None,
+            order_by: None,
+            null_treatment: None,
+        })
+    }
+
+    #[expect(non_snake_case)]
+    fn SUM_B() -> Expr {
+        Expr::AggregateFunction(AggregateFunction {
+            func_def: SUM,
+            args: vec![df_column("table", "b")],
+            distinct: false,
+            filter: None,
+            order_by: None,
+            null_treatment: None,
+        })
+    }
+
+    #[expect(non_snake_case)]
+    fn SUM_D() -> Expr {
+        Expr::AggregateFunction(AggregateFunction {
+            func_def: SUM,
+            args: vec![df_column("table", "d")],
+            distinct: false,
+            filter: None,
+            order_by: None,
+            null_treatment: None,
+        })
+    }
+
     // get_aliased_dyn_proof_exprs
     #[test]
     fn we_can_get_aliased_proof_expr_with_specified_projection_columns() {
@@ -386,6 +586,602 @@ mod tests {
         assert!(matches!(
             get_aliased_dyn_proof_exprs(&table_ref, &[1, 2, 3], &input_schema, &output_schema,),
             Err(PlannerError::UnsupportedDataType { .. })
+        ));
+    }
+
+    // aggregate_to_proof_plan
+    #[test]
+    fn we_can_aggregate_with_group_by_and_sum_count() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Create the aggregate expressions (must follow the pattern: group columns, then SUMs, then COUNT)
+        let aggr_expr = vec![
+            SUM_B(),   // SUM
+            COUNT_1(), // COUNT
+        ];
+
+        // Create the input plan
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "a" => "a",
+            "SUM(table.b)" => "sum_b",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
+                .unwrap();
+
+        // Expected result
+        let expected = DynProofPlan::new_group_by(
+            vec![ColumnExpr::new(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "a".into(),
+                ColumnType::BigInt,
+            ))],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "b".into(),
+                    ColumnType::Int,
+                )),
+                alias: "sum_b".into(),
+            }],
+            "count_1".into(),
+            TableExpr {
+                table_ref: TABLE_REF_TABLE(),
+            },
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_aggregate_with_filters() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            SUM_B(),   // SUM
+            COUNT_1(), // COUNT
+        ];
+
+        // Create filters
+        let filter_exprs = vec![
+            df_column("table", "d"), // Boolean column as filter
+        ];
+
+        // Create the input plan with filters
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                filter_exprs,
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "a" => "a",
+            "SUM(table.b)" => "sum_b",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
+                .unwrap();
+
+        // Expected result
+        let expected = DynProofPlan::new_group_by(
+            vec![ColumnExpr::new(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "a".into(),
+                ColumnType::BigInt,
+            ))],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "b".into(),
+                    ColumnType::Int,
+                )),
+                alias: "sum_b".into(),
+            }],
+            "count_1".into(),
+            TableExpr {
+                table_ref: TABLE_REF_TABLE(),
+            },
+            DynProofExpr::new_column(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "d".into(),
+                ColumnType::Boolean,
+            )),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_aggregate_with_multiple_group_columns() {
+        // Setup group expressions
+        let group_expr = vec![df_column("table", "a"), df_column("table", "c")];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            SUM_B(),   // SUM
+            COUNT_1(), // COUNT
+        ];
+
+        // Create the input plan
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "a" => "a",
+            "c" => "c",
+            "SUM(table.b)" => "sum_b",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
+                .unwrap();
+
+        // Expected result
+        let expected = DynProofPlan::new_group_by(
+            vec![
+                ColumnExpr::new(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "a".into(),
+                    ColumnType::BigInt,
+                )),
+                ColumnExpr::new(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "c".into(),
+                    ColumnType::VarChar,
+                )),
+            ],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "b".into(),
+                    ColumnType::Int,
+                )),
+                alias: "sum_b".into(),
+            }],
+            "count_1".into(),
+            TableExpr {
+                table_ref: TABLE_REF_TABLE(),
+            },
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_aggregate_with_multiple_sum_expressions() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            SUM_B(),   // First SUM
+            SUM_D(),   // Second SUM
+            COUNT_1(), // COUNT
+        ];
+
+        // Create the input plan
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "a" => "a",
+            "SUM(table.b)" => "sum_b",
+            "SUM(table.d)" => "sum_d",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
+                .unwrap();
+
+        // Expected result
+        let expected = DynProofPlan::new_group_by(
+            vec![ColumnExpr::new(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "a".into(),
+                ColumnType::BigInt,
+            ))],
+            vec![
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_column(ColumnRef::new(
+                        TABLE_REF_TABLE(),
+                        "b".into(),
+                        ColumnType::Int,
+                    )),
+                    alias: "sum_b".into(),
+                },
+                AliasedDynProofExpr {
+                    expr: DynProofExpr::new_column(ColumnRef::new(
+                        TABLE_REF_TABLE(),
+                        "d".into(),
+                        ColumnType::Boolean,
+                    )),
+                    alias: "sum_d".into(),
+                },
+            ],
+            "count_1".into(),
+            TableExpr {
+                table_ref: TABLE_REF_TABLE(),
+            },
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_can_aggregate_without_sum_expressions() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            COUNT_1(), // COUNT
+        ];
+
+        // Create the input plan
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "a" => "a",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map)
+                .unwrap();
+
+        // Expected result
+        let expected = DynProofPlan::new_group_by(
+            vec![ColumnExpr::new(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "a".into(),
+                ColumnType::BigInt,
+            ))],
+            vec![], // No SUMs
+            "count_1".into(),
+            TableExpr {
+                table_ref: TABLE_REF_TABLE(),
+            },
+            DynProofExpr::new_literal(LiteralValue::Boolean(true)),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    // Error case tests
+    #[test]
+    fn we_cannot_aggregate_with_non_column_group_expr() {
+        // Setup group expression with a non-column expression
+        let group_expr = vec![Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(df_column("table", "a")),
+            Operator::Plus,
+            Box::new(df_column("table", "b")),
+        ))];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            Expr::BinaryExpr(BinaryExpr::new(
+                Box::new(df_column("table", "a")),
+                Operator::Plus,
+                Box::new(df_column("table", "b")),
+            )),
+            COUNT_1(),
+        ];
+
+        // Create the input plan
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "a+b" => "res",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function - should return an error
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_with_non_aggregate_expression() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Setup a non-aggregate expression
+        let non_agg_expr = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(df_column("table", "b")),
+            Operator::Plus,
+            Box::new(df_column("table", "c")),
+        ));
+
+        // Setup aliased expression
+        let aliased_non_agg = Expr::Alias(Alias {
+            expr: Box::new(non_agg_expr),
+            relation: None,
+            name: "b_plus_c".to_string(),
+        });
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            aliased_non_agg, // Non-aggregate expression
+        ];
+
+        // Create the input plan
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "b+c" => "b_plus_c",
+        };
+
+        // Test the function - should return an error
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_with_non_sum_aggregate_function() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Setup a non-SUM aggregate function (e.g., Avg)
+        let avg_expr = Expr::AggregateFunction(AggregateFunction {
+            func_def: AVG,
+            args: vec![df_column("table", "b")],
+            distinct: false,
+            filter: None,
+            order_by: None,
+            null_treatment: None,
+        });
+
+        // Setup aliased expressions
+        let aliased_avg = Expr::Alias(Alias {
+            expr: Box::new(avg_expr),
+            relation: None,
+            name: "avg_b".to_string(),
+        });
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            aliased_avg, // AVG aggregate (not SUM)
+            COUNT_1(),   // COUNT
+        ];
+
+        // Create the input plan
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let aliased_map = indexmap! {
+            "a" => "a",
+            "AVG(table.b)" => "avg_b",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function - should return an error
+        let result = aggregate_to_proof_plan(
+            &input_plan,
+            &group_expr,
+            &aggr_expr,
+            &SCHEMAS(),
+            &aliased_map,
+        );
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_with_non_count_last_aggregate() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Setup SUM aggregates
+        let sum_expr1 = Expr::AggregateFunction(AggregateFunction {
+            func_def: SUM,
+            args: vec![df_column("table", "b")],
+            distinct: false,
+            filter: None,
+            order_by: None,
+            null_treatment: None,
+        });
+
+        let sum_expr2 = Expr::AggregateFunction(AggregateFunction {
+            func_def: SUM,
+            args: vec![df_column("table", "c")],
+            distinct: false,
+            filter: None,
+            order_by: None,
+            null_treatment: None,
+        });
+
+        // Setup aliased expressions
+        let aliased_sum1 = Expr::Alias(Alias {
+            expr: Box::new(sum_expr1),
+            relation: None,
+            name: "sum_b".to_string(),
+        });
+
+        let aliased_sum2 = Expr::Alias(Alias {
+            expr: Box::new(sum_expr2),
+            relation: None,
+            name: "sum_c".to_string(),
+        });
+
+        // Create the aggregate expressions with no COUNT at the end
+        let aggr_expr = vec![
+            aliased_sum1, // SUM
+            aliased_sum2, // Another SUM (should be COUNT)
+        ];
+
+        // Create the input plan
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                None,
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "a" => "a",
+            "SUM(table.b)" => "sum_b",
+            "SUM(c)" => "sum_c",
+        };
+
+        // Test the function - should return an error
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_with_fetch_limit() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            COUNT_1(), // COUNT
+        ];
+
+        // Create the input plan with fetch limit
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                vec![],
+                Some(10),
+            )
+            .unwrap(),
+        );
+        let alias_map = indexmap! {
+            "a" => "a",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function - should return an error because fetch limit is not supported
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_aggregate_with_non_table_scan_input() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            COUNT_1(), // COUNT
+        ];
+
+        // Create a non-TableScan input plan
+        let input_plan = LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(DFSchema::empty()),
+        });
+        let alias_map = indexmap! {
+            "a" => "a",
+            "COUNT(Int8(1))" => "count_1",
+        };
+
+        // Test the function - should return an error
+        let result =
+            aggregate_to_proof_plan(&input_plan, &group_expr, &aggr_expr, &SCHEMAS(), &alias_map);
+        assert!(matches!(
+            result,
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
         ));
     }
 
@@ -901,6 +1697,140 @@ mod tests {
             ],
         );
         assert_eq!(result, expected);
+    }
+
+    // Aggregate
+    #[test]
+    fn we_can_convert_supported_agg_plan_to_proof_plan() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            SUM_B(),   // SUM
+            COUNT_1(), // COUNT
+        ];
+
+        // Create filters
+        let filter_exprs = vec![
+            df_column("table", "d"), // Boolean column as filter
+        ];
+
+        // Create the input plan with filters
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                filter_exprs,
+                None,
+            )
+            .unwrap(),
+        );
+
+        let agg_plan = LogicalPlan::Aggregate(
+            Aggregate::try_new(Arc::new(input_plan), group_expr.clone(), aggr_expr.clone())
+                .unwrap(),
+        );
+
+        let proj_plan = LogicalPlan::Projection(
+            Projection::try_new(
+                vec![
+                    df_column("table", "a"),
+                    Expr::Column(Column::new(
+                        None::<TableReference>,
+                        "SUM(table.b)".to_string(),
+                    ))
+                    .alias("sum_b"),
+                    Expr::Column(Column::new(
+                        None::<TableReference>,
+                        "COUNT(Int8(1))".to_string(),
+                    ))
+                    .alias("count_1"),
+                ],
+                Arc::new(agg_plan),
+            )
+            .unwrap(),
+        );
+
+        // Test the function
+        let result = logical_plan_to_proof_plan(&proj_plan, &SCHEMAS()).unwrap();
+
+        // Expected result
+        let expected = DynProofPlan::new_group_by(
+            vec![ColumnExpr::new(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "a".into(),
+                ColumnType::BigInt,
+            ))],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::new_column(ColumnRef::new(
+                    TABLE_REF_TABLE(),
+                    "b".into(),
+                    ColumnType::Int,
+                )),
+                alias: "sum_b".into(),
+            }],
+            "count_1".into(),
+            TableExpr {
+                table_ref: TABLE_REF_TABLE(),
+            },
+            DynProofExpr::new_column(ColumnRef::new(
+                TABLE_REF_TABLE(),
+                "d".into(),
+                ColumnType::Boolean,
+            )),
+        );
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_cannot_convert_unsupported_agg_plan_to_proof_plan() {
+        // Setup group expression
+        let group_expr = vec![df_column("table", "a")];
+
+        // Create the aggregate expressions
+        let aggr_expr = vec![
+            SUM_B(),   // SUM
+            COUNT_1(), // COUNT
+        ];
+
+        // Create filters
+        let filter_exprs = vec![
+            df_column("table", "d"), // Boolean column as filter
+        ];
+
+        // Create the input plan with filters
+        let input_plan = LogicalPlan::TableScan(
+            TableScan::try_new(
+                "table",
+                TABLE_SOURCE(),
+                Some(vec![0, 1, 2, 3]),
+                filter_exprs,
+                None,
+            )
+            .unwrap(),
+        );
+
+        let agg_plan = LogicalPlan::Aggregate(
+            Aggregate::try_new(Arc::new(input_plan), group_expr.clone(), aggr_expr.clone())
+                .unwrap(),
+        );
+
+        let proj_plan = LogicalPlan::Projection(
+            Projection::try_new(
+                vec![df_column("table", "a").add(df_column("table", "a"))],
+                Arc::new(agg_plan),
+            )
+            .unwrap(),
+        );
+
+        // Test the function
+        assert!(matches!(
+            logical_plan_to_proof_plan(&proj_plan, &SCHEMAS()),
+            Err(PlannerError::UnsupportedLogicalPlan { .. })
+        ));
     }
 
     // Unsupported

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -21,21 +21,25 @@ pub struct ColumnExpr {
 
 impl ColumnExpr {
     /// Create a new column expression
+    #[must_use]
     pub fn new(column_ref: ColumnRef) -> Self {
         Self { column_ref }
     }
 
     /// Return the column referenced by this [`ColumnExpr`]
+    #[must_use]
     pub fn get_column_reference(&self) -> ColumnRef {
         self.column_ref.clone()
     }
 
     /// Wrap the column output name and its type within the [`ColumnField`]
+    #[must_use]
     pub fn get_column_field(&self) -> ColumnField {
         ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
     }
 
     /// Get the column identifier
+    #[must_use]
     pub fn column_id(&self) -> Ident {
         self.column_ref.column_id()
     }
@@ -45,6 +49,7 @@ impl ColumnExpr {
     ///
     /// Will panic if the column is not found. Shouldn't happen in practice since
     /// code in `sql/parse` should have already checked that the column exists.
+    #[must_use]
     pub fn fetch_column<'a, S: Scalar>(&self, table: &Table<'a, S>) -> Column<'a, S> {
         *table
             .inner_table()

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -67,6 +67,6 @@ pub use table_expr::TableExpr;
 pub(crate) mod test_utility;
 
 mod column_expr;
-pub(crate) use column_expr::ColumnExpr;
+pub use column_expr::ColumnExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod column_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -13,12 +13,13 @@ use crate::{
         proof::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
-        proof_exprs::{AliasedDynProofExpr, DynProofExpr, TableExpr},
+        proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
     },
 };
 use alloc::{boxed::Box, vec::Vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// The query plan for proving a query
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
@@ -98,6 +99,24 @@ impl DynProofPlan {
         filter_expr: DynProofExpr,
     ) -> Self {
         Self::Filter(FilterExec::new(aliased_results, input, filter_expr))
+    }
+
+    /// Creates a new group by plan.
+    #[must_use]
+    pub fn new_group_by(
+        group_by_exprs: Vec<ColumnExpr>,
+        sum_expr: Vec<AliasedDynProofExpr>,
+        count_alias: Ident,
+        table: TableExpr,
+        where_clause: DynProofExpr,
+    ) -> Self {
+        Self::GroupBy(GroupByExec::new(
+            group_by_exprs,
+            sum_expr,
+            count_alias,
+            table,
+            where_clause,
+        ))
     }
 
     /// Creates a new slice plan.


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

Depends on the following PRs:
- [x] #650

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
We need to add provable group bys to `ProofPlan`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.