### PR TITLE
feat: add deserialization utilities for hyperkzg public setup

### DIFF
--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/mod.rs
@@ -10,7 +10,12 @@ mod scalar;
 pub use scalar::BNScalar;
 
 mod public_setup;
-pub use public_setup::{HyperKZGPublicSetup, HyperKZGPublicSetupOwned};
+#[cfg(feature = "std")]
+pub use public_setup::deserialize_flat_compressed_hyperkzg_public_setup_from_reader;
+pub use public_setup::{
+    deserialize_flat_compressed_hyperkzg_public_setup_from_slice, HyperKZGPublicSetup,
+    HyperKZGPublicSetupOwned,
+};
 
 mod commitment;
 pub use commitment::HyperKZGCommitment;

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/public_setup.rs
@@ -1,4 +1,6 @@
+use alloc::vec::Vec;
 use ark_bn254::G1Affine;
+use ark_serialize::{CanonicalDeserialize, Compress, SerializationError, Validate};
 
 /// When borrowed, `PublicSetup` type associated with the `HyperKZG` commitment scheme.
 ///
@@ -6,7 +8,96 @@ use ark_bn254::G1Affine;
 /// For example, deserialization, or generation.
 ///
 /// See [`HyperKZGPublicSetup`] for the actual associated public setup type.
-pub type HyperKZGPublicSetupOwned = alloc::vec::Vec<G1Affine>;
+pub type HyperKZGPublicSetupOwned = Vec<G1Affine>;
 
 /// `PublicSetup` type associated with the `HyperKZG` commitment scheme.
 pub type HyperKZGPublicSetup<'a> = &'a [G1Affine];
+
+const COMPRESSED_SIZE: usize = 32;
+
+/// Deserialize a [`HyperKZGPublicSetupOwned`] from any `Read` implementor.
+///
+/// This expects the same format used in the proof-of-sql public ppot binaries. That is,
+/// ark-serialized, compressed points flatly concatenated in the file (no length prefix).
+#[cfg(feature = "std")]
+pub fn deserialize_flat_compressed_hyperkzg_public_setup_from_reader<R: std::io::Read>(
+    mut reader: R,
+    validate: Validate,
+) -> Result<HyperKZGPublicSetupOwned, SerializationError> {
+    std::iter::repeat_with(|| {
+        let mut buffer = [0; COMPRESSED_SIZE];
+        let num_bytes_read = reader.read(&mut buffer);
+        (buffer, num_bytes_read)
+    })
+    .map_while(|(bytes, num_bytes_read)| match num_bytes_read {
+        Ok(0) => None, // EOF, end iterator
+        Ok(_) => Some(G1Affine::deserialize_with_mode(
+            &bytes[..],
+            Compress::Yes,
+            validate,
+        )),
+        Err(e) => Some(Err(e.into())),
+    })
+    .collect()
+}
+
+/// Deserialize a [`HyperKZGPublicSetupOwned`] from a byte slice.
+///
+/// This expects the same format used in the proof-of-sql public ppot binaries. That is,
+/// ark-serialized, compressed points flatly concatenated in the file (no length prefix).
+pub fn deserialize_flat_compressed_hyperkzg_public_setup_from_slice(
+    bytes: &[u8],
+    validate: Validate,
+) -> Result<HyperKZGPublicSetupOwned, SerializationError> {
+    bytes
+        .chunks(COMPRESSED_SIZE)
+        .map(|chunk| G1Affine::deserialize_with_mode(chunk, Compress::Yes, validate))
+        .collect()
+}
+
+#[cfg(all(test, feature = "std"))]
+mod std_tests {
+    use super::*;
+
+    #[test]
+    fn we_can_deserialize_empty_setup_from_slice() {
+        assert_eq!(
+            deserialize_flat_compressed_hyperkzg_public_setup_from_slice(&[], Validate::Yes)
+                .unwrap(),
+            Vec::<G1Affine>::new(),
+        );
+    }
+
+    #[test]
+    fn we_can_deserialize_empty_setup_from_reader() {
+        let empty: &[u8] = &[];
+        assert_eq!(
+            deserialize_flat_compressed_hyperkzg_public_setup_from_reader(empty, Validate::Yes)
+                .unwrap(),
+            Vec::<G1Affine>::new(),
+        );
+    }
+
+    #[test]
+    fn we_can_deserialize_ppot_02_setup_from_slice() {
+        let bytes = include_bytes!("test_ppot_0080_02.bin");
+        assert_eq!(
+            deserialize_flat_compressed_hyperkzg_public_setup_from_slice(bytes, Validate::Yes)
+                .unwrap()
+                .len(),
+            4,
+        );
+    }
+
+    #[test]
+    fn we_can_deserialize_ppot_02_setup_from_reader() {
+        let file =
+            std::fs::File::open("src/proof_primitive/hyperkzg/test_ppot_0080_02.bin").unwrap();
+        assert_eq!(
+            deserialize_flat_compressed_hyperkzg_public_setup_from_reader(&file, Validate::Yes)
+                .unwrap()
+                .len(),
+            4,
+        );
+    }
+}

--- a/crates/proof-of-sql/src/proof_primitive/hyperkzg/test_ppot_0080_02.bin
+++ b/crates/proof-of-sql/src/proof_primitive/hyperkzg/test_ppot_0080_02.bin
@@ -1,0 +1,1 @@
+›»1¾Ü0N*­¤µl"àéNáhtãQ}¾õÜì:r@#=ÍÃIxƒðÀâ×8`¢Môü]ŽðÏ÷X‰yˆ+ªëø3B(&{ DÆB®-YeßÑ²7<Î¥ûÞøSd»¦úbqJ³"­!0ÄYyü"pÍT|'Ø×·8f^ð–


### PR DESCRIPTION
# Rationale for this change
The hyperkzg setups publicized in our github releases have slightly more complicated serializations than a plain ark-serialized Vec. To handle this slight complication, this change provides couple deserialization methods. One of them iterates through a std reader, and the other uses a slice for no-std deserialization.


# What changes are included in this PR?
Two hyperkzg public setup deserialization methods have been added

# Are these changes tested?
Yes.
