### PR TITLE
refactor: refactor scale cast numerical utils

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -233,7 +233,7 @@ pub fn try_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult
 /// Casting can only be supported if the resulting data type is a superset of the input data type.
 /// For example Deciaml(6,1) can be cast to Decimal(7,1), but not vice versa.
 #[expect(clippy::missing_panics_doc)]
-pub fn try_scale_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult<()> {
+pub fn try_decimal_scale_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult<()> {
     match (from, to) {
         (
             ColumnType::TinyInt
@@ -1003,6 +1003,7 @@ mod test {
         ));
     }
 
+    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_can_properly_determine_if_types_are_scale_castable() {
         for from in [
@@ -1016,15 +1017,17 @@ mod test {
             let from_precision = Precision::new(from.precision_value().unwrap()).unwrap();
             let two_prec = Precision::new(2).unwrap();
             let forty_prec = Precision::new(40).unwrap();
-            try_scale_cast_types(from, ColumnType::Decimal75(two_prec, 0)).unwrap_err();
-            try_scale_cast_types(from, ColumnType::Decimal75(two_prec, -1)).unwrap_err();
-            try_scale_cast_types(from, ColumnType::Decimal75(two_prec, 1)).unwrap_err();
-            try_scale_cast_types(from, ColumnType::Decimal75(from_precision, 0)).unwrap();
-            try_scale_cast_types(from, ColumnType::Decimal75(from_precision, -1)).unwrap_err();
-            try_scale_cast_types(from, ColumnType::Decimal75(from_precision, 1)).unwrap_err();
-            try_scale_cast_types(from, ColumnType::Decimal75(forty_prec, 0)).unwrap();
-            try_scale_cast_types(from, ColumnType::Decimal75(forty_prec, -1)).unwrap_err();
-            try_scale_cast_types(from, ColumnType::Decimal75(forty_prec, 1)).unwrap();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(two_prec, 0)).unwrap_err();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(two_prec, -1)).unwrap_err();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(two_prec, 1)).unwrap_err();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(from_precision, 0)).unwrap();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(from_precision, -1))
+                .unwrap_err();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(from_precision, 1))
+                .unwrap_err();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(forty_prec, 0)).unwrap();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(forty_prec, -1)).unwrap_err();
+            try_decimal_scale_cast_types(from, ColumnType::Decimal75(forty_prec, 1)).unwrap();
         }
 
         let twenty_prec = Precision::new(20).unwrap();
@@ -1032,68 +1035,100 @@ mod test {
         // from_with_negative_scale
         let neg_scale = ColumnType::Decimal75(twenty_prec, -3);
 
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -4)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -3)).unwrap();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -2)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, 1)).unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -4))
+            .unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -3)).unwrap();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -2))
+            .unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, 1)).unwrap_err();
 
         let nineteen_prec = Precision::new(19).unwrap();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -4)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -3)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -2)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, 0)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, 1)).unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -4))
+            .unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -3))
+            .unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -2))
+            .unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, 0))
+            .unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, 1))
+            .unwrap_err();
 
         let twenty_one_prec = Precision::new(21).unwrap();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -4)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -3)).unwrap();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -2)).unwrap();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, 0)).unwrap_err();
-        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, 1)).unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -4))
+            .unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -3))
+            .unwrap();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -2))
+            .unwrap();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, 0))
+            .unwrap_err();
+        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, 1))
+            .unwrap_err();
 
         // from_with_zero_scale
         let zero_scale = ColumnType::Decimal75(twenty_prec, 0);
 
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, -1)).unwrap_err();
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap();
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, 1)).unwrap_err();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, -1))
+            .unwrap_err();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, 1))
+            .unwrap_err();
 
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, -1)).unwrap_err();
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 0)).unwrap_err();
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 1)).unwrap_err();
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 2)).unwrap_err();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, -1))
+            .unwrap_err();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 0))
+            .unwrap_err();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 1))
+            .unwrap_err();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 2))
+            .unwrap_err();
 
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, -1)).unwrap_err();
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 0)).unwrap();
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 1)).unwrap();
-        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 2)).unwrap_err();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, -1))
+            .unwrap_err();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 0))
+            .unwrap();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 1))
+            .unwrap();
+        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 2))
+            .unwrap_err();
 
         // from_with_positive_scale
         let pos_scale = ColumnType::Decimal75(twenty_prec, 3);
 
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, -1)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 2)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 3)).unwrap();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 4)).unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, -1))
+            .unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 2)).unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 3)).unwrap();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 4)).unwrap_err();
 
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, -1)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 0)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 2)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 3)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 4)).unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, -1))
+            .unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 0))
+            .unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 2))
+            .unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 3))
+            .unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 4))
+            .unwrap_err();
 
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, -1)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 0)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 2)).unwrap_err();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 3)).unwrap();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 4)).unwrap();
-        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 5)).unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, -1))
+            .unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 0))
+            .unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 2))
+            .unwrap_err();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 3)).unwrap();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 4)).unwrap();
+        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 5))
+            .unwrap_err();
     }
 
     #[test]
     fn we_cannot_scale_cast_nonsense_pairings() {
-        try_scale_cast_types(ColumnType::Int128, ColumnType::Boolean).unwrap_err();
+        try_decimal_scale_cast_types(ColumnType::Int128, ColumnType::Boolean).unwrap_err();
     }
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -14,8 +14,8 @@ mod slice_decimal_operation;
 
 mod column_type_operation;
 pub use column_type_operation::{
-    try_add_subtract_column_types, try_cast_types, try_divide_column_types,
-    try_multiply_column_types, try_scale_cast_types,
+    try_add_subtract_column_types, try_cast_types, try_decimal_scale_cast_types,
+    try_divide_column_types, try_multiply_column_types,
 };
 
 mod column_arithmetic_operation;

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -1,6 +1,6 @@
 use crate::base::{
     database::{
-        try_cast_types, try_scale_cast_types, Column, ColumnOperationResult, ColumnType,
+        try_cast_types, try_decimal_scale_cast_types, Column, ColumnOperationResult, ColumnType,
         ColumnarValue, LiteralValue,
     },
     math::decimal::Precision,
@@ -721,7 +721,7 @@ pub fn try_get_scaling_factor_with_precision_and_scale<S: Scalar>(
     from_type: ColumnType,
     to_type: ColumnType,
 ) -> ColumnOperationResult<(S, u8, i8)> {
-    try_scale_cast_types(from_type, to_type)?;
+    try_decimal_scale_cast_types(from_type, to_type)?;
     let to_precision = to_type.precision_value().unwrap();
     let to_scale = to_type.scale().unwrap();
     let power = u32::try_from(to_scale - from_type.scale().unwrap()).unwrap();
@@ -736,8 +736,7 @@ pub fn try_get_scaling_factor_with_precision_and_scale<S: Scalar>(
 ///
 /// # Panics
 /// Panics if casting is invalid between the two types
-#[cfg_attr(not(test), expect(dead_code))]
-pub fn scale_cast_column<'a, S: Scalar>(
+pub fn cast_column_to_decimal_with_scaling<'a, S: Scalar>(
     alloc: &'a Bump,
     from_column: Column<'a, S>,
     to_type: ColumnType,
@@ -771,7 +770,7 @@ mod tests {
             scalar::{test_scalar::TestScalar, Scalar, ScalarExt},
         },
         sql::proof_exprs::numerical_util::{
-            modulo_columns, modulo_integer_columns, scale_cast_column,
+            cast_column_to_decimal_with_scaling, modulo_columns, modulo_integer_columns,
             try_get_scaling_factor_with_precision_and_scale,
         },
     };
@@ -1307,7 +1306,11 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            scale_cast_column(&alloc, tiny_int_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                tiny_int_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1320,7 +1323,11 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            scale_cast_column(&alloc, uint8_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                uint8_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1331,7 +1338,11 @@ mod tests {
         let scale = 0i8;
         let scalar_slice = small_int_slice.map(TestScalar::from);
         assert_eq!(
-            scale_cast_column(&alloc, small_int_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                small_int_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1342,7 +1353,11 @@ mod tests {
         let scale = 0i8;
         let scalar_slice = int_slice.map(TestScalar::from);
         assert_eq!(
-            scale_cast_column(&alloc, int_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                int_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1355,7 +1370,11 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(100));
         assert_eq!(
-            scale_cast_column(&alloc, big_int_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                big_int_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1368,7 +1387,11 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            scale_cast_column(&alloc, int_128_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                int_128_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
     }
@@ -1385,7 +1408,11 @@ mod tests {
         let scale = -1i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::TEN);
         assert_eq!(
-            scale_cast_column(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                decimal_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1397,7 +1424,11 @@ mod tests {
         let scale = 1i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::from(1_000));
         assert_eq!(
-            scale_cast_column(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                decimal_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1409,7 +1440,11 @@ mod tests {
         let scale = 2i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::TEN);
         assert_eq!(
-            scale_cast_column(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
+            cast_column_to_decimal_with_scaling(
+                &alloc,
+                decimal_column,
+                ColumnType::Decimal75(prec, scale)
+            ),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -732,6 +732,7 @@ pub fn try_get_scaling_factor_with_precision_and_scale(
 ///
 /// # Panics
 /// Panics if casting is invalid between the two types
+#[cfg_attr(not(test), expect(dead_code))]
 pub fn cast_column_to_decimal_with_scaling<'a, S: Scalar>(
     alloc: &'a Bump,
     from_column: Column<'a, S>,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
