### PR TITLE
refactor!: move `PlaceholderProverError` to `base::proof::error` and rename it `PlaceholderError` to prevent cyclic dependency

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -56,3 +56,10 @@ pub enum ProofSizeMismatch {
     #[snafu(display("Proof doesn't have requested rho length"))]
     RhoLengthNotFound,
 }
+
+/// Errors related to placeholders
+#[derive(Snafu, Debug, PartialEq, Eq)]
+pub enum PlaceholderError {}
+
+/// Result type for placeholder errors
+pub type PlaceholderResult<T> = Result<T, PlaceholderError>;

--- a/crates/proof-of-sql/src/base/proof/mod.rs
+++ b/crates/proof-of-sql/src/base/proof/mod.rs
@@ -1,7 +1,8 @@
 //! Contains the transcript protocol used to construct a proof,
 //! as well as an error type which can occur when verification fails.
 mod error;
-pub use error::{ProofError, ProofSizeMismatch};
+#[expect(unused_imports)]
+pub use error::{PlaceholderError, PlaceholderResult, ProofError, ProofSizeMismatch};
 
 /// Contains an extension trait for `merlin::Transcript`, which is used to construct a proof.
 #[cfg(any(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -61,10 +61,3 @@ impl From<IntermediateDecimalError> for AnalyzeError {
 
 /// Result type for analyze errors
 pub type AnalyzeResult<T> = Result<T, AnalyzeError>;
-
-/// Errors related to placeholders in provers
-#[derive(Snafu, Debug, PartialEq, Eq)]
-pub enum PlaceholderProverError {}
-
-/// Result type for placeholder errors in provers
-pub type PlaceholderProverResult<T> = Result<T, PlaceholderProverError>;

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -6,7 +6,7 @@ use crate::{
             TableRef,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
@@ -14,7 +14,6 @@ use crate::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
         proof_plans::DynProofPlan,
-        PlaceholderProverResult,
     },
 };
 use alloc::{
@@ -179,7 +178,7 @@ impl ProverEvaluate for EVMProofPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         self.inner()
             .first_round_evaluate(builder, alloc, table_map, params)
     }
@@ -189,7 +188,7 @@ impl ProverEvaluate for EVMProofPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         self.inner()
             .final_round_evaluate(builder, alloc, table_map, params)
     }

--- a/crates/proof-of-sql/src/sql/mod.rs
+++ b/crates/proof-of-sql/src/sql/mod.rs
@@ -5,8 +5,7 @@ mod error;
 pub mod evm_proof_plan;
 pub mod parse;
 /// [`AnalyzeError`] temporarily exists until we switch to using Datafusion Analyzer to handle type checking.
-/// [`PlaceholderProverError`] handles errors related to placeholders in provers.
-pub use error::{AnalyzeError, AnalyzeResult, PlaceholderProverError, PlaceholderProverResult};
+pub use error::{AnalyzeError, AnalyzeResult};
 pub mod postprocessing;
 pub mod proof;
 pub mod proof_exprs;

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -1,14 +1,11 @@
 use super::{verification_builder::VerificationBuilder, FinalRoundBuilder, FirstRoundBuilder};
-use crate::{
-    base::{
-        database::{
-            ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
-        },
-        map::{IndexMap, IndexSet},
-        proof::ProofError,
-        scalar::Scalar,
+use crate::base::{
+    database::{
+        ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
     },
-    sql::PlaceholderProverResult,
+    map::{IndexMap, IndexSet},
+    proof::{PlaceholderResult, ProofError},
+    scalar::Scalar,
 };
 use alloc::vec::Vec;
 use bumpalo::Bump;
@@ -46,7 +43,7 @@ pub trait ProverEvaluate {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>>;
+    ) -> PlaceholderResult<Table<'a, S>>;
 
     /// Evaluate the query and modify `FinalRoundBuilder` to store an intermediate representation
     /// of the query result and track all the components needed to form the query's proof.
@@ -60,7 +57,7 @@ pub trait ProverEvaluate {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>>;
+    ) -> PlaceholderResult<Table<'a, S>>;
 }
 
 /// Marker used as a trait bound for generic [`ProofPlan`] types to indicate the honesty of their implementation.

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -14,10 +14,9 @@ use crate::{
         map::{IndexMap, IndexSet},
         math::log2_up,
         polynomial::{compute_evaluation_vector, MultilinearExtension},
-        proof::{Keccak256Transcript, ProofError, Transcript},
+        proof::{Keccak256Transcript, PlaceholderResult, ProofError, Transcript},
     },
     proof_primitive::sumcheck::SumcheckProof,
-    sql::PlaceholderProverResult,
     utils::log,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
@@ -101,7 +100,7 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         accessor: &impl DataAccessor<CP::Scalar>,
         setup: &CP::ProverPublicSetup<'_>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<(Self, OwnedTable<CP::Scalar>)> {
+    ) -> PlaceholderResult<(Self, OwnedTable<CP::Scalar>)> {
         log::log_memory_usage("Start");
 
         let (min_row_num, max_row_num) = get_index_range(accessor, &expr.get_table_references());

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -10,14 +10,11 @@ use crate::{
             Table, TableEvaluation, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
-    sql::{
-        proof::{FirstRoundBuilder, QueryData, SumcheckSubpolynomialType},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FirstRoundBuilder, QueryData, SumcheckSubpolynomialType},
 };
 use bumpalo::Bump;
 use serde::Serialize;
@@ -56,7 +53,7 @@ impl ProverEvaluate for TrivialTestProofPlan {
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let col = vec![self.column_fill_value; self.length];
         if self.produce_length {
             builder.produce_chi_evaluation_length(self.length);
@@ -70,7 +67,7 @@ impl ProverEvaluate for TrivialTestProofPlan {
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let col = alloc.alloc_slice_fill_copy(self.length, self.column_fill_value);
         builder.produce_intermediate_mle(col as &[_]);
         builder.produce_sumcheck_subpolynomial(
@@ -274,7 +271,7 @@ impl ProverEvaluate for SquareTestProofPlan {
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         builder.produce_chi_evaluation_length(2);
         Ok(table([borrowed_bigint("a1", self.res, alloc)]))
     }
@@ -285,7 +282,7 @@ impl ProverEvaluate for SquareTestProofPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let x = *table_map
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
@@ -456,7 +453,7 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         builder.produce_chi_evaluation_length(2);
         Ok(table([borrowed_bigint("a1", self.res, alloc)]))
     }
@@ -467,7 +464,7 @@ impl ProverEvaluate for DoubleSquareTestProofPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let x = *table_map
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
@@ -671,7 +668,7 @@ impl ProverEvaluate for ChallengeTestProofPlan {
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         builder.request_post_result_challenges(2);
         builder.produce_chi_evaluation_length(2);
         Ok(table([borrowed_bigint("a1", [9, 25], alloc)]))
@@ -683,7 +680,7 @@ impl ProverEvaluate for ChallengeTestProofPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let x = *table_map
             .get(&TableRef::new("sxt", "test"))
             .unwrap()
@@ -815,7 +812,7 @@ impl ProverEvaluate for FirstRoundSquareTestProofPlan {
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let res: &[_] = alloc.alloc_slice_copy(&self.res);
         builder.produce_intermediate_mle(res);
         builder.produce_chi_evaluation_length(2);
@@ -828,7 +825,7 @@ impl ProverEvaluate for FirstRoundSquareTestProofPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let x = *table_map
             .get(&TableRef::new("sxt", "test"))
             .unwrap()

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result.rs
@@ -3,8 +3,8 @@ use crate::{
     base::{
         commitment::CommitmentEvaluationProof,
         database::{CommitmentAccessor, DataAccessor, LiteralValue, OwnedTable},
+        proof::PlaceholderResult,
     },
-    sql::PlaceholderProverResult,
     utils::log,
 };
 use serde::{Deserialize, Serialize};
@@ -84,7 +84,7 @@ impl<CP: CommitmentEvaluationProof> VerifiableQueryResult<CP> {
         accessor: &impl DataAccessor<CP::Scalar>,
         setup: &CP::ProverPublicSetup<'_>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Self> {
+    ) -> PlaceholderResult<Self> {
         log::log_memory_usage("Start");
         let (proof, res) = QueryProof::new(expr, accessor, setup, params)?;
         log::log_memory_usage("End");

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -11,13 +11,10 @@ use crate::{
             Table, TableEvaluation, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FirstRoundBuilder, QueryData},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FirstRoundBuilder, QueryData},
 };
 use bumpalo::Bump;
 use serde::Serialize;
@@ -34,7 +31,7 @@ impl ProverEvaluate for EmptyTestQueryExpr {
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let zeros = vec![0_i64; self.length];
         builder.produce_chi_evaluation_length(self.length);
         Ok(table_with_row_count(
@@ -50,7 +47,7 @@ impl ProverEvaluate for EmptyTestQueryExpr {
         alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let zeros = vec![0_i64; self.length];
         let res: &[_] = alloc.alloc_slice_copy(&zeros);
         let _ = std::iter::repeat_with(|| builder.produce_intermediate_mle(res))

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_subtract_expr.rs
@@ -5,13 +5,10 @@ use crate::{
             try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FinalRoundBuilder, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
     utils::log,
 };
 use alloc::boxed::Box;
@@ -48,7 +45,7 @@ impl ProofExpr for AddSubtractExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         let lhs_column: Column<'a, S> = self.lhs.first_round_evaluate(alloc, table, params)?;
         let rhs_column: Column<'a, S> = self.rhs.first_round_evaluate(alloc, table, params)?;
         Ok(Column::Scalar(add_subtract_columns(
@@ -72,7 +69,7 @@ impl ProofExpr for AddSubtractExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column: Column<'a, S> = self

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -3,13 +3,10 @@ use crate::{
     base::{
         database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
     utils::log,
 };
 use alloc::{boxed::Box, vec};
@@ -41,7 +38,7 @@ impl ProofExpr for AndExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column: Column<'a, S> = self.lhs.first_round_evaluate(alloc, table, params)?;
@@ -63,7 +60,7 @@ impl ProofExpr for AndExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column: Column<'a, S> = self

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -3,13 +3,10 @@ use crate::{
     base::{
         database::{try_cast_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FinalRoundBuilder, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
 };
 use alloc::boxed::Box;
 use bumpalo::Bump;
@@ -41,7 +38,7 @@ impl ProofExpr for CastExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         let uncasted_result = self.from_expr.first_round_evaluate(alloc, table, params)?;
         Ok(cast_column(alloc, uncasted_result, self.to_type))
     }
@@ -52,7 +49,7 @@ impl ProofExpr for CastExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         let uncasted_result = self
             .from_expr
             .final_round_evaluate(builder, alloc, table, params)?;

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -3,13 +3,10 @@ use crate::{
     base::{
         database::{Column, ColumnField, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FinalRoundBuilder, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
@@ -74,7 +71,7 @@ impl ProofExpr for ColumnExpr {
         _alloc: &'a Bump,
         table: &Table<'a, S>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         Ok(self.fetch_column(table))
     }
 
@@ -86,7 +83,7 @@ impl ProofExpr for ColumnExpr {
         _alloc: &'a Bump,
         table: &Table<'a, S>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         Ok(self.fetch_column(table))
     }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -6,13 +6,13 @@ use crate::{
     base::{
         database::{try_cast_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
         util::type_check_binary_operation,
-        AnalyzeError, AnalyzeResult, PlaceholderProverResult,
+        AnalyzeError, AnalyzeResult,
     },
 };
 use alloc::{boxed::Box, string::ToString};

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -3,14 +3,11 @@ use crate::{
     base::{
         database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
         slice_ops,
     },
-    sql::{
-        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
     utils::log,
 };
 use alloc::{boxed::Box, vec};
@@ -42,7 +39,7 @@ impl ProofExpr for EqualsExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column = self.lhs.first_round_evaluate(alloc, table, params)?;
@@ -69,7 +66,7 @@ impl ProofExpr for EqualsExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column = self

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -3,7 +3,7 @@ use crate::{
     base::{
         database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
@@ -11,7 +11,6 @@ use crate::{
         proof_gadgets::{
             final_round_evaluate_sign, first_round_evaluate_sign, verifier_evaluate_sign,
         },
-        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -49,7 +48,7 @@ impl ProofExpr for InequalityExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column = self.lhs.first_round_evaluate(alloc, table, params)?;
@@ -84,7 +83,7 @@ impl ProofExpr for InequalityExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column = self

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -3,13 +3,10 @@ use crate::{
     base::{
         database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FinalRoundBuilder, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
     utils::log,
 };
 use bumpalo::Bump;
@@ -49,7 +46,7 @@ impl ProofExpr for LiteralExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let res = Column::from_literal_with_length(&self.value, table.num_rows(), alloc);
@@ -66,7 +63,7 @@ impl ProofExpr for LiteralExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let table_length = table.num_rows();

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -3,13 +3,12 @@ use crate::{
     base::{
         database::{try_multiply_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
         proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
         proof_exprs::multiply_columns,
-        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -42,7 +41,7 @@ impl ProofExpr for MultiplyExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         let lhs_column: Column<'a, S> = self.lhs.first_round_evaluate(alloc, table, params)?;
         let rhs_column: Column<'a, S> = self.rhs.first_round_evaluate(alloc, table, params)?;
         let scalars = multiply_columns(&lhs_column, &rhs_column, alloc);
@@ -60,7 +59,7 @@ impl ProofExpr for MultiplyExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column: Column<'a, S> = self

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -3,13 +3,10 @@ use crate::{
     base::{
         database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FinalRoundBuilder, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
     utils::log,
 };
 use alloc::boxed::Box;
@@ -40,7 +37,7 @@ impl ProofExpr for NotExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let expr_column: Column<'a, S> = self.expr.first_round_evaluate(alloc, table, params)?;
@@ -59,7 +56,7 @@ impl ProofExpr for NotExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let expr_column: Column<'a, S> = self

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -3,13 +3,10 @@ use crate::{
     base::{
         database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
     utils::log,
 };
 use alloc::{boxed::Box, vec};
@@ -41,7 +38,7 @@ impl ProofExpr for OrExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column: Column<'a, S> = self.lhs.first_round_evaluate(alloc, table, params)?;
@@ -62,7 +59,7 @@ impl ProofExpr for OrExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>> {
+    ) -> PlaceholderResult<Column<'a, S>> {
         log::log_memory_usage("Start");
 
         let lhs_column: Column<'a, S> = self

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -2,13 +2,10 @@ use crate::{
     base::{
         database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{FinalRoundBuilder, VerificationBuilder},
-        PlaceholderProverResult,
-    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
 };
 use bumpalo::Bump;
 use core::fmt::Debug;
@@ -27,7 +24,7 @@ pub trait ProofExpr: Debug + Send + Sync {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>>;
+    ) -> PlaceholderResult<Column<'a, S>>;
 
     /// Evaluate the expression, add components needed to prove it, and return thet resulting column
     /// of values
@@ -37,7 +34,7 @@ pub trait ProofExpr: Debug + Send + Sync {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Column<'a, S>>;
+    ) -> PlaceholderResult<Column<'a, S>>;
 
     /// Compute the evaluation of a multilinear extension from this expression
     /// at the random sumcheck point and adds components needed to verify the expression to

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -2,13 +2,12 @@ use crate::{
     base::{
         database::{Column, ColumnRef, LiteralValue, Table},
         map::IndexMap,
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
         proof_exprs::{divide_columns, modulo_columns, DynProofExpr, ProofExpr},
-        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -79,7 +78,7 @@ impl DivideAndModuloExpr {
         table: &Table<'a, S>,
         utilities: &U,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<(Column<'a, S>, Column<'a, S>)> {
+    ) -> PlaceholderResult<(Column<'a, S>, Column<'a, S>)> {
         let lhs_column: Column<'a, S> = self
             .lhs
             .final_round_evaluate(builder, alloc, table, params)?;
@@ -104,7 +103,7 @@ impl DivideAndModuloExpr {
         alloc: &'a Bump,
         table: &Table<'a, S>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<(Column<'a, S>, Column<'a, S>)> {
+    ) -> PlaceholderResult<(Column<'a, S>, Column<'a, S>)> {
         log::log_memory_usage("Start");
         let utilities = StandardDivideAndModuloExprUtilities {};
 

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -11,14 +11,11 @@ use crate::{
             ColumnType, LiteralValue, OwnedTable, Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
 };
 use bumpalo::{
@@ -44,7 +41,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
             assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");
@@ -84,7 +81,7 @@ impl ProverEvaluate for MembershipCheckTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
             assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -10,14 +10,11 @@ use crate::{
             TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
 };
 use bumpalo::Bump;
@@ -36,7 +33,7 @@ impl<const STRICT: bool, const ASC: bool> ProverEvaluate for MonotonicTestPlan<S
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // Get the tables from the map using the table reference
         let table: &Table<'a, S> = table_map
             .get(&self.column.table_ref())
@@ -59,7 +56,7 @@ impl<const STRICT: bool, const ASC: bool> ProverEvaluate for MonotonicTestPlan<S
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // Get the table from the map using the table reference
         let table: &Table<'a, S> = table_map
             .get(&self.column.table_ref())

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -8,14 +8,11 @@ use crate::{
             Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
 };
 use bumpalo::{
@@ -40,7 +37,7 @@ impl ProverEvaluate for PermutationCheckTestPlan {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // Get the tables from the map using the table reference
         let source_table: &Table<'a, S> =
             table_map.get(&self.source_table).expect("Table not found");
@@ -56,7 +53,7 @@ impl ProverEvaluate for PermutationCheckTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // Check that the source columns belong to the source table
         for col_ref in &self.source_columns {
             assert_eq!(self.source_table, col_ref.table_ref(), "Table not found");

--- a/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/range_check_test.rs
@@ -9,14 +9,11 @@ use crate::{
             TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
 };
 use bumpalo::Bump;
@@ -101,7 +98,7 @@ impl ProverEvaluate for RangeCheckTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         builder.request_post_result_challenges(1);
         builder.update_range_length(256);
 
@@ -130,7 +127,7 @@ impl ProverEvaluate for RangeCheckTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let table = table_map
             .get(&self.column.table_ref())
             .expect("Table not found");

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
@@ -8,14 +8,11 @@ use crate::{
             TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
 };
 use bumpalo::Bump;
@@ -37,7 +34,7 @@ impl ProverEvaluate for ShiftTestPlan {
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         builder.request_post_result_challenges(2);
         builder.produce_chi_evaluation_length(self.column_length);
         builder.produce_chi_evaluation_length(self.column_length + 1);
@@ -56,7 +53,7 @@ impl ProverEvaluate for ShiftTestPlan {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // Get the table from the map using the table reference
         let source_table: &Table<'a, S> = table_map
             .get(&self.column.table_ref())

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -4,14 +4,11 @@ use crate::{
             ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
 };
 use alloc::vec::Vec;
@@ -63,7 +60,7 @@ impl ProverEvaluate for DemoMockPlan {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // place prover logic you want to test here
 
         Ok(table_map[&self.column.table_ref()].clone())
@@ -75,7 +72,7 @@ impl ProverEvaluate for DemoMockPlan {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         // place prover logic you want to test here
 
         Ok(table_map[&self.column.table_ref()].clone())

--- a/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/dyn_proof_plan.rs
@@ -8,7 +8,7 @@ use crate::{
             ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
@@ -16,7 +16,6 @@ use crate::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, TableExpr},
-        PlaceholderProverResult,
     },
 };
 use alloc::{boxed::Box, vec::Vec};

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -5,14 +5,11 @@ use crate::{
             TableRef,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
     utils::log,
 };
@@ -75,7 +72,7 @@ impl ProverEvaluate for EmptyExec {
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         // Create an empty table with one row
@@ -95,7 +92,7 @@ impl ProverEvaluate for EmptyExec {
         _alloc: &'a Bump,
         _table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         // Create an empty table with one row

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -6,7 +6,7 @@ use crate::{
             Table, TableEvaluation, TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
         slice_ops,
     },
@@ -16,7 +16,6 @@ use crate::{
             ProverHonestyMarker, SumcheckSubpolynomialType, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, DynProofExpr, ProofExpr, TableExpr},
-        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -150,7 +149,7 @@ impl ProverEvaluate for FilterExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let table = table_map
@@ -169,10 +168,10 @@ impl ProverEvaluate for FilterExec {
         let columns: Vec<_> = self
             .aliased_results
             .iter()
-            .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr.expr.first_round_evaluate(alloc, table, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
 
         // Compute filtered_columns and indexes
         let (filtered_columns, _) = filter_columns(alloc, &columns, selection);
@@ -199,7 +198,7 @@ impl ProverEvaluate for FilterExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let table = table_map
@@ -218,12 +217,12 @@ impl ProverEvaluate for FilterExec {
         let columns: Vec<_> = self
             .aliased_results
             .iter()
-            .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr
                     .expr
                     .final_round_evaluate(builder, alloc, table, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         // Compute filtered_columns
         let (filtered_columns, result_len) = filter_columns(alloc, &columns, selection);
         // 3. Produce MLEs

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -6,7 +6,7 @@ use crate::{
             Table, TableOptions, TableRef, TestAccessor,
         },
         map::IndexMap,
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
@@ -18,7 +18,6 @@ use crate::{
             test_utility::{cols_expr_plan, column, const_int128, equal, tab},
             ProofExpr,
         },
-        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -42,7 +41,7 @@ impl ProverEvaluate for DishonestFilterExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let table = table_map
@@ -60,10 +59,10 @@ impl ProverEvaluate for DishonestFilterExec {
         let columns: Vec<_> = self
             .aliased_results
             .iter()
-            .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr.expr.first_round_evaluate(alloc, table, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         // Compute filtered_columns
         let (filtered_columns, _) = filter_columns(alloc, &columns, selection);
         let filtered_columns = tamper_column(alloc, filtered_columns);
@@ -94,7 +93,7 @@ impl ProverEvaluate for DishonestFilterExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let table = table_map
@@ -112,12 +111,12 @@ impl ProverEvaluate for DishonestFilterExec {
         let columns: Vec<_> = self
             .aliased_results
             .iter()
-            .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr
                     .expr
                     .final_round_evaluate(builder, alloc, table, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         // Compute filtered_columns
         let (filtered_columns, result_len) = filter_columns(alloc, &columns, selection);
         let filtered_columns = tamper_column(alloc, filtered_columns);

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -8,7 +8,7 @@ use crate::{
             TableEvaluation, TableRef,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
         slice_ops,
     },
@@ -18,7 +18,6 @@ use crate::{
             SumcheckSubpolynomialType, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, ColumnExpr, DynProofExpr, ProofExpr, TableExpr},
-        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -199,7 +198,7 @@ impl ProverEvaluate for GroupByExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let table = table_map
@@ -218,17 +217,17 @@ impl ProverEvaluate for GroupByExec {
         let group_by_columns = self
             .group_by_exprs
             .iter()
-            .map(|expr| -> PlaceholderProverResult<Column<'a, S>> {
+            .map(|expr| -> PlaceholderResult<Column<'a, S>> {
                 expr.first_round_evaluate(alloc, table, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         let sum_columns = self
             .sum_expr
             .iter()
-            .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr.expr.first_round_evaluate(alloc, table, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         // Compute filtered_columns
         let AggregatedColumns {
             group_by_columns: group_by_result_columns,
@@ -265,7 +264,7 @@ impl ProverEvaluate for GroupByExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let table = table_map
@@ -283,19 +282,19 @@ impl ProverEvaluate for GroupByExec {
         let group_by_columns = self
             .group_by_exprs
             .iter()
-            .map(|expr| -> PlaceholderProverResult<Column<'a, S>> {
+            .map(|expr| -> PlaceholderResult<Column<'a, S>> {
                 expr.final_round_evaluate(builder, alloc, table, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         let sum_columns = self
             .sum_expr
             .iter()
-            .map(|aliased_expr| -> PlaceholderProverResult<Column<'a, S>> {
+            .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr
                     .expr
                     .final_round_evaluate(builder, alloc, table, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         // 3. Compute filtered_columns
         let AggregatedColumns {
             group_by_columns: group_by_result_columns,

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -6,7 +6,7 @@ use crate::{
             TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
@@ -14,7 +14,6 @@ use crate::{
             FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
         },
         proof_exprs::{AliasedDynProofExpr, ProofExpr},
-        PlaceholderProverResult,
     },
     utils::log,
 };
@@ -131,7 +130,7 @@ impl ProverEvaluate for ProjectionExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let input = self
@@ -142,7 +141,7 @@ impl ProverEvaluate for ProjectionExec {
             .aliased_results
             .iter()
             .map(
-                |aliased_expr| -> PlaceholderProverResult<(Ident, Column<'a, S>)> {
+                |aliased_expr| -> PlaceholderResult<(Ident, Column<'a, S>)> {
                     Ok((
                         aliased_expr.alias.clone(),
                         aliased_expr
@@ -151,7 +150,7 @@ impl ProverEvaluate for ProjectionExec {
                     ))
                 },
             )
-            .collect::<PlaceholderProverResult<IndexMap<_, _>>>()?;
+            .collect::<PlaceholderResult<IndexMap<_, _>>>()?;
 
         let res =
             Table::<'a, S>::try_new_with_options(cols, TableOptions::new(Some(input.num_rows())))
@@ -173,7 +172,7 @@ impl ProverEvaluate for ProjectionExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let input = self
@@ -185,7 +184,7 @@ impl ProverEvaluate for ProjectionExec {
             .aliased_results
             .iter()
             .map(
-                |aliased_expr| -> PlaceholderProverResult<(Ident, Column<'a, S>)> {
+                |aliased_expr| -> PlaceholderResult<(Ident, Column<'a, S>)> {
                     Ok((
                         aliased_expr.alias.clone(),
                         aliased_expr
@@ -194,7 +193,7 @@ impl ProverEvaluate for ProjectionExec {
                     ))
                 },
             )
-            .collect::<PlaceholderProverResult<IndexMap<_, _>>>()?;
+            .collect::<PlaceholderResult<IndexMap<_, _>>>()?;
 
         let res =
             Table::<'a, S>::try_new_with_options(cols, TableOptions::new(Some(input.num_rows())))

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -9,14 +9,11 @@ use crate::{
             TableEvaluation, TableOptions, TableRef,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
     utils::log,
 };
@@ -119,7 +116,7 @@ impl ProverEvaluate for SliceExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         // 1. columns
@@ -165,7 +162,7 @@ impl ProverEvaluate for SliceExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         // 1. columns

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -11,7 +11,7 @@ use crate::{
             TableRef,
         },
         map::{IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
     sql::{
@@ -24,7 +24,6 @@ use crate::{
             first_round_evaluate_membership_check, first_round_evaluate_monotonic,
             verify_membership_check, verify_monotonic,
         },
-        PlaceholderProverResult,
     },
 };
 use alloc::{boxed::Box, vec, vec::Vec};
@@ -319,7 +318,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let left = self
             .left
             .first_round_evaluate(builder, alloc, table_map, params)?;
@@ -437,7 +436,7 @@ impl ProverEvaluate for SortMergeJoinExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let left = self
             .left
             .final_round_evaluate(builder, alloc, table_map, params)?;

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -4,14 +4,11 @@ use crate::{
             ColumnField, ColumnRef, LiteralValue, OwnedTable, Table, TableEvaluation, TableRef,
         },
         map::{indexset, IndexMap, IndexSet},
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, VerificationBuilder,
     },
     utils::log,
 };
@@ -87,7 +84,7 @@ impl ProverEvaluate for TableExec {
         _alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let first_round_table = table_map
@@ -108,7 +105,7 @@ impl ProverEvaluate for TableExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         _params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         log::log_memory_usage("Start");
 
         let final_round_table = table_map

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -7,16 +7,13 @@ use crate::{
         },
         map::{IndexMap, IndexSet},
         polynomial::MultilinearExtension,
-        proof::ProofError,
+        proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
         slice_ops,
     },
-    sql::{
-        proof::{
-            FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate,
-            SumcheckSubpolynomialType, VerificationBuilder,
-        },
-        PlaceholderProverResult,
+    sql::proof::{
+        FinalRoundBuilder, FirstRoundBuilder, ProofPlan, ProverEvaluate, SumcheckSubpolynomialType,
+        VerificationBuilder,
     },
 };
 use alloc::{boxed::Box, vec, vec::Vec};
@@ -117,14 +114,14 @@ impl ProverEvaluate for UnionExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let inputs = self
             .inputs
             .iter()
-            .map(|input| -> PlaceholderProverResult<Table<'a, S>> {
+            .map(|input| -> PlaceholderResult<Table<'a, S>> {
                 input.first_round_evaluate(builder, alloc, table_map, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         let res = table_union(&inputs, alloc, self.schema.clone()).expect("Failed to union tables");
         builder.request_post_result_challenges(2);
         builder.produce_chi_evaluation_length(res.num_rows());
@@ -138,14 +135,14 @@ impl ProverEvaluate for UnionExec {
         alloc: &'a Bump,
         table_map: &IndexMap<TableRef, Table<'a, S>>,
         params: &[LiteralValue],
-    ) -> PlaceholderProverResult<Table<'a, S>> {
+    ) -> PlaceholderResult<Table<'a, S>> {
         let inputs = self
             .inputs
             .iter()
-            .map(|input| -> PlaceholderProverResult<Table<'a, S>> {
+            .map(|input| -> PlaceholderResult<Table<'a, S>> {
                 input.final_round_evaluate(builder, alloc, table_map, params)
             })
-            .collect::<PlaceholderProverResult<Vec<_>>>()?;
+            .collect::<PlaceholderResult<Vec<_>>>()?;
         let input_lengths = inputs.iter().map(Table::num_rows).collect::<Vec<_>>();
         let res = table_union(&inputs, alloc, self.schema.clone()).expect("Failed to union tables");
         let gamma = builder.consume_post_result_challenge();


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Since the verifier can also have placeholder-related errors as easily as the prover let's move the error to `base::proof::error` and add it as a variant of `ProofError` to prevent dependency of `base` on `sql`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- move `PlaceholderProverError` to `base::proof::error`
- rename it to `PlaceholderError`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.