### PR TITLE
feat: add cast expr

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -189,7 +189,6 @@ pub fn try_divide_column_types(
 }
 
 /// Verifies that `from` can be cast to `to`. For now, this supports a limited number of casts.
-#[cfg_attr(not(test), expect(dead_code))]
 pub fn try_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult<()> {
     match (from, to) {
         (

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -14,7 +14,8 @@ mod slice_decimal_operation;
 
 mod column_type_operation;
 pub use column_type_operation::{
-    try_add_subtract_column_types, try_divide_column_types, try_multiply_column_types,
+    try_add_subtract_column_types, try_cast_types, try_divide_column_types,
+    try_multiply_column_types,
 };
 
 mod column_arithmetic_operation;

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -1,0 +1,69 @@
+use super::{numerical_util::cast_column, DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        database::{try_cast_types, Column, ColumnRef, ColumnType, Table},
+        map::{IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
+    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+/// Provable CAST expression
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CastExpr {
+    from_expr: Box<DynProofExpr>,
+    to_type: ColumnType,
+}
+
+impl CastExpr {
+    /// Creates a new `CastExpr`
+    #[expect(dead_code)]
+    pub fn new(from_expr: Box<DynProofExpr>, to_type: ColumnType) -> Self {
+        Self { from_expr, to_type }
+    }
+}
+
+impl ProofExpr for CastExpr {
+    fn data_type(&self) -> ColumnType {
+        try_cast_types(self.from_expr.data_type(), self.to_type)
+            .expect("Failed to cast column type");
+        self.to_type
+    }
+
+    fn result_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+    ) -> Column<'a, S> {
+        let uncasted_result = self.from_expr.result_evaluate(alloc, table);
+        cast_column(alloc, uncasted_result, self.to_type)
+    }
+
+    fn prover_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+    ) -> Column<'a, S> {
+        let uncasted_result = self.from_expr.prover_evaluate(builder, alloc, table);
+        cast_column(alloc, uncasted_result, self.to_type)
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        chi_eval: S,
+    ) -> Result<S, ProofError> {
+        self.from_expr
+            .verifier_evaluate(builder, accessor, chi_eval)
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.from_expr.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -21,7 +21,6 @@ pub struct CastExpr {
 
 impl CastExpr {
     /// Creates a new `CastExpr`
-    #[expect(dead_code)]
     pub fn new(from_expr: Box<DynProofExpr>, to_type: ColumnType) -> Self {
         Self { from_expr, to_type }
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
@@ -1,0 +1,94 @@
+use super::{
+    test_utility::{aliased_plan, cast, column, tab},
+    LiteralExpr,
+};
+use crate::{
+    base::{
+        database::{
+            owned_table_utility::{
+                bigint, boolean, decimal75, int, int128, owned_table, smallint, timestamptz,
+                tinyint,
+            },
+            ColumnType, LiteralValue, OwnedTableTestAccessor, TableRef,
+        },
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    },
+    sql::{
+        proof::{exercise_verification, VerifiableQueryResult},
+        proof_exprs::DynProofExpr,
+        proof_plans::test_utility::filter,
+        AnalyzeError,
+    },
+};
+use blitzar::proof::InnerProductProof;
+
+#[test]
+fn we_can_prove_a_simple_cast_expr() {
+    let data = owned_table([
+        boolean("a", [false, true, false, true]),
+        boolean("b", [true, true, false, true]),
+        boolean("c", [false, false, false, true]),
+        boolean("d", [false, true, false, false]),
+        boolean("e", [false, true, true, false]),
+        timestamptz(
+            "f",
+            PoSQLTimeUnit::Second,
+            PoSQLTimeZone::new(1),
+            [1i64, -500, i64::MAX, 0],
+        ),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = filter(
+        vec![
+            aliased_plan(
+                cast(column(&t, "a", &accessor), ColumnType::TinyInt),
+                "a_cast",
+            ),
+            aliased_plan(
+                cast(column(&t, "b", &accessor), ColumnType::SmallInt),
+                "b_cast",
+            ),
+            aliased_plan(cast(column(&t, "c", &accessor), ColumnType::Int), "c_cast"),
+            aliased_plan(
+                cast(column(&t, "d", &accessor), ColumnType::BigInt),
+                "d_cast",
+            ),
+            aliased_plan(
+                cast(column(&t, "e", &accessor), ColumnType::Int128),
+                "e_cast",
+            ),
+            aliased_plan(
+                cast(column(&t, "f", &accessor), ColumnType::BigInt),
+                "f_cast",
+            ),
+        ],
+        tab(&t),
+        super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let expected_res = owned_table([
+        tinyint("a_cast", [0i8, 1, 0, 1]),
+        smallint("b_cast", [1i16, 1, 0, 1]),
+        int("c_cast", [0i32, 0, 0, 1]),
+        bigint("d_cast", [0i64, 1, 0, 0]),
+        int128("e_cast", [0i128, 1, 1, 0]),
+        bigint("f_cast", [1i64, -500, i64::MAX, 0]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_get_error_if_we_cast_uncastable_type() {
+    let data = owned_table([decimal75("a", 57, 2, [1_i16, 2, 3, 4])]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    assert!(matches!(
+        DynProofExpr::try_new_cast(column(&t, "a", &accessor), ColumnType::BigInt),
+        Err(AnalyzeError::DataTypeMismatch { .. })
+    ));
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -72,3 +72,5 @@ pub use column_expr::ColumnExpr;
 mod column_expr_test;
 
 mod cast_expr;
+#[cfg(all(test, feature = "blitzar"))]
+mod cast_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -70,3 +70,5 @@ mod column_expr;
 pub use column_expr::ColumnExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod column_expr_test;
+
+mod cast_expr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -531,7 +531,6 @@ fn cast_bool_column_to_signed_int_column<'a, S: Scalar>(
 ///
 /// # Panics
 /// Panics if casting is not supported between the two types
-#[cfg_attr(not(test), expect(dead_code))]
 pub fn cast_column<'a, S: Scalar>(
     alloc: &'a Bump,
     from_column: Column<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -1,6 +1,6 @@
 use super::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr};
 use crate::base::{
-    database::{ColumnRef, LiteralValue, SchemaAccessor, TableRef},
+    database::{ColumnRef, ColumnType, LiteralValue, SchemaAccessor, TableRef},
     math::{decimal::Precision, i256::I256},
     scalar::Scalar,
 };
@@ -82,6 +82,10 @@ pub fn subtract(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
 /// - `DynProofExpr::try_new_multiply()` returns an error.
 pub fn multiply(left: DynProofExpr, right: DynProofExpr) -> DynProofExpr {
     DynProofExpr::try_new_multiply(left, right).unwrap()
+}
+
+pub fn cast(left: DynProofExpr, right: ColumnType) -> DynProofExpr {
+    DynProofExpr::try_new_cast(left, right).unwrap()
 }
 
 pub fn const_bool(val: bool) -> DynProofExpr {


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
