### PR TITLE
feat: make `proof-of-sql-planner` WASM-compatible && add CI to check that it builds

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -69,6 +69,11 @@ jobs:
           rustup target add thumbv7em-none-eabi
           cargo check -p proof-of-sql-parser --target thumbv7em-none-eabi --no-default-features
           cargo check -p proof-of-sql --target thumbv7em-none-eabi --no-default-features
+      - name: Check that we can compile `proof-of-sql-planner` to WebAssembly
+        working-directory: ./crates/proof-of-sql-planner
+        run: |
+          cargo install wasm-pack
+          wasm-pack build --target deno
 
   test:
     name: Test Suite

--- a/crates/proof-of-sql-planner/Cargo.toml
+++ b/crates/proof-of-sql-planner/Cargo.toml
@@ -6,18 +6,23 @@ repository.workspace = true
 version.workspace = true
 license-file.workspace = true
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 arrow = { workspace = true }
-datafusion = '38.0.0'
+datafusion = { version = '38.0.0', default-features = false }
+# getrandom and uuid must be compiled with js feature
+getrandom = { version = "0.2.15", features = ["js"] }
 indexmap = { workspace = true }
-proof-of-sql = { path = "../proof-of-sql", features = ["arrow"] }
+proof-of-sql = { path = "../proof-of-sql", default-features = false, features = ["arrow"] }
 proof-of-sql-parser = { path = "../proof-of-sql-parser" }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
+uuid = { version = "1.15.1", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 ark-std = { workspace = true }
-blitzar = { workspace = true }
 bumpalo = { workspace = true }
 
 [lints]

--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -152,7 +152,7 @@ mod tests {
     use indexmap::indexmap;
     use proof_of_sql::{
         base::database::{table_utility::*, ColumnType},
-        proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+        proof_primitive::dory::DoryScalar,
     };
 
     // PoSqlTableSource
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn we_can_create_a_posql_context_provider() {
         // Empty
-        let context_provider = PoSqlContextProvider::<Curve25519Scalar>::default();
+        let context_provider = PoSqlContextProvider::<DoryScalar>::default();
         assert_eq!(context_provider.tables, IndexMap::new());
         assert_eq!(
             context_provider.try_get_df_schemas().unwrap(),
@@ -225,7 +225,7 @@ mod tests {
                     ]
                 )
         };
-        let context_provider = PoSqlContextProvider::<Curve25519Scalar>::new(tables.clone());
+        let context_provider = PoSqlContextProvider::<DoryScalar>::new(tables.clone());
         let schema_a = Schema::new(vec![
             Field::new("a", DataType::Int16, false),
             Field::new("b", DataType::Utf8, false),
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn we_cannot_create_a_posql_context_provider_if_catalog_provided() {
-        let context_provider = PoSqlContextProvider::<Curve25519Scalar>::new(IndexMap::new());
+        let context_provider = PoSqlContextProvider::<DoryScalar>::new(IndexMap::new());
         assert!(matches!(
             context_provider.get_table_source(TableReference::from("catalog.namespace.table")),
             Err(DataFusionError::External(_))


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
We need to make sure the planner crate works with WASM.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- make the planner crate work with WASM
- add this to CI so that this will always be the case
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
N/A
