### PR TITLE
feat: try get scaling factor with precision and scale

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -210,7 +210,6 @@ pub fn try_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult
 /// Verifies that `from` can be cast to `to`.
 /// Casting can only be supported if the resulting data type is a superset of the input data type.
 /// For example Deciaml(6,1) can be cast to Decimal(7,1), but not vice versa.
-#[cfg_attr(not(test), expect(dead_code))]
 #[expect(clippy::missing_panics_doc)]
 pub fn try_scale_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult<()> {
     match (from, to) {

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -15,7 +15,7 @@ mod slice_decimal_operation;
 mod column_type_operation;
 pub use column_type_operation::{
     try_add_subtract_column_types, try_cast_types, try_divide_column_types,
-    try_multiply_column_types,
+    try_multiply_column_types, try_scale_cast_types,
 };
 
 mod column_arithmetic_operation;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The primary calculation that is needed to cast an integer or decimal type to another decimal type is the factor by which the original value needs to be multiplied.

# What changes are included in this PR?

New function `try_get_scaling_factor_with_precision_and_scale`, which returns a scalar, because the value can be as big 10^247.

# Are these changes tested?
Yes
