### PR TITLE
feat: publicize `QueryProof` and `VerifiableQueryResult` fields

### DIFF
--- a/crates/proof-of-sql/src/sql/proof/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof/mod.rs
@@ -36,7 +36,7 @@ pub use proof_plan::ProofPlan;
 pub(crate) use proof_plan::{HonestProver, ProverEvaluate, ProverHonestyMarker};
 
 mod query_proof;
-use query_proof::QueryProof;
+pub use query_proof::QueryProof;
 #[cfg(all(test, feature = "blitzar"))]
 mod query_proof_test;
 

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -82,14 +82,14 @@ pub struct QueryProofPCSProofEvaluations<S> {
 /// cannot maintain any invariant on its data members; hence, they are
 /// all public so as to allow for easy manipulation for testing.
 #[derive(Clone, Serialize, Deserialize)]
-pub(super) struct QueryProof<CP: CommitmentEvaluationProof> {
-    pub first_round_message: FirstRoundMessage<CP::Commitment>,
-    pub final_round_message: FinalRoundMessage<CP::Commitment>,
+pub struct QueryProof<CP: CommitmentEvaluationProof> {
+    pub(super) first_round_message: FirstRoundMessage<CP::Commitment>,
+    pub(super) final_round_message: FinalRoundMessage<CP::Commitment>,
     /// Sumcheck Proof
-    pub sumcheck_proof: SumcheckProof<CP::Scalar>,
-    pub pcs_proof_evaluations: QueryProofPCSProofEvaluations<CP::Scalar>,
+    pub(super) sumcheck_proof: SumcheckProof<CP::Scalar>,
+    pub(super) pcs_proof_evaluations: QueryProofPCSProofEvaluations<CP::Scalar>,
     /// Inner product proof of the MLEs' evaluations
-    pub evaluation_proof: CP,
+    pub(super) evaluation_proof: CP,
 }
 
 impl<CP: CommitmentEvaluationProof> QueryProof<CP> {

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -67,9 +67,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Serialize, Deserialize)]
 pub struct VerifiableQueryResult<CP: CommitmentEvaluationProof> {
     /// The result of the query in intermediate form.
-    pub(super) result: OwnedTable<CP::Scalar>,
+    pub result: OwnedTable<CP::Scalar>,
     /// The proof that the query result is valid.
-    pub(super) proof: QueryProof<CP>,
+    pub proof: QueryProof<CP>,
 }
 
 impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {


### PR DESCRIPTION
# Rationale for this change
It is helpful for apis to expose proofs and query results separately. These are both stored in a VerifiableQueryResult, which is the typical result type for provers. However, not only are its fields private, but the QueryProof type itself is private, so the two outputs cannot be accessed individually pre-verification. This change simply publicizes the necessary items to access the proof and query results individually.

# What changes are included in this PR?
- QueryProof publicized, fields are only public to super
- VerifiableQueryResult fields publicized
- QueryProof re-export publicized

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
