### PR TITLE
refactor: remove `proof_of_sql_parser` dependency from `proof_of_sql_planner`

### DIFF
--- a/crates/proof-of-sql-planner/Cargo.toml
+++ b/crates/proof-of-sql-planner/Cargo.toml
@@ -16,7 +16,6 @@ datafusion = { version = '38.0.0', default-features = false }
 getrandom = { version = "0.2.15", features = ["js"] }
 indexmap = { workspace = true }
 proof-of-sql = { path = "../proof-of-sql", default-features = false, features = ["arrow"] }
-proof-of-sql-parser = { path = "../proof-of-sql-parser" }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
 uuid = { version = "1.15.1", default-features = false, features = ["js"] }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
This PR helps completely decouple the code we want to delete from the code we want to keep. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `AggregateFunc`
- remove dependency on `proof_of_sql_parser` in `proof_of_sql_planner`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.