### PR TITLE
test: add first round builder to mock verification builder

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -13,7 +13,7 @@ use crate::{
         proof::{
             exercise_verification,
             mock_verification_builder::{run_verify_for_each_row, MockVerificationBuilder},
-            FinalRoundBuilder, VerifiableQueryResult,
+            FinalRoundBuilder, FirstRoundBuilder, VerifiableQueryResult,
         },
         proof_exprs::{test_utility::*, AndExpr, ColumnExpr, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
@@ -203,6 +203,7 @@ fn we_can_verify_a_simple_proof() {
         Box::new(DynProofExpr::Column(ColumnExpr::new(b.clone()))),
     );
 
+    let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(4);
     let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
         FinalRoundBuilder::new(4, VecDeque::new());
 
@@ -210,6 +211,7 @@ fn we_can_verify_a_simple_proof() {
 
     let verification_builder = run_verify_for_each_row(
         4,
+        &first_round_builder,
         &final_round_builder,
         3,
         |verification_builder, chi_eval, evaluation_point| {
@@ -256,7 +258,14 @@ fn we_can_reject_a_simple_tampered_proof() {
         .clone()
         .map(|_| zero_vec.clone())
         .collect();
-    let mut verification_builder = MockVerificationBuilder::new(Vec::new(), 3, final_round_mles);
+    let mut verification_builder = MockVerificationBuilder::new(
+        Vec::new(),
+        3,
+        Vec::new(),
+        final_round_mles,
+        Vec::new(),
+        Vec::new(),
+    );
 
     for evaluation_point in evaluation_points {
         let chi_eval = (&[1, 1, 1, 1]).inner_product(evaluation_point);

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -137,7 +137,10 @@ mod tests {
             scalar::test_scalar::TestScalar,
         },
         sql::{
-            proof::{mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder},
+            proof::{
+                mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+                FirstRoundBuilder,
+            },
             proof_exprs::{ColumnExpr, DynProofExpr},
         },
     };
@@ -159,6 +162,7 @@ mod tests {
         );
         let lhs = &[i128::MAX, i128::MIN, 2];
         let rhs = &[3i128, 3, -4];
+        let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(lhs.len());
         let mut final_round_builder = FinalRoundBuilder::new(lhs.len(), VecDeque::new());
         let table = Table::try_new(indexmap! {
             lhs_ident => Column::Int128::<TestScalar>(lhs),
@@ -168,6 +172,7 @@ mod tests {
         divide_and_modulo_expr.prover_evaluate(&mut final_round_builder, &alloc, &table);
         let mock_verification_builder = run_verify_for_each_row(
             lhs.len(),
+            &first_round_builder,
             &final_round_builder,
             4,
             |verification_builder, chi_eval, evaluation_point| {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check.rs
@@ -137,7 +137,10 @@ mod tests {
             polynomial::MultilinearExtension,
             scalar::{test_scalar::TestScalar, Scalar},
         },
-        sql::proof::{mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder},
+        sql::proof::{
+            mock_verification_builder::run_verify_for_each_row, FinalRoundBuilder,
+            FirstRoundBuilder,
+        },
     };
     use bumpalo::Bump;
     use std::collections::VecDeque;
@@ -147,6 +150,7 @@ mod tests {
         let alloc = Bump::new();
         let column = borrowed_bigint::<TestScalar>("a", [1, 2, 3], &alloc).1;
         let candidate_table = borrowed_bigint::<TestScalar>("c", [2, 3, 1], &alloc).1;
+        let first_round_builder: FirstRoundBuilder<'_, _> = FirstRoundBuilder::new(3);
         let mut final_round_builder: FinalRoundBuilder<TestScalar> =
             FinalRoundBuilder::new(3, VecDeque::new());
         final_round_evaluate_permutation_check(
@@ -160,6 +164,7 @@ mod tests {
         );
         let verification_builder = run_verify_for_each_row(
             3,
+            &first_round_builder,
             &final_round_builder,
             3,
             |verification_builder, chi_eval, evaluation_point| {


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There will be changes to `RangeCheck` relatively soon. This PR will make way for easier unit testing of `RangeCheck`, which uses `FirstRoundBuilder`.

# What changes are included in this PR?

- New functionality on `MockVerificationBuilder` to include first round commitments.
- Correction to `try_consume_final_round_mle_evaluation` to enforce the `TooFewMLEEvaluations` error.

# Are these changes tested?
Yes
