### PR TITLE
refactor!: make prover methods fallible in `ProofExpr` and `ProofPlan`

### DIFF
--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -72,7 +72,7 @@ fn posql_end_to_end_test<'a, CP: CommitmentEvaluationProof>(
     let plans = sql_to_proof_plans(sql, &context_provider, &schemas, &config).unwrap();
     // Prove and verify the plans
     for (plan, expected) in plans.iter().zip(expected_results.iter()) {
-        let res = VerifiableQueryResult::<CP>::new(plan, &accessor, &prover_setup, params);
+        let res = VerifiableQueryResult::<CP>::new(plan, &accessor, &prover_setup, params).unwrap();
         let res = res
             .verify(plan, &accessor, &verifier_setup, params)
             .unwrap()
@@ -104,7 +104,7 @@ fn posql_end_to_end_test_with_postprocessing<'a, CP: CommitmentEvaluationProof>(
     {
         // Prove and verify the plans
         let plan = plan_with_postprocessing.plan();
-        let res = VerifiableQueryResult::<CP>::new(plan, &accessor, &prover_setup, params);
+        let res = VerifiableQueryResult::<CP>::new(plan, &accessor, &prover_setup, params).unwrap();
         let raw_table = res
             .verify(plan, &accessor, &verifier_setup, params)
             .unwrap()

--- a/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
@@ -170,7 +170,7 @@ fn bench_inner_product_proof(cli: &Cli, queries: &[QueryEntry]) {
 
         for _ in 0..cli.iterations {
             let result: VerifiableQueryResult<InnerProductProof> =
-                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &(), &[]);
+                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &(), &[]).unwrap();
             result
                 .verify(query_expr.proof_expr(), &accessor, &(), &[])
                 .unwrap();
@@ -207,7 +207,8 @@ fn bench_dory(cli: &Cli, queries: &[QueryEntry]) {
 
         for _ in 0..cli.iterations {
             let result: VerifiableQueryResult<DoryEvaluationProof> =
-                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &prover_setup, &[]);
+                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &prover_setup, &[])
+                    .unwrap();
             result
                 .verify(query_expr.proof_expr(), &accessor, &verifier_setup, &[])
                 .unwrap();
@@ -261,7 +262,8 @@ fn bench_dynamic_dory(cli: &Cli, queries: &[QueryEntry]) {
 
         for _ in 0..cli.iterations {
             let result: VerifiableQueryResult<DynamicDoryEvaluationProof> =
-                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &&prover_setup, &[]);
+                VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &&prover_setup, &[])
+                    .unwrap();
             result
                 .verify(query_expr.proof_expr(), &accessor, &&verifier_setup, &[])
                 .unwrap();
@@ -322,7 +324,8 @@ fn bench_hyperkzg(cli: &Cli, queries: &[QueryEntry]) {
                     &accessor,
                     &prover_setup.as_slice(),
                     &[],
-                );
+                )
+                .unwrap();
             result
                 .verify(query_expr.proof_expr(), &accessor, &&vk, &[])
                 .unwrap();

--- a/crates/proof-of-sql/examples/albums/main.rs
+++ b/crates/proof-of-sql/examples/albums/main.rs
@@ -49,7 +49,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/avocado-prices/main.rs
+++ b/crates/proof-of-sql/examples/avocado-prices/main.rs
@@ -53,7 +53,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/books/main.rs
+++ b/crates/proof-of-sql/examples/books/main.rs
@@ -48,7 +48,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/brands/main.rs
+++ b/crates/proof-of-sql/examples/brands/main.rs
@@ -48,7 +48,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/census/main.rs
+++ b/crates/proof-of-sql/examples/census/main.rs
@@ -55,7 +55,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/countries/main.rs
+++ b/crates/proof-of-sql/examples/countries/main.rs
@@ -49,7 +49,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/dinosaurs/main.rs
+++ b/crates/proof-of-sql/examples/dinosaurs/main.rs
@@ -49,7 +49,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/dog_breeds/main.rs
+++ b/crates/proof-of-sql/examples/dog_breeds/main.rs
@@ -46,7 +46,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/hello_world/main.rs
+++ b/crates/proof-of-sql/examples/hello_world/main.rs
@@ -74,7 +74,8 @@ fn main() {
         &accessor,
         &&prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     end_timer(timer);
     let timer = start_timer("Verifying Proof");
     let result = verifiable_result.verify(query.proof_expr(), &accessor, &&verifier_setup, &[]);

--- a/crates/proof-of-sql/examples/plastics/main.rs
+++ b/crates/proof-of-sql/examples/plastics/main.rs
@@ -48,7 +48,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -250,7 +250,8 @@ fn main() {
                 &csv_accessor,
                 &&prover_setup,
                 &[],
-            );
+            )
+            .expect("Failed to generate proof");
             end_timer(timer);
             fs::write(
                 file,

--- a/crates/proof-of-sql/examples/programming_books/main.rs
+++ b/crates/proof-of-sql/examples/programming_books/main.rs
@@ -46,7 +46,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/rockets/main.rs
+++ b/crates/proof-of-sql/examples/rockets/main.rs
@@ -48,7 +48,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/space/main.rs
+++ b/crates/proof-of-sql/examples/space/main.rs
@@ -57,7 +57,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/stocks/main.rs
+++ b/crates/proof-of-sql/examples/stocks/main.rs
@@ -48,7 +48,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/sushi/main.rs
+++ b/crates/proof-of-sql/examples/sushi/main.rs
@@ -38,7 +38,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
     // Verify the result with the proof:
     print!("Verifying proof...");

--- a/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
+++ b/crates/proof-of-sql/examples/tech_gadget_prices/main.rs
@@ -37,7 +37,7 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )?;
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     print!("Verifying proof...");

--- a/crates/proof-of-sql/examples/vehicles/main.rs
+++ b/crates/proof-of-sql/examples/vehicles/main.rs
@@ -49,7 +49,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/examples/wood_types/main.rs
+++ b/crates/proof-of-sql/examples/wood_types/main.rs
@@ -49,7 +49,8 @@ fn prove_and_verify_query(
         accessor,
         &prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     println!("Done in {} ms.", now.elapsed().as_secs_f64() * 1000.);
 
     // Verify the result with the proof:

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -63,10 +63,8 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
 
 /// Errors related to placeholders in provers
-#[allow(dead_code)]
 #[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum PlaceholderProverError {}
 
 /// Result type for placeholder errors in provers
-#[allow(dead_code)]
 pub type PlaceholderProverResult<T> = Result<T, PlaceholderProverError>;

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -61,3 +61,12 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
+
+/// Errors related to placeholders in provers
+#[allow(dead_code)]
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum PlaceholderProverError {}
+
+/// Result type for placeholder errors in provers
+#[allow(dead_code)]
+pub type PlaceholderProverResult<T> = Result<T, PlaceholderProverError>;

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -14,6 +14,7 @@ use crate::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
         proof_plans::DynProofPlan,
+        PlaceholderProverResult,
     },
 };
 use alloc::{
@@ -178,7 +179,7 @@ impl ProverEvaluate for EVMProofPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         self.inner()
             .first_round_evaluate(builder, alloc, table_map, params)
     }
@@ -188,7 +189,7 @@ impl ProverEvaluate for EVMProofPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         self.inner()
             .final_round_evaluate(builder, alloc, table_map, params)
     }

--- a/crates/proof-of-sql/src/sql/mod.rs
+++ b/crates/proof-of-sql/src/sql/mod.rs
@@ -4,8 +4,9 @@ mod error;
 /// This module holds the [`EVMProofPlan`] struct and its implementation, which allows for EVM compatible serialization.
 pub mod evm_proof_plan;
 pub mod parse;
-/// This temporarily exists until we switch to using Datafusion Analyzer to handle type checking.
-pub use error::{AnalyzeError, AnalyzeResult};
+/// [`AnalyzeError`] temporarily exists until we switch to using Datafusion Analyzer to handle type checking.
+/// [`PlaceholderProverError`] handles errors related to placeholders in provers.
+pub use error::{AnalyzeError, AnalyzeResult, PlaceholderProverError, PlaceholderProverResult};
 pub mod postprocessing;
 pub mod proof;
 pub mod proof_exprs;

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,11 +1,14 @@
 use super::{verification_builder::VerificationBuilder, FinalRoundBuilder, FirstRoundBuilder};
-use crate::base::{
-    database::{
-        ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
+use crate::{
+    base::{
+        database::{
+            ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
+        },
+        map::{IndexMap, IndexSet},
+        proof::ProofError,
+        scalar::Scalar,
     },
-    map::{IndexMap, IndexSet},
-    proof::ProofError,
-    scalar::Scalar,
+    sql::PlaceholderProverResult,
 };
 use alloc::vec::Vec;
 use bumpalo::Bump;
@@ -43,7 +46,7 @@ pub trait ProverEvaluate {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> Table<'a, S>;
+    ) -> PlaceholderProverResult<Table<'a, S>>;
 
     /// Evaluate the query and modify `FinalRoundBuilder` to store an intermediate representation
     /// of the query result and track all the components needed to form the query's proof.
@@ -57,7 +60,7 @@ pub trait ProverEvaluate {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> Table<'a, S>;
+    ) -> PlaceholderProverResult<Table<'a, S>>;
 }
 
 /// Marker used as a trait bound for generic [`ProofPlan`] types to indicate the honesty of their implementation.

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -4,6 +4,7 @@ use crate::{
         commitment::CommitmentEvaluationProof,
         database::{CommitmentAccessor, DataAccessor, LiteralValue, OwnedTable},
     },
+    sql::PlaceholderProverResult,
     utils::log,
 };
 use serde::{Deserialize, Serialize};
@@ -83,11 +84,11 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         accessor: &impl DataAccessor<CP::Scalar>,
         setup: &CP::ProverPublicSetup<'_>,
         params: &[LiteralValue],
-    ) -> Self {
+    ) -> PlaceholderProverResult<Self> {
         log::log_memory_usage("Start");
-        let (proof, res) = QueryProof::new(expr, accessor, setup, params);
+        let (proof, res) = QueryProof::new(expr, accessor, setup, params)?;
         log::log_memory_usage("End");
-        Self { result: res, proof }
+        Ok(Self { result: res, proof })
     }
 
     /// Verify a `VerifiableQueryResult`. Upon success, this function returns the finalized form of

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -48,7 +48,7 @@ fn we_can_prove_a_typical_add_subtract_query() {
             const_bigint(3),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -96,7 +96,7 @@ fn we_can_prove_a_typical_add_subtract_query_with_decimals() {
             const_decimal75(12, 4, 3500),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -143,7 +143,7 @@ fn result_expr_can_overflow() {
         equal(column(&t, "b", &accessor), const_bigint(1)),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     assert!(matches!(
         verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::Overflow)
@@ -169,7 +169,7 @@ fn overflow_in_nonselected_rows_doesnt_error_out() {
         equal(column(&t, "b", &accessor), const_bigint(0)),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -195,7 +195,7 @@ fn overflow_in_where_clause_doesnt_error_out() {
         ),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -230,7 +230,7 @@ fn result_expr_can_overflow_more() {
         const_bool(true),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     assert!(matches!(
         verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::Overflow)
@@ -291,7 +291,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -346,7 +346,9 @@ fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_result_evalua
         column(&t, "b", &accessor),
         subtract(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let res = add_subtract_expr.result_evaluate(&alloc, &data, &[]);
+    let res = add_subtract_expr
+        .result_evaluate(&alloc, &data, &[])
+        .unwrap();
     let expected_res_scalar = [0, 2, 2, 4]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -6,7 +6,10 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        PlaceholderProverResult,
+    },
     utils::log,
 };
 use alloc::{boxed::Box, vec};
@@ -38,11 +41,11 @@ impl ProofExpr for AndExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(alloc, table, params);
-        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(alloc, table, params);
+        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let res =
@@ -50,7 +53,7 @@ impl ProofExpr for AndExpr {
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     #[tracing::instrument(name = "AndExpr::prover_evaluate", level = "debug", skip_all)]
@@ -60,11 +63,11 @@ impl ProofExpr for AndExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table, params);
-        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table, params);
+        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let n = lhs.len();
@@ -86,7 +89,7 @@ impl ProofExpr for AndExpr {
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -51,7 +51,7 @@ fn we_can_prove_a_simple_and_query() {
             ),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -83,7 +83,7 @@ fn we_can_prove_a_simple_and_query_with_128_bits() {
             ),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -135,7 +135,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(&t, "c", &accessor), const_bigint(filter_val2)),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -189,7 +189,7 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
         equal(column(&t, "b", &accessor), const_int128(1)),
         equal(column(&t, "d", &accessor), const_varchar("t")),
     );
-    let res = and_expr.result_evaluate(&alloc, &data, &[]);
+    let res = and_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[false, true, false, false]);
     assert_eq!(res, expected_res);
 }
@@ -216,7 +216,9 @@ fn we_can_verify_a_simple_proof() {
     let mut final_round_builder: FinalRoundBuilder<'_, TestScalar> =
         FinalRoundBuilder::new(4, VecDeque::new());
 
-    and_expr.prover_evaluate(&mut final_round_builder, &alloc, &table, &[]);
+    and_expr
+        .prover_evaluate(&mut final_round_builder, &alloc, &table, &[])
+        .unwrap();
 
     let verification_builder = run_verify_for_each_row(
         4,

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -6,7 +6,10 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        PlaceholderProverResult,
+    },
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -38,9 +41,9 @@ impl ProofExpr for CastExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S> {
-        let uncasted_result = self.from_expr.result_evaluate(alloc, table, params);
-        cast_column(alloc, uncasted_result, self.to_type)
+    ) -> PlaceholderProverResult<Column<'a, S>> {
+        let uncasted_result = self.from_expr.result_evaluate(alloc, table, params)?;
+        Ok(cast_column(alloc, uncasted_result, self.to_type))
     }
 
     fn prover_evaluate<'a, S: Scalar>(
@@ -49,11 +52,11 @@ impl ProofExpr for CastExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         let uncasted_result = self
             .from_expr
-            .prover_evaluate(builder, alloc, table, params);
-        cast_column(alloc, uncasted_result, self.to_type)
+            .prover_evaluate(builder, alloc, table, params)?;
+        Ok(cast_column(alloc, uncasted_result, self.to_type))
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr_test.rs
@@ -67,7 +67,7 @@ fn we_can_prove_a_simple_cast_expr() {
         tab(&t),
         super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -6,7 +6,10 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        PlaceholderProverResult,
+    },
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
@@ -71,8 +74,8 @@ impl ProofExpr for ColumnExpr {
         _alloc: &'a Bump,
         table: &Table<'a, S>,
         _params: &[LiteralValue],
-    ) -> Column<'a, S> {
-        self.fetch_column(table)
+    ) -> PlaceholderProverResult<Column<'a, S>> {
+        Ok(self.fetch_column(table))
     }
 
     /// Given the selected rows (as a slice of booleans), evaluate the column expression and
@@ -83,8 +86,8 @@ impl ProofExpr for ColumnExpr {
         _alloc: &'a Bump,
         table: &Table<'a, S>,
         _params: &[LiteralValue],
-    ) -> Column<'a, S> {
-        self.fetch_column(table)
+    ) -> PlaceholderProverResult<Column<'a, S>> {
+        Ok(self.fetch_column(table))
     }
 
     /// Evaluate the column expression at the sumcheck's random point,

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr_test.rs
@@ -25,7 +25,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
             vec![ColumnField::new("a".into(), ColumnType::Boolean)],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -12,7 +12,7 @@ use crate::{
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
         util::type_check_binary_operation,
-        AnalyzeError, AnalyzeResult,
+        AnalyzeError, AnalyzeResult, PlaceholderProverResult,
     },
 };
 use alloc::{boxed::Box, string::ToString};

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -38,7 +38,8 @@ fn we_can_prove_an_equality_query_with_no_rows() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -63,7 +64,8 @@ fn we_can_prove_another_equality_query_with_no_rows() {
         tab(&t),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -92,7 +94,8 @@ fn we_can_prove_a_nested_equality_query_with_no_rows() {
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -121,7 +124,7 @@ fn we_can_prove_an_equality_query_with_a_single_selected_row() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -147,7 +150,7 @@ fn we_can_prove_another_equality_query_with_a_single_selected_row() {
         tab(&t),
         equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -173,7 +176,7 @@ fn we_can_prove_an_equality_query_with_a_single_non_selected_row() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -213,7 +216,7 @@ fn we_can_prove_an_equality_query_with_multiple_rows() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -257,7 +260,7 @@ fn we_can_prove_a_nested_equality_query_with_multiple_rows() {
             equal(column(&t, "a", &accessor), column(&t, "b", &accessor)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -298,7 +301,7 @@ fn we_can_prove_an_equality_query_with_a_nonzero_comparison() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_bigint(123_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -340,7 +343,7 @@ fn we_can_prove_an_equality_query_with_a_string_comparison() {
         tab(&t),
         equal(column(&t, "c", &accessor), const_varchar("ghi")),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -392,7 +395,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 const_varchar(filter_val.as_str()),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -457,7 +460,7 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
         column(&t, "e", &accessor),
         const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ZERO),
     );
-    let res = equals_expr.result_evaluate(&alloc, &data, &[]);
+    let res = equals_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[true, false, true, false]);
     assert_eq!(res, expected_res);
 }
@@ -483,7 +486,8 @@ fn we_can_query_with_varbinary_equality() {
     );
 
     // Execute and verify query
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -9,6 +9,7 @@ use crate::{
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
         proof_gadgets::{prover_evaluate_sign, result_evaluate_sign, verifier_evaluate_sign},
+        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -42,11 +43,11 @@ impl ProofExpr for InequalityExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let lhs_column = self.lhs.result_evaluate(alloc, table, params);
-        let rhs_column = self.rhs.result_evaluate(alloc, table, params);
+        let lhs_column = self.lhs.result_evaluate(alloc, table, params)?;
+        let rhs_column = self.rhs.result_evaluate(alloc, table, params)?;
         let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);
         let rhs_scale = self.rhs.data_type().scale().unwrap_or(0);
         let table_length = table.num_rows();
@@ -63,7 +64,7 @@ impl ProofExpr for InequalityExpr {
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     #[tracing::instrument(name = "InequalityExpr::prover_evaluate", level = "debug", skip_all)]
@@ -73,11 +74,11 @@ impl ProofExpr for InequalityExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let lhs_column = self.lhs.prover_evaluate(builder, alloc, table, params);
-        let rhs_column = self.rhs.prover_evaluate(builder, alloc, table, params);
+        let lhs_column = self.lhs.prover_evaluate(builder, alloc, table, params)?;
+        let rhs_column = self.rhs.prover_evaluate(builder, alloc, table, params)?;
         let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);
         let rhs_scale = self.rhs.data_type().scale().unwrap_or(0);
         let diff = if self.is_lt {
@@ -93,7 +94,7 @@ impl ProofExpr for InequalityExpr {
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -48,7 +48,8 @@ fn we_can_compare_columns_with_small_timestamp_values_gte() {
         ),
     );
 
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -86,7 +87,8 @@ fn we_can_compare_columns_with_small_timestamp_values_lte() {
         ),
     );
 
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -111,7 +113,7 @@ fn we_can_compare_a_constant_column() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -132,7 +134,7 @@ fn we_can_compare_a_varying_column_with_constant_sign() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -171,7 +173,7 @@ fn we_can_compare_columns_with_extreme_values() {
             column(&t, "boolean", &accessor),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -199,7 +201,7 @@ fn we_can_compare_columns_with_small_decimal_values_without_scale() {
         tab(&t),
         lte(column(&t, "e", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -232,7 +234,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_scale() {
         tab(&t),
         lte(column(&t, "f", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -266,7 +268,7 @@ fn we_can_compare_columns_with_small_decimal_values_with_differing_scale_gte() {
         tab(&t),
         gte(column(&t, "f", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -303,7 +305,7 @@ fn we_can_compare_columns_returning_extreme_decimal_values() {
         tab(&t),
         lte(column(&t, "b", &accessor), const_bigint(0_i64)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -355,7 +357,7 @@ fn we_can_compare_two_columns() {
         tab(&t),
         lte(column(&t, "a", &accessor), column(&t, "b", &accessor)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -379,7 +381,7 @@ fn we_can_compare_a_varying_column_with_constant_absolute_value() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -403,7 +405,7 @@ fn we_can_compare_a_constant_column_of_negative_columns() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -427,7 +429,7 @@ fn we_can_compare_a_varying_column_with_negative_only_signs() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(5)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -448,7 +450,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -469,7 +471,7 @@ fn we_can_compare_column_with_greater_than_or_equal() {
         tab(&t),
         gte(column(&t, "a", &accessor), const_bigint(1)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -497,7 +499,7 @@ fn we_can_run_nested_comparison() {
             column(&t, "boolean", &accessor),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -518,7 +520,7 @@ fn we_can_compare_a_column_with_varying_absolute_values_and_signs_and_a_constant
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -539,7 +541,7 @@ fn we_can_compare_a_constant_column_of_zeros() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -560,7 +562,7 @@ fn the_sign_can_be_0_or_1_for_a_constant_column_of_zeros() {
         tab(&t),
         lte(column(&t, "a", &accessor), const_bigint(0)),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -600,7 +602,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             tab(&t),
             lte(column(&t, "a", &accessor), const_bigint(filter_val)),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -647,7 +649,7 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
     let lhs_expr: DynProofExpr = column(&t, "a", &accessor);
     let rhs_expr = column(&t, "b", &accessor);
     let lte_expr = lte(lhs_expr, rhs_expr);
-    let res = lte_expr.result_evaluate(&alloc, &data, &[]);
+    let res = lte_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[true, false, true]);
     assert_eq!(res, expected_res);
 }
@@ -665,7 +667,7 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
     let col_expr: DynProofExpr = column(&t, "a", &accessor);
     let lit_expr = const_bigint(1);
     let gte_expr = gte(col_expr, lit_expr);
-    let res = gte_expr.result_evaluate(&alloc, &data, &[]);
+    let res = gte_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[false, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -6,7 +6,10 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        PlaceholderProverResult,
+    },
     utils::log,
 };
 use bumpalo::Bump;
@@ -46,14 +49,14 @@ impl ProofExpr for LiteralExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         _params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let res = Column::from_literal_with_length(&self.value, table.num_rows(), alloc);
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]
@@ -63,7 +66,7 @@ impl ProofExpr for LiteralExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         _params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let table_length = table.num_rows();
@@ -71,7 +74,7 @@ impl ProofExpr for LiteralExpr {
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -52,7 +52,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
             tab(&t),
             const_bool(lit),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -101,7 +101,7 @@ fn we_can_prove_a_query_with_a_single_selected_row() {
         tab(&t),
         const_bool(true),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -121,7 +121,7 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
         tab(&t),
         const_bool(false),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -137,7 +137,7 @@ fn we_can_compute_the_correct_output_of_a_literal_expr_using_result_evaluate() {
     let data: Table<Curve25519Scalar> =
         table([borrowed_bigint("a", [123_i64, 456, 789, 1011], &alloc)]);
     let literal_expr: DynProofExpr = const_bool(true);
-    let res = literal_expr.result_evaluate(&alloc, &data, &[]);
+    let res = literal_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[true, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -59,7 +59,7 @@ fn we_can_prove_a_typical_multiply_query() {
             const_decimal75(3, 2, 819),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -108,7 +108,7 @@ fn result_expr_can_overflow() {
         equal(column(&t, "b", &accessor), const_bigint(2)),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     assert!(matches!(
         verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::Overflow)
@@ -134,7 +134,7 @@ fn overflow_in_nonselected_rows_doesnt_error_out() {
         equal(column(&t, "b", &accessor), const_bigint(0)),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -163,7 +163,7 @@ fn overflow_in_where_clause_doesnt_error_out() {
         ),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -192,7 +192,7 @@ fn result_expr_can_overflow_more() {
         const_bool(true),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     assert!(matches!(
         verifiable_res.verify(&ast, &accessor, &(), &[]),
         Err(QueryError::Overflow)
@@ -240,7 +240,7 @@ fn where_clause_can_wrap_around() {
         ),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -317,7 +317,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -372,7 +372,7 @@ fn we_can_compute_the_correct_output_of_a_multiply_expr_using_result_evaluate() 
         column(&t, "b", &accessor),
         subtract(column(&t, "a", &accessor), const_decimal75(2, 1, 15)),
     );
-    let res = arithmetic_expr.result_evaluate(&alloc, &data, &[]);
+    let res = arithmetic_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res_scalar = [0, 5, 75, 25]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -36,7 +36,7 @@ fn we_can_prove_a_not_equals_query_with_a_single_selected_row() {
         tab(&t),
         not(equal(column(&t, "b", &accessor), const_bigint(1))),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -83,7 +83,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 ),
             )),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -129,7 +129,7 @@ fn we_can_compute_the_correct_output_of_a_not_expr_using_result_evaluate() {
     let t = TableRef::new("sxt", "t");
     accessor.add_table(t.clone(), data.clone(), 0);
     let not_expr: DynProofExpr = not(equal(column(&t, "b", &accessor), const_int128(1)));
-    let res = not_expr.result_evaluate(&alloc, &data, &[]);
+    let res = not_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[true, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -6,7 +6,10 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        PlaceholderProverResult,
+    },
     utils::log,
 };
 use alloc::{boxed::Box, vec};
@@ -38,18 +41,18 @@ impl ProofExpr for OrExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(alloc, table, params);
-        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(alloc, table, params);
+        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let res = Column::Boolean(result_evaluate_or(table.num_rows(), alloc, lhs, rhs));
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     #[tracing::instrument(name = "OrExpr::prover_evaluate", level = "debug", skip_all)]
@@ -59,18 +62,18 @@ impl ProofExpr for OrExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S> {
+    ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table, params);
-        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table, params);
+        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let res = Column::Boolean(prover_evaluate_or(builder, alloc, lhs, rhs));
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -38,7 +38,7 @@ fn we_can_prove_a_simple_or_query() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -66,7 +66,7 @@ fn we_can_prove_a_simple_or_query_with_variable_integer_types() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -95,7 +95,7 @@ fn we_can_prove_an_or_query_where_both_lhs_and_rhs_are_true() {
             equal(column(&t, "d", &accessor), const_varchar("g")),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -147,7 +147,7 @@ fn test_random_tables_with_given_offset(offset: usize) {
                 equal(column(&t, "c", &accessor), const_bigint(filter_val2)),
             ),
         );
-        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
         exercise_verification(&verifiable_res, &ast, &accessor, &t);
         let res = verifiable_res
             .verify(&ast, &accessor, &(), &[])
@@ -201,7 +201,7 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
         equal(column(&t, "b", &accessor), const_int128(1)),
         equal(column(&t, "d", &accessor), const_varchar("g")),
     );
-    let res = and_expr.result_evaluate(&alloc, &data, &[]);
+    let res = and_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[false, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -5,7 +5,10 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        PlaceholderProverResult,
+    },
 };
 use bumpalo::Bump;
 use core::fmt::Debug;
@@ -24,7 +27,7 @@ pub trait ProofExpr: Debug + Send + Sync {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S>;
+    ) -> PlaceholderProverResult<Column<'a, S>>;
 
     /// Evaluate the expression, add components needed to prove it, and return thet resulting column
     /// of values
@@ -34,7 +37,7 @@ pub trait ProofExpr: Debug + Send + Sync {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> Column<'a, S>;
+    ) -> PlaceholderProverResult<Column<'a, S>>;
 
     /// Compute the evaluation of a multilinear extension from this expression
     /// at the random sumcheck point and adds components needed to verify the expression to

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -41,7 +41,7 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
         ),
         not(equal(column(&t, "c", &accessor), const_int128(3))),
     );
-    let res = bool_expr.result_evaluate(&alloc, &data, &[]);
+    let res = bool_expr.result_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[
         false, true, false, true, false, true, false, true, false, true, false, true, false, true,
         false, false, false,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -14,8 +14,11 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{
-        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+        },
+        PlaceholderProverResult,
     },
 };
 use bumpalo::{
@@ -41,7 +44,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
             assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");
@@ -69,7 +72,10 @@ impl ProverEvaluate for MembershipCheckTestPlan {
             &candidate_columns,
         );
         builder.request_post_result_challenges(2);
-        table([(Ident::new("multiplicities"), Column::Int128(multiplicities))])
+        Ok(table([(
+            Ident::new("multiplicities"),
+            Column::Int128(multiplicities),
+        )]))
     }
 
     fn final_round_evaluate<'a, S: Scalar>(
@@ -78,7 +84,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
             assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");
@@ -130,7 +136,10 @@ impl ProverEvaluate for MembershipCheckTestPlan {
             &source_columns,
             &candidate_columns,
         );
-        table([(Ident::new("multiplicities"), Column::Int128(multiplicities))])
+        Ok(table([(
+            Ident::new("multiplicities"),
+            Column::Int128(multiplicities),
+        )]))
     }
 }
 
@@ -230,7 +239,7 @@ mod tests {
             )],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -278,7 +287,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -326,7 +335,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let actual = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .unwrap()
@@ -366,7 +375,7 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -398,7 +407,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -431,7 +440,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -463,7 +472,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -494,6 +503,6 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -11,8 +11,11 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{
-        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+        },
+        PlaceholderProverResult,
     },
 };
 use bumpalo::{
@@ -37,14 +40,14 @@ impl ProverEvaluate for PermutationCheckTestPlan {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         // Get the tables from the map using the table reference
         let source_table: &Table<'a, S> =
             table_map.get(&self.source_table).expect("Table not found");
         // Produce chi evaluation length
         builder.produce_chi_evaluation_length(source_table.num_rows());
         builder.request_post_result_challenges(2);
-        table_with_row_count([], 0)
+        Ok(table_with_row_count([], 0))
     }
 
     fn final_round_evaluate<'a, S: Scalar>(
@@ -53,7 +56,7 @@ impl ProverEvaluate for PermutationCheckTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
             assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");
@@ -104,7 +107,7 @@ impl ProverEvaluate for PermutationCheckTestPlan {
             &source_columns,
             &candidate_columns,
         );
-        table_with_row_count([], 0)
+        Ok(table_with_row_count([], 0))
     }
 }
 
@@ -198,7 +201,7 @@ mod tests {
             )],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -241,7 +244,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -284,7 +287,7 @@ mod tests {
             ],
         };
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
         assert!(verifiable_res.verify(&plan, &accessor, &(), &[]).is_ok());
     }
 
@@ -319,7 +322,7 @@ mod tests {
                 ColumnType::BigInt,
             )],
         };
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -351,7 +354,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -384,7 +387,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -416,7 +419,7 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 
     #[test]
@@ -447,6 +450,6 @@ mod tests {
             candidate_columns: vec![],
         };
         let _verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -7,8 +7,11 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{
-        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+        },
+        PlaceholderProverResult,
     },
 };
 use alloc::vec::Vec;
@@ -60,10 +63,10 @@ impl ProverEvaluate for DemoMockPlan {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         // place prover logic you want to test here
 
-        table_map[&self.column.table_ref()].clone()
+        Ok(table_map[&self.column.table_ref()].clone())
     }
 
     fn final_round_evaluate<'a, S: Scalar>(
@@ -72,10 +75,10 @@ impl ProverEvaluate for DemoMockPlan {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         // place prover logic you want to test here
 
-        table_map[&self.column.table_ref()].clone()
+        Ok(table_map[&self.column.table_ref()].clone())
     }
 }
 
@@ -106,7 +109,7 @@ mod tests {
             (),
         );
         let verifiable_res =
-            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+            VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
         let res = verifiable_res
             .verify(&plan, &accessor, &(), &[])
             .expect("verification should suceeed")

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -16,6 +16,7 @@ use crate::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
+        PlaceholderProverResult,
     },
 };
 use alloc::{boxed::Box, vec::Vec};

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -8,8 +8,11 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{
-        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+        },
+        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -72,7 +75,7 @@ impl ProverEvaluate for EmptyExec {
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         // Create an empty table with one row
@@ -82,7 +85,7 @@ impl ProverEvaluate for EmptyExec {
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 
     #[tracing::instrument(name = "EmptyExec::final_round_evaluate", level = "debug", skip_all)]
@@ -92,7 +95,7 @@ impl ProverEvaluate for EmptyExec {
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         // Create an empty table with one row
@@ -102,6 +105,6 @@ impl ProverEvaluate for EmptyExec {
 
         log::log_memory_usage("End");
 
-        res
+        Ok(res)
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test.rs
@@ -163,7 +163,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_filter() {
         OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
     let where_clause = equal(column(&t, "a", &accessor), const_int128(5_i128));
     let ast = filter(cols_expr_plan(&t, &["b"], &accessor), tab(&t), where_clause);
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -206,12 +206,10 @@ fn we_can_get_an_empty_result_from_a_basic_filter_on_an_empty_table_using_first_
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -257,12 +255,10 @@ fn we_can_get_an_empty_result_from_a_basic_filter_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -296,12 +292,10 @@ fn we_can_get_no_columns_from_a_basic_filter_with_no_selected_columns_using_firs
     let expr = filter(cols_expr_plan(&t, &[], &accessor), tab(&t), where_clause);
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
@@ -341,12 +335,10 @@ fn we_can_get_the_correct_result_from_a_basic_filter_using_first_round_evaluate(
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -375,7 +367,7 @@ fn we_can_prove_a_filter_on_an_empty_table() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
@@ -403,7 +395,7 @@ fn we_can_prove_a_filter_with_empty_results() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(106)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -442,7 +434,7 @@ fn we_can_prove_a_filter() {
         tab(&t),
         equal(column(&t, "a", &accessor), const_int128(105)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec_test.rs
@@ -29,7 +29,7 @@ fn we_can_prove_aggregation_without_group_by() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -57,7 +57,7 @@ fn we_can_prove_a_simple_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -92,7 +92,7 @@ fn we_can_prove_a_group_by_with_bigint_columns() {
         tab(&t),
         equal(column(&t, "b", &accessor), const_int128(99)),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -214,7 +214,7 @@ fn we_can_prove_a_complex_group_by_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -247,7 +247,7 @@ fn we_can_prove_a_complex_group_by_query_with_many_columns() {
             equal(column(&t, "varchar_filter", &accessor), const_varchar("f2")),
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -131,7 +131,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_basic_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -166,7 +166,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_nontrivial_projection() {
             ],
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -208,7 +208,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
             equal(column(&t, "a", &accessor), const_int128(5)),
         ),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -258,12 +258,10 @@ fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_re
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -309,12 +307,10 @@ fn we_can_get_no_columns_from_a_basic_projection_with_no_selected_columns_using_
     );
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
@@ -369,12 +365,10 @@ fn we_can_get_the_correct_result_from_a_basic_projection_using_first_round_evalu
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -419,7 +413,7 @@ fn we_can_prove_a_projection_on_an_empty_table() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
         bigint("b", [3; 0]),
@@ -465,7 +459,7 @@ fn we_can_prove_a_projection() {
             ],
         ),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec_test.rs
@@ -44,7 +44,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -73,7 +73,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_slice_exec() {
         1,
         Some(2),
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -121,12 +121,10 @@ fn we_can_get_an_empty_result_from_a_slice_on_an_empty_table_using_first_round_e
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -177,12 +175,10 @@ fn we_can_get_an_empty_result_from_a_slice_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -220,12 +216,10 @@ fn we_can_get_no_columns_from_a_slice_with_empty_input_using_first_round_evaluat
     );
     let fields = &[];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected = OwnedTable::try_new(IndexMap::default()).unwrap();
@@ -269,12 +263,10 @@ fn we_can_get_the_correct_result_from_a_slice_using_first_round_evaluate() {
         ),
     ];
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(expr.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        expr.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(fields)
     .unwrap();
     let expected: OwnedTable<Curve25519Scalar> = owned_table([
@@ -317,7 +309,7 @@ fn we_can_prove_a_slice_exec() {
         2,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -366,7 +358,7 @@ fn we_can_prove_a_nested_slice_exec() {
         1,
         Some(1),
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -415,7 +407,7 @@ fn we_can_prove_a_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -464,7 +456,7 @@ fn we_can_prove_another_nested_slice_exec_with_no_rows() {
         3,
         None,
     );
-    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     exercise_verification(&res, &expr, &accessor, &t);
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     let expected = owned_table([
@@ -517,7 +509,7 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])
@@ -539,7 +531,7 @@ fn we_can_create_and_prove_a_slice_exec_on_top_of_an_empty_exec() {
     let empty_table = owned_table([]);
     let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_empty_with_setup(());
     let expr = slice_exec(empty_exec(), 3, Some(2));
-    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]);
+    let res = VerifiableQueryResult::<InnerProductProof>::new(&expr, &accessor, &(), &[]).unwrap();
     let res = res.verify(&expr, &accessor, &(), &[]).unwrap().table;
     assert_eq!(res, empty_table);
 }
@@ -566,7 +558,7 @@ fn we_cannot_prove_a_slice_exec_if_it_has_groupby_as_input_for_now() {
         None,
     );
     let res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&expr, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&expr, &accessor, &(), &[]).unwrap();
     assert!(matches!(
         res.verify(&expr, &accessor, &(), &[]),
         Err(QueryError::ProofError {

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec_test.rs
@@ -57,7 +57,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_sort_merge_join() {
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -123,7 +123,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_sort_m
         Some(3),
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -237,7 +237,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_complex_query_involving_two_so
     );
 
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_cats);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -302,7 +302,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join() {
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -355,7 +355,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_right);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -406,7 +406,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &table_left);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -453,7 +453,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_sort_merge_join_if_one_o
         vec![Ident::new("id"), Ident::new("name"), Ident::new("human")],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -7,8 +7,11 @@ use crate::{
         proof::ProofError,
         scalar::Scalar,
     },
-    sql::proof::{
-        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+    sql::{
+        proof::{
+            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
+        },
+        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -84,7 +87,7 @@ impl ProverEvaluate for TableExec {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let first_round_table = table_map
@@ -94,7 +97,7 @@ impl ProverEvaluate for TableExec {
 
         log::log_memory_usage("End");
 
-        first_round_table
+        Ok(first_round_table)
     }
 
     #[tracing::instrument(name = "TableExec::final_round_evaluate", level = "debug", skip_all)]
@@ -105,7 +108,7 @@ impl ProverEvaluate for TableExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> Table<'a, S> {
+    ) -> PlaceholderProverResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let final_round_table = table_map
@@ -115,6 +118,6 @@ impl ProverEvaluate for TableExec {
 
         log::log_memory_usage("End");
 
-        final_round_table
+        Ok(final_round_table)
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec_test.rs
@@ -24,7 +24,7 @@ fn we_can_create_and_prove_an_empty_table_exec() {
         (),
     );
     let verifiable_res =
-        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(&plan, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])
         .unwrap()
@@ -68,7 +68,7 @@ fn we_can_create_and_prove_a_table_exec() {
         0_usize,
         (),
     );
-    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&plan, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &plan, &accessor, &table_ref);
     let res = verifiable_res
         .verify(&plan, &accessor, &(), &[])

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec_test.rs
@@ -30,7 +30,7 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_with_no_tables() {
         ],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -57,7 +57,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_with_one_table() {
         vec![column_field("a", ColumnType::BigInt)],
     );
     let verifiable_res: VerifiableQueryResult<InnerProductProof> =
-        VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+        VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -88,7 +88,8 @@ fn we_can_prove_and_get_the_correct_empty_result_from_a_union_exec() {
         ],
         vec![column_field("a", ColumnType::BigInt)],
     );
-    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]);
+    let verifiable_res =
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[]).unwrap();
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
         .unwrap()
@@ -138,7 +139,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_union_exec() {
             column_field("b", ColumnType::VarChar),
         ],
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -279,7 +280,7 @@ fn we_can_prove_and_get_the_correct_result_from_a_more_complex_union_exec() {
             column_field("b", ColumnType::VarChar),
         ],
     );
-    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]);
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
     exercise_verification(&verifiable_res, &ast, &accessor, &t0);
     let res = verifiable_res
         .verify(&ast, &accessor, &(), &[])
@@ -354,12 +355,10 @@ fn we_can_get_result_from_union_using_first_round_evaluate() {
         fields.clone(),
     );
     let first_round_builder = &mut FirstRoundBuilder::new(data_length);
-    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(ast.first_round_evaluate(
-        first_round_builder,
-        &alloc,
-        &table_map,
-        &[],
-    ))
+    let res: OwnedTable<Curve25519Scalar> = ProvableQueryResult::from(
+        ast.first_round_evaluate(first_round_builder, &alloc, &table_map, &[])
+            .unwrap(),
+    )
     .to_owned_table(&fields)
     .unwrap();
 

--- a/crates/proof-of-sql/tests/decimal_integration_tests.rs
+++ b/crates/proof-of-sql/tests/decimal_integration_tests.rs
@@ -36,7 +36,8 @@ fn run_query(
 
     let query = QueryExpr::try_new(query_str.parse().unwrap(), "sxt".into(), &accessor).unwrap();
     let proof =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = proof
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -43,7 +43,8 @@ fn we_can_prove_a_minimal_filter_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -78,7 +79,8 @@ fn we_can_prove_a_minimal_filter_query_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
@@ -111,7 +113,8 @@ fn we_can_prove_a_minimal_filter_query_with_dynamic_dory() {
         &accessor,
         &&prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &&verifier_setup, &[])
         .unwrap()
@@ -136,7 +139,8 @@ fn we_can_prove_a_basic_equality_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -171,7 +175,8 @@ fn we_can_prove_a_basic_equality_query_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
@@ -207,7 +212,8 @@ fn we_can_prove_a_basic_equality_query_with_hyperkzg() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<CP>::new(query.proof_expr(), &accessor, &&ark_setup[..], &[]);
+        VerifiableQueryResult::<CP>::new(query.proof_expr(), &accessor, &&ark_setup[..], &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &&vk, &[])
         .unwrap()
@@ -232,7 +238,8 @@ fn we_can_prove_a_basic_inequality_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -263,7 +270,8 @@ fn we_can_prove_a_basic_query_containing_extrema_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -310,7 +318,8 @@ fn we_can_prove_a_basic_query_containing_extrema_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
@@ -341,7 +350,8 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -377,7 +387,8 @@ fn we_can_prove_a_query_with_arithmetic_in_where_clause_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
@@ -407,7 +418,8 @@ fn we_can_prove_a_basic_equality_with_out_of_order_results_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -444,7 +456,8 @@ fn we_can_prove_a_basic_inequality_query_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
@@ -498,7 +511,8 @@ fn we_can_prove_a_complex_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -549,7 +563,8 @@ fn we_can_prove_a_complex_query_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
@@ -582,7 +597,8 @@ fn we_can_prove_a_minimal_group_by_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result: OwnedTable<Curve25519Scalar> = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -616,7 +632,8 @@ fn we_can_prove_a_basic_group_by_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -678,7 +695,8 @@ fn we_can_prove_a_cat_group_by_query_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -753,7 +771,8 @@ fn we_can_prove_a_cat_group_by_query_with_dynamic_dory() {
         &accessor,
         &&prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &&verifier_setup, &[])
         .unwrap()
@@ -797,7 +816,8 @@ fn we_can_prove_a_basic_group_by_query_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
@@ -831,7 +851,8 @@ fn we_can_prove_a_varbinary_equality_query_with_hex_literal() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -857,7 +878,8 @@ fn we_can_prove_a_query_with_overflow_with_curve25519() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     assert!(matches!(
         verifiable_result.verify(query.proof_expr(), &accessor, &(), &[]),
         Err(QueryError::Overflow)
@@ -890,7 +912,8 @@ fn we_can_prove_a_query_with_overflow_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     assert!(matches!(
         verifiable_result.verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[]),
         Err(QueryError::Overflow)
@@ -919,7 +942,8 @@ fn we_can_perform_arithmetic_and_conditional_operations_on_tinyint() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -950,7 +974,8 @@ fn we_can_perform_equality_checks_on_var_binary() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -1028,7 +1053,8 @@ fn we_can_perform_rich_equality_checks_on_var_binary() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()
@@ -1183,7 +1209,8 @@ fn we_can_perform_equality_checks_on_rich_var_binary_data() {
     )
     .unwrap();
     let verifiable_result =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &(), &[])
         .unwrap()

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -56,7 +56,8 @@ fn we_can_prove_a_basic_query_containing_rfc3339_timestamp_with_dory() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()
@@ -95,7 +96,8 @@ fn run_timestamp_query_test(
     let query = QueryExpr::try_new(query_str.parse().unwrap(), "sxt".into(), &accessor).unwrap();
 
     let proof =
-        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[]);
+        VerifiableQueryResult::<InnerProductProof>::new(query.proof_expr(), &accessor, &(), &[])
+            .unwrap();
 
     // Verify the results
     let owned_table_result = proof
@@ -444,7 +446,8 @@ fn we_can_prove_timestamp_inequality_queries_with_multiple_columns() {
         &accessor,
         &dory_prover_setup,
         &[],
-    );
+    )
+    .unwrap();
     let owned_table_result = verifiable_result
         .verify(query.proof_expr(), &accessor, &dory_verifier_setup, &[])
         .unwrap()


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
This PR continues the changes from #683 aimed at generalizing `ProofExpr` and `ProofPlan` to accommodate parameterized queries.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `PlaceholderProverError` and corresponding result, `PlaceholderProverResult`.
- make `ProofExpr::result_evaluate`,  `ProofExpr::prover_evaluate`, `ProofPlan::first_round_evaluate`,  `ProofExpr::final_round_evaluate` return `PlaceholderProverResult`.
- make `QueryProof::new` and `VerifiableQueryResult::new` return `PlaceholderProverResult`.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.