### PR TITLE
feat: add `PlaceholderExpr`

### DIFF
--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -1,3 +1,4 @@
+use crate::base::database::ColumnType;
 use snafu::Snafu;
 
 #[derive(Snafu, Debug)]
@@ -20,6 +21,8 @@ pub enum ProofError {
     FieldCountMismatch,
     #[snafu(transparent)]
     ProofSizeMismatch { source: ProofSizeMismatch },
+    #[snafu(transparent)]
+    PlaceholderError { source: PlaceholderError },
 }
 
 #[derive(Snafu, Debug)]
@@ -59,7 +62,27 @@ pub enum ProofSizeMismatch {
 
 /// Errors related to placeholders
 #[derive(Snafu, Debug, PartialEq, Eq)]
-pub enum PlaceholderError {}
+pub enum PlaceholderError {
+    #[snafu(display("Invalid placeholder id: {id}, number of params: {num_params}"))]
+    /// Placeholder id is invalid
+    InvalidPlaceholderId {
+        /// The invalid placeholder id
+        id: usize,
+        /// The number of parameters
+        num_params: usize,
+    },
+
+    #[snafu(display("Invalid placeholder type: {id}, expected: {expected}, actual: {actual}"))]
+    /// Placeholder type is invalid
+    InvalidPlaceholderType {
+        /// The invalid placeholder id
+        id: usize,
+        /// The expected type
+        expected: ColumnType,
+        /// The actual type
+        actual: ColumnType,
+    },
+}
 
 /// Result type for placeholder errors
 pub type PlaceholderResult<T> = Result<T, PlaceholderError>;

--- a/crates/proof-of-sql/src/base/proof/mod.rs
+++ b/crates/proof-of-sql/src/base/proof/mod.rs
@@ -1,7 +1,6 @@
 //! Contains the transcript protocol used to construct a proof,
 //! as well as an error type which can occur when verification fails.
 mod error;
-#[expect(unused_imports)]
 pub use error::{PlaceholderError, PlaceholderResult, ProofError, ProofSizeMismatch};
 
 /// Contains an extension trait for `merlin::Transcript`, which is used to construct a proof.

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -1,6 +1,6 @@
 use super::{
     cast_expr::CastExpr, AddSubtractExpr, AndExpr, ColumnExpr, EqualsExpr, InequalityExpr,
-    LiteralExpr, MultiplyExpr, NotExpr, OrExpr, ProofExpr,
+    LiteralExpr, MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr,
 };
 use crate::{
     base::{
@@ -35,6 +35,8 @@ pub enum DynProofExpr {
     Not(NotExpr),
     /// Provable CONST expression
     Literal(LiteralExpr),
+    /// Provable placeholder expression
+    Placeholder(PlaceholderExpr),
     /// Provable AST expression for an equals expression
     Equals(EqualsExpr),
     /// Provable AST expression for an inequality expression
@@ -73,6 +75,11 @@ impl DynProofExpr {
     #[must_use]
     pub fn new_literal(value: LiteralValue) -> Self {
         Self::Literal(LiteralExpr::new(value))
+    }
+    /// Create placeholder expression
+    #[must_use]
+    pub fn new_placeholder(id: usize, column_type: ColumnType) -> Self {
+        Self::Placeholder(PlaceholderExpr::new(id, column_type))
     }
     /// Create a new equals expression
     pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -25,6 +25,11 @@ pub(crate) use literal_expr::LiteralExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod literal_expr_test;
 
+mod placeholder_expr;
+pub(crate) use placeholder_expr::PlaceholderExpr;
+#[cfg(all(test, feature = "blitzar"))]
+mod placeholder_expr_test;
+
 mod and_expr;
 pub(crate) use and_expr::AndExpr;
 #[cfg(all(test, feature = "blitzar"))]

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
@@ -1,0 +1,163 @@
+use super::ProofExpr;
+use crate::{
+    base::{
+        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        map::{IndexMap, IndexSet},
+        proof::{PlaceholderError, PlaceholderResult, ProofError},
+        scalar::Scalar,
+    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    utils::log,
+};
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+/// Provable placeholder expression
+///
+/// This node allows us to easily represent queries like
+///    select $0, $1 from T
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlaceholderExpr {
+    pub(crate) id: usize,
+    pub(crate) column_type: ColumnType,
+}
+
+impl PlaceholderExpr {
+    /// Creates a new `PlaceholderExpr`
+    pub fn new(id: usize, column_type: ColumnType) -> Self {
+        Self { id, column_type }
+    }
+
+    /// Replace the placeholder with the correct value in `params`
+    ///
+    /// Note that this function will return an error if
+    /// 1. The placeholder id is out of bounds
+    /// 2. The placeholder type does not match the type of the value in `params`
+    fn interpolate<'a>(
+        &self,
+        params: &'a [LiteralValue],
+    ) -> Result<&'a LiteralValue, PlaceholderError> {
+        if self.id >= params.len() {
+            return Err(PlaceholderError::InvalidPlaceholderId {
+                id: self.id,
+                num_params: params.len(),
+            });
+        }
+        let param_value = &params[self.id];
+        if param_value.column_type() != self.column_type {
+            return Err(PlaceholderError::InvalidPlaceholderType {
+                id: self.id,
+                expected: self.column_type,
+                actual: params[self.id].column_type(),
+            });
+        }
+        Ok(param_value)
+    }
+}
+
+impl ProofExpr for PlaceholderExpr {
+    fn data_type(&self) -> ColumnType {
+        self.column_type
+    }
+
+    #[tracing::instrument(
+        name = "PlaceholderExpr::first_round_evaluate",
+        level = "debug",
+        skip_all
+    )]
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        log::log_memory_usage("Start");
+
+        let param_value = self.interpolate(params)?;
+        let res = Column::from_literal_with_length(param_value, table.num_rows(), alloc);
+
+        log::log_memory_usage("End");
+
+        Ok(res)
+    }
+
+    #[tracing::instrument(
+        name = "PlaceholderExpr::final_round_evaluate",
+        level = "debug",
+        skip_all
+    )]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        _builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        log::log_memory_usage("Start");
+
+        let param_value = self.interpolate(params)?;
+        let res = Column::from_literal_with_length(param_value, table.num_rows(), alloc);
+
+        log::log_memory_usage("End");
+
+        Ok(res)
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        _builder: &mut impl VerificationBuilder<S>,
+        _accessor: &IndexMap<ColumnRef, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        let param_value = self.interpolate(params)?;
+        Ok(chi_eval * param_value.to_scalar::<S>())
+    }
+
+    fn get_column_references(&self, _columns: &mut IndexSet<ColumnRef>) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // interpolate
+    #[test]
+    fn we_cannot_interpolate_placeholder_if_id_is_out_of_bounds() {
+        // Empty params
+        let placeholder_expr = PlaceholderExpr::new(0, ColumnType::Boolean);
+        let params = vec![];
+        let res = placeholder_expr.interpolate(&params);
+        assert!(matches!(
+            res,
+            Err(PlaceholderError::InvalidPlaceholderId { .. })
+        ));
+
+        // Params exist but not enough of them
+        let placeholder_expr = PlaceholderExpr::new(2, ColumnType::Boolean);
+        let params = vec![LiteralValue::Boolean(true), LiteralValue::Boolean(false)];
+        let res = placeholder_expr.interpolate(&params);
+        assert!(matches!(
+            res,
+            Err(PlaceholderError::InvalidPlaceholderId { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_interpolate_placeholder_if_types_do_not_match() {
+        let placeholder_expr = PlaceholderExpr::new(0, ColumnType::Boolean);
+        let params = vec![LiteralValue::BigInt(123)];
+        let res = placeholder_expr.interpolate(&params);
+        assert!(matches!(
+            res,
+            Err(PlaceholderError::InvalidPlaceholderType { .. })
+        ));
+    }
+
+    #[test]
+    fn we_can_interpolate_placeholder_if_id_is_in_bounds_and_types_match() {
+        let placeholder_expr = PlaceholderExpr::new(0, ColumnType::Boolean);
+        let params = vec![LiteralValue::Boolean(true)];
+        let res = placeholder_expr.interpolate(&params);
+        assert_eq!(res.unwrap(), &LiteralValue::Boolean(true));
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
@@ -1,0 +1,294 @@
+use super::{DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        commitment::InnerProductProof,
+        database::{
+            owned_table_utility::*, table_utility::*, Column, ColumnType, LiteralValue,
+            OwnedTableTestAccessor, Table, TableRef, TableTestAccessor,
+        },
+        proof::{PlaceholderError, ProofError},
+    },
+    proof_primitive::inner_product::curve_25519_scalar::Curve25519Scalar,
+    sql::{
+        proof::{QueryError, VerifiableQueryResult},
+        proof_exprs::test_utility::*,
+        proof_plans::test_utility::*,
+    },
+};
+use bumpalo::Bump;
+use rand::{
+    distributions::{Distribution, Uniform},
+    rngs::StdRng,
+};
+use rand_core::SeedableRng;
+
+fn test_random_tables_with_given_offset(offset: usize) {
+    let dist = Uniform::new(-3, 4);
+    let mut rng = StdRng::from_seed([0u8; 32]);
+    for _ in 0..20 {
+        // Generate random table
+        let n = Uniform::new(1, 21).sample(&mut rng);
+        let data = owned_table([
+            boolean("a", dist.sample_iter(&mut rng).take(n).map(|v| v < 0)),
+            varchar(
+                "b",
+                dist.sample_iter(&mut rng).take(n).map(|v| format!("s{v}")),
+            ),
+            bigint("c", dist.sample_iter(&mut rng).take(n)),
+        ]);
+
+        // Generate random values to filter by
+        let random_bigint = dist.sample(&mut rng);
+        let random_bigint_literal = LiteralValue::BigInt(random_bigint);
+        let random_varchar = format!("s{}", dist.sample(&mut rng));
+        let random_varchar_literal = LiteralValue::VarChar(random_varchar.clone());
+
+        // Create and verify proof
+        let t = TableRef::new("sxt", "t");
+        let accessor = OwnedTableTestAccessor::<InnerProductProof>::new_from_table(
+            t.clone(),
+            data.clone(),
+            offset,
+            (),
+        );
+        let ast = filter(
+            vec![
+                col_expr_plan(&t, "a", &accessor),
+                col_expr_plan(&t, "b", &accessor),
+                col_expr_plan(&t, "c", &accessor),
+                aliased_placeholder(0, ColumnType::BigInt, "p0"),
+                aliased_placeholder(1, ColumnType::VarChar, "p1"),
+            ],
+            tab(&t),
+            const_bool(true),
+        );
+        let params = vec![random_bigint_literal, random_varchar_literal];
+        let verifiable_res =
+            VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &params).unwrap();
+        let res = verifiable_res
+            .verify(&ast, &accessor, &(), &params)
+            .unwrap()
+            .table;
+
+        // Calculate/compare expected result
+        let expected_a: Vec<bool> = data["a"].bool_iter().copied().collect();
+        let expected_b: Vec<String> = data["b"].string_iter().cloned().collect();
+        let expected_c: Vec<i64> = data["c"].i64_iter().copied().collect();
+        let expected_p0: Vec<i64> = vec![random_bigint; n];
+        let expected_p1: Vec<String> = vec![random_varchar.clone(); n];
+        let expected_result = owned_table([
+            boolean("a", expected_a),
+            varchar("b", expected_b),
+            bigint("c", expected_c),
+            bigint("p0", expected_p0),
+            varchar("p1", expected_p1),
+        ]);
+
+        assert_eq!(expected_result, res);
+    }
+}
+
+#[test]
+fn we_can_query_random_tables_using_a_zero_offset() {
+    test_random_tables_with_given_offset(0);
+}
+
+#[test]
+fn we_can_query_random_tables_using_a_non_zero_offset() {
+    test_random_tables_with_given_offset(5121);
+}
+
+#[test]
+fn we_can_prove_a_query_with_a_single_selected_row() {
+    let data = owned_table([bigint("a", [123_i64])]);
+    let expected_res = owned_table([boolean("p0", [true])]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = filter(
+        vec![aliased_placeholder(0, ColumnType::Boolean, "p0")],
+        tab(&t),
+        const_bool(true),
+    );
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+        &ast,
+        &accessor,
+        &(),
+        &[LiteralValue::Boolean(true)],
+    )
+    .unwrap();
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[LiteralValue::Boolean(true)])
+        .unwrap()
+        .table;
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_a_query_with_a_single_non_selected_row() {
+    let data = owned_table([bigint("a", [123_i64])]);
+    let expected_res = owned_table([boolean("p0", [true; 0])]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = filter(
+        vec![aliased_placeholder(0, ColumnType::Boolean, "p0")],
+        tab(&t),
+        const_bool(false),
+    );
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+        &ast,
+        &accessor,
+        &(),
+        &[LiteralValue::Boolean(true)],
+    )
+    .unwrap();
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[LiteralValue::Boolean(true)])
+        .unwrap()
+        .table;
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_compute_the_correct_output_of_a_placeholder_expr_using_first_round_evaluate() {
+    let alloc = Bump::new();
+    let data: Table<Curve25519Scalar> =
+        table([borrowed_bigint("a", [123_i64, 456, 789, 1011], &alloc)]);
+    let placeholder_expr: DynProofExpr = DynProofExpr::new_placeholder(0, ColumnType::BigInt);
+    let res = placeholder_expr
+        .first_round_evaluate(&alloc, &data, &[LiteralValue::BigInt(504_i64)])
+        .unwrap();
+    let expected_res = Column::BigInt(&[504, 504, 504, 504]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_cannot_prove_placeholder_expr_if_interpolate_fails() {
+    let alloc = Bump::new();
+    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
+    let t = TableRef::new("sxt", "t");
+    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = filter(
+        vec![aliased_placeholder(0, ColumnType::Boolean, "p0")],
+        tab(&t),
+        const_bool(true),
+    );
+    assert!(matches!(
+        VerifiableQueryResult::<InnerProductProof>::new(&ast, &accessor, &(), &[],),
+        Err(PlaceholderError::InvalidPlaceholderId { .. })
+    ));
+}
+
+#[test]
+fn we_cannot_verify_placeholder_expr_if_interpolate_fails() {
+    let alloc = Bump::new();
+    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64], &alloc)]);
+    let t = TableRef::new("sxt", "t");
+    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = filter(
+        vec![aliased_placeholder(0, ColumnType::Boolean, "p0")],
+        tab(&t),
+        const_bool(true),
+    );
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+        &ast,
+        &accessor,
+        &(),
+        &[LiteralValue::Boolean(true)],
+    )
+    .unwrap();
+    assert!(matches!(
+        verifiable_res.verify(&ast, &accessor, &(), &[]),
+        Err(QueryError::ProofError {
+            source: ProofError::PlaceholderError { .. }
+        })
+    ));
+}
+
+#[test]
+fn we_can_verify_placeholder_expr_if_and_only_if_prover_and_verifier_have_the_same_valid_params() {
+    let alloc = Bump::new();
+    let data: Table<Curve25519Scalar> = table([borrowed_bigint("a", [123_i64, 456], &alloc)]);
+    let t = TableRef::new("sxt", "t");
+    let accessor = TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = filter(
+        vec![
+            col_expr_plan(&t, "a", &accessor),
+            aliased_placeholder(0, ColumnType::BigInt, "p0"),
+            aliased_placeholder(1, ColumnType::VarChar, "p1"),
+        ],
+        tab(&t),
+        const_bool(true),
+    );
+    let verifiable_res = VerifiableQueryResult::<InnerProductProof>::new(
+        &ast,
+        &accessor,
+        &(),
+        &[
+            LiteralValue::BigInt(504_i64),
+            LiteralValue::VarChar("abc".to_string()),
+        ],
+    )
+    .unwrap();
+
+    // Try some wrong values
+    assert!(matches!(
+        verifiable_res.clone().verify(
+            &ast,
+            &accessor,
+            &(),
+            &[
+                LiteralValue::BigInt(503_i64),
+                LiteralValue::VarChar("abc".to_string())
+            ]
+        ),
+        Err(QueryError::ProofError { .. })
+    ));
+
+    assert!(matches!(
+        verifiable_res.clone().verify(
+            &ast,
+            &accessor,
+            &(),
+            &[
+                LiteralValue::BigInt(504_i64),
+                LiteralValue::VarChar("abcd".to_string())
+            ]
+        ),
+        Err(QueryError::ProofError { .. })
+    ));
+
+    assert!(matches!(
+        verifiable_res.clone().verify(
+            &ast,
+            &accessor,
+            &(),
+            &[
+                LiteralValue::BigInt(503_i64),
+                LiteralValue::VarChar("abcd".to_string())
+            ]
+        ),
+        Err(QueryError::ProofError { .. })
+    ));
+
+    // Now try the correct values
+    let res = verifiable_res
+        .verify(
+            &ast,
+            &accessor,
+            &(),
+            &[
+                LiteralValue::BigInt(504_i64),
+                LiteralValue::VarChar("abc".to_string()),
+            ],
+        )
+        .unwrap()
+        .table;
+    let expected_res = owned_table([
+        bigint("a", [123_i64, 456]),
+        bigint("p0", [504_i64, 504]),
+        varchar("p1", ["abc", "abc"]),
+    ]);
+    assert_eq!(res, expected_res);
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr_test.rs
@@ -1,4 +1,4 @@
-use super::{DynProofExpr, ProofExpr};
+use super::{DynProofExpr, PlaceholderExpr, ProofExpr};
 use crate::{
     base::{
         commitment::InnerProductProof,
@@ -21,6 +21,13 @@ use rand::{
     rngs::StdRng,
 };
 use rand_core::SeedableRng;
+
+#[test]
+fn we_can_get_id_and_type_of_placeholder_expr() {
+    let expr = PlaceholderExpr::new(0, ColumnType::Boolean);
+    assert_eq!(expr.data_type(), ColumnType::Boolean);
+    assert_eq!(expr.id(), 0);
+}
 
 fn test_random_tables_with_given_offset(offset: usize) {
     let dist = Uniform::new(-3, 4);

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -133,6 +133,14 @@ pub fn const_decimal75<T: Into<I256>>(precision: u8, scale: i8, val: T) -> DynPr
     ))
 }
 
+/// Aliased placeholder expression
+pub fn aliased_placeholder(index: usize, col_type: ColumnType, alias: &str) -> AliasedDynProofExpr {
+    AliasedDynProofExpr {
+        expr: DynProofExpr::new_placeholder(index, col_type),
+        alias: alias.into(),
+    }
+}
+
 pub fn tab(tab: &TableRef) -> TableExpr {
     TableExpr {
         table_ref: tab.clone(),


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Now we can add `PlaceholderExpr`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add variants to `PlaceholderError`
- add `PlaceholderExpr`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.