### PR TITLE
feat: support scaling-free casting for nonzero scale

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -216,8 +216,9 @@ pub fn try_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult
             | ColumnType::BigInt
             | ColumnType::Int128,
         )
-        | (ColumnType::Decimal75(_, 0), ColumnType::Decimal75(_, 0)) => {
+        | (ColumnType::Decimal75(_, _), ColumnType::Decimal75(_, _)) => {
             to.precision_value().unwrap() >= from.precision_value().unwrap()
+                && to.scale() == from.scale()
         }
         _ => false,
     }
@@ -912,6 +913,20 @@ mod test {
             .unwrap();
             try_cast_types(from, ColumnType::Decimal75(Precision::new(2).unwrap(), 0)).unwrap_err();
         }
+    }
+
+    #[test]
+    fn we_can_cast_decimal_to_decimal_with_same_scale() {
+        try_cast_types(
+            ColumnType::Decimal75(Precision::new(2).unwrap(), 1),
+            ColumnType::Decimal75(Precision::new(3).unwrap(), 1),
+        )
+        .unwrap();
+        try_cast_types(
+            ColumnType::Decimal75(Precision::new(2).unwrap(), 1),
+            ColumnType::Decimal75(Precision::new(3).unwrap(), 2),
+        )
+        .unwrap_err();
     }
 
     #[test]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

`CastExpr` needs to support casting from one decimal to another if the scale is the same in both decimals.

# What changes are included in this PR?

Additional support for casting decimals.

# Are these changes tested?
Yes
