### PR TITLE
refactor: use `indexmap_with_default` and `indexset_with_default`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ ff = { version = "0.13.0"}
 flexbuffers = { version = "2.0.0" }
 halo2curves = { version = "0.8.0", default-features = false }
 hex = { version = "0.4.3" }
-indexmap = { version = "2.1", default-features = false }
+indexmap = { version = "2.8", default-features = false }
 indicatif = { version = "0.17.8", default-features = false }
 itertools = { version = "0.13.0", default-features = false, features = ["use_alloc"] }
 lalrpop = { version = "0.22.0" }

--- a/crates/proof-of-sql/src/base/map.rs
+++ b/crates/proof-of-sql/src/base/map.rs
@@ -2,41 +2,17 @@ pub(crate) type IndexMap<K, V> =
     indexmap::IndexMap<K, V, core::hash::BuildHasherDefault<ahash::AHasher>>;
 pub(crate) type IndexSet<T> = indexmap::IndexSet<T, core::hash::BuildHasherDefault<ahash::AHasher>>;
 
-// Adapted from `indexmap`.
-
 /// Create an [`IndexMap`][self::IndexMap] from a list of key-value pairs
-macro_rules! indexmap_macro {
-    ($($key:expr => $value:expr,)+) => { $crate::base::map::indexmap!($($key => $value),+) };
-    ($($key:expr => $value:expr),*) => {
-        {
-            // Note: `stringify!($key)` is just here to consume the repetition,
-            // but we throw away that string literal during constant evaluation.
-            const CAP: usize = <[()]>::len(&[$({ stringify!($key); }),*]);
-            #[allow(unused_mut)]
-            let mut map = $crate::base::map::IndexMap::with_capacity_and_hasher(CAP, <_>::default());
-            $(
-                map.insert($key, $value);
-            )*
-            map
-        }
-    };
+macro_rules! indexmap {
+    ($($key:expr => $value:expr,)+) => { indexmap::indexmap_with_default!{ahash::AHasher; $($key => $value),+} };
+    ($($key:expr => $value:expr),*) => { indexmap::indexmap_with_default!{ahash::AHasher; $($key => $value),*} };
 }
 
 /// Create an [`IndexSet`][self::IndexSet] from a list of values
-macro_rules! indexset_macro {
-    ($($value:expr,)+) => { $crate::base::map::indexset!($($value),+) };
-    ($($value:expr),*) => {
-        {
-            const CAP: usize = <[()]>::len(&[$({ stringify!($value); }),*]);
-            #[allow(unused_mut)]
-            let mut set = $crate::base::map::IndexSet::with_capacity_and_hasher(CAP, <_>::default());
-            $(
-                set.insert($value);
-            )*
-            set
-        }
-    };
+macro_rules! indexset {
+    ($($value:expr,)+) => { indexmap::indexset_with_default!{ahash::AHasher; $($value),+} };
+    ($($value:expr),*) => { indexmap::indexset_with_default!{ahash::AHasher; $($value),*} };
 }
 
-pub(crate) use indexmap_macro as indexmap;
-pub(crate) use indexset_macro as indexset;
+pub(crate) use indexmap;
+pub(crate) use indexset;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Now that `indexmap_with_default` and `indexset_with_default` were released by `indexmap` 2.8.0 and have been in use for 3 weeks without any compliants we should switch to them and simplify `base/map.rs` 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
Simplify `base/map.rs`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.