### PR TITLE
feat!: ban $0 && add placeholders to the planner

### DIFF
--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -1,7 +1,10 @@
 use arrow::datatypes::DataType;
 use datafusion::{
     common::DataFusionError,
-    logical_expr::{expr::AggregateFunction, Expr, LogicalPlan, Operator},
+    logical_expr::{
+        expr::{AggregateFunction, Placeholder},
+        Expr, LogicalPlan, Operator,
+    },
     physical_plan,
 };
 use proof_of_sql::{base::math::decimal::DecimalError, sql::AnalyzeError};
@@ -40,6 +43,18 @@ pub enum PlannerError {
     TableNotFound {
         /// Table name
         table_name: String,
+    },
+    /// Returned when a placeholder id is invalid
+    #[snafu(display("Placeholder id {id:?} is invalid"))]
+    InvalidPlaceholderId {
+        /// Unsupported placeholder id
+        id: String,
+    },
+    /// Returned when a placeholder is untyped
+    #[snafu(display("Placeholder {placeholder:?} is untyped"))]
+    UntypedPlaceholder {
+        /// Untyped placeholder
+        placeholder: Placeholder,
     },
     /// Returned when a datatype is not supported
     #[snafu(display("Unsupported datatype: {}", data_type))]

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -1,7 +1,13 @@
-use super::{column_to_column_ref, scalar_value_to_literal_value, PlannerError, PlannerResult};
+use super::{
+    column_to_column_ref, placeholder_to_placeholder_expr, scalar_value_to_literal_value,
+    PlannerError, PlannerResult,
+};
 use datafusion::{
     common::DFSchema,
-    logical_expr::{expr::Alias, BinaryExpr, Expr, Operator},
+    logical_expr::{
+        expr::{Alias, Unnest},
+        BinaryExpr, Expr, Operator,
+    },
 };
 use proof_of_sql::sql::proof_exprs::DynProofExpr;
 
@@ -13,6 +19,7 @@ pub fn expr_to_proof_expr(expr: &Expr, schema: &DFSchema) -> PlannerResult<DynPr
     match expr {
         Expr::Alias(Alias { expr, .. }) => expr_to_proof_expr(expr, schema),
         Expr::Column(col) => Ok(DynProofExpr::new_column(column_to_column_ref(col, schema)?)),
+        Expr::Placeholder(placeholder) => placeholder_to_placeholder_expr(placeholder),
         Expr::BinaryExpr(BinaryExpr { left, right, op }) => {
             let left_proof_expr = expr_to_proof_expr(left, schema)?;
             let right_proof_expr = expr_to_proof_expr(right, schema)?;
@@ -324,20 +331,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn we_cannot_convert_unsupported_logical_expr_to_proof_expr() {
-        // Unsupported logical expression
-        let expr = Expr::Placeholder(Placeholder {
-            id: "$1".to_string(),
-            data_type: None,
-        });
-        let schema = df_schema("namespace.table_name", vec![]);
-        assert!(matches!(
-            expr_to_proof_expr(&expr, &schema),
-            Err(PlannerError::UnsupportedLogicalExpression { .. })
-        ));
-    }
-
+    // Cast
     #[test]
     fn we_can_convert_cast_expr_to_proof_expr() {
         // Unsupported logical expression
@@ -400,6 +394,32 @@ mod tests {
         assert!(matches!(
             expression,
             PlannerError::AnalyzeError { source: _ }
+        ));
+    }
+
+    // Placeholder
+    #[test]
+    fn we_can_convert_placeholder_to_proof_expr() {
+        let expr = Expr::Placeholder(Placeholder {
+            id: "$1".to_string(),
+            data_type: Some(DataType::Int32),
+        });
+        let schema = df_schema("namespace.table_name", vec![]);
+        let expression = expr_to_proof_expr(&expr, &schema).unwrap();
+        assert_eq!(
+            expression,
+            DynProofExpr::try_new_placeholder(1, ColumnType::Int).unwrap()
+        );
+    }
+
+    // Unsupported logical expression
+    #[test]
+    fn we_cannot_convert_unsupported_expr_to_proof_expr() {
+        let expr = Expr::Unnest(Unnest::new(Expr::Literal(ScalarValue::Int32(Some(100)))));
+        let schema = df_schema("namespace.table_name", vec![]);
+        assert!(matches!(
+            expr_to_proof_expr(&expr, &schema),
+            Err(PlannerError::UnsupportedLogicalExpression { .. })
         ));
     }
 }

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -4,10 +4,7 @@ use super::{
 };
 use datafusion::{
     common::DFSchema,
-    logical_expr::{
-        expr::{Alias, Unnest},
-        BinaryExpr, Expr, Operator,
-    },
+    logical_expr::{expr::Alias, BinaryExpr, Expr, Operator},
 };
 use proof_of_sql::sql::proof_exprs::DynProofExpr;
 
@@ -91,7 +88,10 @@ mod tests {
     use arrow::datatypes::DataType;
     use datafusion::{
         common::ScalarValue,
-        logical_expr::{expr::Placeholder, Cast},
+        logical_expr::{
+            expr::{Placeholder, Unnest},
+            Cast,
+        },
     };
     use proof_of_sql::base::database::{ColumnRef, ColumnType, LiteralValue, TableRef};
 

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -26,6 +26,6 @@ pub use proof_plan_with_postprocessing::{
 mod util;
 pub use util::column_fields_to_schema;
 pub(crate) use util::{
-    column_to_column_ref, df_schema_to_column_fields, scalar_value_to_literal_value,
-    table_reference_to_table_ref,
+    column_to_column_ref, df_schema_to_column_fields, placeholder_to_placeholder_expr,
+    scalar_value_to_literal_value, table_reference_to_table_ref,
 };

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -18,12 +18,8 @@ use sqlparser::ast::Ident;
 /// Parse a placeholder string of the form "$1", "$2", etc. into a `usize`.
 fn parse_placeholder_id(s: &str) -> Option<usize> {
     s.strip_prefix('$')
-        // Must not be empty
-        .filter(|digits| !digits.is_empty())
         // Must be all digits
-        .filter(|digits| digits.chars().all(|c| c.is_ascii_digit()))
-        // Disallow leading zero
-        .filter(|digits| !digits.starts_with('0'))
+        .filter(|digits| digits.chars().all(|c| c.is_ascii_digit()) && !digits.starts_with('0'))
         // Finally, parse
         .and_then(|digits| digits.parse().ok())
 }
@@ -181,6 +177,8 @@ mod tests {
 
     #[test]
     fn we_cannot_parse_placeholder_id_without_dollar_sign() {
+        // "" => None
+        assert_eq!(parse_placeholder_id(""), None);
         // "1" => None
         assert_eq!(parse_placeholder_id("1"), None);
     }

--- a/crates/proof-of-sql-planner/src/util.rs
+++ b/crates/proof-of-sql-planner/src/util.rs
@@ -3,13 +3,51 @@ use arrow::datatypes::{Field, Schema};
 use datafusion::{
     catalog::TableReference,
     common::{Column, DFSchema, ScalarValue},
+    logical_expr::expr::Placeholder,
 };
-use proof_of_sql::base::{
-    database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
-    math::decimal::Precision,
-    posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+use proof_of_sql::{
+    base::{
+        database::{ColumnField, ColumnRef, ColumnType, LiteralValue, TableRef},
+        math::decimal::Precision,
+        posql_time::{PoSQLTimeUnit, PoSQLTimeZone},
+    },
+    sql::proof_exprs::DynProofExpr,
 };
 use sqlparser::ast::Ident;
+
+/// Parse a placeholder string of the form "$1", "$2", etc. into a `usize`.
+fn parse_placeholder_id(s: &str) -> Option<usize> {
+    s.strip_prefix('$')
+        // Must not be empty
+        .filter(|digits| !digits.is_empty())
+        // Must be all digits
+        .filter(|digits| digits.chars().all(|c| c.is_ascii_digit()))
+        // Disallow leading zero
+        .filter(|digits| !digits.starts_with('0'))
+        // Finally, parse
+        .and_then(|digits| digits.parse().ok())
+}
+
+/// Convert a datafusion [`Placeholder`] to a Proof of SQL [`PlaceholderExpr`]
+#[expect(clippy::missing_panics_doc, reason = "can not actually panic")]
+pub(crate) fn placeholder_to_placeholder_expr(
+    placeholder: &Placeholder,
+) -> PlannerResult<DynProofExpr> {
+    let df_id = placeholder.id.clone();
+    let df_type = placeholder.data_type.clone();
+    let posql_id = parse_placeholder_id(&df_id)
+        .ok_or_else(|| PlannerError::InvalidPlaceholderId { id: df_id.clone() })?;
+    let posql_type = df_type
+        .clone()
+        .ok_or(PlannerError::UntypedPlaceholder {
+            placeholder: placeholder.clone(),
+        })?
+        .try_into()
+        .map_err(|_| PlannerError::UnsupportedDataType {
+            data_type: df_type.clone().unwrap(),
+        })?;
+    Ok(DynProofExpr::try_new_placeholder(posql_id, posql_type)?)
+}
 
 /// Convert a [`TableReference`] to a [`TableRef`]
 ///
@@ -131,6 +169,80 @@ pub(crate) fn df_schema_to_column_fields(schema: &DFSchema) -> PlannerResult<Vec
 mod tests {
     use super::*;
     use arrow::datatypes::DataType;
+
+    // parse_placeholder_id
+    #[test]
+    fn we_can_parse_valid_placeholder_id() {
+        // "$1" => Some(1)
+        assert_eq!(parse_placeholder_id("$1"), Some(1));
+        // "$123" => Some(123)
+        assert_eq!(parse_placeholder_id("$123"), Some(123));
+    }
+
+    #[test]
+    fn we_cannot_parse_placeholder_id_without_dollar_sign() {
+        // "1" => None
+        assert_eq!(parse_placeholder_id("1"), None);
+    }
+
+    #[test]
+    fn we_cannot_parse_placeholder_id_empty_after_dollar_sign() {
+        // "$" => None
+        assert_eq!(parse_placeholder_id("$"), None);
+    }
+
+    #[test]
+    fn we_cannot_parse_placeholder_id_with_non_digits() {
+        // "$abc" => None
+        assert_eq!(parse_placeholder_id("$abc"), None);
+        // "$1x" => None
+        assert_eq!(parse_placeholder_id("$1x"), None);
+    }
+
+    #[test]
+    fn we_cannot_parse_placeholder_id_with_leading_zero() {
+        // "$0" => None
+        assert_eq!(parse_placeholder_id("$0"), None);
+        // "$01" => None
+        assert_eq!(parse_placeholder_id("$01"), None);
+    }
+
+    // placeholder_to_placeholder_expr
+    #[test]
+    fn we_can_convert_valid_placeholder_to_placeholder_expr() {
+        let placeholder = Placeholder {
+            id: "$42".to_string(),
+            data_type: Some(DataType::Int32),
+        };
+        let expected = DynProofExpr::try_new_placeholder(42, ColumnType::Int).unwrap();
+        let result = placeholder_to_placeholder_expr(&placeholder).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn we_cannot_convert_placeholder_without_type() {
+        let placeholder = Placeholder {
+            id: "$1".to_string(),
+            data_type: None,
+        };
+        assert!(matches!(
+            placeholder_to_placeholder_expr(&placeholder),
+            Err(PlannerError::UntypedPlaceholder { .. })
+        ));
+    }
+
+    #[test]
+    fn we_cannot_convert_placeholder_with_invalid_id() {
+        let placeholder = Placeholder {
+            // Something invalid like "$0" or "1"
+            id: "$0".to_string(),
+            data_type: Some(DataType::Int32),
+        };
+        assert!(matches!(
+            placeholder_to_placeholder_expr(&placeholder),
+            Err(PlannerError::InvalidPlaceholderId { .. })
+        ));
+    }
 
     // TableReference to TableRef
     #[test]

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -175,7 +175,8 @@ fn test_tableless_queries() {
 fn test_simple_filter_queries() {
     let alloc = Bump::new();
     let sql = "select id, name from cats where age > 2;
-    select * from cats;";
+    select * from cats;
+    select name == $1 as name_eq from cats;";
     let tables: IndexMap<TableRef, Table<DoryScalar>> = indexmap! {
         TableRef::from_names(None, "cats") => table(
             vec![
@@ -195,6 +196,7 @@ fn test_simple_filter_queries() {
             varchar("name", ["Chloe", "Margaret", "Katy", "Lucy", "Prudence"]),
             tinyint("age", [13_i8, 2, 0, 4, 4]),
         ]),
+        owned_table([boolean("name_eq", [false, false, true, false, false])]),
     ];
 
     // Create public parameters for DynamicDoryEvaluationProof
@@ -208,7 +210,7 @@ fn test_simple_filter_queries() {
         &expected_results,
         &prover_setup,
         &verifier_setup,
-        &[],
+        &[LiteralValue::VarChar("Katy".to_string())],
     );
 }
 

--- a/crates/proof-of-sql/src/base/proof/error.rs
+++ b/crates/proof-of-sql/src/base/proof/error.rs
@@ -82,6 +82,10 @@ pub enum PlaceholderError {
         /// The actual type
         actual: ColumnType,
     },
+
+    #[snafu(display("Placeholder id must be greater than 0"))]
+    /// Placeholder id is zero
+    ZeroPlaceholderId,
 }
 
 /// Result type for placeholder errors

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -1,6 +1,7 @@
 use crate::base::{
     database::ColumnType,
     math::decimal::{DecimalError, IntermediateDecimalError},
+    proof::PlaceholderError,
 };
 use alloc::string::{String, ToString};
 use core::result::Result;
@@ -42,6 +43,13 @@ pub enum AnalyzeError {
     DecimalConversionError {
         /// The underlying source error
         source: DecimalError,
+    },
+
+    #[snafu(transparent)]
+    /// Errors related to placeholders
+    PlaceholderError {
+        /// The underlying source error
+        source: PlaceholderError,
     },
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -77,9 +77,11 @@ impl DynProofExpr {
         Self::Literal(LiteralExpr::new(value))
     }
     /// Create placeholder expression
-    #[must_use]
-    pub fn new_placeholder(id: usize, column_type: ColumnType) -> Self {
-        Self::Placeholder(PlaceholderExpr::new(id, column_type))
+    pub fn try_new_placeholder(id: usize, column_type: ColumnType) -> AnalyzeResult<Self> {
+        Ok(Self::Placeholder(PlaceholderExpr::try_new(
+            id,
+            column_type,
+        )?))
     }
     /// Create a new equals expression
     pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
@@ -51,18 +51,18 @@ impl PlaceholderExpr {
         &self,
         params: &'a [LiteralValue],
     ) -> Result<&'a LiteralValue, PlaceholderError> {
-        let param_value =
-            params
-                .get(self.id - 1)
-                .ok_or(PlaceholderError::InvalidPlaceholderId {
-                    id: self.id,
-                    num_params: params.len(),
-                })?;
+        let pos = self.id - 1;
+        let param_value = params
+            .get(pos)
+            .ok_or(PlaceholderError::InvalidPlaceholderId {
+                id: self.id,
+                num_params: params.len(),
+            })?;
         if param_value.column_type() != self.column_type {
             return Err(PlaceholderError::InvalidPlaceholderType {
                 id: self.id,
                 expected: self.column_type,
-                actual: params[self.id - 1].column_type(),
+                actual: param_value.column_type(),
             });
         }
         Ok(param_value)

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -136,7 +136,7 @@ pub fn const_decimal75<T: Into<I256>>(precision: u8, scale: i8, val: T) -> DynPr
 /// Aliased placeholder expression
 pub fn aliased_placeholder(index: usize, col_type: ColumnType, alias: &str) -> AliasedDynProofExpr {
     AliasedDynProofExpr {
-        expr: DynProofExpr::new_placeholder(index, col_type),
+        expr: DynProofExpr::try_new_placeholder(index, col_type).unwrap(),
         alias: alias.into(),
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Postgres which uses $1, $2 etc as placeholders doesn't allow $0 hence we shouldn't either to make our placeholders easier to use.

Moreover I added this feature to the planner.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- ban $0 as a placeholder
- add placeholder to the planner
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.