### PR TITLE
docs: correct vary mask docs

### DIFF
--- a/crates/proof-of-sql/src/base/bit/bit_distribution.rs
+++ b/crates/proof-of-sql/src/base/bit/bit_distribution.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// Describe the distribution of bit values in a table column
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct BitDistribution {
-    /// Identifies all columns that are identical to the leading column (the sign column). The lead bit indicates if the sign column is constant
+    /// Identifies all columns that are not either identical to or the inverse of the leading column (the sign column). The lead bit indicates if the sign column is constant
     pub(crate) vary_mask: [u64; 4],
     /// Identifies all columns that are the identical to the lead column. The lead bit indicates the sign of the last row of data (only relevant if the sign is constant)
     pub(crate) leading_bit_mask: [u64; 4],


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This was a docs mistake.

# What changes are included in this PR?

A single doc change

# Are these changes tested?
No new tests
