### PR TITLE
refactor!: rename `ProofExpr::result_evaluate` to `first_round_evaluate` and `ProofExpr::prover_evaluate` to `final_round_evaluate`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr_test.rs
@@ -331,7 +331,7 @@ fn we_can_query_random_tables_using_a_non_zero_offset() {
 
 // b + a - 1
 #[test]
-fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data = table([
         borrowed_smallint("a", [1_i16, 2, 3, 4], &alloc),
@@ -347,7 +347,7 @@ fn we_can_compute_the_correct_output_of_an_add_subtract_expr_using_result_evalua
         subtract(column(&t, "a", &accessor), const_bigint(1)),
     );
     let res = add_subtract_expr
-        .result_evaluate(&alloc, &data, &[])
+        .first_round_evaluate(&alloc, &data, &[])
         .unwrap();
     let expected_res_scalar = [0, 2, 2, 4]
         .iter()

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -35,8 +35,8 @@ impl ProofExpr for AndExpr {
         ColumnType::Boolean
     }
 
-    #[tracing::instrument(name = "AndExpr::result_evaluate", level = "debug", skip_all)]
-    fn result_evaluate<'a, S: Scalar>(
+    #[tracing::instrument(name = "AndExpr::first_round_evaluate", level = "debug", skip_all)]
+    fn first_round_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
         table: &Table<'a, S>,
@@ -44,8 +44,8 @@ impl ProofExpr for AndExpr {
     ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let lhs_column: Column<'a, S> = self.lhs.result_evaluate(alloc, table, params)?;
-        let rhs_column: Column<'a, S> = self.rhs.result_evaluate(alloc, table, params)?;
+        let lhs_column: Column<'a, S> = self.lhs.first_round_evaluate(alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self.rhs.first_round_evaluate(alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let res =
@@ -56,8 +56,8 @@ impl ProofExpr for AndExpr {
         Ok(res)
     }
 
-    #[tracing::instrument(name = "AndExpr::prover_evaluate", level = "debug", skip_all)]
-    fn prover_evaluate<'a, S: Scalar>(
+    #[tracing::instrument(name = "AndExpr::final_round_evaluate", level = "debug", skip_all)]
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -66,8 +66,12 @@ impl ProofExpr for AndExpr {
     ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table, params)?;
-        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table, params)?;
+        let lhs_column: Column<'a, S> = self
+            .lhs
+            .final_round_evaluate(builder, alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self
+            .rhs
+            .final_round_evaluate(builder, alloc, table, params)?;
         let lhs = lhs_column.as_boolean().expect("lhs is not boolean");
         let rhs = rhs_column.as_boolean().expect("rhs is not boolean");
         let n = lhs.len();

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -174,7 +174,7 @@ fn we_can_query_random_tables_using_a_non_zero_offset() {
 }
 
 #[test]
-fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_an_and_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data = table([
         borrowed_bigint("a", [1, 2, 3, 4], &alloc),
@@ -189,7 +189,7 @@ fn we_can_compute_the_correct_output_of_an_and_expr_using_result_evaluate() {
         equal(column(&t, "b", &accessor), const_int128(1)),
         equal(column(&t, "d", &accessor), const_varchar("t")),
     );
-    let res = and_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = and_expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[false, true, false, false]);
     assert_eq!(res, expected_res);
 }
@@ -217,7 +217,7 @@ fn we_can_verify_a_simple_proof() {
         FinalRoundBuilder::new(4, VecDeque::new());
 
     and_expr
-        .prover_evaluate(&mut final_round_builder, &alloc, &table, &[])
+        .final_round_evaluate(&mut final_round_builder, &alloc, &table, &[])
         .unwrap();
 
     let verification_builder = run_verify_for_each_row(

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -36,17 +36,17 @@ impl ProofExpr for CastExpr {
         self.to_type
     }
 
-    fn result_evaluate<'a, S: Scalar>(
+    fn first_round_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
     ) -> PlaceholderProverResult<Column<'a, S>> {
-        let uncasted_result = self.from_expr.result_evaluate(alloc, table, params)?;
+        let uncasted_result = self.from_expr.first_round_evaluate(alloc, table, params)?;
         Ok(cast_column(alloc, uncasted_result, self.to_type))
     }
 
-    fn prover_evaluate<'a, S: Scalar>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -55,7 +55,7 @@ impl ProofExpr for CastExpr {
     ) -> PlaceholderProverResult<Column<'a, S>> {
         let uncasted_result = self
             .from_expr
-            .prover_evaluate(builder, alloc, table, params)?;
+            .final_round_evaluate(builder, alloc, table, params)?;
         Ok(cast_column(alloc, uncasted_result, self.to_type))
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -69,7 +69,7 @@ impl ProofExpr for ColumnExpr {
 
     /// Evaluate the column expression and
     /// add the result to the [`FirstRoundBuilder`](crate::sql::proof::FirstRoundBuilder)
-    fn result_evaluate<'a, S: Scalar>(
+    fn first_round_evaluate<'a, S: Scalar>(
         &self,
         _alloc: &'a Bump,
         table: &Table<'a, S>,
@@ -80,7 +80,7 @@ impl ProofExpr for ColumnExpr {
 
     /// Given the selected rows (as a slice of booleans), evaluate the column expression and
     /// add the components needed to prove the result
-    fn prover_evaluate<'a, S: Scalar>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         _builder: &mut FinalRoundBuilder<'a, S>,
         _alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr_test.rs
@@ -434,7 +434,7 @@ fn we_can_query_random_tables_using_a_non_zero_offset() {
 }
 
 #[test]
-fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_an_equals_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data: Table<Curve25519Scalar> = table([
         borrowed_bigint("a", [1, 2, 3, 4], &alloc),
@@ -460,7 +460,9 @@ fn we_can_compute_the_correct_output_of_an_equals_expr_using_result_evaluate() {
         column(&t, "e", &accessor),
         const_scalar::<Curve25519Scalar, _>(Curve25519Scalar::ZERO),
     );
-    let res = equals_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = equals_expr
+        .first_round_evaluate(&alloc, &data, &[])
+        .unwrap();
     let expected_res = Column::Boolean(&[true, false, true, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr_test.rs
@@ -637,7 +637,7 @@ fn we_can_query_random_tables_using_a_non_zero_offset() {
 }
 
 #[test]
-fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data = table([
         borrowed_bigint("a", [-1, 9, 1], &alloc),
@@ -649,13 +649,13 @@ fn we_can_compute_the_correct_output_of_a_lte_inequality_expr_using_result_evalu
     let lhs_expr: DynProofExpr = column(&t, "a", &accessor);
     let rhs_expr = column(&t, "b", &accessor);
     let lte_expr = lte(lhs_expr, rhs_expr);
-    let res = lte_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = lte_expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[true, false, true]);
     assert_eq!(res, expected_res);
 }
 
 #[test]
-fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data = table([
         borrowed_bigint("a", [-1, 9, 1], &alloc),
@@ -667,7 +667,7 @@ fn we_can_compute_the_correct_output_of_a_gte_inequality_expr_using_result_evalu
     let col_expr: DynProofExpr = column(&t, "a", &accessor);
     let lit_expr = const_bigint(1);
     let gte_expr = gte(col_expr, lit_expr);
-    let res = gte_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = gte_expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[false, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -43,8 +43,8 @@ impl ProofExpr for LiteralExpr {
         self.value.column_type()
     }
 
-    #[tracing::instrument(name = "LiteralExpr::result_evaluate", level = "debug", skip_all)]
-    fn result_evaluate<'a, S: Scalar>(
+    #[tracing::instrument(name = "LiteralExpr::first_round_evaluate", level = "debug", skip_all)]
+    fn first_round_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
         table: &Table<'a, S>,
@@ -59,8 +59,8 @@ impl ProofExpr for LiteralExpr {
         Ok(res)
     }
 
-    #[tracing::instrument(name = "LiteralExpr::prover_evaluate", level = "debug", skip_all)]
-    fn prover_evaluate<'a, S: Scalar>(
+    #[tracing::instrument(name = "LiteralExpr::final_round_evaluate", level = "debug", skip_all)]
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         _builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr_test.rs
@@ -132,12 +132,14 @@ fn we_can_prove_a_query_with_a_single_non_selected_row() {
 }
 
 #[test]
-fn we_can_compute_the_correct_output_of_a_literal_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_a_literal_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data: Table<Curve25519Scalar> =
         table([borrowed_bigint("a", [123_i64, 456, 789, 1011], &alloc)]);
     let literal_expr: DynProofExpr = const_bool(true);
-    let res = literal_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = literal_expr
+        .first_round_evaluate(&alloc, &data, &[])
+        .unwrap();
     let expected_res = Column::Boolean(&[true, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr_test.rs
@@ -357,7 +357,7 @@ fn we_can_query_random_tables_using_a_non_zero_offset() {
 
 // b * (a - 1.5)
 #[test]
-fn we_can_compute_the_correct_output_of_a_multiply_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_a_multiply_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data = table([
         borrowed_smallint("a", [1_i16, 2, 3, 4], &alloc),
@@ -372,7 +372,9 @@ fn we_can_compute_the_correct_output_of_a_multiply_expr_using_result_evaluate() 
         column(&t, "b", &accessor),
         subtract(column(&t, "a", &accessor), const_decimal75(2, 1, 15)),
     );
-    let res = arithmetic_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = arithmetic_expr
+        .first_round_evaluate(&alloc, &data, &[])
+        .unwrap();
     let expected_res_scalar = [0, 5, 75, 25]
         .iter()
         .map(|v| Curve25519Scalar::from(*v))

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -34,8 +34,8 @@ impl ProofExpr for NotExpr {
         ColumnType::Boolean
     }
 
-    #[tracing::instrument(name = "NotExpr::result_evaluate", level = "debug", skip_all)]
-    fn result_evaluate<'a, S: Scalar>(
+    #[tracing::instrument(name = "NotExpr::first_round_evaluate", level = "debug", skip_all)]
+    fn first_round_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
         table: &Table<'a, S>,
@@ -43,7 +43,7 @@ impl ProofExpr for NotExpr {
     ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let expr_column: Column<'a, S> = self.expr.result_evaluate(alloc, table, params)?;
+        let expr_column: Column<'a, S> = self.expr.first_round_evaluate(alloc, table, params)?;
         let expr = expr_column.as_boolean().expect("expr is not boolean");
         let res = Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]));
 
@@ -52,8 +52,8 @@ impl ProofExpr for NotExpr {
         Ok(res)
     }
 
-    #[tracing::instrument(name = "NotExpr::prover_evaluate", level = "debug", skip_all)]
-    fn prover_evaluate<'a, S: Scalar>(
+    #[tracing::instrument(name = "NotExpr::final_round_evaluate", level = "debug", skip_all)]
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -62,8 +62,9 @@ impl ProofExpr for NotExpr {
     ) -> PlaceholderProverResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
-        let expr_column: Column<'a, S> =
-            self.expr.prover_evaluate(builder, alloc, table, params)?;
+        let expr_column: Column<'a, S> = self
+            .expr
+            .final_round_evaluate(builder, alloc, table, params)?;
         let expr = expr_column.as_boolean().expect("expr is not boolean");
         let res = Column::Boolean(alloc.alloc_slice_fill_with(expr.len(), |i| !expr[i]));
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr_test.rs
@@ -118,7 +118,7 @@ fn we_can_query_random_tables_with_a_non_zero_offset() {
 }
 
 #[test]
-fn we_can_compute_the_correct_output_of_a_not_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_a_not_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data = table([
         borrowed_bigint("a", [123, 456], &alloc),
@@ -129,7 +129,7 @@ fn we_can_compute_the_correct_output_of_a_not_expr_using_result_evaluate() {
     let t = TableRef::new("sxt", "t");
     accessor.add_table(t.clone(), data.clone(), 0);
     let not_expr: DynProofExpr = not(equal(column(&t, "b", &accessor), const_int128(1)));
-    let res = not_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = not_expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[true, false]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -186,7 +186,7 @@ fn we_can_query_random_tables_with_a_non_zero_offset() {
 }
 
 #[test]
-fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_output_of_an_or_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data = table([
         borrowed_bigint("a", [1, 2, 3, 4], &alloc),
@@ -201,7 +201,7 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_result_evaluate() {
         equal(column(&t, "b", &accessor), const_int128(1)),
         equal(column(&t, "d", &accessor), const_varchar("g")),
     );
-    let res = and_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = and_expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[false, true, true, true]);
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -22,7 +22,7 @@ pub trait ProofExpr: Debug + Send + Sync {
     /// This returns the result of evaluating the expression on the given table, and returns
     /// a column of values. This result slice is guaranteed to have length `table_length`.
     /// Implementations must ensure that the returned slice has length `table_length`.
-    fn result_evaluate<'a, S: Scalar>(
+    fn first_round_evaluate<'a, S: Scalar>(
         &self,
         alloc: &'a Bump,
         table: &Table<'a, S>,
@@ -31,7 +31,7 @@ pub trait ProofExpr: Debug + Send + Sync {
 
     /// Evaluate the expression, add components needed to prove it, and return thet resulting column
     /// of values
-    fn prover_evaluate<'a, S: Scalar>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr_test.rs
@@ -6,7 +6,7 @@ use crate::base::{
 use bumpalo::Bump;
 
 #[test]
-fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluate() {
+fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_first_round_evaluate() {
     let alloc = Bump::new();
     let data = table([
         borrowed_bigint(
@@ -41,7 +41,7 @@ fn we_can_compute_the_correct_result_of_a_complex_bool_expr_using_result_evaluat
         ),
         not(equal(column(&t, "c", &accessor), const_int128(3))),
     );
-    let res = bool_expr.result_evaluate(&alloc, &data, &[]).unwrap();
+    let res = bool_expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[
         false, true, false, true, false, true, false, true, false, true, false, true, false, true,
         false, false, false,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -72,7 +72,7 @@ impl DivideAndModuloExpr {
     /// This is abstracted into its own function for ease of unit testing.
     /// The `utilities` function is where any functionality that needs to be mocked
     /// can be provided.
-    fn prover_evaluate_base<'a, S: Scalar, U: DivideAndModuloExprUtilities<S>>(
+    fn final_round_evaluate_base<'a, S: Scalar, U: DivideAndModuloExprUtilities<S>>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -80,8 +80,12 @@ impl DivideAndModuloExpr {
         utilities: &U,
         params: &[LiteralValue],
     ) -> PlaceholderProverResult<(Column<'a, S>, Column<'a, S>)> {
-        let lhs_column: Column<'a, S> = self.lhs.prover_evaluate(builder, alloc, table, params)?;
-        let rhs_column: Column<'a, S> = self.rhs.prover_evaluate(builder, alloc, table, params)?;
+        let lhs_column: Column<'a, S> = self
+            .lhs
+            .final_round_evaluate(builder, alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self
+            .rhs
+            .final_round_evaluate(builder, alloc, table, params)?;
 
         let (quotient_wrapped, _quotient) =
             utilities.divide_columns(&lhs_column, &rhs_column, alloc);
@@ -94,7 +98,7 @@ impl DivideAndModuloExpr {
     }
 
     #[cfg_attr(not(test), expect(dead_code))]
-    fn prover_evaluate<'a, S: Scalar>(
+    fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,
         alloc: &'a Bump,
@@ -104,7 +108,7 @@ impl DivideAndModuloExpr {
         log::log_memory_usage("Start");
         let utilities = StandardDivideAndModuloExprUtilities {};
 
-        let res = self.prover_evaluate_base(builder, alloc, table, &utilities, params)?;
+        let res = self.final_round_evaluate_base(builder, alloc, table, &utilities, params)?;
 
         log::log_memory_usage("End");
 
@@ -178,7 +182,7 @@ mod tests {
         })
         .unwrap();
         divide_and_modulo_expr
-            .prover_evaluate(&mut final_round_builder, &alloc, &table, &[])
+            .final_round_evaluate(&mut final_round_builder, &alloc, &table, &[])
             .unwrap();
         let mock_verification_builder = run_verify_for_each_row(
             lhs.len(),

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -20,7 +20,9 @@ use shift::{final_round_evaluate_shift, first_round_evaluate_shift, verify_shift
 #[cfg(test)]
 mod shift_test;
 mod sign_expr;
-pub(crate) use sign_expr::{prover_evaluate_sign, result_evaluate_sign, verifier_evaluate_sign};
+pub(crate) use sign_expr::{
+    final_round_evaluate_sign, first_round_evaluate_sign, verifier_evaluate_sign,
+};
 #[cfg(feature = "blitzar")]
 #[allow(dead_code)]
 mod range_check;

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic.rs
@@ -1,6 +1,6 @@
 //! Prove that a column is increasing or decreasing, strictly or non-strictly.
 use super::{
-    final_round_evaluate_shift, first_round_evaluate_shift, prover_evaluate_sign,
+    final_round_evaluate_shift, final_round_evaluate_sign, first_round_evaluate_shift,
     verifier_evaluate_sign, verify_shift,
 };
 use crate::{
@@ -74,7 +74,7 @@ pub(crate) fn final_round_evaluate_monotonic<'a, S: Scalar, const STRICT: bool, 
     };
 
     // 3. Prove the sign of `ind`
-    prover_evaluate_sign(builder, alloc, ind);
+    final_round_evaluate_sign(builder, alloc, ind);
 }
 
 pub(crate) fn verify_monotonic<S: Scalar, const STRICT: bool, const ASC: bool>(

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr.rs
@@ -20,7 +20,7 @@ use core::ops::Shl;
 /// Panics if `bits.last()` is `None` or if `result.len()` does not match `table_length`.
 ///
 /// todo! make this more efficient and targeted at just the sign bit rather than all bits to create a proof
-pub fn result_evaluate_sign<'a, S: Scalar>(
+pub fn first_round_evaluate_sign<'a, S: Scalar>(
     table_length: usize,
     alloc: &'a Bump,
     expr: &'a [S],
@@ -46,7 +46,7 @@ pub fn result_evaluate_sign<'a, S: Scalar>(
 ///
 /// Note: We can only prove the sign bit for non-zero scalars, and we restict
 /// the range of non-zero scalar so that there is a unique sign representation.
-pub fn prover_evaluate_sign<'a, S: Scalar>(
+pub fn final_round_evaluate_sign<'a, S: Scalar>(
     builder: &mut FinalRoundBuilder<'a, S>,
     alloc: &'a Bump,
     expr: &'a [S],
@@ -77,7 +77,7 @@ pub fn prover_evaluate_sign<'a, S: Scalar>(
 /// Panics if `bit_evals` is empty and `dist` indicates a variable lead bit.
 /// This would mean that there is no way to determine the sign bit.
 ///
-/// See [`prover_evaluate_sign`].
+/// See [`final_round_evaluate_sign`].
 pub fn verifier_evaluate_sign<S: Scalar>(
     builder: &mut impl VerificationBuilder<S>,
     eval: S,

--- a/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/sign_expr_test.rs
@@ -1,4 +1,4 @@
-use super::{prover_evaluate_sign, result_evaluate_sign, verifier_evaluate_sign};
+use super::{final_round_evaluate_sign, first_round_evaluate_sign, verifier_evaluate_sign};
 use crate::{
     base::{
         bit::BitDistribution,
@@ -19,7 +19,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_constant_column() {
     let alloc = Bump::new();
     let data: Vec<TestScalar> = data.into_iter().map(TestScalar::from).collect();
     let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
-    let sign = prover_evaluate_sign(&mut builder, &alloc, &data);
+    let sign = final_round_evaluate_sign(&mut builder, &alloc, &data);
     assert_eq!(sign, [false; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
 }
@@ -31,7 +31,7 @@ fn prover_evaluation_generates_the_bit_distribution_of_a_negative_constant_colum
     let alloc = Bump::new();
     let data: Vec<TestScalar> = data.into_iter().map(TestScalar::from).collect();
     let mut builder = FinalRoundBuilder::new(2, VecDeque::new());
-    let sign = prover_evaluate_sign(&mut builder, &alloc, &data);
+    let sign = final_round_evaluate_sign(&mut builder, &alloc, &data);
     assert_eq!(sign, [true; 3]);
     assert_eq!(builder.bit_distributions(), [dist]);
 }
@@ -104,26 +104,26 @@ fn verification_of_constant_data_fails_if_the_commitment_doesnt_match_the_bit_di
 }
 
 #[test]
-fn we_can_compute_the_correct_sign_of_scalars_using_result_evaluate_sign_for_a_constant() {
+fn we_can_compute_the_correct_sign_of_scalars_using_first_round_evaluate_sign_for_a_constant() {
     let data: &[TestScalar] = &[(-123).into(), (-123).into()];
     let alloc = Bump::new();
-    let res = result_evaluate_sign(2, &alloc, data);
+    let res = first_round_evaluate_sign(2, &alloc, data);
     let expected_res = [true, true];
     assert_eq!(res, expected_res);
 }
 
 #[test]
-fn we_can_compute_the_correct_sign_of_scalars_using_result_evaluate_sign_with_varying_bits_and_fixed_sign(
+fn we_can_compute_the_correct_sign_of_scalars_using_first_round_evaluate_sign_with_varying_bits_and_fixed_sign(
 ) {
     let data: &[TestScalar] = &[123.into(), 452.into(), 0.into(), 789.into(), 910.into()];
     let alloc = Bump::new();
-    let res = result_evaluate_sign(5, &alloc, data);
+    let res = first_round_evaluate_sign(5, &alloc, data);
     let expected_res = [false, false, false, false, false];
     assert_eq!(res, expected_res);
 }
 
 #[test]
-fn we_can_compute_the_correct_sign_of_scalars_using_result_evaluate_sign_with_varying_bits_and_sign(
+fn we_can_compute_the_correct_sign_of_scalars_using_first_round_evaluate_sign_with_varying_bits_and_sign(
 ) {
     let data: &[TestScalar] = &[
         123.into(),
@@ -133,7 +133,7 @@ fn we_can_compute_the_correct_sign_of_scalars_using_result_evaluate_sign_with_va
         (-910).into(),
     ];
     let alloc = Bump::new();
-    let res = result_evaluate_sign(5, &alloc, data);
+    let res = first_round_evaluate_sign(5, &alloc, data);
     let expected_res = [false, true, false, false, true];
     assert_eq!(res, expected_res);
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -157,8 +157,9 @@ impl ProverEvaluate for FilterExec {
             .get(&self.table.table_ref)
             .expect("Table not found");
         // 1. selection
-        let selection_column: Column<'a, S> =
-            self.where_clause.result_evaluate(alloc, table, params)?;
+        let selection_column: Column<'a, S> = self
+            .where_clause
+            .first_round_evaluate(alloc, table, params)?;
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
@@ -169,7 +170,7 @@ impl ProverEvaluate for FilterExec {
             .aliased_results
             .iter()
             .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
-                aliased_expr.expr.result_evaluate(alloc, table, params)
+                aliased_expr.expr.first_round_evaluate(alloc, table, params)
             })
             .collect::<PlaceholderProverResult<Vec<_>>>()?;
 
@@ -207,7 +208,7 @@ impl ProverEvaluate for FilterExec {
         // 1. selection
         let selection_column: Column<'a, S> = self
             .where_clause
-            .prover_evaluate(builder, alloc, table, params)?;
+            .final_round_evaluate(builder, alloc, table, params)?;
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
@@ -220,7 +221,7 @@ impl ProverEvaluate for FilterExec {
             .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
                 aliased_expr
                     .expr
-                    .prover_evaluate(builder, alloc, table, params)
+                    .final_round_evaluate(builder, alloc, table, params)
             })
             .collect::<PlaceholderProverResult<Vec<_>>>()?;
         // Compute filtered_columns

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -49,8 +49,9 @@ impl ProverEvaluate for DishonestFilterExec {
             .get(&self.table.table_ref)
             .expect("Table not found");
         // 1. selection
-        let selection_column: Column<'a, S> =
-            self.where_clause.result_evaluate(alloc, table, params)?;
+        let selection_column: Column<'a, S> = self
+            .where_clause
+            .first_round_evaluate(alloc, table, params)?;
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
@@ -60,7 +61,7 @@ impl ProverEvaluate for DishonestFilterExec {
             .aliased_results
             .iter()
             .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
-                aliased_expr.expr.result_evaluate(alloc, table, params)
+                aliased_expr.expr.first_round_evaluate(alloc, table, params)
             })
             .collect::<PlaceholderProverResult<Vec<_>>>()?;
         // Compute filtered_columns
@@ -102,7 +103,7 @@ impl ProverEvaluate for DishonestFilterExec {
         // 1. selection
         let selection_column: Column<'a, S> = self
             .where_clause
-            .prover_evaluate(builder, alloc, table, params)?;
+            .final_round_evaluate(builder, alloc, table, params)?;
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
@@ -114,7 +115,7 @@ impl ProverEvaluate for DishonestFilterExec {
             .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
                 aliased_expr
                     .expr
-                    .prover_evaluate(builder, alloc, table, params)
+                    .final_round_evaluate(builder, alloc, table, params)
             })
             .collect::<PlaceholderProverResult<Vec<_>>>()?;
         // Compute filtered_columns

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -206,8 +206,9 @@ impl ProverEvaluate for GroupByExec {
             .get(&self.table.table_ref)
             .expect("Table not found");
         // 1. selection
-        let selection_column: Column<'a, S> =
-            self.where_clause.result_evaluate(alloc, table, params)?;
+        let selection_column: Column<'a, S> = self
+            .where_clause
+            .first_round_evaluate(alloc, table, params)?;
 
         let selection = selection_column
             .as_boolean()
@@ -218,14 +219,14 @@ impl ProverEvaluate for GroupByExec {
             .group_by_exprs
             .iter()
             .map(|expr| -> PlaceholderProverResult<Column<'a, S>> {
-                expr.result_evaluate(alloc, table, params)
+                expr.first_round_evaluate(alloc, table, params)
             })
             .collect::<PlaceholderProverResult<Vec<_>>>()?;
         let sum_columns = self
             .sum_expr
             .iter()
             .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
-                aliased_expr.expr.result_evaluate(alloc, table, params)
+                aliased_expr.expr.first_round_evaluate(alloc, table, params)
             })
             .collect::<PlaceholderProverResult<Vec<_>>>()?;
         // Compute filtered_columns
@@ -273,7 +274,7 @@ impl ProverEvaluate for GroupByExec {
         // 1. selection
         let selection_column: Column<'a, S> = self
             .where_clause
-            .prover_evaluate(builder, alloc, table, params)?;
+            .final_round_evaluate(builder, alloc, table, params)?;
         let selection = selection_column
             .as_boolean()
             .expect("selection is not boolean");
@@ -283,7 +284,7 @@ impl ProverEvaluate for GroupByExec {
             .group_by_exprs
             .iter()
             .map(|expr| -> PlaceholderProverResult<Column<'a, S>> {
-                expr.prover_evaluate(builder, alloc, table, params)
+                expr.final_round_evaluate(builder, alloc, table, params)
             })
             .collect::<PlaceholderProverResult<Vec<_>>>()?;
         let sum_columns = self
@@ -292,7 +293,7 @@ impl ProverEvaluate for GroupByExec {
             .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
                 aliased_expr
                     .expr
-                    .prover_evaluate(builder, alloc, table, params)
+                    .final_round_evaluate(builder, alloc, table, params)
             })
             .collect::<PlaceholderProverResult<Vec<_>>>()?;
         // 3. Compute filtered_columns

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -145,7 +145,9 @@ impl ProverEvaluate for ProjectionExec {
                 |aliased_expr| -> PlaceholderProverResult<(Ident, Column<'a, S>)> {
                     Ok((
                         aliased_expr.alias.clone(),
-                        aliased_expr.expr.result_evaluate(alloc, &input, params)?,
+                        aliased_expr
+                            .expr
+                            .first_round_evaluate(alloc, &input, params)?,
                     ))
                 },
             )
@@ -188,7 +190,7 @@ impl ProverEvaluate for ProjectionExec {
                         aliased_expr.alias.clone(),
                         aliased_expr
                             .expr
-                            .prover_evaluate(builder, alloc, &input, params)?,
+                            .final_round_evaluate(builder, alloc, &input, params)?,
                     ))
                 },
             )

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec_test.rs
@@ -219,7 +219,8 @@ fn we_can_prove_and_get_the_correct_result_from_a_composed_projection() {
 }
 
 #[test]
-fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_result_evaluate() {
+fn we_can_get_an_empty_result_from_a_basic_projection_on_an_empty_table_using_first_round_evaluate()
+{
     let alloc = Bump::new();
     let data = table([
         borrowed_bigint("a", [0; 0], &alloc),

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -158,7 +158,7 @@ impl ProverEvaluate for SliceExec {
         Ok(res)
     }
 
-    #[tracing::instrument(name = "SliceExec::prover_evaluate", level = "debug", skip_all)]
+    #[tracing::instrument(name = "SliceExec::final_round_evaluate", level = "debug", skip_all)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -131,7 +131,7 @@ impl ProverEvaluate for UnionExec {
         Ok(res)
     }
 
-    #[tracing::instrument(name = "UnionExec::prover_evaluate", level = "debug", skip_all)]
+    #[tracing::instrument(name = "UnionExec::final_round_evaluate", level = "debug", skip_all)]
     fn final_round_evaluate<'a, S: Scalar>(
         &self,
         builder: &mut FinalRoundBuilder<'a, S>,


### PR DESCRIPTION
Depends on #689.

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
`result_evaluate` and `prover_evaluate` in `ProofExpr` are now misnomers. Let's correct the naming so that `ProofExpr` and `ProofPlan` are in sync in terms of names.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- rename `ProofExpr::result_evaluate` to `first_round_evaluate`
- rename `ProofExpr::prover_evaluate` to `final_round_evaluate`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.