### PR TITLE
fix: correct visit_binary_expr

### DIFF
--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -211,24 +211,7 @@ impl QueryContextBuilder<'_> {
     ) -> ConversionResult<ColumnType> {
         let left_dtype = self.visit_expr(left)?;
         let right_dtype = self.visit_expr(right)?;
-        check_dtypes(left_dtype, right_dtype, op)?;
-        match op {
-            BinaryOperator::And
-            | BinaryOperator::Or
-            | BinaryOperator::Eq
-            | BinaryOperator::Gt
-            | BinaryOperator::Lt => Ok(ColumnType::Boolean),
-            BinaryOperator::Multiply
-            | BinaryOperator::Divide
-            | BinaryOperator::Minus
-            | BinaryOperator::Plus => Ok(left_dtype),
-            _ => {
-                // Handle unsupported binary operations
-                Err(ConversionError::UnsupportedOperation {
-                    message: format!("{op:?}"),
-                })
-            }
-        }
+        Ok(check_dtypes(left_dtype, right_dtype, op)?)
     }
 
     fn visit_unary_expr(

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -5,7 +5,7 @@ use crate::{
         scalar::{Scalar, ScalarExt},
         slice_ops,
     },
-    sql::{util::type_check_binary_operation, AnalyzeError, AnalyzeResult},
+    sql::{util::try_binary_operation_type, AnalyzeError, AnalyzeResult},
 };
 use alloc::string::ToString;
 use bumpalo::Bump;
@@ -33,7 +33,7 @@ pub fn scale_and_subtract_literal<S: Scalar>(
     } else {
         BinaryOperator::Lt
     };
-    if type_check_binary_operation(lhs_type, rhs_type, &operator).is_none() {
+    if try_binary_operation_type(lhs_type, rhs_type, &operator).is_none() {
         return Err(AnalyzeError::DataTypeMismatch {
             left_type: lhs_type.to_string(),
             right_type: rhs_type.to_string(),
@@ -106,7 +106,7 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
     } else {
         BinaryOperator::Lt
     };
-    if type_check_binary_operation(lhs_type, rhs_type, &operator).is_none() {
+    if try_binary_operation_type(lhs_type, rhs_type, &operator).is_none() {
         return Err(AnalyzeError::DataTypeMismatch {
             left_type: lhs_type.to_string(),
             right_type: rhs_type.to_string(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/comparison_util.rs
@@ -33,7 +33,7 @@ pub fn scale_and_subtract_literal<S: Scalar>(
     } else {
         BinaryOperator::Lt
     };
-    if !type_check_binary_operation(lhs_type, rhs_type, &operator) {
+    if type_check_binary_operation(lhs_type, rhs_type, &operator).is_none() {
         return Err(AnalyzeError::DataTypeMismatch {
             left_type: lhs_type.to_string(),
             right_type: rhs_type.to_string(),
@@ -106,7 +106,7 @@ pub(crate) fn scale_and_subtract<'a, S: Scalar>(
     } else {
         BinaryOperator::Lt
     };
-    if !type_check_binary_operation(lhs_type, rhs_type, &operator) {
+    if type_check_binary_operation(lhs_type, rhs_type, &operator).is_none() {
         return Err(AnalyzeError::DataTypeMismatch {
             left_type: lhs_type.to_string(),
             right_type: rhs_type.to_string(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
-        util::type_check_binary_operation,
+        util::try_binary_operation_type,
         AnalyzeError, AnalyzeResult,
     },
 };
@@ -87,7 +87,7 @@ impl DynProofExpr {
     pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Eq).is_some() {
+        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Eq).is_some() {
             Ok(Self::Equals(EqualsExpr::new(Box::new(lhs), Box::new(rhs))))
         } else {
             Err(AnalyzeError::DataTypeMismatch {
@@ -104,7 +104,7 @@ impl DynProofExpr {
     ) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Lt).is_some() {
+        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Lt).is_some() {
             Ok(Self::Inequality(InequalityExpr::new(
                 Box::new(lhs),
                 Box::new(rhs),
@@ -122,8 +122,7 @@ impl DynProofExpr {
     pub fn try_new_add(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Plus).is_some()
-        {
+        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Plus).is_some() {
             Ok(Self::AddSubtract(AddSubtractExpr::new(
                 Box::new(lhs),
                 Box::new(rhs),
@@ -141,8 +140,7 @@ impl DynProofExpr {
     pub fn try_new_subtract(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Minus).is_some()
-        {
+        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Minus).is_some() {
             Ok(Self::AddSubtract(AddSubtractExpr::new(
                 Box::new(lhs),
                 Box::new(rhs),
@@ -160,7 +158,7 @@ impl DynProofExpr {
     pub fn try_new_multiply(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Multiply)
+        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Multiply)
             .is_some()
         {
             Ok(Self::Multiply(MultiplyExpr::new(

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -87,7 +87,7 @@ impl DynProofExpr {
     pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Eq) {
+        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Eq).is_some() {
             Ok(Self::Equals(EqualsExpr::new(Box::new(lhs), Box::new(rhs))))
         } else {
             Err(AnalyzeError::DataTypeMismatch {
@@ -104,7 +104,7 @@ impl DynProofExpr {
     ) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Lt) {
+        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Lt).is_some() {
             Ok(Self::Inequality(InequalityExpr::new(
                 Box::new(lhs),
                 Box::new(rhs),
@@ -122,7 +122,8 @@ impl DynProofExpr {
     pub fn try_new_add(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Plus) {
+        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Plus).is_some()
+        {
             Ok(Self::AddSubtract(AddSubtractExpr::new(
                 Box::new(lhs),
                 Box::new(rhs),
@@ -140,7 +141,8 @@ impl DynProofExpr {
     pub fn try_new_subtract(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Minus) {
+        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Minus).is_some()
+        {
             Ok(Self::AddSubtract(AddSubtractExpr::new(
                 Box::new(lhs),
                 Box::new(rhs),
@@ -158,7 +160,9 @@ impl DynProofExpr {
     pub fn try_new_multiply(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
-        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Multiply) {
+        if type_check_binary_operation(lhs_datatype, rhs_datatype, &BinaryOperator::Multiply)
+            .is_some()
+        {
             Ok(Self::Multiply(MultiplyExpr::new(
                 Box::new(lhs),
                 Box::new(rhs),

--- a/crates/proof-of-sql/src/sql/util.rs
+++ b/crates/proof-of-sql/src/sql/util.rs
@@ -14,7 +14,7 @@ use sqlparser::ast::BinaryOperator;
 /// # Returns
 ///
 /// * `Some(result_type)` if the operation is valid, `None` otherwise.
-pub(crate) fn type_check_binary_operation(
+pub(crate) fn try_binary_operation_type(
     left_dtype: ColumnType,
     right_dtype: ColumnType,
     binary_operator: &BinaryOperator,
@@ -77,7 +77,7 @@ pub(crate) fn check_dtypes(
     right_dtype: ColumnType,
     binary_operator: &BinaryOperator,
 ) -> AnalyzeResult<ColumnType> {
-    type_check_binary_operation(left_dtype, right_dtype, binary_operator).ok_or(
+    try_binary_operation_type(left_dtype, right_dtype, binary_operator).ok_or(
         AnalyzeError::DataTypeMismatch {
             left_type: left_dtype.to_string(),
             right_type: right_dtype.to_string(),
@@ -87,13 +87,13 @@ pub(crate) fn check_dtypes(
 
 #[cfg(test)]
 mod tests {
-    use super::type_check_binary_operation;
+    use super::try_binary_operation_type;
     use crate::base::{database::ColumnType, math::decimal::Precision};
     use sqlparser::ast::BinaryOperator;
 
     #[test]
     fn we_can_return_none_if_decimal_has_too_high_of_precision() {
-        assert!(type_check_binary_operation(
+        assert!(try_binary_operation_type(
             ColumnType::Int,
             ColumnType::Decimal75(Precision::new(40).unwrap(), 0),
             &BinaryOperator::Gt
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn we_can_return_none_for_unsupported_operation() {
-        assert!(type_check_binary_operation(
+        assert!(try_binary_operation_type(
             ColumnType::Int,
             ColumnType::Decimal75(Precision::new(40).unwrap(), 0),
             &BinaryOperator::BitwiseXor
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn we_can_return_value_for_divide() {
-        assert!(type_check_binary_operation(
+        assert!(try_binary_operation_type(
             ColumnType::Int,
             ColumnType::Decimal75(Precision::new(40).unwrap(), 0),
             &BinaryOperator::Divide

--- a/crates/proof-of-sql/src/sql/util.rs
+++ b/crates/proof-of-sql/src/sql/util.rs
@@ -84,3 +84,40 @@ pub(crate) fn check_dtypes(
         },
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::type_check_binary_operation;
+    use crate::base::{database::ColumnType, math::decimal::Precision};
+    use sqlparser::ast::BinaryOperator;
+
+    #[test]
+    fn we_can_return_none_if_decimal_has_too_high_of_precision() {
+        assert!(type_check_binary_operation(
+            ColumnType::Int,
+            ColumnType::Decimal75(Precision::new(40).unwrap(), 0),
+            &BinaryOperator::Gt
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn we_can_return_none_for_unsupported_operation() {
+        assert!(type_check_binary_operation(
+            ColumnType::Int,
+            ColumnType::Decimal75(Precision::new(40).unwrap(), 0),
+            &BinaryOperator::BitwiseXor
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn we_can_return_value_for_divide() {
+        assert!(type_check_binary_operation(
+            ColumnType::Int,
+            ColumnType::Decimal75(Precision::new(40).unwrap(), 0),
+            &BinaryOperator::Divide
+        )
+        .is_some());
+    }
+}

--- a/crates/proof-of-sql/src/sql/util.rs
+++ b/crates/proof-of-sql/src/sql/util.rs
@@ -13,60 +13,61 @@ use sqlparser::ast::BinaryOperator;
 ///
 /// # Returns
 ///
-/// * `true` if the operation is valid, `false` otherwise.
+/// * `Some(result_type)` if the operation is valid, `None` otherwise.
 pub(crate) fn type_check_binary_operation(
     left_dtype: ColumnType,
     right_dtype: ColumnType,
     binary_operator: &BinaryOperator,
-) -> bool {
+) -> Option<ColumnType> {
     match binary_operator {
-        BinaryOperator::And | BinaryOperator::Or => {
-            matches!(
-                (left_dtype, right_dtype),
-                (ColumnType::Boolean, ColumnType::Boolean)
-            )
-        }
-        BinaryOperator::Eq => {
-            matches!(
-                (left_dtype, right_dtype),
-                (ColumnType::VarChar, ColumnType::VarChar)
-                    | (ColumnType::VarBinary, ColumnType::VarBinary)
-                    | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
-                    | (ColumnType::Boolean, ColumnType::Boolean)
-                    | (_, ColumnType::Scalar)
-                    | (ColumnType::Scalar, _)
-            ) || (left_dtype.is_numeric() && right_dtype.is_numeric())
-        }
+        BinaryOperator::And | BinaryOperator::Or => matches!(
+            (left_dtype, right_dtype),
+            (ColumnType::Boolean, ColumnType::Boolean)
+        )
+        .then_some(ColumnType::Boolean),
+        BinaryOperator::Eq => (matches!(
+            (left_dtype, right_dtype),
+            (ColumnType::VarChar, ColumnType::VarChar)
+                | (ColumnType::VarBinary, ColumnType::VarBinary)
+                | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
+                | (ColumnType::Boolean, ColumnType::Boolean)
+                | (_, ColumnType::Scalar)
+                | (ColumnType::Scalar, _)
+        ) || (left_dtype.is_numeric() && right_dtype.is_numeric()))
+        .then_some(ColumnType::Boolean),
         BinaryOperator::Gt | BinaryOperator::Lt => {
             if left_dtype == ColumnType::VarChar || right_dtype == ColumnType::VarChar {
-                return false;
+                return None;
             }
             // Due to constraints in bitwise_verification we limit the precision of decimal types to 38
             if let ColumnType::Decimal75(precision, _) = left_dtype {
                 if precision.value() > 38 {
-                    return false;
+                    return None;
                 }
             }
             if let ColumnType::Decimal75(precision, _) = right_dtype {
                 if precision.value() > 38 {
-                    return false;
+                    return None;
                 }
             }
-            left_dtype.is_numeric() && right_dtype.is_numeric()
+            (left_dtype.is_numeric() && right_dtype.is_numeric()
                 || matches!(
                     (left_dtype, right_dtype),
                     (ColumnType::Boolean, ColumnType::Boolean)
                         | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
-                )
+                ))
+            .then_some(ColumnType::Boolean)
         }
         BinaryOperator::Plus | BinaryOperator::Minus => {
-            try_add_subtract_column_types(left_dtype, right_dtype).is_ok()
+            try_add_subtract_column_types(left_dtype, right_dtype).ok()
         }
-        BinaryOperator::Multiply => try_multiply_column_types(left_dtype, right_dtype).is_ok(),
-        BinaryOperator::Divide => left_dtype.is_numeric() && right_dtype.is_numeric(),
+        BinaryOperator::Multiply => try_multiply_column_types(left_dtype, right_dtype).ok(),
+        BinaryOperator::Divide => {
+            (left_dtype.is_numeric() && right_dtype.is_numeric()).then_some(left_dtype)
+        }
         _ => {
             // Handle unsupported binary operations
-            false
+            None
         }
     }
 }
@@ -75,13 +76,11 @@ pub(crate) fn check_dtypes(
     left_dtype: ColumnType,
     right_dtype: ColumnType,
     binary_operator: &BinaryOperator,
-) -> AnalyzeResult<()> {
-    if type_check_binary_operation(left_dtype, right_dtype, binary_operator) {
-        Ok(())
-    } else {
-        Err(AnalyzeError::DataTypeMismatch {
+) -> AnalyzeResult<ColumnType> {
+    type_check_binary_operation(left_dtype, right_dtype, binary_operator).ok_or(
+        AnalyzeError::DataTypeMismatch {
             left_type: left_dtype.to_string(),
             right_type: right_dtype.to_string(),
-        })
-    }
+        },
+    )
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
