### PR TITLE
feat!: rearrange serialization order of TableCommitment fields

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/table_commitment.rs
+++ b/crates/proof-of-sql/src/base/commitment/table_commitment.rs
@@ -86,8 +86,8 @@ pub struct TableCommitment<C>
 where
     C: Commitment,
 {
-    column_commitments: ColumnCommitments<C>,
     range: Range<usize>,
+    column_commitments: ColumnCommitments<C>,
 }
 
 impl<C: Commitment> TableCommitment<C> {
@@ -124,8 +124,8 @@ impl<C: Commitment> TableCommitment<C> {
     ) -> Result<Self, NegativeRange> {
         if range.start <= range.end {
             Ok(TableCommitment {
-                column_commitments,
                 range,
+                column_commitments,
             })
         } else {
             Err(NegativeRange)
@@ -316,8 +316,8 @@ impl<C: Commitment> TableCommitment<C> {
         let column_commitments = self.column_commitments.try_add(other.column_commitments)?;
 
         Ok(TableCommitment {
-            column_commitments,
             range,
+            column_commitments,
         })
     }
 
@@ -350,8 +350,8 @@ impl<C: Commitment> TableCommitment<C> {
         let column_commitments = self.column_commitments.try_sub(other.column_commitments)?;
 
         Ok(TableCommitment {
-            column_commitments,
             range,
+            column_commitments,
         })
     }
 }


### PR DESCRIPTION
# Rationale for this change
The current standard for serializing/deserializing table commitments uses bincode, and the order of struct fields in bincode serialization deterministically matches the order of the struct fields in rust. This standard was chosen because, despite it being a binary format, custom deserialization for it can easily be written in any language. So, at the moment, the serialization order for table commitments is something like..
1. commitments
2. column commitment metadata
3. range

Many use cases for custom deserialization don't care about the column commitment metadata, but do care about the commitments and range. So, it would be nice for these use cases to place the range first before the dynamically sized items so that custom deserializers don't have to worry about that dynamic sizing, and don't have to manually skip the commitment metadata. This change reorders the serialization to be more like...
1. range
2. commitments
3. column commitment metadata

# What changes are included in this PR?
- swap order of range and column commitments in `TableCommitment`

# Are these changes tested?
These changes do not affect business logic, which is verified by existing tests.
