### PR TITLE
feat: add `ScaleCastExpr`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -77,5 +77,11 @@ pub use column_expr::ColumnExpr;
 mod column_expr_test;
 
 mod cast_expr;
+pub(crate) use cast_expr::CastExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod cast_expr_test;
+
+mod scale_cast_expr;
+pub(crate) use scale_cast_expr::ScaleCastExpr;
+//#[cfg(all(test, feature = "blitzar"))]
+//mod scale_cast_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -740,9 +740,9 @@ pub fn try_get_scaling_factor_with_precision_and_scale<S: Scalar>(
 pub fn scale_cast_column<'a, S: Scalar>(
     alloc: &'a Bump,
     from_column: Column<'a, S>,
+    from_type: ColumnType,
     to_type: ColumnType,
 ) -> Column<'a, S> {
-    let from_type = from_column.column_type();
     let (scaling_factor, precision, scale) =
         try_get_scaling_factor_with_precision_and_scale::<S>(from_type, to_type).unwrap_or_else(
             |_| panic!("Unable to get scaling factor between types {from_type} and {to_type}"),
@@ -1307,7 +1307,12 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            scale_cast_column(&alloc, tiny_int_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                tiny_int_column,
+                ColumnType::TinyInt,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1320,7 +1325,12 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            scale_cast_column(&alloc, uint8_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                uint8_column,
+                ColumnType::Uint,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1331,7 +1341,12 @@ mod tests {
         let scale = 0i8;
         let scalar_slice = small_int_slice.map(TestScalar::from);
         assert_eq!(
-            scale_cast_column(&alloc, small_int_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                small_int_column,
+                ColumnType::SmallInt,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1342,7 +1357,12 @@ mod tests {
         let scale = 0i8;
         let scalar_slice = int_slice.map(TestScalar::from);
         assert_eq!(
-            scale_cast_column(&alloc, int_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                int_column,
+                ColumnType::Int,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1355,7 +1375,12 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(100));
         assert_eq!(
-            scale_cast_column(&alloc, big_int_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                big_int_column,
+                ColumnType::BigInt,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1368,7 +1393,12 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            scale_cast_column(&alloc, int_128_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                int_128_column,
+                ColumnType::Int128,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
     }
@@ -1385,7 +1415,12 @@ mod tests {
         let scale = -1i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::TEN);
         assert_eq!(
-            scale_cast_column(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                decimal_column,
+                ColumnType::Decimal75(Precision::new(2).unwrap(), -2),
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1397,7 +1432,12 @@ mod tests {
         let scale = 1i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::from(1_000));
         assert_eq!(
-            scale_cast_column(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                decimal_column,
+                ColumnType::Decimal75(Precision::new(2).unwrap(), -2),
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1409,7 +1449,12 @@ mod tests {
         let scale = 2i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::TEN);
         assert_eq!(
-            scale_cast_column(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
+            scale_cast_column(
+                &alloc,
+                decimal_column,
+                ColumnType::Decimal75(Precision::new(2).unwrap(), 1),
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/scale_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scale_cast_expr.rs
@@ -1,0 +1,83 @@
+use super::{numerical_util::cast_column, DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        database::{try_scale_cast_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        map::{IndexMap, IndexSet},
+        proof::{PlaceholderResult, ProofError},
+        scalar::Scalar,
+    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+/// Provable CAST expression
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ScaleCastExpr {
+    from_expr: Box<DynProofExpr>,
+    to_type: ColumnType,
+}
+
+impl ScaleCastExpr {
+    /// Creates a new `ScaleCastExpr`
+    pub fn new(from_expr: Box<DynProofExpr>, to_type: ColumnType) -> Self {
+        Self { from_expr, to_type }
+    }
+}
+
+impl ProofExpr for ScaleCastExpr {
+    fn data_type(&self) -> ColumnType {
+        try_scale_cast_types(self.from_expr.data_type(), self.to_type)
+            .expect("Failed to cast column type");
+        self.to_type
+    }
+
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let uncasted_result = self.from_expr.first_round_evaluate(alloc, table, params)?;
+        Ok(cast_column(
+            alloc,
+            uncasted_result,
+            self.from_expr.data_type(),
+            self.to_type,
+        ))
+    }
+
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let uncasted_result = self
+            .from_expr
+            .final_round_evaluate(builder, alloc, table, params)?;
+        Ok(cast_column(
+            alloc,
+            uncasted_result,
+            self.from_expr.data_type(),
+            self.to_type,
+        ))
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        self.from_expr
+            .verifier_evaluate(builder, accessor, chi_eval, params)
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.from_expr.get_column_references(columns);
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
