### PR TITLE
test: add unit tests for `evm_proof_plan`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -2,7 +2,7 @@ use snafu::Snafu;
 
 /// Represents errors that can occur in the EVM proof plan module.
 #[derive(Snafu, Debug, PartialEq)]
-pub(super) enum Error {
+pub(crate) enum Error {
     /// Error indicating that the plan is not supported.
     #[snafu(display("plan not yet supported"))]
     NotSupported,

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -10,15 +10,15 @@ use alloc::boxed::Box;
 use serde::{Deserialize, Serialize};
 
 /// Represents an expression that can be serialized for EVM.
-#[derive(Serialize, Deserialize)]
-pub(super) enum Expr {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) enum Expr {
     Column(ColumnExpr),
     Equals(EqualsExpr),
     Literal(LiteralExpr),
 }
 impl Expr {
     /// Try to create an `Expr` from a `DynProofExpr`.
-    pub(super) fn try_from_proof_expr(
+    pub(crate) fn try_from_proof_expr(
         expr: &DynProofExpr,
         column_refs: &IndexSet<ColumnRef>,
     ) -> Result<Self, Error> {
@@ -36,7 +36,7 @@ impl Expr {
         }
     }
 
-    pub(super) fn try_into_proof_expr(
+    pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
     ) -> Result<DynProofExpr, Error> {
@@ -53,13 +53,19 @@ impl Expr {
 }
 
 /// Represents a column expression.
-#[derive(Serialize, Deserialize)]
-pub(super) struct ColumnExpr {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ColumnExpr {
     column_number: usize,
 }
+
 impl ColumnExpr {
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn new(column_number: usize) -> Self {
+        Self { column_number }
+    }
+
     /// Try to create a `ColumnExpr` from a `proof_exprs::ColumnExpr`.
-    fn try_from_proof_expr(
+    pub(crate) fn try_from_proof_expr(
         expr: &proof_exprs::ColumnExpr,
         column_refs: &IndexSet<ColumnRef>,
     ) -> Result<Self, Error> {
@@ -70,7 +76,7 @@ impl ColumnExpr {
         })
     }
 
-    fn try_into_proof_expr(
+    pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
     ) -> Result<proof_exprs::ColumnExpr, Error> {
@@ -84,20 +90,25 @@ impl ColumnExpr {
 }
 
 /// Represents a literal expression.
-#[derive(Serialize, Deserialize)]
-pub(super) enum LiteralExpr {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) enum LiteralExpr {
     BigInt(i64),
 }
 impl LiteralExpr {
+    #[expect(dead_code)]
+    pub(crate) fn new(value: i64) -> Self {
+        Self::BigInt(value)
+    }
+
     /// Try to create a `LiteralExpr` from a `proof_exprs::LiteralExpr`.
-    fn try_from_proof_expr(expr: &proof_exprs::LiteralExpr) -> Result<Self, Error> {
+    pub(crate) fn try_from_proof_expr(expr: &proof_exprs::LiteralExpr) -> Result<Self, Error> {
         match expr.value {
             LiteralValue::BigInt(value) => Ok(LiteralExpr::BigInt(value)),
             _ => Err(Error::NotSupported),
         }
     }
 
-    fn to_proof_expr(&self) -> proof_exprs::LiteralExpr {
+    pub(crate) fn to_proof_expr(&self) -> proof_exprs::LiteralExpr {
         match self {
             LiteralExpr::BigInt(value) => {
                 proof_exprs::LiteralExpr::new(LiteralValue::BigInt(*value))
@@ -107,14 +118,23 @@ impl LiteralExpr {
 }
 
 /// Represents an equals expression.
-#[derive(Serialize, Deserialize)]
-pub(super) struct EqualsExpr {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct EqualsExpr {
     lhs: Box<Expr>,
     rhs: Box<Expr>,
 }
+
 impl EqualsExpr {
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn new(lhs: Expr, rhs: Expr) -> Self {
+        Self {
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+        }
+    }
+
     /// Try to create an `EqualsExpr` from a `proof_exprs::EqualsExpr`.
-    fn try_from_proof_expr(
+    pub(crate) fn try_from_proof_expr(
         expr: &proof_exprs::EqualsExpr,
         column_refs: &IndexSet<ColumnRef>,
     ) -> Result<Self, Error> {
@@ -124,7 +144,7 @@ impl EqualsExpr {
         })
     }
 
-    fn try_into_proof_expr(
+    pub(crate) fn try_into_proof_expr(
         &self,
         column_refs: &IndexSet<ColumnRef>,
     ) -> Result<proof_exprs::EqualsExpr, Error> {
@@ -132,5 +152,175 @@ impl EqualsExpr {
             lhs: Box::new(self.lhs.try_into_proof_expr(column_refs)?),
             rhs: Box::new(self.rhs.try_into_proof_expr(column_refs)?),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{ColumnType, TableRef},
+            map::indexset,
+        },
+        sql::proof_exprs::test_utility::*,
+    };
+
+    // ColumnExpr
+    #[test]
+    fn we_can_put_a_column_expr_in_evm() {
+        let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
+        let ident = "a".into();
+        let column_ref = ColumnRef::new(table_ref.clone(), ident, ColumnType::BigInt);
+
+        let evm_column_expr = ColumnExpr::try_from_proof_expr(
+            &proof_exprs::ColumnExpr::new(column_ref.clone()),
+            &indexset! {column_ref.clone()},
+        )
+        .unwrap();
+        assert_eq!(evm_column_expr.column_number, 0);
+
+        // Roundtrip
+        let roundtripped_column_expr = evm_column_expr
+            .try_into_proof_expr(&indexset! {column_ref.clone()})
+            .unwrap();
+        assert_eq!(roundtripped_column_expr.column_ref, column_ref);
+    }
+
+    #[test]
+    fn we_cannot_put_a_column_expr_in_evm_if_column_not_found() {
+        let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
+        let ident = "a".into();
+        let column_ref = ColumnRef::new(table_ref.clone(), ident, ColumnType::BigInt);
+
+        assert_eq!(
+            ColumnExpr::try_from_proof_expr(
+                &proof_exprs::ColumnExpr::new(column_ref.clone()),
+                &indexset! {}
+            ),
+            Err(Error::ColumnNotFound)
+        );
+    }
+
+    #[test]
+    fn we_cannot_get_a_column_expr_from_evm_if_column_number_out_of_bounds() {
+        let evm_column_expr = ColumnExpr { column_number: 0 };
+        let column_refs = IndexSet::<ColumnRef>::default();
+        assert_eq!(
+            evm_column_expr
+                .try_into_proof_expr(&column_refs)
+                .unwrap_err(),
+            Error::ColumnNotFound
+        );
+    }
+
+    // LiteralExpr
+    #[test]
+    fn we_can_put_a_literal_expr_in_evm() {
+        let evm_literal_expr = LiteralExpr::try_from_proof_expr(&proof_exprs::LiteralExpr::new(
+            LiteralValue::BigInt(5),
+        ))
+        .unwrap();
+        assert_eq!(evm_literal_expr, LiteralExpr::BigInt(5));
+
+        // Roundtrip
+        let roundtripped_literal_expr = evm_literal_expr.to_proof_expr();
+        assert_eq!(roundtripped_literal_expr.value, LiteralValue::BigInt(5));
+    }
+
+    #[test]
+    fn we_cannot_put_a_literal_expr_in_evm_if_not_supported() {
+        assert!(matches!(
+            LiteralExpr::try_from_proof_expr(&proof_exprs::LiteralExpr::new(
+                LiteralValue::Boolean(true)
+            )),
+            Err(Error::NotSupported)
+        ));
+    }
+
+    // EqualsExpr
+    #[test]
+    fn we_can_put_an_equals_expr_in_evm() {
+        let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
+        let ident_a = "a".into();
+        let ident_b = "b".into();
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+
+        let equals_expr = proof_exprs::EqualsExpr::new(
+            Box::new(DynProofExpr::new_column(column_ref_b.clone())),
+            Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(5))),
+        );
+
+        let evm_equals_expr = EqualsExpr::try_from_proof_expr(
+            &equals_expr,
+            &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+        )
+        .unwrap();
+        assert_eq!(
+            evm_equals_expr,
+            EqualsExpr {
+                lhs: Box::new(Expr::Column(ColumnExpr { column_number: 1 })),
+                rhs: Box::new(Expr::Literal(LiteralExpr::BigInt(5)))
+            }
+        );
+
+        // Roundtrip
+        let roundtripped_equals_expr = evm_equals_expr
+            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .unwrap();
+        assert_eq!(roundtripped_equals_expr, equals_expr);
+    }
+
+    // Expr
+    #[test]
+    fn we_can_put_a_proof_expr_in_evm() {
+        let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
+        let ident_a = "a".into();
+        let ident_b = "b".into();
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+
+        let expr = equal(
+            DynProofExpr::new_column(column_ref_b.clone()),
+            DynProofExpr::new_literal(LiteralValue::BigInt(5)),
+        );
+        let evm_expr = Expr::try_from_proof_expr(
+            &expr,
+            &indexset! {column_ref_a.clone(), column_ref_b.clone()},
+        )
+        .unwrap();
+        let expected_evm_expr = Expr::Equals(EqualsExpr {
+            lhs: Box::new(Expr::Column(ColumnExpr { column_number: 1 })),
+            rhs: Box::new(Expr::Literal(LiteralExpr::BigInt(5))),
+        });
+        assert_eq!(evm_expr, expected_evm_expr);
+
+        // Roundtrip
+        let roundtripped_expr = evm_expr
+            .try_into_proof_expr(&indexset! {column_ref_a.clone(), column_ref_b.clone()})
+            .unwrap();
+        assert_eq!(roundtripped_expr, expr);
+    }
+
+    #[test]
+    fn we_cannot_put_a_proof_expr_in_evm_if_not_supported() {
+        let table_ref: TableRef = TableRef::try_from("namespace.table").unwrap();
+        let ident_a = "a".into();
+        let ident_b = "b".into();
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
+
+        assert!(matches!(
+            Expr::try_from_proof_expr(
+                &DynProofExpr::try_new_add(
+                    DynProofExpr::new_column(column_ref_a.clone()),
+                    DynProofExpr::new_column(column_ref_b.clone())
+                )
+                .unwrap(),
+                &indexset! {column_ref_a.clone(), column_ref_b.clone()}
+            ),
+            Err(Error::NotSupported)
+        ));
     }
 }

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -14,14 +14,14 @@ use serde::{Deserialize, Serialize};
 use sqlparser::ast::Ident;
 
 /// Represents a plan that can be serialized for EVM.
-#[derive(Serialize, Deserialize)]
-pub(super) enum Plan {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) enum Plan {
     Filter(FilterExec),
 }
 
 impl Plan {
     /// Try to create a `Plan` from a `DynProofPlan`.
-    pub(super) fn try_from_proof_plan(
+    pub(crate) fn try_from_proof_plan(
         plan: &DynProofPlan,
         table_refs: &IndexSet<TableRef>,
         column_refs: &IndexSet<ColumnRef>,
@@ -35,7 +35,7 @@ impl Plan {
         }
     }
 
-    pub(super) fn try_into_proof_plan(
+    pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
         column_refs: &IndexSet<ColumnRef>,
@@ -50,8 +50,8 @@ impl Plan {
 }
 
 /// Represents a filter execution plan.
-#[derive(Serialize, Deserialize)]
-pub(super) struct FilterExec {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct FilterExec {
     table_number: usize,
     where_clause: Expr,
     results: Vec<Expr>,
@@ -59,7 +59,7 @@ pub(super) struct FilterExec {
 
 impl FilterExec {
     /// Try to create a `FilterExec` from a `proof_plans::FilterExec`.
-    fn try_from_proof_plan(
+    pub(crate) fn try_from_proof_plan(
         plan: &proof_plans::FilterExec,
         table_refs: &IndexSet<TableRef>,
         column_refs: &IndexSet<ColumnRef>,
@@ -77,7 +77,7 @@ impl FilterExec {
         })
     }
 
-    fn try_into_proof_plan(
+    pub(crate) fn try_into_proof_plan(
         &self,
         table_refs: &IndexSet<TableRef>,
         column_refs: &IndexSet<ColumnRef>,
@@ -102,5 +102,89 @@ impl FilterExec {
             },
             self.where_clause.try_into_proof_expr(column_refs)?,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        base::{
+            database::{ColumnType, LiteralValue},
+            map::indexset,
+        },
+        sql::{
+            evm_proof_plan::exprs::{ColumnExpr, EqualsExpr, LiteralExpr},
+            proof_exprs::{self, AliasedDynProofExpr, DynProofExpr},
+            proof_plans::DynProofPlan,
+        },
+    };
+
+    #[test]
+    fn we_can_put_filter_exec_in_evm() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let identifier_a = "a".into();
+        let identifier_b = "b".into();
+        let alias = "alias".to_string();
+
+        let column_ref_a = ColumnRef::new(table_ref.clone(), identifier_a, ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), identifier_b, ColumnType::BigInt);
+
+        let filter_exec = proof_plans::FilterExec::new(
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::Column(proof_exprs::ColumnExpr::new(column_ref_b.clone())),
+                alias: Ident::new(alias.clone()),
+            }],
+            TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            DynProofExpr::Equals(proof_exprs::EqualsExpr::new(
+                Box::new(DynProofExpr::Column(proof_exprs::ColumnExpr::new(
+                    column_ref_a.clone(),
+                ))),
+                Box::new(DynProofExpr::Literal(proof_exprs::LiteralExpr::new(
+                    LiteralValue::BigInt(5),
+                ))),
+            )),
+        );
+
+        let evm_filter_exec = FilterExec::try_from_proof_plan(
+            &filter_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+        )
+        .unwrap();
+
+        let expected_evm_filter_exec = FilterExec {
+            table_number: 0,
+            where_clause: Expr::Equals(EqualsExpr::new(
+                Expr::Column(ColumnExpr::new(0)),
+                Expr::Literal(LiteralExpr::BigInt(5)),
+            )),
+            results: vec![Expr::Column(ColumnExpr::new(1))],
+        };
+
+        assert_eq!(evm_filter_exec, expected_evm_filter_exec);
+
+        // Roundtrip
+        let roundtripped_filter_exec = FilterExec::try_into_proof_plan(
+            &evm_filter_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+            &indexset![alias],
+        )
+        .unwrap();
+        assert_eq!(roundtripped_filter_exec, filter_exec);
+    }
+
+    #[test]
+    fn we_cannot_put_unsupported_proof_plan_in_evm() {
+        let plan = DynProofPlan::new_empty();
+        let table_refs = indexset![];
+        let column_refs = indexset![];
+        assert!(matches!(
+            Plan::try_from_proof_plan(&plan, &table_refs, &column_refs),
+            Err(Error::NotSupported)
+        ));
     }
 }


### PR DESCRIPTION
Depends on #658 
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Add unit tests to `evm_proof_plan` to make it more maintainable.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add unit tests to `evm_proof_plan`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.