### PR TITLE
feat!: add `params` to `ProofExpr` and `ProofPlan`

### DIFF
--- a/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
@@ -170,9 +170,9 @@ fn bench_inner_product_proof(cli: &Cli, queries: &[QueryEntry]) {
 
         for _ in 0..cli.iterations {
             let result: VerifiableQueryResult<InnerProductProof> =
-                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &());
+                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &(), &[]);
             result
-                .verify(query_expr.proof_expr(), &accessor, &())
+                .verify(query_expr.proof_expr(), &accessor, &(), &[])
                 .unwrap();
         }
     }
@@ -207,9 +207,9 @@ fn bench_dory(cli: &Cli, queries: &[QueryEntry]) {
 
         for _ in 0..cli.iterations {
             let result: VerifiableQueryResult<DoryEvaluationProof> =
-                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &prover_setup);
+                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &prover_setup, &[]);
             result
-                .verify(query_expr.proof_expr(), &accessor, &verifier_setup)
+                .verify(query_expr.proof_expr(), &accessor, &verifier_setup, &[])
                 .unwrap();
         }
     }
@@ -261,9 +261,9 @@ fn bench_dynamic_dory(cli: &Cli, queries: &[QueryEntry]) {
 
         for _ in 0..cli.iterations {
             let result: VerifiableQueryResult<DynamicDoryEvaluationProof> =
-                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &&prover_setup);
+                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &&prover_setup, &[]);
             result
-                .verify(query_expr.proof_expr(), &accessor, &&verifier_setup)
+                .verify(query_expr.proof_expr(), &accessor, &&verifier_setup, &[])
                 .unwrap();
         }
     }
@@ -321,9 +321,10 @@ fn bench_hyperkzg(cli: &Cli, queries: &[QueryEntry]) {
                     query_expr.proof_expr(),
                     &accessor,
                     &prover_setup.as_slice(),
+                    &[],
                 );
             result
-                .verify(query_expr.proof_expr(), &accessor, &&vk)
+                .verify(query_expr.proof_expr(), &accessor, &&vk, &[])
                 .unwrap();
         }
     }

--- a/crates/proof-of-sql/examples/albums/main.rs
+++ b/crates/proof-of-sql/examples/albums/main.rs
@@ -48,6 +48,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -55,7 +56,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/avocado-prices/main.rs
+++ b/crates/proof-of-sql/examples/avocado-prices/main.rs
@@ -52,6 +52,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -59,7 +60,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/books/main.rs
+++ b/crates/proof-of-sql/examples/books/main.rs
@@ -47,6 +47,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -54,7 +55,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/brands/main.rs
+++ b/crates/proof-of-sql/examples/brands/main.rs
@@ -47,6 +47,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -54,7 +55,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/census/main.rs
+++ b/crates/proof-of-sql/examples/census/main.rs
@@ -54,6 +54,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -61,7 +62,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/countries/main.rs
+++ b/crates/proof-of-sql/examples/countries/main.rs
@@ -48,6 +48,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -55,7 +56,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/dinosaurs/main.rs
+++ b/crates/proof-of-sql/examples/dinosaurs/main.rs
@@ -48,6 +48,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -55,7 +56,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql/examples/dog_breeds/main.rs
@@ -45,6 +45,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -52,7 +53,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/hello_world/main.rs
+++ b/crates/proof-of-sql/examples/hello_world/main.rs
@@ -73,10 +73,11 @@ fn main() {
         query.proof_expr(),
         &accessor,
         &&prover_setup,
+        &[],
     );
     end_timer(timer);
     let timer = start_timer("Verifying Proof");
-    let result = verifiable_result.verify(query.proof_expr(), &accessor, &&verifier_setup);
+    let result = verifiable_result.verify(query.proof_expr(), &accessor, &&verifier_setup, &[]);
     end_timer(timer);
     match result {
         Ok(result) => {

--- a/crates/proof-of-sql/examples/plastics/main.rs
+++ b/crates/proof-of-sql/examples/plastics/main.rs
@@ -47,6 +47,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -54,7 +55,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -249,6 +249,7 @@ fn main() {
                 query.proof_expr(),
                 &csv_accessor,
                 &&prover_setup,
+                &[],
             );
             end_timer(timer);
             fs::write(
@@ -274,7 +275,7 @@ fn main() {
 
             let timer = start_timer("Verifying Proof");
             let query_result = result
-                .verify(query.proof_expr(), &commit_accessor, &&verifier_setup)
+                .verify(query.proof_expr(), &commit_accessor, &&verifier_setup, &[])
                 .expect("Failed to verify proof");
             end_timer(timer);
             println!(

--- a/crates/proof-of-sql/examples/programming_books/main.rs
+++ b/crates/proof-of-sql/examples/programming_books/main.rs
@@ -45,6 +45,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -52,7 +53,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/rockets/main.rs
+++ b/crates/proof-of-sql/examples/rockets/main.rs
@@ -47,6 +47,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -54,7 +55,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/space/main.rs
+++ b/crates/proof-of-sql/examples/space/main.rs
@@ -56,6 +56,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -63,7 +64,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/stocks/main.rs
+++ b/crates/proof-of-sql/examples/stocks/main.rs
@@ -47,6 +47,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -54,7 +55,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/sushi/main.rs
+++ b/crates/proof-of-sql/examples/sushi/main.rs
@@ -37,13 +37,14 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
     // Verify the result with the proof:
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);
     // Display the result

--- a/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
+++ b/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
@@ -36,12 +36,14 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     print!("Verifying proof...");
     let now = Instant::now();
-    let result = verifiable_result.verify(query_plan.proof_expr(), accessor, &verifier_setup)?;
+    let result =
+        verifiable_result.verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])?;
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     println!("Query Result:");

--- a/crates/proof-of-sql/examples/vehicles/main.rs
+++ b/crates/proof-of-sql/examples/vehicles/main.rs
@@ -48,6 +48,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -55,7 +56,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/examples/wood_types/main.rs
+++ b/crates/proof-of-sql/examples/wood_types/main.rs
@@ -48,6 +48,7 @@ fn prove_and_verify_query(
         query_plan.proof_expr(),
         accessor,
         &prover_setup,
+        &[],
     );
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
@@ -55,7 +56,7 @@ fn prove_and_verify_query(
     print!("Verifying proof...");
     let now = Instant::now();
     let result = verifiable_result
-        .verify(query_plan.proof_expr(), accessor, &verifier_setup)
+        .verify(query_plan.proof_expr(), accessor, &verifier_setup, &[])
         .unwrap();
     let result = apply_postprocessing_steps(result.table, query_plan.postprocessing());
     println!("Verified in {} ms.", now.elapsed().as_secs_f64() * 1000.);

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -2,7 +2,8 @@ use super::{error::Error, plans::Plan};
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, ColumnType, OwnedTable, Table, TableEvaluation, TableRef,
+            ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTable, Table, TableEvaluation,
+            TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -155,9 +156,10 @@ impl ProofPlan for EVMProofPlan {
         accessor: &IndexMap<ColumnRef, S>,
         result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
+        params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         self.inner()
-            .verifier_evaluate(builder, accessor, result, chi_eval_map)
+            .verifier_evaluate(builder, accessor, result, chi_eval_map, params)
     }
     fn get_column_result_fields(&self) -> Vec<ColumnField> {
         self.inner().get_column_result_fields()
@@ -175,15 +177,19 @@ impl ProverEvaluate for EVMProofPlan {
         builder: &mut FirstRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        params: &[LiteralValue],
     ) -> Table<'a, S> {
-        self.inner().first_round_evaluate(builder, alloc, table_map)
+        self.inner()
+            .first_round_evaluate(builder, alloc, table_map, params)
     }
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        params: &[LiteralValue],
     ) -> Table<'a, S> {
-        self.inner().final_round_evaluate(builder, alloc, table_map)
+        self.inner()
+            .final_round_evaluate(builder, alloc, table_map, params)
     }
 }

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,6 +1,8 @@
 use super::{verification_builder::VerificationBuilder, FinalRoundBuilder, FirstRoundBuilder};
 use crate::base::{
-    database::{ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableRef},
+    database::{
+        ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
+    },
     map::{IndexMap, IndexSet},
     proof::ProofError,
     scalar::Scalar,
@@ -19,6 +21,7 @@ pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
         accessor: &IndexMap<ColumnRef, S>,
         result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
+        params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError>;
 
     /// Return all the result column fields
@@ -39,6 +42,7 @@ pub trait ProverEvaluate {
         builder: &mut FirstRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        params: &[LiteralValue],
     ) -> Table<'a, S>;
 
     /// Evaluate the query and modify `FinalRoundBuilder` to store an intermediate representation
@@ -52,6 +56,7 @@ pub trait ProverEvaluate {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        params: &[LiteralValue],
     ) -> Table<'a, S>;
 }
 

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -7,8 +7,8 @@ use crate::{
         database::{
             owned_table_utility::{bigint, owned_table},
             table_utility::*,
-            ColumnField, ColumnRef, ColumnType, OwnedTable, OwnedTableTestAccessor, Table,
-            TableEvaluation, TableRef,
+            ColumnField, ColumnRef, ColumnType, LiteralValue, OwnedTable, OwnedTableTestAccessor,
+            Table, TableEvaluation, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
@@ -30,6 +30,7 @@ impl ProverEvaluate for EmptyTestQueryExpr {
         builder: &mut FirstRoundBuilder<'a, S>,
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         let zeros = vec![0_i64; self.length];
         builder.produce_chi_evaluation_length(self.length);
@@ -45,6 +46,7 @@ impl ProverEvaluate for EmptyTestQueryExpr {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         let zeros = vec![0_i64; self.length];
         let res: &[_] = alloc.alloc_slice_copy(&zeros);
@@ -65,6 +67,7 @@ impl ProofPlan for EmptyTestQueryExpr {
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
+        _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         assert_eq!(
             builder.try_consume_final_round_mle_evaluations(self.columns)?,
@@ -103,11 +106,11 @@ fn we_can_verify_queries_on_an_empty_table() {
         0,
         (),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]);
     let QueryData {
         verification_hash: _,
         table,
-    } = res.verify(&expr, &accessor, &()).unwrap();
+    } = res.verify(&expr, &accessor, &(), &[]).unwrap();
     let expected_res = owned_table([bigint("a1", [0; 0])]);
     assert_eq!(table, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test_utility.rs
@@ -29,19 +29,19 @@ pub fn exercise_verification(
     table_ref: &TableRef,
 ) {
     res.clone()
-        .verify(expr, accessor, &())
+        .verify(expr, accessor, &(), &[])
         .expect("Verification failed");
 
     // try changing the result
     let mut res_p = res.clone();
     res_p.result = tampered_table(&res.result);
-    assert!(res_p.verify(expr, accessor, &()).is_err());
+    assert!(res_p.verify(expr, accessor, &(), &[]).is_err());
 
     // try changing MLE evaluations
     for i in 0..res.proof.pcs_proof_evaluations.final_round.len() {
         let mut res_p = res.clone();
         res_p.proof.pcs_proof_evaluations.final_round[i] += Curve25519Scalar::one();
-        assert!(res_p.verify(expr, accessor, &()).is_err());
+        assert!(res_p.verify(expr, accessor, &(), &[]).is_err());
     }
 
     // try changing intermediate commitments
@@ -57,7 +57,7 @@ pub fn exercise_verification(
     for i in 0..res.proof.final_round_message.round_commitments.len() {
         let mut res_p = res.clone();
         res_p.proof.final_round_message.round_commitments[i] = commit_p;
-        assert!(res_p.verify(expr, accessor, &()).is_err());
+        assert!(res_p.verify(expr, accessor, &(), &[]).is_err());
     }
 
     // try changing the offset
@@ -76,9 +76,9 @@ pub fn exercise_verification(
         let offset_generators = accessor.get_offset(table_ref);
         let mut fake_accessor = accessor.clone();
         fake_accessor.update_offset(table_ref, offset_generators);
-        res.clone().verify(expr, &fake_accessor, &()).unwrap();
+        res.clone().verify(expr, &fake_accessor, &(), &[]).unwrap();
         fake_accessor.update_offset(table_ref, offset_generators + 1);
-        assert!(res.clone().verify(expr, &fake_accessor, &()).is_err());
+        assert!(res.clone().verify(expr, &fake_accessor, &(), &[]).is_err());
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -48,9 +48,12 @@ fn we_can_prove_a_typical_add_subtract_query() {
             const_bigint(3),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         smallint("a", [3_i16, 4]),
         bigint("c", [2_i16, 0]),
@@ -93,9 +96,12 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
             const_decimal75(12, 4, 3500),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         decimal75("a", 12, 1, [4_i64, 2]),
         decimal75("c", 17, 3, [1040_i64, 477]),
@@ -137,9 +143,9 @@ fn result_expr_can_overflow() {
         equal(column(&t, "b", &accessor), const_bigint(1)),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     assert!(matches!(
-        verifiable_res.verify(&ast, &accessor, &()),
+        verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::Overflow)
     ));
 }
@@ -163,9 +169,12 @@ fn overflow_in_nonselected_rows_doesnt_error_out() {
         equal(column(&t, "b", &accessor), const_bigint(0)),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([smallint("c", [i16::MIN + 1])]);
     assert_eq!(res, expected_res);
 }
@@ -186,9 +195,12 @@ fn overflow_in_where_clause_doesnt_error_out() {
         ),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [i64::MAX]), smallint("b", [1_i16])]);
     assert_eq!(res, expected_res);
 }
@@ -218,9 +230,9 @@ fn result_expr_can_overflow_more() {
         const_bool(true),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     assert!(matches!(
-        verifiable_res.verify(&ast, &accessor, &()),
+        verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::Overflow)
     ));
 }
@@ -279,9 +291,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &[])
+            .unwrap()
+            .table;
 
         // Calculate/compare expected result
         let (expected_f, expected_d): (Vec<_>, Vec<_>) = multizip((
@@ -331,7 +346,7 @@ fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_result_evalua
         column(&t, "b", &accessor),
         subtract(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let res = add_subtract_expr.result_evaluate(&alloc, &data);
+    let res = add_subtract_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res_scalar = [0, 2, 2, 4]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,7 +1,7 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, Table},
+        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -37,11 +37,12 @@ impl ProofExpr for AndExpr {
         &self,
         alloc: &'a Bump,
         table: &Table<'a, S>,
+        params: &[LiteralValue],
     ) -> Column<'a, S> {
         log::log_memory_usage("Start");
 
-        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(alloc, table);
-        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(alloc, table);
+        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(alloc, table, params);
+        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(alloc, table, params);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let res =
@@ -58,11 +59,12 @@ impl ProofExpr for AndExpr {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table: &Table<'a, S>,
+        params: &[LiteralValue],
     ) -> Column<'a, S> {
         log::log_memory_usage("Start");
 
-        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table);
-        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table);
+        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table, params);
+        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table, params);
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let n = lhs.len();
@@ -92,9 +94,14 @@ impl ProofExpr for AndExpr {
         builder: &mut impl VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         chi_eval: S,
+        params: &[LiteralValue],
     ) -> Result<S, ProofError> {
-        let lhs = self.lhs.verifier_evaluate(builder, accessor, chi_eval)?;
-        let rhs = self.rhs.verifier_evaluate(builder, accessor, chi_eval)?;
+        let lhs = self
+            .lhs
+            .verifier_evaluate(builder, accessor, chi_eval, params)?;
+        let rhs = self
+            .rhs
+            .verifier_evaluate(builder, accessor, chi_eval, params)?;
 
         // lhs_and_rhs
         let lhs_and_rhs = builder.try_consume_final_round_mle_evaluation()?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -51,9 +51,12 @@ fn we_can_prove_a_simple_and_query() {
             ),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [2]), varchar("d", ["t"])]);
     assert_eq!(res, expected_res);
 }
@@ -80,9 +83,12 @@ fn we_can_prove_a_simple_and_query_with_128_bits() {
             ),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([int128("a", [2]), varchar("d", ["t"])]);
     assert_eq!(res, expected_res);
 }
@@ -129,9 +135,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(&t, "c", &accessor), const_bigint(filter_val2)),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &[])
+            .unwrap()
+            .table;
 
         // Calculate/compare expected result
         let (expected_a, expected_d): (Vec<_>, Vec<_>) = multizip((
@@ -180,7 +189,7 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
         equal(column(&t, "b", &accessor), const_int128(1)),
         equal(column(&t, "d", &accessor), const_varchar("t")),
     );
-    let res = and_expr.result_evaluate(&alloc, &data);
+    let res = and_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res = Column::Boolean(&[false, true, false, false]);
     assert_eq!(res, expected_res);
 }
@@ -207,7 +216,7 @@ fn we_can_verify_a_simple_proof() {
     let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
         FinalRoundBuilder::new(4, VecDeque::new());
 
-    and_expr.prover_evaluate(&mut final_round_builder, &alloc, &table);
+    and_expr.prover_evaluate(&mut final_round_builder, &alloc, &table, &[]);
 
     let verification_builder = run_verify_for_each_row(
         4,
@@ -220,7 +229,7 @@ fn we_can_verify_a_simple_proof() {
                 b.clone() => rhs.inner_product(evaluation_point)
             };
             and_expr
-                .verifier_evaluate(verification_builder, &accessor, chi_eval)
+                .verifier_evaluate(verification_builder, &accessor, chi_eval, &[])
                 .unwrap();
         },
     );
@@ -274,7 +283,7 @@ fn we_can_reject_a_simple_tampered_proof() {
             b.clone() => rhs.inner_product(evaluation_point)
         };
         and_expr
-            .verifier_evaluate(&mut verification_builder, &accessor, chi_eval)
+            .verifier_evaluate(&mut verification_builder, &accessor, chi_eval, &[])
             .unwrap();
         verification_builder.increment_row_index();
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
@@ -67,9 +67,12 @@ fn we_can_prove_a_simple_cast_expr() {
         tab(&t),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         tinyint("a_cast", [0i8, 1, 0, 1]),
         smallint("b_cast", [1i16, 1, 0, 1]),

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -1,7 +1,7 @@
 use super::ProofExpr;
 use crate::{
     base::{
-        database::{Column, ColumnField, ColumnRef, ColumnType, Table},
+        database::{Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -70,6 +70,7 @@ impl ProofExpr for ColumnExpr {
         &self,
         _alloc: &'a Bump,
         table: &Table<'a, S>,
+        _params: &[LiteralValue],
     ) -> Column<'a, S> {
         self.fetch_column(table)
     }
@@ -81,6 +82,7 @@ impl ProofExpr for ColumnExpr {
         _builder: &mut FinalRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         table: &Table<'a, S>,
+        _params: &[LiteralValue],
     ) -> Column<'a, S> {
         self.fetch_column(table)
     }
@@ -92,6 +94,7 @@ impl ProofExpr for ColumnExpr {
         _builder: &mut impl VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         _chi_eval: S,
+        _params: &[LiteralValue],
     ) -> Result<S, ProofError> {
         Ok(*accessor
             .get(&self.column_ref)

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -25,9 +25,12 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
             vec![ColumnField::new("a".into(), ColumnType::Boolean)],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([boolean("a", [true, false])]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -38,8 +38,11 @@ fn we_can_prove_an_equality_query_with_no_rows() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [0; 0]), varchar("d", [""; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -60,8 +63,11 @@ fn we_can_prove_another_equality_query_with_no_rows() {
         tab(&t),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [0; 0]), varchar("d", [""; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -86,8 +92,11 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("b", [1; 0]),
         varchar("c", ["t"; 0]),
@@ -112,9 +121,12 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([varchar("d", ["abc"]), bigint("a", [123_i64])]);
     assert_eq!(res, expected_res);
 }
@@ -135,9 +147,12 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
         tab(&t),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([varchar("d", ["abc"]), bigint("a", [123_i64])]);
     assert_eq!(res, expected_res);
 }
@@ -158,9 +173,12 @@ fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [0; 0]),
         varchar("d", [""; 0]),
@@ -195,9 +213,12 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [1, 3]),
         varchar("c", ["t", "jj"]),
@@ -236,9 +257,12 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [1, 2]),
         varchar("c", ["t", "ghi"]),
@@ -274,9 +298,12 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(123_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [1, 3]),
         varchar("c", ["t", "jj"]),
@@ -313,9 +340,12 @@ fn we_can_prove_an_equality_query_with_a_string_comparison() {
         tab(&t),
         equal(column(&t, "c", &accessor), const_varchar("ghi")),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [2, 5]),
         bigint("b", [5, 0]),
@@ -362,9 +392,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 const_varchar(filter_val.as_str()),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &[])
+            .unwrap()
+            .table;
 
         // Calculate/compare expected result
         let (expected_a, expected_d): (Vec<_>, Vec<_>) = multizip((
@@ -424,7 +457,7 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
         column(&t, "e", &accessor),
         const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ZERO),
     );
-    let res = equals_expr.result_evaluate(&alloc, &data);
+    let res = equals_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res = Column::Boolean(&[true, false, true, false]);
     assert_eq!(res, expected_res);
 }
@@ -450,8 +483,11 @@ fn we_can_query_with_varbinary_equality() {
     );
 
     // Execute and verify query
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
 
     // Expected result: only the second row should be returned
     let expected_res = owned_table([bigint("a", [4567]), varbinary("b", [&[4, 5, 6, 7]])]);

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -48,8 +48,11 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
         ),
     );
 
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([timestamptz(
         "a",
         PoSQLTimeUnit::Second,
@@ -83,8 +86,11 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
         ),
     );
 
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([timestamptz(
         "a",
         PoSQLTimeUnit::Second,
@@ -105,9 +111,12 @@ fn we_can_compare_a_constant_column() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [0; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -123,9 +132,12 @@ fn we_can_compare_a_varying_column_with_constant_sign() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [0; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -159,9 +171,12 @@ fn we_can_compare_columns_with_extreme_values() {
             column(&t, "boolean", &accessor),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("bigint_b", [i64::MAX, i64::MIN])]);
     assert_eq!(res, expected_res);
 }
@@ -184,9 +199,12 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
         tab(&t),
         lte(column(&t, "e", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [25]),
         varchar("d", ["de"]),
@@ -214,9 +232,12 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
         tab(&t),
         lte(column(&t, "f", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [123]),
         varchar("d", ["abc"]),
@@ -245,9 +266,12 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
         tab(&t),
         gte(column(&t, "f", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [25]),
         varchar("d", ["de"]),
@@ -279,9 +303,12 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
         tab(&t),
         lte(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [25]),
         varchar("d", ["de"]),
@@ -328,9 +355,12 @@ fn we_can_compare_two_columns() {
         tab(&t),
         lte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [1_i64, 7])]);
     assert_eq!(res, expected_res);
 }
@@ -349,9 +379,12 @@ fn we_can_compare_a_varying_column_with_constant_absolute_value() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -370,9 +403,12 @@ fn we_can_compare_a_constant_column_of_negative_columns() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -391,9 +427,12 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -409,9 +448,12 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -427,9 +469,12 @@ fn we_can_compare_column_with_greater_than_or_equal() {
         tab(&t),
         gte(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [2_i64])]);
     assert_eq!(res, expected_res);
 }
@@ -452,9 +497,12 @@ fn we_can_run_nested_comparison() {
             column(&t, "boolean", &accessor),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [1_i64, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -470,9 +518,12 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [1_i64])]);
     assert_eq!(res, expected_res);
 }
@@ -488,9 +539,12 @@ fn we_can_compare_a_constant_column_of_zeros() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected_res);
 }
@@ -506,9 +560,12 @@ fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected = owned_table([bigint("b", [1_i64, 2, 3])]);
     assert_eq!(res, expected);
 }
@@ -543,9 +600,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
             tab(&t),
             lte(column(&t, "a", &accessor), const_bigint(filter_val)),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &[])
+            .unwrap()
+            .table;
 
         // Calculate/compare expected result
         let (expected_a, expected_b): (Vec<_>, Vec<_>) =
@@ -587,7 +647,7 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
     let lhs_expr: DynProofExpr = column(&t, "a", &accessor);
     let rhs_expr = column(&t, "b", &accessor);
     let lte_expr = lte(lhs_expr, rhs_expr);
-    let res = lte_expr.result_evaluate(&alloc, &data);
+    let res = lte_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res = Column::Boolean(&[true, false, true]);
     assert_eq!(res, expected_res);
 }
@@ -605,7 +665,7 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
     let col_expr: DynProofExpr = column(&t, "a", &accessor);
     let lit_expr = const_bigint(1);
     let gte_expr = gte(col_expr, lit_expr);
-    let res = gte_expr.result_evaluate(&alloc, &data);
+    let res = gte_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res = Column::Boolean(&[false, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -45,6 +45,7 @@ impl ProofExpr for LiteralExpr {
         &self,
         alloc: &'a Bump,
         table: &Table<'a, S>,
+        _params: &[LiteralValue],
     ) -> Column<'a, S> {
         log::log_memory_usage("Start");
 
@@ -61,6 +62,7 @@ impl ProofExpr for LiteralExpr {
         _builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table: &Table<'a, S>,
+        _params: &[LiteralValue],
     ) -> Column<'a, S> {
         log::log_memory_usage("Start");
 
@@ -77,6 +79,7 @@ impl ProofExpr for LiteralExpr {
         _builder: &mut impl VerificationBuilder<S>,
         _accessor: &IndexMap<ColumnRef, S>,
         chi_eval: S,
+        _params: &[LiteralValue],
     ) -> Result<S, ProofError> {
         Ok(chi_eval * self.value.to_scalar())
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -52,9 +52,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
             tab(&t),
             const_bool(lit),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &[])
+            .unwrap()
+            .table;
 
         // Calculate/compare expected result
         let (expected_a, expected_b, expected_c): (Vec<bool>, Vec<String>, Vec<i64>) = if lit {
@@ -98,9 +101,12 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         tab(&t),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     assert_eq!(res, expected_res);
 }
 
@@ -115,9 +121,12 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
         tab(&t),
         const_bool(false),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [1_i64; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -128,7 +137,7 @@ fn we_can_compute_the_correct_output_of_a_literal_expr_using_result_evaluate() {
     let data: Table<Curve25519Scalar> =
         table([borrowed_bigint("a", [123_i64, 456, 789, 1011], &alloc)]);
     let literal_expr: DynProofExpr = const_bool(true);
-    let res = literal_expr.result_evaluate(&alloc, &data);
+    let res = literal_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res = Column::Boolean(&[true, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -59,9 +59,12 @@ fn we_can_prove_a_typical_multiply_query() {
             const_decimal75(3, 2, 819),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         int("a", [2_i32, 6]),
         bigint("c", [0_i64, 2]),
@@ -105,9 +108,9 @@ fn result_expr_can_overflow() {
         equal(column(&t, "b", &accessor), const_bigint(2)),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     assert!(matches!(
-        verifiable_res.verify(&ast, &accessor, &()),
+        verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::Overflow)
     ));
 }
@@ -131,9 +134,12 @@ fn overflow_in_nonselected_rows_doesnt_error_out() {
         equal(column(&t, "b", &accessor), const_bigint(0)),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([smallint("c", [0_i16])]);
     assert_eq!(res, expected_res);
 }
@@ -157,9 +163,12 @@ fn overflow_in_where_clause_doesnt_error_out() {
         ),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [i64::MAX]), smallint("b", [2_i16])]);
     assert_eq!(res, expected_res);
 }
@@ -183,9 +192,9 @@ fn result_expr_can_overflow_more() {
         const_bool(true),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     assert!(matches!(
-        verifiable_res.verify(&ast, &accessor, &()),
+        verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::Overflow)
     ));
 }
@@ -231,9 +240,12 @@ fn where_clause_can_wrap_around() {
         ),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint(
             "a",
@@ -305,9 +317,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &[])
+            .unwrap()
+            .table;
 
         // Calculate/compare expected result
         let (expected_f, expected_d): (Vec<_>, Vec<_>) = multizip((
@@ -357,7 +372,7 @@ fn we_can_compute_the_correct_output_of_a_multiply_expr_using_result_evaluate() 
         column(&t, "b", &accessor),
         subtract(column(&t, "a", &accessor), const_decimal75(2, 1, 15)),
     );
-    let res = arithmetic_expr.result_evaluate(&alloc, &data);
+    let res = arithmetic_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res_scalar = [0, 5, 75, 25]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -36,9 +36,12 @@ fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
         tab(&t),
         not(equal(column(&t, "b", &accessor), const_bigint(1))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [123]), varchar("d", ["alfa"])]);
     assert_eq!(res, expected_res);
 }
@@ -80,9 +83,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             )),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &[])
+            .unwrap()
+            .table;
 
         // Calculate/compare expected result
         let (expected_a, expected_b): (Vec<_>, Vec<_>) =
@@ -123,7 +129,7 @@ fn we_can_compute_the_correct_output_of_a_not_expr_using_result_evaluate() {
     let t = TableRef::new("sxt", "t");
     accessor.add_table(t.clone(), data.clone(), 0);
     let not_expr: DynProofExpr = not(equal(column(&t, "b", &accessor), const_int128(1)));
-    let res = not_expr.result_evaluate(&alloc, &data);
+    let res = not_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res = Column::Boolean(&[true, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -38,9 +38,12 @@ fn we_can_prove_a_simple_or_query() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [2_i64, 3]), varchar("d", ["t", "g"])]);
     assert_eq!(res, expected_res);
 }
@@ -63,9 +66,12 @@ fn we_can_prove_a_simple_or_query_with_variable_integer_types() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([int128("a", [2_i64, 3]), varchar("d", ["t", "g"])]);
     assert_eq!(res, expected_res);
 }
@@ -89,9 +95,12 @@ fn we_can_prove_an_or_query_where_both_lhs_and_rhs_are_true() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [2_i64, 3, 4]), varchar("d", ["t", "g", "efg"])]);
     assert_eq!(res, expected_res);
 }
@@ -138,9 +147,12 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(&t, "c", &accessor), const_bigint(filter_val2)),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
-        let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &[])
+            .unwrap()
+            .table;
 
         // Calculate/compare expected result
         let (expected_a, expected_d): (Vec<_>, Vec<_>) = multizip((
@@ -189,7 +201,7 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
         equal(column(&t, "b", &accessor), const_int128(1)),
         equal(column(&t, "d", &accessor), const_varchar("g")),
     );
-    let res = and_expr.result_evaluate(&alloc, &data);
+    let res = and_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res = Column::Boolean(&[false, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, Table},
+        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -23,6 +23,7 @@ pub trait ProofExpr: Debug + Send + Sync {
         &self,
         alloc: &'a Bump,
         table: &Table<'a, S>,
+        params: &[LiteralValue],
     ) -> Column<'a, S>;
 
     /// Evaluate the expression, add components needed to prove it, and return thet resulting column
@@ -32,6 +33,7 @@ pub trait ProofExpr: Debug + Send + Sync {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table: &Table<'a, S>,
+        params: &[LiteralValue],
     ) -> Column<'a, S>;
 
     /// Compute the evaluation of a multilinear extension from this expression
@@ -42,6 +44,7 @@ pub trait ProofExpr: Debug + Send + Sync {
         builder: &mut impl VerificationBuilder<S>,
         accessor: &IndexMap<ColumnRef, S>,
         chi_eval: S,
+        params: &[LiteralValue],
     ) -> Result<S, ProofError>;
 
     /// Insert in the [`IndexSet`] `columns` all the column

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -41,7 +41,7 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
         ),
         not(equal(column(&t, "c", &accessor), const_int128(3))),
     );
-    let res = bool_expr.result_evaluate(&alloc, &data);
+    let res = bool_expr.result_evaluate(&alloc, &data, &[]);
     let expected_res = Column::Boolean(&[
         false, true, false, true, false, true, false, true, false, true, false, true, false, true,
         false, false, false,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -8,7 +8,7 @@ use crate::{
     base::{
         database::{
             owned_table_utility::*, table_utility::table, Column, ColumnField, ColumnRef,
-            ColumnType, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnType, LiteralValue, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
@@ -40,6 +40,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
         builder: &mut FirstRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
@@ -76,6 +77,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
@@ -161,6 +163,7 @@ impl ProofPlan for MembershipCheckTestPlan {
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
+        _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         // Get the challenges from the builder
         let alpha = builder.try_consume_post_result_challenge()?;
@@ -226,8 +229,12 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        let actual = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        let actual = verifiable_res
+            .verify(&plan, &accessor, &(), &[])
+            .unwrap()
+            .table;
         let expected = owned_table([int128("multiplicities", [2_i128, 3, 0])]);
         assert_eq!(actual, expected);
     }
@@ -270,8 +277,12 @@ mod tests {
                 ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        let actual = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        let actual = verifiable_res
+            .verify(&plan, &accessor, &(), &[])
+            .unwrap()
+            .table;
         let expected = owned_table([int128("multiplicities", [3_i128, 2, 0])]);
         assert_eq!(actual, expected);
     }
@@ -314,8 +325,12 @@ mod tests {
                 ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        let actual = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        let actual = verifiable_res
+            .verify(&plan, &accessor, &(), &[])
+            .unwrap()
+            .table;
         let expected = owned_table([int128("multiplicities", [0_i128; 3])]);
         assert_eq!(actual, expected);
     }
@@ -351,7 +366,7 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 
     #[test]
@@ -383,7 +398,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 
     #[test]
@@ -416,7 +431,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 
     #[test]
@@ -448,7 +463,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 
     #[test]
@@ -479,6 +494,6 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -6,7 +6,8 @@ use super::monotonic::{
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableOptions,
+            TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
@@ -31,6 +32,7 @@ impl<const STRICT: bool, const ASC: bool> ProverEvaluate for MonotonicTestPlan<S
         builder: &mut FirstRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // Get the tables from the map using the table reference
         let table: &Table<'a, S> = table_map
@@ -51,6 +53,7 @@ impl<const STRICT: bool, const ASC: bool> ProverEvaluate for MonotonicTestPlan<S
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // Get the table from the map using the table reference
         let table: &Table<'a, S> = table_map
@@ -93,6 +96,7 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
+        _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         // Get the challenges from the builder
         let alpha = builder.try_consume_post_result_challenge()?;
@@ -130,8 +134,9 @@ mod tests {
         let plan = MonotonicTestPlan::<STRICT, ASC> {
             column: ColumnRef::new(table_ref, column_name.into(), column_type),
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, accessor, &());
-        let res = verifiable_res.verify(&plan, accessor, &());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, accessor, &(), &[]);
+        let res = verifiable_res.verify(&plan, accessor, &(), &[]);
         if shall_error {
             assert!(matches!(
                 res,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -4,8 +4,8 @@ use super::permutation_check::{final_round_evaluate_permutation_check, verify_pe
 use crate::{
     base::{
         database::{
-            table_utility::table_with_row_count, ColumnField, ColumnRef, OwnedTable, Table,
-            TableEvaluation, TableOptions, TableRef,
+            table_utility::table_with_row_count, ColumnField, ColumnRef, LiteralValue, OwnedTable,
+            Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
@@ -36,6 +36,7 @@ impl ProverEvaluate for PermutationCheckTestPlan {
         builder: &mut FirstRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // Get the tables from the map using the table reference
         let source_table: &Table<'a, S> =
@@ -51,6 +52,7 @@ impl ProverEvaluate for PermutationCheckTestPlan {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
@@ -131,6 +133,7 @@ impl ProofPlan for PermutationCheckTestPlan {
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
+        _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         // Get the challenges from the builder
         let alpha = builder.try_consume_post_result_challenge()?;
@@ -194,8 +197,9 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
     #[test]
@@ -236,8 +240,9 @@ mod tests {
                 ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
     #[test]
@@ -278,8 +283,9 @@ mod tests {
                 ColumnRef::new(candidate_table_ref, "e".into(), ColumnType::Boolean),
             ],
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
     #[test]
@@ -313,7 +319,7 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 
     #[test]
@@ -345,7 +351,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 
     #[test]
@@ -378,7 +384,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 
     #[test]
@@ -410,7 +416,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 
     #[test]
@@ -441,6 +447,6 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
@@ -4,7 +4,8 @@ use super::shift::{final_round_evaluate_shift, first_round_evaluate_shift, verif
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableOptions,
+            TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
@@ -32,6 +33,7 @@ impl ProverEvaluate for ShiftTestPlan {
         builder: &mut FirstRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         builder.request_post_result_challenges(2);
         builder.produce_chi_evaluation_length(self.column_length);
@@ -48,6 +50,7 @@ impl ProverEvaluate for ShiftTestPlan {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // Get the table from the map using the table reference
         let source_table: &Table<'a, S> = table_map
@@ -108,6 +111,7 @@ impl ProofPlan for ShiftTestPlan {
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
+        _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         // Get the challenges from the builder
         let alpha = builder.try_consume_post_result_challenge()?;
@@ -173,8 +177,9 @@ mod tests {
             ),
             column_length: 3,
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        let res = verifiable_res.verify(&plan, &accessor, &());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        let res = verifiable_res.verify(&plan, &accessor, &(), &[]);
         assert!(res.is_ok());
 
         // Varchar column
@@ -187,8 +192,9 @@ mod tests {
             ),
             column_length: 3,
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        let res = verifiable_res.verify(&plan, &accessor, &());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        let res = verifiable_res.verify(&plan, &accessor, &(), &[]);
         assert!(res.is_ok());
 
         // Boolean column
@@ -201,8 +207,9 @@ mod tests {
             ),
             column_length: 3,
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        let res = verifiable_res.verify(&plan, &accessor, &());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        let res = verifiable_res.verify(&plan, &accessor, &(), &[]);
         assert!(res.is_ok());
     }
 
@@ -241,8 +248,9 @@ mod tests {
             ),
             column_length: 3,
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        assert!(verifiable_res.verify(&plan, &accessor, &()).is_err());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_err());
 
         // Varchar column
         let plan = ShiftTestPlan {
@@ -254,8 +262,9 @@ mod tests {
             ),
             column_length: 3,
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        assert!(verifiable_res.verify(&plan, &accessor, &()).is_err());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_err());
 
         // Boolean column
         let plan = ShiftTestPlan {
@@ -267,8 +276,9 @@ mod tests {
             ),
             column_length: 3,
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        assert!(verifiable_res.verify(&plan, &accessor, &()).is_err());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_err());
 
         // Success case: The last pair of columns is correct even though the others are not
         let plan = ShiftTestPlan {
@@ -280,8 +290,9 @@ mod tests {
             ),
             column_length: 3,
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        assert!(verifiable_res.verify(&plan, &accessor, &()).is_ok());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
     #[should_panic(expected = "Shifted column length mismatch")]
@@ -314,8 +325,9 @@ mod tests {
             ),
             column_length: 7,
         };
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-        let res = verifiable_res.verify(&plan, &accessor, &());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        let res = verifiable_res.verify(&plan, &accessor, &(), &[]);
         assert!(res.is_err());
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableRef},
+        database::{
+            ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
+        },
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -25,6 +27,7 @@ impl ProofPlan for DemoMockPlan {
         accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
+        _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         // place verification logic you want to test here
 
@@ -56,6 +59,7 @@ impl ProverEvaluate for DemoMockPlan {
         _builder: &mut FirstRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // place prover logic you want to test here
 
@@ -67,6 +71,7 @@ impl ProverEvaluate for DemoMockPlan {
         _builder: &mut FinalRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         // place prover logic you want to test here
 
@@ -100,9 +105,10 @@ mod tests {
             0_usize,
             (),
         );
-        let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
         let res = verifiable_res
-            .verify(&plan, &accessor, &())
+            .verify(&plan, &accessor, &(), &[])
             .expect("verification should suceeed")
             .table;
         assert_eq!(res, table);

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -4,7 +4,9 @@ use super::{
 };
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableRef},
+        database::{
+            ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
+        },
         map::{IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -1,7 +1,8 @@
 use crate::{
     base::{
         database::{
-            ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
+            ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableOptions,
+            TableRef,
         },
         map::{IndexMap, IndexSet},
         proof::ProofError,
@@ -42,6 +43,7 @@ impl ProofPlan for EmptyExec {
         _accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
+        _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         Ok(TableEvaluation::new(
             Vec::<S>::new(),
@@ -69,6 +71,7 @@ impl ProverEvaluate for EmptyExec {
         _builder: &mut FirstRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         log::log_memory_usage("Start");
 
@@ -88,6 +91,7 @@ impl ProverEvaluate for EmptyExec {
         _builder: &mut FinalRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         log::log_memory_usage("Start");
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -163,9 +163,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_filter() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let where_clause = equal(column(&t, "a", &accessor), const_int128(5_i128));
     let ast = filter(cols_expr_plan(&t, &["b"], &accessor), tab(&t), where_clause);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("b", [3_i64, 5])]);
     assert_eq!(res, expected_res);
 }
@@ -207,6 +210,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_first_
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -257,6 +261,7 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_first_round_evaluate() {
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -295,6 +300,7 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_firs
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -339,6 +345,7 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_first_round_evaluate(
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -368,8 +375,8 @@ fn we_can_prove_a_filter_on_an_empty_table() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]);
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
         int128("c", [3; 0]),
@@ -396,9 +403,9 @@ fn we_can_prove_a_filter_with_empty_results() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
         int128("c", [3; 0]),
@@ -435,9 +442,9 @@ fn we_can_prove_a_filter() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(105)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3, 7]),
         int128("c", [3, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
@@ -29,9 +29,9 @@ fn we_can_prove_aggregation_without_group_by() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_c", [101 + 104 + 102 + 103]),
         bigint("__count__", [4]),
@@ -57,9 +57,9 @@ fn we_can_prove_a_simple_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
         bigint("sum_c", [101 + 104, 102 + 103]),
@@ -92,9 +92,9 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("a", [1, 2]),
         bigint("sum_c", [(101 + 104) * 2 + 2, (102 + 103) * 2 + 2]),
@@ -214,9 +214,9 @@ fn we_can_prove_a_complex_group_by_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         scalar("scalar_group", [4, 4, 4]),
         int128("int128_group", [8, 8, 9]),
@@ -247,9 +247,9 @@ fn we_can_prove_a_complex_group_by_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("sum_int", [1406 + 927 + 637]),
         int128("sum_128", [(1342 + 1262 + 513) * 4]),

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -131,9 +131,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected = owned_table([bigint("b", [1_i64, 2, 3, 4, 5, 1, 2, 3, 4, 5])]);
     assert_eq!(res, expected);
 }
@@ -163,9 +166,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected = owned_table([
         bigint("b", [2_i64, 3, 4, 5, 6]),
         bigint("prod", [1_i64, 8, 15, 8, 25]),
@@ -202,9 +208,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
             equal(column(&t, "a", &accessor), const_int128(5)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected = owned_table([bigint("b", [5_i64, 7]), bigint("prod", [32_i64, 60])]);
     assert_eq!(res, expected);
 }
@@ -253,6 +262,7 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -303,6 +313,7 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -362,6 +373,7 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_first_round_evalu
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -407,8 +419,8 @@ fn we_can_prove_a_projection_on_an_empty_table() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]);
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
         int128("prod", [3; 0]),
@@ -453,9 +465,9 @@ fn we_can_prove_a_projection() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [1, 2, 3, 4, 7]),
         int128("c", [1, 3, 3, 4, 5]),

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -44,9 +44,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [2_i64, 3]), varchar("b", ["2", "3"])]);
     assert_eq!(res, expected_res);
 }
@@ -70,9 +73,12 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [0_i64; 0]), varchar("b", [""; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -119,6 +125,7 @@ fn we_can_get_an_empty_result_from_a_slice_on_an_empty_table_using_first_round_e
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -174,6 +181,7 @@ fn we_can_get_an_empty_result_from_a_slice_using_first_round_evaluate() {
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -216,6 +224,7 @@ fn we_can_get_no_columns_from_a_slice_with_empty_input_using_first_round_evaluat
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -264,6 +273,7 @@ fn we_can_get_the_correct_result_from_a_slice_using_first_round_evaluate() {
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(fields)
     .unwrap();
@@ -307,9 +317,9 @@ fn we_can_prove_a_slice_exec() {
         2,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [4]),
         int128("c", [4]),
@@ -356,9 +366,9 @@ fn we_can_prove_a_nested_slice_exec() {
         1,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [4]),
         int128("c", [4]),
@@ -405,9 +415,9 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -454,9 +464,9 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &());
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     exercise_verification(&res, &expr, &accessor, &t);
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [0; 0]),
         int128("c", [0; 0]),
@@ -507,9 +517,12 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
-    let res = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected = owned_table([
         bigint("language_rank", [1_i64, 2, 3]),
         varchar("language_name", ["Español", "Português", "Français"]),
@@ -526,8 +539,8 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_an_empty_exec() {
     let empty_table = owned_table([]);
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let expr = slice_exec(empty_exec(), 3, Some(2));
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &());
-    let res = res.verify(&expr, &accessor, &()).unwrap().table;
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]);
+    let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     assert_eq!(res, empty_table);
 }
 
@@ -553,9 +566,9 @@ fn we_cannot_prove_a_slice_exec_if_it_has_groupby_as_input_for_now() {
         None,
     );
     let res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&expr, &accessor, &());
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
     assert!(matches!(
-        res.verify(&expr, &accessor, &()),
+        res.verify(&expr, &accessor, &(), &[]),
         Err(QueryError::ProofError {
             source: ProofError::UnsupportedQueryPlan { .. }
         })

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -57,9 +57,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("id", [1_i64, 1, 2, 2, 4]),
         varchar("name", ["Chloe", "Chloe", "Margaret", "Margaret", "Lucy"]),
@@ -120,9 +123,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
         Some(3),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("id", [2_i64, 2]),
         varchar("name", ["Margaret", "Margaret"]),
@@ -231,9 +237,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
     );
 
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("id", [1_i64, 1, 2, 2, 10]),
         varchar("name", ["Chloe", "Chloe", "Margaret", "Margaret", "Nova"]),
@@ -293,9 +302,12 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("id", [0_i64; 0]),
         varchar("name", [""; 0]),
@@ -343,9 +355,12 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &table_right);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("id", [0_i64; 0]),
         varchar("name", [""; 0]),
@@ -391,9 +406,12 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("id", [0_i64; 0]),
         varchar("name", [""; 0]),
@@ -435,8 +453,11 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("id", [0_i64; 0]),
         varchar("name", [""; 0]),

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -1,6 +1,8 @@
 use crate::{
     base::{
-        database::{ColumnField, ColumnRef, OwnedTable, Table, TableEvaluation, TableRef},
+        database::{
+            ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
+        },
         map::{indexset, IndexMap, IndexSet},
         proof::ProofError,
         scalar::Scalar,
@@ -41,6 +43,7 @@ impl ProofPlan for TableExec {
         accessor: &IndexMap<ColumnRef, S>,
         _result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
+        params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         let column_evals = self
             .schema
@@ -80,6 +83,7 @@ impl ProverEvaluate for TableExec {
         _builder: &mut FirstRoundBuilder<'a, S>,
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         log::log_memory_usage("Start");
 
@@ -100,6 +104,7 @@ impl ProverEvaluate for TableExec {
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
+        _params: &[LiteralValue],
     ) -> Table<'a, S> {
         log::log_memory_usage("Start");
 

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -23,8 +23,12 @@ fn we_can_create_and_prove_an_empty_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &());
-    let res = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected = owned_table([bigint("a", [0_i64; 0])]);
     assert_eq!(res, expected);
 }
@@ -64,9 +68,12 @@ fn we_can_create_and_prove_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
-    let res = verifiable_res.verify(&plan, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&plan, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected = owned_table([
         bigint("language_rank", [0, 1, 2, 3]),
         varchar(

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -30,8 +30,11 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_with_no_tables() {
         ],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [0_i64; 0]), varchar("b", [""; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -54,8 +57,11 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_with_one_table() {
         vec![column_field("a", ColumnType::BigInt)],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [2_i64, 3, 4])]);
     assert_eq!(res, expected_res);
 }
@@ -82,8 +88,11 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
         ],
         vec![column_field("a", ColumnType::BigInt)],
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &());
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([bigint("a", [0_i64; 0])]);
     assert_eq!(res, expected_res);
 }
@@ -129,9 +138,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
             column_field("b", ColumnType::VarChar),
         ],
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t0);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [1_i64, 2, 3, 4, 5, 2, 3, 4, 5, 6]),
         varchar("b", ["1", "2", "3", "4", "5", "2", "3", "4", "5", "6"]),
@@ -267,9 +279,12 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
             column_field("b", ColumnType::VarChar),
         ],
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &());
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
     exercise_verification(&verifiable_res, &ast, &accessor, &t0);
-    let res = verifiable_res.verify(&ast, &accessor, &()).unwrap().table;
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
     let expected_res = owned_table([
         bigint("a", [5_i64, 2, 3, 4, 5, 6, 7, 105, 5, 6, 7, 7, 8, 9, 10]),
         varchar(
@@ -343,6 +358,7 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
         first_round_builder,
         &alloc,
         &table_map,
+        &[],
     ))
     .to_owned_table(&fields)
     .unwrap();

--- a/crates/proof-of-sql/tests/decimal_integration_tests.rs
+++ b/crates/proof-of-sql/tests/decimal_integration_tests.rs
@@ -35,9 +35,10 @@ fn run_query(
     accessor.add_table(TableRef::new("sxt", "table"), data, 0);
 
     let query = QueryExpr::try_new(query_str.parse().unwrap(), "sxt".into(), &accessor).unwrap();
-    let proof = VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let proof =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let owned_table_result: OwnedTable<_> =

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -43,9 +43,9 @@ fn we_can_prove_a_minimal_filter_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([boolean("a", [true])]);
@@ -77,9 +77,10 @@ fn we_can_prove_a_minimal_filter_query_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([boolean("a", [false])]);
@@ -109,9 +110,10 @@ fn we_can_prove_a_minimal_filter_query_with_dynamic_dory() {
         query.proof_expr(),
         &accessor,
         &&prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &&verifier_setup)
+        .verify(query.proof_expr(), &accessor, &&verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([boolean("a", [false])]);
@@ -134,9 +136,9 @@ fn we_can_prove_a_basic_equality_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 1])]);
@@ -168,9 +170,10 @@ fn we_can_prove_a_basic_equality_query_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 1])]);
@@ -204,9 +207,9 @@ fn we_can_prove_a_basic_equality_query_with_hyperkzg() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<CP>::new(query.proof_expr(), &accessor, &&ark_setup[..]);
+        VerifiableQueryResult::<CP>::new(query.proof_expr(), &accessor, &&ark_setup[..], &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &&vk)
+        .verify(query.proof_expr(), &accessor, &&vk, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 1])]);
@@ -229,9 +232,9 @@ fn we_can_prove_a_basic_inequality_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [1, 3]), bigint("b", [1, 2])]);
@@ -260,9 +263,9 @@ fn we_can_prove_a_basic_query_containing_extrema_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -306,9 +309,10 @@ fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -337,9 +341,9 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -372,9 +376,10 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [3]), bigint("b", [2])]);
@@ -402,9 +407,9 @@ fn we_can_prove_a_basic_equality_with_out_of_order_results_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -438,9 +443,10 @@ fn we_can_prove_a_basic_inequality_query_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [2]), bigint("b", [0])]);
@@ -492,9 +498,9 @@ fn we_can_prove_a_complex_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -542,9 +548,10 @@ fn we_can_prove_a_complex_query_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -575,9 +582,9 @@ fn we_can_prove_a_minimal_group_by_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result: OwnedTable<Curve25519Scalar> = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let transformed_result: OwnedTable<Curve25519Scalar> =
@@ -609,9 +616,9 @@ fn we_can_prove_a_basic_group_by_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -671,9 +678,9 @@ fn we_can_prove_a_cat_group_by_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -745,9 +752,10 @@ fn we_can_prove_a_cat_group_by_query_with_dynamic_dory() {
         query.proof_expr(),
         &accessor,
         &&prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &&verifier_setup)
+        .verify(query.proof_expr(), &accessor, &&verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -788,9 +796,10 @@ fn we_can_prove_a_basic_group_by_query_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -822,9 +831,9 @@ fn we_can_prove_a_varbinary_equality_query_with_hex_literal() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([bigint("a", [4567]), varbinary("b", [vec![4, 5, 6, 7]])]);
@@ -848,9 +857,9 @@ fn we_can_prove_a_query_with_overflow_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     assert!(matches!(
-        verifiable_result.verify(query.proof_expr(), &accessor, &()),
+        verifiable_result.verify(query.proof_expr(), &accessor, &(), &[]),
         Err(QueryError::Overflow)
     ));
 }
@@ -880,9 +889,10 @@ fn we_can_prove_a_query_with_overflow_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     assert!(matches!(
-        verifiable_result.verify(query.proof_expr(), &accessor, &dory_verifier_setup,),
+        verifiable_result.verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[]),
         Err(QueryError::Overflow)
     ));
 }
@@ -909,9 +919,9 @@ fn we_can_perform_arithmetic_and_conditional_operations_on_tinyint() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([tinyint("result", [9_i8, 10])]);
@@ -940,9 +950,9 @@ fn we_can_perform_equality_checks_on_var_binary() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -1018,9 +1028,9 @@ fn we_can_perform_rich_equality_checks_on_var_binary() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([
@@ -1173,9 +1183,9 @@ fn we_can_perform_equality_checks_on_rich_var_binary_data() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
 

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -55,9 +55,10 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([timestamptz(
@@ -93,11 +94,12 @@ fn run_timestamp_query_test(
     // Parse and execute the query
     let query = QueryExpr::try_new(query_str.parse().unwrap(), "sxt".into(), &accessor).unwrap();
 
-    let proof = VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &());
+    let proof =
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
 
     // Verify the results
     let owned_table_result = proof
-        .verify(query.proof_expr(), &accessor, &())
+        .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
         .table;
     let expected_result = owned_table([timestamptz(
@@ -441,9 +443,10 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         query.proof_expr(),
         &accessor,
         &dory_prover_setup,
+        &[],
     );
     let owned_table_result = verifiable_result
-        .verify(query.proof_expr(), &accessor, &dory_verifier_setup)
+        .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
         .table;
     let expected_result = owned_table([


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
In order to support parameterized queries we need to make a few breaking changes to `ProofExpr` and `ProofPlan`. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `params: &[LiteralValue]` to `ProofExpr` and `ProofPlan` proof and verification-related methods
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.