### PR TITLE
feat!: impl `Deserialize` for `EVMProofPlan`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -12,4 +12,7 @@ pub(super) enum Error {
     /// Error indicating that the table was not found.
     #[snafu(display("table not found"))]
     TableNotFound,
+    /// Error indicating that table name can not be parsed into `TableRef`.
+    #[snafu(display("table name can not be parsed into TableRef"))]
+    InvalidTableName,
 }

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -7,10 +7,10 @@ use crate::{
     sql::proof_exprs::{self, DynProofExpr},
 };
 use alloc::boxed::Box;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Represents an expression that can be serialized for EVM.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub(super) enum Expr {
     Column(ColumnExpr),
     Equals(EqualsExpr),
@@ -35,10 +35,25 @@ impl Expr {
             _ => Err(Error::NotSupported),
         }
     }
+
+    pub(super) fn try_into_proof_expr(
+        &self,
+        column_refs: &IndexSet<ColumnRef>,
+    ) -> Result<DynProofExpr, Error> {
+        match self {
+            Expr::Column(column_expr) => Ok(DynProofExpr::Column(
+                column_expr.try_into_proof_expr(column_refs)?,
+            )),
+            Expr::Equals(equals_expr) => Ok(DynProofExpr::Equals(
+                equals_expr.try_into_proof_expr(column_refs)?,
+            )),
+            Expr::Literal(literal_expr) => Ok(DynProofExpr::Literal(literal_expr.to_proof_expr())),
+        }
+    }
 }
 
 /// Represents a column expression.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub(super) struct ColumnExpr {
     column_number: usize,
 }
@@ -54,10 +69,22 @@ impl ColumnExpr {
                 .ok_or(Error::ColumnNotFound)?,
         })
     }
+
+    fn try_into_proof_expr(
+        &self,
+        column_refs: &IndexSet<ColumnRef>,
+    ) -> Result<proof_exprs::ColumnExpr, Error> {
+        Ok(proof_exprs::ColumnExpr::new(
+            column_refs
+                .get_index(self.column_number)
+                .ok_or(Error::ColumnNotFound)?
+                .clone(),
+        ))
+    }
 }
 
 /// Represents a literal expression.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub(super) enum LiteralExpr {
     BigInt(i64),
 }
@@ -69,10 +96,18 @@ impl LiteralExpr {
             _ => Err(Error::NotSupported),
         }
     }
+
+    fn to_proof_expr(&self) -> proof_exprs::LiteralExpr {
+        match self {
+            LiteralExpr::BigInt(value) => {
+                proof_exprs::LiteralExpr::new(LiteralValue::BigInt(*value))
+            }
+        }
+    }
 }
 
 /// Represents an equals expression.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub(super) struct EqualsExpr {
     lhs: Box<Expr>,
     rhs: Box<Expr>,
@@ -86,6 +121,16 @@ impl EqualsExpr {
         Ok(EqualsExpr {
             lhs: Box::new(Expr::try_from_proof_expr(&expr.lhs, column_refs)?),
             rhs: Box::new(Expr::try_from_proof_expr(&expr.rhs, column_refs)?),
+        })
+    }
+
+    fn try_into_proof_expr(
+        &self,
+        column_refs: &IndexSet<ColumnRef>,
+    ) -> Result<proof_exprs::EqualsExpr, Error> {
+        Ok(proof_exprs::EqualsExpr {
+            lhs: Box::new(self.lhs.try_into_proof_expr(column_refs)?),
+            rhs: Box::new(self.rhs.try_into_proof_expr(column_refs)?),
         })
     }
 }

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -63,9 +63,14 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
         .chain(&0_usize.to_be_bytes())
         .chain(&1_usize.to_be_bytes())
         .chain("b".as_bytes())
+        .chain(&5_u32.to_be_bytes())
         .chain(&0_usize.to_be_bytes())
         .chain(&1_usize.to_be_bytes())
         .chain("a".as_bytes())
+        .chain(&5_u32.to_be_bytes())
+        .chain(&1_usize.to_be_bytes())
+        .chain(&5_usize.to_be_bytes())
+        .chain("alias".as_bytes())
         .chain([])
         .chain(&0_u32.to_be_bytes()) //   FilterExec
         .chain(&0_usize.to_be_bytes()) //   table_number
@@ -81,4 +86,70 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
         .copied()
         .collect();
     assert_eq!(bytes, expected_bytes);
+}
+
+#[test]
+fn we_can_deserialize_proof_plan_for_simple_filter() {
+    let table_ref: TableRef = "namespace.table".parse().unwrap();
+    let identifier_a = "a".into();
+    let identifier_b = "b".into();
+    let identifier_alias = "alias".into();
+
+    let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
+    let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
+
+    let expected_plan = DynProofPlan::Filter(FilterExec::new(
+        vec![AliasedDynProofExpr {
+            expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b)),
+            alias: identifier_alias,
+        }],
+        TableExpr { table_ref },
+        DynProofExpr::Equals(EqualsExpr::new(
+            Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a))),
+            Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                LiteralValue::BigInt(5),
+            ))),
+        )),
+    ));
+
+    let serialized: Vec<_> = iter::empty()
+        .chain(&1_usize.to_be_bytes())
+        .chain(&15_usize.to_be_bytes())
+        .chain("namespace.table".as_bytes())
+        .chain(&2_usize.to_be_bytes())
+        .chain(&0_usize.to_be_bytes())
+        .chain(&1_usize.to_be_bytes())
+        .chain("b".as_bytes())
+        .chain(&5_u32.to_be_bytes())
+        .chain(&0_usize.to_be_bytes())
+        .chain(&1_usize.to_be_bytes())
+        .chain("a".as_bytes())
+        .chain(&5_u32.to_be_bytes())
+        .chain(&1_usize.to_be_bytes())
+        .chain(&5_usize.to_be_bytes())
+        .chain("alias".as_bytes())
+        .chain([])
+        .chain(&0_u32.to_be_bytes()) //   FilterExec
+        .chain(&0_usize.to_be_bytes()) //   table_number
+        .chain(&1_u32.to_be_bytes()) //     where_clause - EqualsExpr
+        .chain(&0_u32.to_be_bytes()) //       lhs - ColumnExpr
+        .chain(&1_usize.to_be_bytes()) //       column_number
+        .chain(&2_u32.to_be_bytes()) //       rhs - LiteralExpr
+        .chain(&0_u32.to_be_bytes()) //         type
+        .chain(&5_i64.to_be_bytes()) //         value
+        .chain(&1_usize.to_be_bytes()) //   results.len()
+        .chain(&0_u32.to_be_bytes()) //     results[0] - ColumnExpr
+        .chain(&0_usize.to_be_bytes()) //     column_number
+        .copied()
+        .collect();
+
+    let deserialized = bincode::serde::decode_from_slice::<EVMProofPlan, _>(
+        &serialized,
+        bincode::config::legacy()
+            .with_fixed_int_encoding()
+            .with_big_endian(),
+    )
+    .unwrap();
+    let plan = deserialized.0.inner();
+    assert_eq!(plan, &expected_plan);
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There is a serialize implementation for `EVMProofPlan` but no deserialize implementation. There needs to be a deserialize implementation.

# What changes are included in this PR?

1. Adding functionality to the serialization implementation as needed to make deserialization possible.
2. Adding deserialize implementation.

# Are these changes tested?
No
