### PR TITLE
bench: add CSV and console output for proof generation and verification 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ byte-slice-cast = { version = "1.2.1", default-features = false }
 clap = { version = "4.5.4" }
 criterion = { version = "0.5.1" }
 chrono = { version = "=0.4.39", default-features = false }
+csv = { version = "1.3.1" }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
 datafusion = { version = "38.0.0", default-features = false }
 derive_more = { version = "0.99" }

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -34,6 +34,7 @@ bumpalo = { workspace = true, features = ["collections"] }
 bytemuck = { workspace = true }
 byte-slice-cast = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"], optional = true }
+csv = { workspace = true, optional = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true }
@@ -87,7 +88,7 @@ development = ["arrow-csv", "criterion", "opentelemetry", "opentelemetry-jaeger"
 default = ["arrow", "perf"]
 utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2", "dep:clap", "dep:tempfile"]
 arrow = ["dep:arrow", "std"]
-bench = ["blitzar", "dep:clap", "dep:rand", "hyperkzg_proof", "opentelemetry", "opentelemetry-jaeger", "std", "tracing-opentelemetry", "tracing-subscriber" ]
+bench = ["blitzar", "dep:clap", "csv", "dep:rand", "hyperkzg_proof", "opentelemetry", "opentelemetry-jaeger", "std", "tracing-opentelemetry", "tracing-subscriber" ]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
 hyperkzg_proof = ["dep:nova-snark", "std", "dep:ff", "dep:halo2curves", "blitzar"]
 test = ["dep:rand", "std"]

--- a/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
@@ -220,6 +220,8 @@ fn bench_inner_product_proof(cli: &Cli, queries: &[QueryEntry]) {
                 VerifiableQueryResult::new(query_expr.proof_expr(), &accessor, &(), &[]).unwrap();
             let generate_proof_elapsed = time.elapsed().as_millis();
 
+            let num_query_results = result.result.num_rows();
+
             // Verify the proof
             let time = Instant::now();
             result
@@ -244,6 +246,7 @@ fn bench_inner_product_proof(cli: &Cli, queries: &[QueryEntry]) {
 
             // Print results to console
             if !cli.silence {
+                eprintln!("Number of query results: {num_query_results}");
                 eprintln!("Inner Product Proof - generate proof: {generate_proof_elapsed} ms");
                 eprintln!("Inner Product Proof - verify proof: {verify_elapsed} ms");
                 println!(
@@ -345,6 +348,8 @@ fn bench_dory(cli: &Cli, queries: &[QueryEntry]) {
             .unwrap();
             let generate_proof_elapsed = time.elapsed().as_millis();
 
+            let num_query_results = result.result.num_rows();
+
             // Verify the proof
             let time = Instant::now();
             result
@@ -374,6 +379,7 @@ fn bench_dory(cli: &Cli, queries: &[QueryEntry]) {
 
             // Print results to console
             if !cli.silence {
+                eprintln!("Number of query results: {num_query_results}");
                 eprintln!("Dory - generate proof: {generate_proof_elapsed} ms");
                 eprintln!("Dory - verify proof: {verify_elapsed} ms");
                 println!(
@@ -422,6 +428,8 @@ fn bench_dynamic_dory(cli: &Cli, queries: &[QueryEntry]) {
                     .unwrap();
             let generate_proof_elapsed = time.elapsed().as_millis();
 
+            let num_query_results = result.result.num_rows();
+
             // Verify the proof
             let time = Instant::now();
             result
@@ -446,6 +454,7 @@ fn bench_dynamic_dory(cli: &Cli, queries: &[QueryEntry]) {
 
             // Print results to console
             if !cli.silence {
+                eprintln!("Number of query results: {num_query_results}");
                 eprintln!("Dynamic Dory - generate proof: {generate_proof_elapsed} ms");
                 eprintln!("Dynamic Dory - verify proof: {verify_elapsed} ms");
                 println!(
@@ -521,6 +530,8 @@ fn bench_hyperkzg(cli: &Cli, queries: &[QueryEntry]) {
                 .unwrap();
             let generate_proof_elapsed = time.elapsed().as_millis();
 
+            let num_query_results = result.result.num_rows();
+
             // Verify the proof
             let time = Instant::now();
             result
@@ -545,6 +556,7 @@ fn bench_hyperkzg(cli: &Cli, queries: &[QueryEntry]) {
 
             // Print results to console
             if !cli.silence {
+                eprintln!("Number of query results: {num_query_results}");
                 eprintln!("HyperKZG - generate proof: {generate_proof_elapsed} ms");
                 eprintln!("HyperKZG - verify proof: {verify_elapsed} ms");
                 println!(

--- a/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
@@ -246,7 +246,10 @@ fn bench_inner_product_proof(cli: &Cli, queries: &[QueryEntry]) {
             if !cli.silence {
                 eprintln!("Inner Product Proof - generate proof: {generate_proof_elapsed} ms");
                 eprintln!("Inner Product Proof - verify proof: {verify_elapsed} ms");
-                println!("Inner Product Proof, {title}, {}, {generate_proof_elapsed}, {verify_elapsed}, {i}", cli.table_size);
+                println!(
+                    "Inner Product Proof,{title},{},{generate_proof_elapsed},{verify_elapsed},{i}",
+                    cli.table_size
+                );
             }
         }
     }
@@ -374,7 +377,7 @@ fn bench_dory(cli: &Cli, queries: &[QueryEntry]) {
                 eprintln!("Dory - generate proof: {generate_proof_elapsed} ms");
                 eprintln!("Dory - verify proof: {verify_elapsed} ms");
                 println!(
-                    "Dory, {title}, {}, {generate_proof_elapsed}, {verify_elapsed}, {i}",
+                    "Dory,{title},{},{generate_proof_elapsed},{verify_elapsed},{i}",
                     cli.table_size
                 );
             }
@@ -446,7 +449,7 @@ fn bench_dynamic_dory(cli: &Cli, queries: &[QueryEntry]) {
                 eprintln!("Dynamic Dory - generate proof: {generate_proof_elapsed} ms");
                 eprintln!("Dynamic Dory - verify proof: {verify_elapsed} ms");
                 println!(
-                    "Dynamic Dory, {title}, {}, {generate_proof_elapsed}, {verify_elapsed}, {i}",
+                    "Dynamic Dory,{title},{},{generate_proof_elapsed},{verify_elapsed},{i}",
                     cli.table_size
                 );
             }
@@ -545,7 +548,7 @@ fn bench_hyperkzg(cli: &Cli, queries: &[QueryEntry]) {
                 eprintln!("HyperKZG - generate proof: {generate_proof_elapsed} ms");
                 eprintln!("HyperKZG - verify proof: {verify_elapsed} ms");
                 println!(
-                    "HyperKZG, {title}, {}, {generate_proof_elapsed}, {verify_elapsed}, {i}",
+                    "HyperKZG,{title},{},{generate_proof_elapsed},{verify_elapsed},{i}",
                     cli.table_size
                 );
             }
@@ -572,7 +575,9 @@ fn main() {
     let cli = Cli::parse();
 
     if cli.write_header && !cli.silence {
-        println!("commitment_scheme, query, table_size, generate_proof (ms), verify_proof (ms), iteration");
+        println!(
+            "commitment_scheme,query,table_size,generate_proof (ms),verify_proof (ms),iteration"
+        );
     }
 
     let queries = if cli.query == Query::All {

--- a/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
@@ -153,7 +153,7 @@ struct Cli {
     #[arg(short='x', long, env, action=ArgAction::SetTrue)]
     silence: bool,
 
-    /// Write CVS header to console
+    /// Write CSV header to console
     #[arg(short, long, env, action=ArgAction::SetTrue)]
     write_header: bool,
 

--- a/crates/proof-of-sql/benches/jaeger/bin/utils/mod.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/utils/mod.rs
@@ -2,4 +2,5 @@ pub mod benchmark_accessor;
 pub mod jaeger_setup;
 pub mod queries;
 pub mod random_util;
+pub mod results_io;
 use random_util::OptionalRandBound;

--- a/crates/proof-of-sql/benches/jaeger/bin/utils/results_io.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/utils/results_io.rs
@@ -1,0 +1,58 @@
+use csv::{Writer, WriterBuilder};
+use std::{fs::OpenOptions, io::BufWriter, path::Path};
+
+/// Writes the header to the CSV file.
+///
+/// # Arguments
+/// * `writer` - A mutable reference to the CSV writer.
+///
+/// # Panics
+/// * If the header cannot be written to the CSV file.
+fn write_csv_header(writer: &mut Writer<BufWriter<std::fs::File>>) {
+    writer
+        .write_record([
+            "commitment_scheme",
+            "query",
+            "table_size",
+            "generate_proof (ms)",
+            "verify_proof (ms)",
+            "iteration",
+        ])
+        .expect("Failed to write headers to CSV file.");
+}
+
+/// Appends values to an existing CSV file or creates a new one if it doesn't exist.
+///
+/// # Arguments
+/// * `file_path` - The path to the CSV file.
+/// * `new_row` - A vector of strings to append to the file.
+///
+/// # Panics
+/// * If the file cannot be opened, read, or appended.
+pub fn append_to_csv(file_path: &Path, new_row: &[String]) {
+    // Open the file in append mode or create it if it doesn't exist
+    let file = OpenOptions::new()
+        .read(true)
+        .append(true)
+        .create(true)
+        .open(file_path)
+        .expect("Failed to open or create the CSV file.");
+
+    // Check if the file is empty to determine if we need to write headers
+    let is_empty = file.metadata().map(|m| m.len() == 0).unwrap_or(true);
+
+    // Create a CSV writer
+    let mut writer = WriterBuilder::new().from_writer(BufWriter::new(file));
+
+    // Write headers if the file is empty
+    if is_empty {
+        write_csv_header(&mut writer);
+    }
+
+    // Write new row to the CSV file
+    writer
+        .write_record(new_row)
+        .expect("Failed to write row to CSV file.");
+
+    writer.flush().expect("Failed to flush CSV writer.");
+}


### PR DESCRIPTION
# Rationale for this change
To further improve the benchmark binary, this PR adds both console output and CSV file saving to the benchmarks. The CSV will log the proof generation and verification time. The output will be written to the console by default and a CSV file optionally. 

A user will be able to define a CSV path or add `-w > file_name.csv` to the console command to generate CSV files.

# What changes are included in this PR?
- The `csv` create is added as optional to the project and included under the `benches` feature flag in commit https://github.com/spaceandtimelabs/sxt-proof-of-sql/commit/acf366bba7d9eb01e797a1fb6a40e89e754ba73e
- A new module,, `results_io` is added to the benchmark utils folder that will handle creating and appending data to a CSV file in commit https://github.com/spaceandtimelabs/sxt-proof-of-sql/commit/8d93fa29bce47a484b8d44e3f038717167461210
- The `jaeger_benches` module is updated to write console and CSV output in commit https://github.com/spaceandtimelabs/sxt-proof-of-sql/commit/c1ec711aa1748f7ea64b902373ac539a0764f239
  - An option for silencing console output is added - default is `false`.
  - An option for writing the CSV header to the console is added - default is `false`.
  - An option for defining a CSV file path is added. If the file does not exist, it will be created automatically.
- Documentation is update in commit https://github.com/spaceandtimelabs/sxt-proof-of-sql/commit/ca3120126d2b9facfc6bce95134577100bbafe2f
- The number of query results is printed on the console in commit https://github.com/spaceandtimelabs/sxt-proof-of-sql/pull/717/commits/4118440b327a02c0cc11b6345056b24940f785d1
- The previous benchmarks are extracted into a generic function in commit https://github.com/spaceandtimelabs/sxt-proof-of-sql/pull/717/commits/0702c466a93cddfa817a1c90cc20f1735016be94

# Are these changes tested?
Yes
