### PR TITLE
feat: add divide and modulo gadget skeleton

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -55,6 +55,8 @@ mod numerical_util;
 pub(crate) use numerical_util::{
     add_subtract_columns, multiply_columns, scale_and_add_subtract_eval,
 };
+#[cfg(test)]
+pub(crate) use numerical_util::{divide_columns, modulo_columns};
 
 mod equals_expr;
 pub(crate) use equals_expr::EqualsExpr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -391,10 +391,10 @@ pub(crate) fn divide_columns<'a, S: Scalar>(
     }
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
 /// Take the modulo of one column against another.
 /// # Panics
 /// Panics if: `lhs` and `rhs` are not of the same length.
+#[cfg_attr(not(test), expect(dead_code))]
 pub(crate) fn modulo_columns<'a, S: Scalar>(
     lhs: &Column<'a, S>,
     rhs: &Column<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -1,0 +1,186 @@
+use crate::{
+    base::{
+        database::{Column, ColumnRef, Table},
+        map::IndexMap,
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        proof_exprs::{divide_columns, modulo_columns, DynProofExpr, ProofExpr},
+    },
+    utils::log,
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+/// TODO: This struct is only partially complete. This should not be used yet. Several constraints still need to be added.
+/// A gadget for proving divide and modulo expressions in tandem.
+/// They must be proved in tandem under this protocol.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DivideAndModuloExpr {
+    pub lhs: Box<DynProofExpr>,
+    pub rhs: Box<DynProofExpr>,
+}
+
+trait DivideAndModuloExprUtilities<S: Scalar> {
+    fn divide_columns<'a>(
+        &self,
+        lhs: &Column<'a, S>,
+        rhs: &Column<'a, S>,
+        alloc: &'a Bump,
+    ) -> (Column<'a, S>, &'a [S]);
+
+    fn modulo_columns<'a>(
+        &self,
+        lhs: &Column<'a, S>,
+        rhs: &Column<'a, S>,
+        alloc: &'a Bump,
+    ) -> Column<'a, S>;
+}
+
+struct StandardDivideAndModuloExprUtilities;
+
+impl<S: Scalar> DivideAndModuloExprUtilities<S> for StandardDivideAndModuloExprUtilities {
+    fn divide_columns<'a>(
+        &self,
+        lhs: &Column<'a, S>,
+        rhs: &Column<'a, S>,
+        alloc: &'a Bump,
+    ) -> (Column<'a, S>, &'a [S]) {
+        divide_columns(lhs, rhs, alloc)
+    }
+
+    fn modulo_columns<'a>(
+        &self,
+        lhs: &Column<'a, S>,
+        rhs: &Column<'a, S>,
+        alloc: &'a Bump,
+    ) -> Column<'a, S> {
+        modulo_columns(lhs, rhs, alloc)
+    }
+}
+
+impl DivideAndModuloExpr {
+    #[cfg_attr(not(test), expect(dead_code))]
+    fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
+        Self { lhs, rhs }
+    }
+
+    /// This is abstracted into its own function for ease of unit testing.
+    /// The `utilities` function is where any functionality that needs to be mocked
+    /// can be provided.
+    fn prover_evaluate_base<'a, S: Scalar, U: DivideAndModuloExprUtilities<S>>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        utilities: &U,
+    ) -> (Column<'a, S>, Column<'a, S>) {
+        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table);
+        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table);
+
+        let (quotient_wrapped, _quotient) =
+            utilities.divide_columns(&lhs_column, &rhs_column, alloc);
+        let remainder = utilities.modulo_columns(&lhs_column, &rhs_column, alloc);
+
+        builder.produce_intermediate_mle(quotient_wrapped);
+        builder.produce_intermediate_mle(remainder);
+
+        (quotient_wrapped, remainder)
+    }
+
+    #[cfg_attr(not(test), expect(dead_code))]
+    fn prover_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+    ) -> (Column<'a, S>, Column<'a, S>) {
+        log::log_memory_usage("Start");
+        let utilities = StandardDivideAndModuloExprUtilities {};
+
+        let res = self.prover_evaluate_base(builder, alloc, table, &utilities);
+
+        log::log_memory_usage("End");
+
+        res
+    }
+
+    #[cfg_attr(not(test), expect(dead_code))]
+    fn verifier_evaluate<S: Scalar, B: VerificationBuilder<S>>(
+        &self,
+        builder: &mut B,
+        accessor: &IndexMap<ColumnRef, S>,
+        one_eval: S,
+    ) -> Result<(S, S), ProofError> {
+        let _lhs = self.lhs.verifier_evaluate(builder, accessor, one_eval)?;
+        let _rhs = self.rhs.verifier_evaluate(builder, accessor, one_eval)?;
+
+        // lhs_times_rhs
+        let quotient_wrapped = builder.try_consume_final_round_mle_evaluation()?;
+        let remainder = builder.try_consume_final_round_mle_evaluation()?;
+
+        Ok((quotient_wrapped, remainder))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DivideAndModuloExpr;
+    use crate::{
+        base::{
+            database::{Column, ColumnRef, ColumnType, Table, TableRef},
+            map::indexmap,
+            polynomial::MultilinearExtension,
+            scalar::test_scalar::TestScalar,
+        },
+        sql::{
+            proof::{mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder},
+            proof_exprs::{ColumnExpr, DynProofExpr},
+        },
+    };
+    use bumpalo::Bump;
+    use sqlparser::ast::Ident;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn we_can_verify_simple_expr() {
+        let alloc = Bump::new();
+        let table_ref: TableRef = "sxt.t".parse().unwrap();
+        let lhs_ident = Ident::from("lhs");
+        let rhs_ident = Ident::from("rhs");
+        let lhs_ref = ColumnRef::new(table_ref.clone(), lhs_ident.clone(), ColumnType::Int128);
+        let rhs_ref = ColumnRef::new(table_ref, rhs_ident.clone(), ColumnType::Int128);
+        let divide_and_modulo_expr = DivideAndModuloExpr::new(
+            Box::new(DynProofExpr::Column(ColumnExpr::new(lhs_ref.clone()))),
+            Box::new(DynProofExpr::Column(ColumnExpr::new(rhs_ref.clone()))),
+        );
+        let lhs = &[i128::MAX, i128::MIN, 2];
+        let rhs = &[3i128, 3, -4];
+        let mut final_round_builder = FinalRoundBuilder::new(lhs.len(), VecDeque::new());
+        let table = Table::try_new(indexmap! {
+            lhs_ident => Column::Int128::<TestScalar>(lhs),
+            rhs_ident => Column::Int128::<TestScalar>(rhs),
+        })
+        .unwrap();
+        divide_and_modulo_expr.prover_evaluate(&mut final_round_builder, &alloc, &table);
+        let mock_verification_builder = run_verify_for_each_row(
+            lhs.len(),
+            &final_round_builder,
+            4,
+            |verification_builder, chi_eval, evaluation_point| {
+                let accessor = indexmap! {
+                    lhs_ref.clone() => lhs.inner_product(evaluation_point),
+                    rhs_ref.clone() => rhs.inner_product(evaluation_point)
+                };
+                divide_and_modulo_expr
+                    .verifier_evaluate(verification_builder, &accessor, chi_eval)
+                    .unwrap();
+            },
+        );
+        let matrix = mock_verification_builder.get_identity_results();
+        assert!(matrix.into_iter().all(|v| v.into_iter().all(|b| b)));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -1,4 +1,6 @@
 //! This module contains shared proof logic for multiple `ProofExpr` / `ProofPlan` implementations.
+#[cfg(test)]
+mod divide_and_modulo_expr;
 mod membership_check;
 mod monotonic;
 #[allow(dead_code)]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Because the div and mod gadget has so many constraints, it needs to be broken down into several PRs. This first PR provides a prover and verifier that returns the results but enforces no constraints. The constraints will be added in subsequent PRs.

# What changes are included in this PR?

New DivAndModExpr

# Are these changes tested?
Yes
