### PR TITLE
ci: remove `opt-level` from `profile.test` in top level `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,9 +82,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)
 missing_errors_doc = "allow"
 pedantic = { level = "warn", priority = -1 }
 
-[profile.test]
-opt-level = 3
-
 [patch.crates-io]
 # patch for sqlparser no_std compatibility with the serde feature enabled.
 # required until sqlparser releases a similar update and proof-of-sql upgrades to it.


### PR DESCRIPTION
Specifying `opt-level` actually increases test time in CI hence let's revert #688.