### PR TITLE
fix: transition from allow to expect for turning off clippy lints

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
       - name: Run clippy
-        run: cargo cl -- -D warnings
+        run: cargo cl -- -D warnings -A unfulfilled_lint_expectations
 
   coverage:
     name: Code Coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)
 [workspace.lints.clippy]
 missing_errors_doc = "allow"
 pedantic = { level = "warn", priority = -1 }
+allow_attributes = "warn"
 
 [patch.crates-io]
 # patch for sqlparser no_std compatibility with the serde feature enabled.

--- a/crates/proof-of-sql-parser/src/lib.rs
+++ b/crates/proof-of-sql-parser/src/lib.rs
@@ -35,7 +35,7 @@ pub use resource_id::ResourceId;
 pub mod sqlparser;
 
 // lalrpop-generated code is not clippy-compliant
-lalrpop_mod!(#[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items, clippy::pedantic, clippy::missing_panics_doc)] pub sql);
+lalrpop_mod!(#[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items, clippy::pedantic, clippy::missing_panics_doc, clippy::allow_attributes)] pub sql);
 
 /// Implement [`Deserialize`](serde::Deserialize) through [`FromStr`](core::str::FromStr) to avoid invalid identifiers.
 #[macro_export]

--- a/crates/proof-of-sql-parser/src/posql_time/error.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/error.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 /// Errors related to time operations, including timezone and timestamp conversions.
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions)]
 #[derive(Snafu, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PoSQLTimestampError {
     /// Error when the timezone string provided cannot be parsed into a valid timezone.

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -5,7 +5,7 @@ use core::hash::Hash;
 use serde::{Deserialize, Serialize};
 
 /// Represents a fully parsed timestamp with detailed time unit and timezone information
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PoSQLTimestamp {
     /// The datetime representation in UTC.

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 /// An intermediate type representing the time units from a parsed query
-#[allow(clippy::module_name_repetitions)]
+#[expect(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PoSQLTimeUnit {
     /// Represents seconds with precision 0: ex "2024-06-20 12:34:56"
@@ -56,7 +56,7 @@ impl fmt::Display for PoSQLTimeUnit {
 // allow(deprecated) for the sole purpose of testing that
 // timestamp precision is parsed correctly.
 #[cfg(test)]
-#[allow(deprecated, clippy::missing_panics_doc)]
+#[expect(deprecated, clippy::missing_panics_doc)]
 mod time_unit_tests {
     use super::*;
     use crate::posql_time::{PoSQLTimestamp, PoSQLTimestampError};
@@ -64,7 +64,7 @@ mod time_unit_tests {
     use chrono::{TimeZone, Utc};
 
     #[test]
-    #[allow(clippy::unnecessary_fallible_conversions)]
+    #[expect(clippy::unnecessary_fallible_conversions)]
     fn test_u64_conversion() {
         assert_eq!(PoSQLTimeUnit::Second.try_into(), Ok(0));
         assert_eq!(PoSQLTimeUnit::Millisecond.try_into(), Ok(3));

--- a/crates/proof-of-sql/benches/jaeger/bin/utils/queries.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/utils/queries.rs
@@ -185,7 +185,7 @@ pub const QUERIES: &[QueryEntry] = &[
 /// # Returns
 /// * `Some((&str, &str, &[(&str, ColumnType, OptionalRandBound)]))` if the query is found.
 /// * `None` if no query with the given title exists.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub fn get_query(title: &str) -> Option<QueryEntry> {
     QUERIES
         .iter()

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -7,7 +7,7 @@ pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAcc
 mod column;
 pub use column::{Column, ColumnField, ColumnRef, ColumnType};
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod slice_operation;
 
 mod slice_decimal_operation;
@@ -27,7 +27,7 @@ pub(super) use column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanO
 mod column_index_operation;
 pub(super) use column_index_operation::apply_column_to_indexes;
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 mod column_repetition_operation;
 pub(super) use column_repetition_operation::{ColumnRepeatOp, ElementwiseRepeatOp, RepetitionOp};
 
@@ -125,5 +125,5 @@ pub(crate) mod order_by_util;
 #[cfg(test)]
 mod order_by_util_test;
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod join_util;

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -72,13 +72,13 @@ fn zigzag_decode(from: u64) -> i64 {
 macro_rules! impl_varint {
     ($t:ty, unsigned) => {
         impl VarInt for $t {
-            #[allow(clippy::cast_lossless)]
+            #[expect(clippy::cast_lossless)]
             fn required_space(self) -> usize {
                 (self as u64).required_space()
             }
 
             #[expect(clippy::cast_possible_truncation)]
-            #[allow(clippy::cast_lossless)]
+            #[expect(clippy::cast_lossless)]
             fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
                 let (n, s) = u64::decode_var(src)?;
                 // This check is required to ensure that we actually return `None` when `src` has a value that would overflow `Self`.
@@ -89,7 +89,7 @@ macro_rules! impl_varint {
                 }
             }
 
-            #[allow(clippy::cast_lossless)]
+            #[expect(clippy::cast_lossless)]
             fn encode_var(self, dst: &mut [u8]) -> usize {
                 (self as u64).encode_var(dst)
             }
@@ -97,13 +97,13 @@ macro_rules! impl_varint {
     };
     ($t:ty, signed) => {
         impl VarInt for $t {
-            #[allow(clippy::cast_lossless)]
+            #[expect(clippy::cast_lossless)]
             fn required_space(self) -> usize {
                 (self as i64).required_space()
             }
 
             #[expect(clippy::cast_possible_truncation)]
-            #[allow(clippy::cast_lossless)]
+            #[expect(clippy::cast_lossless)]
             fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
                 let (n, s) = i64::decode_var(src)?;
                 // This check is required to ensure that we actually return `None` when `src` has a value that would overflow `Self`.
@@ -114,7 +114,7 @@ macro_rules! impl_varint {
                 }
             }
 
-            #[allow(clippy::cast_lossless)]
+            #[expect(clippy::cast_lossless)]
             fn encode_var(self, dst: &mut [u8]) -> usize {
                 (self as i64).encode_var(dst)
             }

--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -15,7 +15,7 @@ use num_traits::{Inv, One, Zero};
 // Allow missing panics documentation because the function should not panic under normal conditions.
 /// unless x is one of 0,1,...,d, in which case, f(x) is already known.
 #[expect(clippy::missing_panics_doc)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub fn interpolate_uni_poly<F>(polynomial: &[F], x: F) -> F
 where
     F: Copy
@@ -76,7 +76,7 @@ where
 /// Let `d` be `evals.len() - 1` and let `f` be the polynomial such that `f(i) = evals[i]`.
 /// The output of this function is the vector of coefficients of `f`, with the leading coefficient first.
 /// That is, `f(x) = evals[j] * x^(d - j)`.
-#[allow(
+#[expect(
     clippy::missing_panics_doc,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap

--- a/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/dory_messages.rs
@@ -25,7 +25,7 @@ pub struct DoryMessages {
 }
 impl_serde_for_ark_serde_checked!(DoryMessages);
 
-#[cfg_attr(not(test), allow(dead_code))]
+#[cfg_attr(not(test), expect(dead_code))]
 impl DoryMessages {
     /// Pushes a field element from the prover onto the queue, and appends it to the transcript.
     pub(super) fn prover_send_F_message(&mut self, transcript: &mut impl Transcript, message: F) {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -3,7 +3,7 @@
 mod divide_and_modulo_expr;
 mod membership_check;
 mod monotonic;
-#[allow(dead_code)]
+#[expect(dead_code)]
 mod permutation_check;
 mod shift;
 pub(crate) use membership_check::{
@@ -24,7 +24,7 @@ pub(crate) use sign_expr::{
     final_round_evaluate_sign, first_round_evaluate_sign, verifier_evaluate_sign,
 };
 #[cfg(feature = "blitzar")]
-#[allow(dead_code)]
+#[expect(dead_code)]
 mod range_check;
 #[cfg(all(test, feature = "blitzar"))]
 mod range_check_test;


### PR DESCRIPTION
/claim #545

* Changed Clippy annotations from `#[allow]` to `#[expect]` in multiple files to improve code clarity and maintainability. 

* Added `allow_attributes = "warn"` to the Clippy configuration in `Cargo.toml` to handle attribute warnings.

