### PR TITLE
feat: add `PostprocessingError` and `SelectPostprocessing`

### DIFF
--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -16,7 +16,8 @@ pub use expr::expr_to_proof_expr;
 mod error;
 pub use error::{PlannerError, PlannerResult};
 mod plan;
-mod postprocessing;
+/// Proof of SQL Postprocessing. Used when the last step of the logical plan is an unprovable projection.
+pub mod postprocessing;
 pub use plan::logical_plan_to_proof_plan;
 mod util;
 pub use util::column_fields_to_schema;

--- a/crates/proof-of-sql-planner/src/postprocessing/error.rs
+++ b/crates/proof-of-sql-planner/src/postprocessing/error.rs
@@ -1,0 +1,15 @@
+use snafu::Snafu;
+
+/// Errors in postprocessing
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum PostprocessingError {
+    /// Errors in evaluation of `Expression`s
+    #[snafu(transparent)]
+    ExpressionEvaluationError {
+        /// The underlying source error
+        source: crate::postprocessing::ExpressionEvaluationError,
+    },
+}
+
+/// Result type for postprocessing
+pub type PostprocessingResult<T> = core::result::Result<T, PostprocessingError>;

--- a/crates/proof-of-sql-planner/src/postprocessing/mod.rs
+++ b/crates/proof-of-sql-planner/src/postprocessing/mod.rs
@@ -1,4 +1,7 @@
-/// TODO: add docs
+/// Proof of SQL Postprocessing. Used when the last step of the logical plan is an unprovable projection.
+mod error;
+#[cfg(test)]
+pub use error::{PostprocessingError, PostprocessingResult};
 mod expression_evaluation;
 #[cfg(test)]
 pub(crate) use expression_evaluation::evaluate_expr;

--- a/crates/proof-of-sql-planner/src/postprocessing/postprocessing_step.rs
+++ b/crates/proof-of-sql-planner/src/postprocessing/postprocessing_step.rs
@@ -1,0 +1,9 @@
+use super::PostprocessingResult;
+use proof_of_sql::base::{database::OwnedTable, scalar::Scalar};
+use core::fmt::Debug;
+
+/// A trait for postprocessing steps that can be applied to an `OwnedTable`.
+pub trait PostprocessingStep<S: Scalar>: Debug + Send + Sync {
+    /// Apply the postprocessing step to the `OwnedTable` and return the result.
+    fn apply(&self, owned_table: OwnedTable<S>) -> PostprocessingResult<OwnedTable<S>>;
+}

--- a/crates/proof-of-sql-planner/src/postprocessing/select_postprocessing.rs
+++ b/crates/proof-of-sql-planner/src/postprocessing/select_postprocessing.rs
@@ -1,0 +1,42 @@
+use super::{evaluate_expr, PostprocessingResult, PostprocessingStep};
+use proof_of_sql::base::{
+    database::{OwnedColumn, OwnedTable},
+    map::IndexMap,
+    scalar::Scalar,
+};
+use alloc::vec::Vec;
+use datafusion::logical_expr::Alias;
+use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
+
+/// The select expression used to select, reorder, and apply alias transformations
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SelectPostprocessing {
+    /// The aliased expressions we select
+    aliased_exprs: Vec<Alias>,
+}
+
+impl SelectPostprocessing {
+    /// Create a new `SelectPostprocessing` node.
+    #[must_use]
+    pub fn new(aliased_exprs: Vec<Alias>) -> Self {
+        Self { aliased_exprs }
+    }
+}
+
+impl<S: Scalar> PostprocessingStep<S> for SelectPostprocessing {
+    /// Apply the select transformation to the given `OwnedTable`.
+    fn apply(&self, owned_table: OwnedTable<S>) -> PostprocessingResult<OwnedTable<S>> {
+        let cols: IndexMap<Ident, OwnedColumn<S>> = self
+            .aliased_exprs
+            .iter()
+            .map(
+                |aliased_expr| -> PostprocessingResult<(Ident, OwnedColumn<S>)> {
+                    let result_column = evaluate_expr(&owned_table, &aliased_expr.expr)?;
+                    Ok((aliased_expr.name.into(), result_column))
+                },
+            )
+            .collect::<PostprocessingResult<_>>()?;
+        Ok(OwnedTable::try_new(cols)?)
+    }
+}

--- a/crates/proof-of-sql-planner/src/postprocessing/select_postprocessing_test.rs
+++ b/crates/proof-of-sql-planner/src/postprocessing/select_postprocessing_test.rs
@@ -1,0 +1,63 @@
+use super::SelectPostprocessing;
+use core::ops::Add;
+use datafusion::logical_expr::Alias;
+use proof_of_sql::{
+    base::database::{owned_table_utility::*, OwnedTable},
+    proof_primitive::dory::DoryScalar,
+};
+
+#[test]
+fn we_can_filter_out_owned_table_columns() {
+    let table: OwnedTable<DoryScalar> = owned_table([
+        bigint("c", [-5_i64, 1, -56, 2]),
+        varchar("a", ["d", "a", "f", "b"]),
+    ]);
+    let postprocessing = SelectPostprocessing::new(vec![Alias::new(df_column("schema.table_name", "a"), None, "a")]);
+    let expected_table = owned_table([varchar("a", ["d", "a", "f", "b"])]);
+    let actual_table = postprocessing.apply(table).unwrap();
+    assert_eq!(actual_table, expected_table);
+}
+
+#[test]
+fn we_can_reorder_and_rename_owned_table_columns() {
+    let table: OwnedTable<DoryScalar> = owned_table([
+        int128("c", [-5_i128, 1, -56, 2]),
+        varchar("a", ["d", "a", "f", "b"]),
+    ]);
+
+    // Build a single SelectPostprocessing, renaming columns "a" -> "b" and "c" -> "d",
+    // in that order.
+    let postprocessing = SelectPostprocessing::new(vec![
+        Alias::new(df_column("schema.table_name", "a"), None, "b"),
+        Alias::new(df_column("schema.table_name", "c"), None, "d"),
+    ]);
+
+    let expected_table = owned_table([
+        varchar("b", ["d", "a", "f", "b"]),
+        int128("d", [-5_i128, 1, -56, 2]),
+    ]);
+
+    let actual_table = postprocessing.apply(table).unwrap();
+    assert_eq!(actual_table, expected_table);
+}
+
+#[test]
+fn we_can_do_computation_on_owned_table_columns() {
+    let table: OwnedTable<DoryScalar> = owned_table([
+        bigint("c", [1, 2, 3, 4])
+    ]);
+
+    // Create a single postprocessing step that produces
+    // (c + c + 1) as a new column named "res".
+    let transformed_expr = df_column("schema.table_name", "c").add(df_column("schema.table_name", "c")).add(1);
+    let postprocessing = SelectPostprocessing::new(vec![
+        Alias::new(transformed_expr, None, "res"),
+    ]);
+
+    let expected_table = owned_table([
+        bigint("res", [3, 5, 7, 9])
+    ]);
+
+    let actual_table = postprocessing.apply(table).unwrap();
+    assert_eq!(actual_table, expected_table);
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.
My first CLI-made PR here lol (Thanks @tlovell-sxt for reminding me of this!)
# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
We need to add `SelectPostprocessing` to do `GROUP BY` with currently unsupported output column ordering as well as division.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `PostprocessingError` which looks like a stub but can be expanded whenever we need more postprocessing
- add `PostprocessingStep`
- add `SelectPostprocessing`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Will be.
