### PR TITLE
test: Improving test coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ zerocopy = { version = "0.7.34" }
 
 [workspace.lints.rust]
 missing_docs = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
 
 [workspace.lints.clippy]
 missing_errors_doc = "allow"

--- a/crates/proof-of-sql-parser/src/intermediate_ast.rs
+++ b/crates/proof-of-sql-parser/src/intermediate_ast.rs
@@ -49,6 +49,15 @@ pub struct AliasedResultExpr {
     pub alias: Identifier,
 }
 
+impl From<AliasedResultExpr> for SelectResultExpr {
+    fn from(value: AliasedResultExpr) -> Self {
+        SelectResultExpr::AliasedResultExpr(AliasedResultExpr {
+            expr: value.expr,
+            alias: value.alias,
+        })
+    }
+}
+
 impl AliasedResultExpr {
     /// Create a new `AliasedResultExpr`
     #[must_use]
@@ -225,6 +234,7 @@ impl Expression {
     }
 
     /// Create a new `FIRST()`
+    #[cfg_attr(coverage_nightly, coverage(off))]
     #[must_use]
     pub fn first(self) -> Box<Self> {
         Box::new(Expression::Aggregation {

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -60,7 +60,34 @@ impl fmt::Display for PoSQLTimeUnit {
 mod time_unit_tests {
     use super::*;
     use crate::posql_time::{PoSQLTimestamp, PoSQLTimestampError};
+    use alloc::string::ToString;
     use chrono::{TimeZone, Utc};
+
+    #[test]
+    #[allow(clippy::unnecessary_fallible_conversions)]
+    fn test_u64_conversion() {
+        assert_eq!(PoSQLTimeUnit::Second.try_into(), Ok(0));
+        assert_eq!(PoSQLTimeUnit::Millisecond.try_into(), Ok(3));
+        assert_eq!(PoSQLTimeUnit::Microsecond.try_into(), Ok(6));
+        assert_eq!(PoSQLTimeUnit::Nanosecond.try_into(), Ok(9));
+    }
+
+    #[test]
+    fn test_precision_display() {
+        let input = "2023-06-26T12:34:56Z";
+        let result = PoSQLTimestamp::try_from(input).unwrap();
+        assert_eq!(result.timeunit().to_string(), "seconds (precision: 0)");
+        let input = "2023-06-26T12:34:56.123456Z";
+        let result = PoSQLTimestamp::try_from(input).unwrap();
+        assert_eq!(result.timeunit().to_string(), "microseconds (precision: 6)");
+        let input = "2023-06-26T12:34:56.123Z";
+        let result = PoSQLTimestamp::try_from(input).unwrap();
+        assert_eq!(result.timeunit().to_string(), "milliseconds (precision: 3)");
+
+        let input = "2023-06-26T12:34:56.123456789Z";
+        let result = PoSQLTimestamp::try_from(input).unwrap();
+        assert_eq!(result.timeunit().to_string(), "nanoseconds (precision: 9)");
+    }
 
     #[test]
     fn test_valid_precisions() {

--- a/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_repetition_operation.rs
@@ -201,6 +201,17 @@ mod tests {
             result,
             Column::VarChar((&doubled_strings, &doubled_scalars))
         );
+
+        let column: Column<TestScalar> = Column::Boolean(&[false, true, false]);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(
+            result.as_boolean().unwrap(),
+            &[false, false, true, true, false, false]
+        );
+
+        let column: Column<TestScalar> = Column::Uint8(&[3u8, 5u8, 2u8]);
+        let result = ElementwiseRepeatOp::column_op::<TestScalar>(&column, &bump, 2);
+        assert_eq!(result.as_uint8().unwrap(), &[3u8, 3u8, 5u8, 5u8, 2u8, 2u8]);
     }
 
     #[test]


### PR DESCRIPTION
Started adding tests. Will try to cover code that would add value. 

/claim #560


# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

Gradually increasing test coverage

# What changes are included in this PR?

## Added new tests
```
proof-of-sql-parser/src/posql_time/timezone.rs
proof-of-sql-parser/src/posql_time/timestamp.rs
proof-of-sql-parser/src/identifier.rs
proof-of-sql-parser/src/intermediate_ast.rs
```

Additionally, added check for time zone boundaries, hours should not be over 12, and minutes should not be over 60 (please correct me if I am doing it wrong). This change is also tested

## Ignoring
Ignored because some tests felt redundant, I am open for suggestions.

```
proof-of-sql/src/base/arrow/owned_and_arrow_conversions.rs
proof-of-sql/src/base/arrow/column_arrow_conversions.rs
proof-of-sql/src/base/database/column_repetition_operation.rs
```


# Are these changes tested?
Yes.

