### PR TITLE
feat: add scalar to int and decimal casts

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -895,6 +895,24 @@ mod test {
     }
 
     #[test]
+    fn we_cannot_cast_integers_to_decimal_with_lower_precision() {
+        for from in [
+            ColumnType::TinyInt,
+            ColumnType::Uint8,
+            ColumnType::SmallInt,
+            ColumnType::Int,
+            ColumnType::BigInt,
+            ColumnType::Int128,
+            ColumnType::Decimal75(Precision::new(60).unwrap(), 0),
+        ] {
+            assert!(matches!(
+                try_cast_types(from, ColumnType::Decimal75(Precision::new(2).unwrap(), 0)),
+                Err(ColumnOperationError::CastingError { .. })
+            ));
+        }
+    }
+
+    #[test]
     fn we_can_cast_integers_and_decimal_to_decimal() {
         for from in [
             ColumnType::TinyInt,

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -34,7 +34,7 @@ pub trait Scalar:
     + for<'a> core::convert::From<&'a u8> // Required for `Column` to implement `MultilinearExtension`
     + for<'a> core::convert::From<&'a u64> // Required for `Column` to implement `MultilinearExtension`
     + core::convert::TryInto <bool>
-    + core::convert::TryInto<u8>
+    + core::convert::TryInto <u8>
     + core::convert::TryInto <i8>
     + core::convert::TryInto <i16>
     + core::convert::TryInto <i32>

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -40,7 +40,12 @@ impl ProofExpr for CastExpr {
         params: &[LiteralValue],
     ) -> PlaceholderResult<Column<'a, S>> {
         let uncasted_result = self.from_expr.first_round_evaluate(alloc, table, params)?;
-        Ok(cast_column(alloc, uncasted_result, self.to_type))
+        Ok(cast_column(
+            alloc,
+            uncasted_result,
+            self.from_expr.data_type(),
+            self.to_type,
+        ))
     }
 
     fn final_round_evaluate<'a, S: Scalar>(
@@ -53,7 +58,12 @@ impl ProofExpr for CastExpr {
         let uncasted_result = self
             .from_expr
             .final_round_evaluate(builder, alloc, table, params)?;
-        Ok(cast_column(alloc, uncasted_result, self.to_type))
+        Ok(cast_column(
+            alloc,
+            uncasted_result,
+            self.from_expr.data_type(),
+            self.to_type,
+        ))
     }
 
     fn verifier_evaluate<S: Scalar>(

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -592,15 +592,11 @@ fn cast_scalar_slice_to_int_slice<'a, I: Copy, S: Scalar + TryInto<I>>(
     alloc: &'a Bump,
     column: &[S],
 ) -> &'a [I] {
-    let converted = column
-        .iter()
-        .map(|s| {
-            TryInto::<I>::try_into(*s)
-                .map_err(|_| format!("Failed to cast {} to {}", s, core::any::type_name::<I>()))
-                .unwrap()
-        })
-        .collect::<Vec<_>>();
-    alloc.alloc_slice_copy(&converted)
+    alloc.alloc_slice_fill_iter(column.iter().map(|s| {
+        TryInto::<I>::try_into(*s)
+            .map_err(|_| format!("Failed to cast {} to {}", s, core::any::type_name::<I>()))
+            .unwrap()
+    }))
 }
 
 /// Cast a slice of [`Scalar`]s to a [`Column`] of ints


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
