### PR TITLE
feat: scaling cast expr

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/decimal_scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/decimal_scaling_cast_expr.rs
@@ -26,7 +26,6 @@ pub struct DecimalScalingCastExpr {
 
 impl DecimalScalingCastExpr {
     /// Creates a new `CastExpr`
-    #[expect(dead_code)]
     pub fn try_new(
         from_expr: Box<DynProofExpr>,
         to_type: ColumnType,

--- a/crates/proof-of-sql/src/sql/proof_exprs/decimal_scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/decimal_scaling_cast_expr.rs
@@ -1,0 +1,95 @@
+use super::{
+    numerical_util::{
+        cast_column_to_decimal_with_scaling, try_get_scaling_factor_with_precision_and_scale,
+    },
+    DynProofExpr, ProofExpr,
+};
+use crate::{
+    base::{
+        database::{Column, ColumnOperationResult, ColumnRef, ColumnType, LiteralValue, Table},
+        map::{IndexMap, IndexSet},
+        proof::{PlaceholderResult, ProofError},
+        scalar::Scalar,
+    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct DecimalScalingCastExpr {
+    from_expr: Box<DynProofExpr>,
+    to_type: ColumnType,
+    scaling_factor: [u64; 4],
+}
+
+impl DecimalScalingCastExpr {
+    /// Creates a new `CastExpr`
+    #[expect(dead_code)]
+    pub fn try_new(
+        from_expr: Box<DynProofExpr>,
+        to_type: ColumnType,
+    ) -> ColumnOperationResult<Self> {
+        let scaling_factor =
+            try_get_scaling_factor_with_precision_and_scale(from_expr.data_type(), to_type)?.0;
+        Ok(Self {
+            from_expr,
+            to_type,
+            scaling_factor: scaling_factor.into(),
+        })
+    }
+}
+
+impl ProofExpr for DecimalScalingCastExpr {
+    fn data_type(&self) -> ColumnType {
+        self.to_type
+    }
+
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let uncasted_result = self.from_expr.first_round_evaluate(alloc, table, params)?;
+        Ok(cast_column_to_decimal_with_scaling(
+            alloc,
+            uncasted_result,
+            self.to_type,
+        ))
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let uncasted_result = self
+            .from_expr
+            .final_round_evaluate(builder, alloc, table, params)?;
+        Ok(cast_column_to_decimal_with_scaling(
+            alloc,
+            uncasted_result,
+            self.to_type,
+        ))
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        self.from_expr
+            .verifier_evaluate(builder, accessor, chi_eval, params)
+            .map(|unscaled_eval| S::from(self.scaling_factor) * unscaled_eval)
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.from_expr.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/decimal_scaling_cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/decimal_scaling_cast_expr_test.rs
@@ -1,0 +1,149 @@
+use crate::{
+    base::{
+        database::{
+            owned_table_utility::{
+                bigint, decimal75, int, int128, owned_table, smallint, tinyint, uint8,
+            },
+            ColumnType, LiteralValue, OwnedTableTestAccessor, TableRef,
+        },
+        math::decimal::Precision,
+    },
+    sql::{
+        proof::{exercise_verification, VerifiableQueryResult},
+        proof_exprs::{
+            test_utility::{aliased_plan, column, decimal_scaling_cast, tab},
+            LiteralExpr,
+        },
+        proof_plans::test_utility::filter,
+    },
+};
+use blitzar::proof::InnerProductProof;
+
+#[test]
+fn we_can_prove_a_simple_decimal_scale_cast_expr_from_int_to_decimal() {
+    let data = owned_table([
+        tinyint("a", [1]),
+        uint8("b", [1]),
+        smallint("c", [1i16]),
+        int("d", [1i32]),
+        bigint("e", [1i64]),
+        int128("f", [1i128]),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = filter(
+        vec![
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "a", &accessor),
+                    ColumnType::Decimal75(Precision::new(4).unwrap(), 1),
+                ),
+                "a_cast",
+            ),
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "b", &accessor),
+                    ColumnType::Decimal75(Precision::new(4).unwrap(), 1),
+                ),
+                "b_cast",
+            ),
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "c", &accessor),
+                    ColumnType::Decimal75(Precision::new(6).unwrap(), 1),
+                ),
+                "c_cast",
+            ),
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "d", &accessor),
+                    ColumnType::Decimal75(Precision::new(11).unwrap(), 1),
+                ),
+                "d_cast",
+            ),
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "e", &accessor),
+                    ColumnType::Decimal75(Precision::new(20).unwrap(), 1),
+                ),
+                "e_cast",
+            ),
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "f", &accessor),
+                    ColumnType::Decimal75(Precision::new(40).unwrap(), 1),
+                ),
+                "f_cast",
+            ),
+        ],
+        tab(&t),
+        super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
+    let expected_res = owned_table([
+        decimal75("a_cast", 4, 1, [10]),
+        decimal75("b_cast", 4, 1, [10]),
+        decimal75("c_cast", 6, 1, [10]),
+        decimal75("d_cast", 11, 1, [10]),
+        decimal75("e_cast", 20, 1, [10]),
+        decimal75("f_cast", 40, 1, [10]),
+    ]);
+    assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_can_prove_a_simple_decimal_scale_cast_expr_from_decimal_to_decimal() {
+    let data = owned_table([
+        decimal75("a", 4, -2, [10]),
+        decimal75("b", 4, 1, [1]),
+        decimal75("c", 6, 0, [10]),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        OwnedTableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data, 0, ());
+    let ast = filter(
+        vec![
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "a", &accessor),
+                    ColumnType::Decimal75(Precision::new(5).unwrap(), -1),
+                ),
+                "a_cast",
+            ),
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "b", &accessor),
+                    ColumnType::Decimal75(Precision::new(5).unwrap(), 2),
+                ),
+                "b_cast",
+            ),
+            aliased_plan(
+                decimal_scaling_cast(
+                    column(&t, "c", &accessor),
+                    ColumnType::Decimal75(Precision::new(7).unwrap(), 0),
+                ),
+                "c_cast",
+            ),
+        ],
+        tab(&t),
+        super::DynProofExpr::Literal(LiteralExpr::new(LiteralValue::Boolean(true))),
+    );
+    let verifiable_res = VerifiableQueryResult::new(&ast, &accessor, &(), &[]).unwrap();
+    exercise_verification(&verifiable_res, &ast, &accessor, &t);
+    let res = verifiable_res
+        .verify(&ast, &accessor, &(), &[])
+        .unwrap()
+        .table;
+    let expected_res = owned_table([
+        decimal75("a_cast", 5, -1, [100]),
+        decimal75("b_cast", 5, 2, [10]),
+        decimal75("c_cast", 7, 0, [10]),
+    ]);
+    assert_eq!(res, expected_res);
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -79,3 +79,5 @@ mod column_expr_test;
 mod cast_expr;
 #[cfg(all(test, feature = "blitzar"))]
 mod cast_expr_test;
+
+mod decimal_scaling_cast_expr;

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -81,3 +81,5 @@ mod cast_expr;
 mod cast_expr_test;
 
 mod decimal_scaling_cast_expr;
+#[cfg(all(test, feature = "blitzar"))]
+mod decimal_scaling_cast_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -732,7 +732,6 @@ pub fn try_get_scaling_factor_with_precision_and_scale(
 ///
 /// # Panics
 /// Panics if casting is invalid between the two types
-#[cfg_attr(not(test), expect(dead_code))]
 pub fn cast_column_to_decimal_with_scaling<'a, S: Scalar>(
     alloc: &'a Bump,
     from_column: Column<'a, S>,

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -88,6 +88,10 @@ pub fn cast(left: DynProofExpr, right: ColumnType) -> DynProofExpr {
     DynProofExpr::try_new_cast(left, right).unwrap()
 }
 
+pub fn decimal_scaling_cast(left: DynProofExpr, right: ColumnType) -> DynProofExpr {
+    DynProofExpr::try_new_decimal_scaling_cast(left, right).unwrap()
+}
+
 pub fn const_bool(val: bool) -> DynProofExpr {
     DynProofExpr::new_literal(LiteralValue::Boolean(val))
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This PR finishes the creation of the `DecimalScalingCastExpr`. This will allow proof expressions to cast ints and decimals to decimals.

# What changes are included in this PR?

- Rename utility functions that are meant to cast to decimals to include the word decimal
- New `DecimalScalingCastExpr`
- New variant in `DynProofExpr`

# Are these changes tested?
Yes
