### PR TITLE
test: add tests for agg without `GROUP BY`

### DIFF
--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -251,7 +251,10 @@ fn test_group_by() {
     select human, sum(weight), count(1) as num_cats from cats group by human;
     select human, sum(weight) as total_weight, count(1) as num_cats from cats group by human;
     select human, sum(2 * weight), count(1) from cats group by human;
-    select human, sum(2 * weight + 1) as total_transformed_weight, count(1) from cats group by human;";
+    select human, sum(2 * weight + 1) as total_transformed_weight, count(1) from cats group by human;
+    select sum(2 * weight + 1) as total_transformed_weight, count(1) as num_cats from cats;
+    select count(1) as num_cats from cats;
+    select count(1) from cats;";
     let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
         TableRef::from_names(None, "cats") => table(
             vec![
@@ -296,6 +299,12 @@ fn test_group_by() {
             decimal75("total_transformed_weight", 25, 1, [510, 220]),
             bigint("COUNT(Int64(1))", [3_i64, 2]),
         ]),
+        owned_table([
+            decimal75("total_transformed_weight", 25, 1, [730]),
+            bigint("num_cats", [5_i64]),
+        ]),
+        owned_table([bigint("num_cats", [5_i64])]),
+        owned_table([bigint("COUNT(Int64(1))", [5_i64])]),
     ];
 
     // Create public parameters for DynamicDoryEvaluationProof


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
We can in fact do provable aggregation without any `GROUP BY` using `GroupByExec`.  In fact we already have this in examples. Now we need to formally establish that this works and put it in tests.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
Add tests for provable aggregations without `GROUP BY`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.