### PR TITLE
feat: add `try_cast_types`

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -86,6 +86,15 @@ pub enum ColumnOperationError {
         /// `ColumnType` of right operand
         right_type: ColumnType,
     },
+
+    /// Errors related to casting between two types.
+    #[snafu(display("Cannot fit {left_type} into {right_type} without losing data"))]
+    CastingError {
+        /// `ColumnType` of left operand
+        left_type: ColumnType,
+        /// `ColumnType` of right operand
+        right_type: ColumnType,
+    },
 }
 
 /// Result type for column operations


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This is a preparatory commit for the `CastExpr`

# What changes are included in this PR?

A new function to determine if a `ColumnType` can be cast to another `ColumnType`

# Are these changes tested?
Yes