### PR TITLE
feat(sol): add `AddExpr` and `SubtractExpr`

### DIFF
--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -57,6 +57,10 @@ uint32 constant COLUMN_EXPR_VARIANT = 0;
 uint32 constant LITERAL_EXPR_VARIANT = 1;
 /// @dev Equals variant constant for proof expressions
 uint32 constant EQUALS_EXPR_VARIANT = 2;
+/// @dev Add variant constant for proof expressions
+uint32 constant ADD_EXPR_VARIANT = 3;
+/// @dev Subtract variant constant for proof expressions
+uint32 constant SUBTRACT_EXPR_VARIANT = 4;
 
 /// @dev Filter variant constant for proof plans
 uint32 constant FILTER_EXEC_VARIANT = 0;

--- a/solidity/src/proof_exprs/ProofExpr.pre.sol
+++ b/solidity/src/proof_exprs/ProofExpr.pre.sol
@@ -12,7 +12,9 @@ library ProofExpr {
     enum ExprVariant {
         Column,
         Literal,
-        Equals
+        Equals,
+        Add,
+        Subtract
     }
 
     /// @notice Evaluates a proof expression
@@ -90,6 +92,14 @@ library ProofExpr {
             function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL SubtractExpr.pre.sol
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
 
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 let proof_expr_variant := shr(UINT32_PADDING_BITS, calldataload(expr_ptr))
@@ -107,6 +117,14 @@ library ProofExpr {
                 case 2 {
                     case_const(2, EQUALS_EXPR_VARIANT)
                     expr_ptr_out, eval := equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
+                }
+                case 3 {
+                    case_const(3, ADD_EXPR_VARIANT)
+                    expr_ptr_out, eval := add_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
+                }
+                case 4 {
+                    case_const(4, SUBTRACT_EXPR_VARIANT)
+                    expr_ptr_out, eval := subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
                 }
                 default { err(ERR_UNSUPPORTED_PROOF_EXPR_VARIANT) }
             }

--- a/solidity/src/proof_exprs/SubtractExpr.pre.sol
+++ b/solidity/src/proof_exprs/SubtractExpr.pre.sol
@@ -6,15 +6,15 @@ import "../base/Constants.sol";
 import "../base/Errors.sol";
 import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
 
-/// @title EqualsExpr
-/// @dev Library for handling equality comparison expressions between two proof expressions
-library EqualsExpr {
-    /// @notice Evaluates an equals expression by comparing two sub-expressions
+/// @title SubtractExpr
+/// @dev Library for handling subtracting two proof expressions
+library SubtractExpr {
+    /// @notice Evaluates an subtract expression by subtracting one sub-expression from the other
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
     /// ##### Signature
     /// ```yul
-    /// equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval
+    /// subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval
     /// ```
     /// ##### Parameters
     /// * `expr_ptr` - calldata pointer to the expression data
@@ -23,44 +23,18 @@ library EqualsExpr {
     /// ##### Return Values
     /// * `expr_ptr_out` - pointer to the remaining expression after consuming both sub-expressions
     /// * `eval` - the evaluation result from the builder's final round MLE
-    /// @notice Evaluates two sub-expressions and produces identity constraints checking their equality
-    /// @notice ##### Constraints
-    /// * Inputs: \\(L=\texttt{lhs}\\), \\(R=\texttt{rhs}\\) with length \\(n\\), and thus \\(\chi_{[0,n)}=\texttt{chi}\\).
-    ///   Note: `proof_expr_evaluate` guarentees that the lengths of \\(L\\) and \\(R\\) are equal the lengths of `chi_{[0,n)}`.
-    /// * Outputs: \\(E=\texttt{result}\\) with length \\(n\\)
-    /// * Hints: \\(D^\star=\texttt{diff_star}\\)
-    /// * Helpers: \\(D :\equiv L - R=\texttt{diff}\\)
-    /// * Constraints:
-    /// \\[\begin{aligned}
-    /// E \cdot D &\equiv 0\\\\
-    /// \chi_{[0,n)} - (D\cdot D^\star + E) &\equiv 0
-    /// \end{aligned}\\]
-    /// @notice ##### Proof of Correctness
-    /// @notice **Theorem:** Given columns \\(L\\) and \\(R\\) of length \\(n\\),
-    /// \\[E[i] = \begin{cases} 1 & L[i] = R[i] \text{ and } i < n\\\\ 0 & \text{else}\end{cases}\\]
-    /// if and only if there exits a \\(D^\star\\) such that
-    /// \\[\begin{aligned}
-    /// E[i] \cdot D[i] &= 0\\\\
-    /// \chi_{[0,n)}[i] - (D[i]\cdot D^\star[i] + E[i]) &= 0
-    /// \end{aligned}\\]
-    /// for all \\(i\\), where \\(D[i] = L[i] - R[i]\\).
-    /// @notice **Completeness Proof:**
-    /// Setting \\[D^\star[i] = \begin{cases} (D[i])^{-1} & D[i] \neq 0\\\ 0 & \text{else}\end{cases}\\] satisfies the above equations.
-    /// @notice **Soundness Proof:**
-    /// * If \\(i<n\\) and \\(L[i] \neq R[i]\\), then \\(D[i] \neq 0\\) and \\(E[i] = 0\\) by the first equation.
-    /// * If \\(i<n\\) and \\(L[i] = R[i]\\), then \\(D[i] = 0\\) and \\(E[i] = \chi_{[0,n)}[i] = 1\\) by the second equation.
-    /// * If \\(i \geq n\\), then \\(L[i] = 0 = R[i]\\) and \\(E[i] = \chi_{[0,n)}[i] = 0\\) by the second equation.
+    /// @notice Evaluates two sub-expressions and subtract one from the other
     /// ##### Proof Plan Encoding
-    /// The equals expression is encoded as follows:
+    /// The subtract expression is encoded as follows:
     /// 1. The left hand side expression
     /// 2. The right hand side expression
-    /// @param __expr The equals expression data
+    /// @param __expr The subtract expression data
     /// @param __builder The verification builder
     /// @param __chiEval The chi value for evaluation
     /// @return __exprOut The remaining expression after processing
     /// @return __builderOut The verification builder result
     /// @return __eval The evaluated result
-    function __equalsExprEvaluate( // solhint-disable-line gas-calldata-parameters
+    function __subtractExprEvaluate( // solhint-disable-line gas-calldata-parameters
     bytes calldata __expr, VerificationBuilder.Builder memory __builder, uint256 __chiEval)
         external
         pure
@@ -95,12 +69,12 @@ library EqualsExpr {
             function literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL AddExpr.pre.sol
-            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+            // IMPORT-YUL EqualsExpr.pre.sol
+            function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL SubtractExpr.pre.sol
-            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+            // IMPORT-YUL AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
@@ -116,37 +90,19 @@ library EqualsExpr {
                 revert(0, 0)
             }
 
-            function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 let lhs_eval
                 expr_ptr, lhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
                 let rhs_eval
                 expr_ptr, rhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
-                let diff_eval := addmod(lhs_eval, mulmod(MODULUS_MINUS_ONE, rhs_eval, MODULUS), MODULUS)
-                let diff_star_eval := builder_consume_final_round_mle(builder_ptr)
-                result_eval := mod(builder_consume_final_round_mle(builder_ptr), MODULUS)
-
-                builder_produce_identity_constraint(builder_ptr, mulmod(result_eval, diff_eval, MODULUS), 2)
-                builder_produce_identity_constraint(
-                    builder_ptr,
-                    addmod(
-                        chi_eval,
-                        mulmod(
-                            MODULUS_MINUS_ONE,
-                            addmod(mulmod(diff_eval, diff_star_eval, MODULUS), result_eval, MODULUS),
-                            MODULUS
-                        ),
-                        MODULUS
-                    ),
-                    2
-                )
-
+                result_eval := addmod(lhs_eval, mulmod(MODULUS_MINUS_ONE, rhs_eval, MODULUS), MODULUS)
                 expr_ptr_out := expr_ptr
             }
 
             let __exprOutOffset
-            __exprOutOffset, __eval := equals_expr_evaluate(__expr.offset, __builder, __chiEval)
+            __exprOutOffset, __eval := subtract_expr_evaluate(__expr.offset, __builder, __chiEval)
             __exprOut.offset := __exprOutOffset
             // slither-disable-next-line write-after-write
             __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -132,6 +132,14 @@ library FilterExec {
             function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/SubtractExpr.pre.sol
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -95,6 +95,14 @@ library ProofPlan {
             function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/SubtractExpr.pre.sol
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -270,6 +270,14 @@ library Verifier {
             function literal_expr_evaluate(expr_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/SubtractExpr.pre.sol
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/test/proof_exprs/AddExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/AddExpr.t.pre.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {AddExpr} from "../../src/proof_exprs/AddExpr.pre.sol";
+import {F} from "../base/FieldUtil.sol";
+
+contract AddExprTest is Test {
+    function testSimpleAddExpr() public pure {
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(7)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(5)),
+            hex"abcdef"
+        );
+        VerificationBuilder.Builder memory builder;
+
+        uint256 eval;
+        (expr, builder, eval) = AddExpr.__addExprEvaluate(expr, builder, 10);
+
+        assert(eval == 120);
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testFuzzAddExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        int64 lhsValue,
+        int64 rhsValue,
+        bytes memory trailingExpr
+    ) public pure {
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, lhsValue),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, rhsValue),
+            trailingExpr
+        );
+
+        uint256 eval;
+        (expr, builder, eval) = AddExpr.__addExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == ((F.from(lhsValue) + F.from(rhsValue)) * F.from(chiEvaluation)).into());
+        assert(expr.length == trailingExpr.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+}

--- a/solidity/test/proof_exprs/ProofExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/ProofExpr.t.pre.sol
@@ -75,10 +75,52 @@ contract ProofExprTest is Test {
         }
     }
 
+    function testAddExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            ADD_EXPR_VARIANT,
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(2)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(2)),
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 3);
+
+        assert(eval == 12); // 2 * 3 + 2 * 3
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testSubtractExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            SUBTRACT_EXPR_VARIANT,
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(3)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(2)),
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 3);
+
+        assert(eval == 3); // 3 * 3 - 2 * 3
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testUnsupportedVariant() public {
         VerificationBuilder.Builder memory builder;
-        bytes memory exprIn = abi.encodePacked(uint32(3), hex"abcdef");
+        bytes memory exprIn = abi.encodePacked(uint32(5), hex"abcdef");
         vm.expectRevert(Errors.UnsupportedProofExprVariant.selector);
         ProofExpr.__proofExprEvaluate(exprIn, builder, 0);
     }
@@ -87,5 +129,7 @@ contract ProofExprTest is Test {
         assert(uint32(ProofExpr.ExprVariant.Column) == COLUMN_EXPR_VARIANT);
         assert(uint32(ProofExpr.ExprVariant.Literal) == LITERAL_EXPR_VARIANT);
         assert(uint32(ProofExpr.ExprVariant.Equals) == EQUALS_EXPR_VARIANT);
+        assert(uint32(ProofExpr.ExprVariant.Add) == ADD_EXPR_VARIANT);
+        assert(uint32(ProofExpr.ExprVariant.Subtract) == SUBTRACT_EXPR_VARIANT);
     }
 }

--- a/solidity/test/proof_exprs/SubtractExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/SubtractExpr.t.pre.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {SubtractExpr} from "../../src/proof_exprs/SubtractExpr.pre.sol";
+import {F} from "../base/FieldUtil.sol";
+
+contract SubtractExprTest is Test {
+    function testSimpleSubtractExpr() public pure {
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(7)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(5)),
+            hex"abcdef"
+        );
+        VerificationBuilder.Builder memory builder;
+
+        uint256 eval;
+        (expr, builder, eval) = SubtractExpr.__subtractExprEvaluate(expr, builder, 10);
+
+        assert(eval == 20);
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testFuzzSubtractExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        int64 lhsValue,
+        int64 rhsValue,
+        bytes memory trailingExpr
+    ) public pure {
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, lhsValue),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, rhsValue),
+            trailingExpr
+        );
+
+        uint256 eval;
+        (expr, builder, eval) = SubtractExpr.__subtractExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == ((F.from(lhsValue) - F.from(rhsValue)) * F.from(chiEvaluation)).into());
+        assert(expr.length == trailingExpr.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+}


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
It is necessary to allow `AddExpr` and `SubtractExpr`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- add `AddExpr` and `SubtractExpr`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.