### PR TITLE
refactor: clean up all `allow`s

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld
       - name: Run clippy
-        run: cargo cl -- -D warnings -A unfulfilled_lint_expectations
+        run: cargo cl -- -D warnings
 
   coverage:
     name: Code Coverage

--- a/crates/proof-of-sql-parser/src/lib.rs
+++ b/crates/proof-of-sql-parser/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![cfg_attr(test, allow(clippy::missing_panics_doc))]
+#![cfg_attr(test, expect(clippy::missing_panics_doc))]
 extern crate alloc;
 
 /// Module for handling an intermediate timestamp type received from the lexer.
@@ -35,7 +35,7 @@ pub use resource_id::ResourceId;
 pub mod sqlparser;
 
 // lalrpop-generated code is not clippy-compliant
-lalrpop_mod!(#[allow(clippy::all, missing_docs, clippy::missing_docs_in_private_items, clippy::pedantic, clippy::missing_panics_doc, clippy::allow_attributes)] pub sql);
+lalrpop_mod!(#[expect(clippy::all, missing_docs, clippy::pedantic, clippy::missing_panics_doc, clippy::allow_attributes, reason = "lalrpop-generated code can not be expected to be clippy-compliant or use expect")] pub sql);
 
 /// Implement [`Deserialize`](serde::Deserialize) through [`FromStr`](core::str::FromStr) to avoid invalid identifiers.
 #[macro_export]

--- a/crates/proof-of-sql-parser/src/posql_time/error.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/error.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 /// Errors related to time operations, including timezone and timestamp conversions.
-#[expect(clippy::module_name_repetitions)]
 #[derive(Snafu, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PoSQLTimestampError {
     /// Error when the timezone string provided cannot be parsed into a valid timezone.

--- a/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/timestamp.rs
@@ -5,7 +5,6 @@ use core::hash::Hash;
 use serde::{Deserialize, Serialize};
 
 /// Represents a fully parsed timestamp with detailed time unit and timezone information
-#[expect(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PoSQLTimestamp {
     /// The datetime representation in UTC.

--- a/crates/proof-of-sql-parser/src/posql_time/unit.rs
+++ b/crates/proof-of-sql-parser/src/posql_time/unit.rs
@@ -3,7 +3,6 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 /// An intermediate type representing the time units from a parsed query
-#[expect(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PoSQLTimeUnit {
     /// Represents seconds with precision 0: ex "2024-06-20 12:34:56"
@@ -53,7 +52,7 @@ impl fmt::Display for PoSQLTimeUnit {
     }
 }
 
-// allow(deprecated) for the sole purpose of testing that
+// expect(deprecated) for the sole purpose of testing that
 // timestamp precision is parsed correctly.
 #[cfg(test)]
 #[expect(deprecated, clippy::missing_panics_doc)]

--- a/crates/proof-of-sql-planner/tests/e2e_tests.rs
+++ b/crates/proof-of-sql-planner/tests/e2e_tests.rs
@@ -1,5 +1,4 @@
 //! In this file we run end-to-end tests for Proof of SQL.
-#![cfg_attr(test, allow(clippy::missing_panics_doc))]
 use ark_std::test_rng;
 use bumpalo::Bump;
 use datafusion::{catalog::TableReference, common::DFSchema, config::ConfigOptions};

--- a/crates/proof-of-sql/benches/bench_append_rows.rs
+++ b/crates/proof-of-sql/benches/bench_append_rows.rs
@@ -5,7 +5,7 @@
 //! ```bash
 //! cargo bench --features "test" --bench bench_append_rows
 //! ```
-#![allow(missing_docs, clippy::missing_docs_in_private_items)]
+#![expect(missing_docs, clippy::missing_docs_in_private_items)]
 use ark_std::test_rng;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use proof_of_sql::{

--- a/crates/proof-of-sql/benches/jaeger/bin/utils/queries.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/utils/queries.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::cast_possible_wrap)]
+#![expect(clippy::cast_possible_wrap)]
 use super::OptionalRandBound;
 use proof_of_sql::base::database::ColumnType;
 
@@ -185,7 +185,6 @@ pub const QUERIES: &[QueryEntry] = &[
 /// # Returns
 /// * `Some((&str, &str, &[(&str, ColumnType, OptionalRandBound)]))` if the query is found.
 /// * `None` if no query with the given title exists.
-#[expect(dead_code)]
 pub fn get_query(title: &str) -> Option<QueryEntry> {
     QUERIES
         .iter()

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -7,7 +7,7 @@ pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAcc
 mod column;
 pub use column::{Column, ColumnField, ColumnRef, ColumnType};
 
-#[expect(dead_code)]
+#[cfg_attr(not(test), expect(dead_code))]
 pub(crate) mod slice_operation;
 
 mod slice_decimal_operation;
@@ -27,7 +27,6 @@ pub(super) use column_comparison_operation::{ComparisonOp, EqualOp, GreaterThanO
 mod column_index_operation;
 pub(super) use column_index_operation::apply_column_to_indexes;
 
-#[expect(dead_code)]
 mod column_repetition_operation;
 pub(super) use column_repetition_operation::{ColumnRepeatOp, ElementwiseRepeatOp, RepetitionOp};
 
@@ -125,5 +124,5 @@ pub(crate) mod order_by_util;
 #[cfg(test)]
 mod order_by_util_test;
 
-#[expect(dead_code)]
+#[cfg_attr(not(test), expect(dead_code))]
 pub(crate) mod join_util;

--- a/crates/proof-of-sql/src/base/encode/varint_trait.rs
+++ b/crates/proof-of-sql/src/base/encode/varint_trait.rs
@@ -72,13 +72,13 @@ fn zigzag_decode(from: u64) -> i64 {
 macro_rules! impl_varint {
     ($t:ty, unsigned) => {
         impl VarInt for $t {
-            #[expect(clippy::cast_lossless)]
+            #[allow(clippy::cast_lossless, clippy::allow_attributes, reason = "In a macro different instances can differ hence allow can not be replaced with expect")]
             fn required_space(self) -> usize {
                 (self as u64).required_space()
             }
 
             #[expect(clippy::cast_possible_truncation)]
-            #[expect(clippy::cast_lossless)]
+            #[allow(clippy::cast_lossless, clippy::allow_attributes, reason = "In a macro different instances can differ hence allow can not be replaced with expect")]
             fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
                 let (n, s) = u64::decode_var(src)?;
                 // This check is required to ensure that we actually return `None` when `src` has a value that would overflow `Self`.
@@ -89,7 +89,7 @@ macro_rules! impl_varint {
                 }
             }
 
-            #[expect(clippy::cast_lossless)]
+            #[allow(clippy::cast_lossless, clippy::allow_attributes, reason = "In a macro different instances can differ hence allow can not be replaced with expect")]
             fn encode_var(self, dst: &mut [u8]) -> usize {
                 (self as u64).encode_var(dst)
             }
@@ -97,13 +97,13 @@ macro_rules! impl_varint {
     };
     ($t:ty, signed) => {
         impl VarInt for $t {
-            #[expect(clippy::cast_lossless)]
+            #[allow(clippy::cast_lossless, clippy::allow_attributes, reason = "In a macro different instances can differ hence allow can not be replaced with expect")]
             fn required_space(self) -> usize {
                 (self as i64).required_space()
             }
 
             #[expect(clippy::cast_possible_truncation)]
-            #[expect(clippy::cast_lossless)]
+            #[allow(clippy::cast_lossless, clippy::allow_attributes, reason = "In a macro different instances can differ hence allow can not be replaced with expect")]
             fn decode_var(src: &[u8]) -> Option<(Self, usize)> {
                 let (n, s) = i64::decode_var(src)?;
                 // This check is required to ensure that we actually return `None` when `src` has a value that would overflow `Self`.
@@ -114,7 +114,7 @@ macro_rules! impl_varint {
                 }
             }
 
-            #[expect(clippy::cast_lossless)]
+            #[allow(clippy::cast_lossless, clippy::allow_attributes, reason = "In a macro different instances can differ hence allow can not be replaced with expect")]
             fn encode_var(self, dst: &mut [u8]) -> usize {
                 (self as i64).encode_var(dst)
             }

--- a/crates/proof-of-sql/src/base/polynomial/interpolate.rs
+++ b/crates/proof-of-sql/src/base/polynomial/interpolate.rs
@@ -15,7 +15,7 @@ use num_traits::{Inv, One, Zero};
 // Allow missing panics documentation because the function should not panic under normal conditions.
 /// unless x is one of 0,1,...,d, in which case, f(x) is already known.
 #[expect(clippy::missing_panics_doc)]
-#[expect(dead_code)]
+#[cfg_attr(not(test), expect(dead_code))]
 pub fn interpolate_uni_poly<F>(polynomial: &[F], x: F) -> F
 where
     F: Copy

--- a/crates/proof-of-sql/src/base/posql_time/unit.rs
+++ b/crates/proof-of-sql/src/base/posql_time/unit.rs
@@ -67,7 +67,7 @@ impl fmt::Display for PoSQLTimeUnit {
     }
 }
 
-// allow(deprecated) for the sole purpose of testing that
+// expect(deprecated) for the sole purpose of testing that
 // timestamp precision is parsed correctly.
 #[cfg(test)]
 #[expect(clippy::missing_panics_doc)]

--- a/crates/proof-of-sql/src/base/scalar/scalar.rs
+++ b/crates/proof-of-sql/src/base/scalar/scalar.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::module_inception)]
+#![expect(clippy::module_inception)]
 
 use crate::base::{encode::VarInt, ref_into::RefInto, scalar::ScalarConversionError};
 use alloc::string::String;

--- a/crates/proof-of-sql/src/lib.rs
+++ b/crates/proof-of-sql/src/lib.rs
@@ -1,7 +1,6 @@
-#![cfg_attr(test, allow(clippy::missing_panics_doc))]
+#![cfg_attr(test, expect(clippy::missing_panics_doc))]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(clippy::module_name_repetitions)]
 
 extern crate alloc;
 

--- a/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/mod.rs
@@ -15,7 +15,7 @@
 //! This can be extended in the future to achieve hiding, but that isn't needed for our initial use-case.
 
 // This is so that the naming in the code more closely matches the naming in the paper, since the paper used both capital and non-capital letters.
-#![allow(non_snake_case)]
+#![expect(non_snake_case)]
 
 use ark_bls12_381::{Fr as F, G1Affine, G1Projective, G2Affine, G2Projective};
 /// The pairing output of the BLS12-381 curve.

--- a/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
+++ b/crates/proof-of-sql/src/proof_primitive/dory/scalar_product.rs
@@ -1,4 +1,3 @@
-#![allow(unused_variables)]
 use super::{pairings, DoryMessages, ProverState, VerifierSetup, VerifierState};
 use crate::{base::proof::Transcript, utils::log};
 
@@ -33,7 +32,7 @@ pub fn scalar_product_prove(
     let E_2 = state.v2[0];
     messages.prover_send_G1_message(transcript, E_1);
     messages.prover_send_G2_message(transcript, E_2);
-    let (d, d_inv) = messages.verifier_F_message(transcript);
+    let (_d, _d_inv) = messages.verifier_F_message(transcript);
 }
 
 /// This is the verifier side of the Scalar-Product algorithm in section 3.1 of https://eprint.iacr.org/2020/1274.pdf.

--- a/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
+++ b/crates/proof-of-sql/src/sql/proof/provable_query_result.rs
@@ -17,7 +17,7 @@ pub struct ProvableQueryResult {
     data: Vec<u8>,
 }
 
-// TODO: Handle truncation properly. The `allow(clippy::cast_possible_truncation)` is a temporary fix and should be replaced with proper logic to manage possible truncation scenarios.
+// TODO: Handle truncation properly. The `expect(clippy::cast_possible_truncation)` is a temporary fix and should be replaced with proper logic to manage possible truncation scenarios.
 impl ProvableQueryResult {
     #[expect(clippy::cast_possible_truncation)]
     /// The number of columns in the result

--- a/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/mod.rs
@@ -3,7 +3,7 @@
 mod divide_and_modulo_expr;
 mod membership_check;
 mod monotonic;
-#[expect(dead_code)]
+#[cfg_attr(not(test), expect(dead_code))]
 mod permutation_check;
 mod shift;
 pub(crate) use membership_check::{
@@ -24,7 +24,7 @@ pub(crate) use sign_expr::{
     final_round_evaluate_sign, first_round_evaluate_sign, verifier_evaluate_sign,
 };
 #[cfg(feature = "blitzar")]
-#[expect(dead_code)]
+#[cfg_attr(not(test), expect(dead_code))]
 mod range_check;
 #[cfg(all(test, feature = "blitzar"))]
 mod range_check_test;

--- a/crates/proof-of-sql/tests/decimal_integration_tests.rs
+++ b/crates/proof-of-sql/tests/decimal_integration_tests.rs
@@ -1,6 +1,6 @@
 //! Decimal integration tests for the proof-of-sql crate.
 #![cfg(feature = "test")]
-#![cfg_attr(test, allow(clippy::missing_panics_doc))]
+#![cfg_attr(test, expect(clippy::missing_panics_doc))]
 #[cfg(feature = "blitzar")]
 use blitzar::proof::InnerProductProof;
 #[cfg(feature = "blitzar")]

--- a/crates/proof-of-sql/tests/integration_tests.rs
+++ b/crates/proof-of-sql/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 //! Other integration tests for the proof-of-sql crate.
 #![cfg(feature = "test")]
-#![cfg_attr(test, allow(clippy::missing_panics_doc))]
+#![cfg_attr(test, expect(clippy::missing_panics_doc))]
 use ark_std::test_rng;
 #[cfg(feature = "blitzar")]
 use proof_of_sql::base::commitment::InnerProductProof;

--- a/crates/proof-of-sql/tests/timestamp_integration_tests.rs
+++ b/crates/proof-of-sql/tests/timestamp_integration_tests.rs
@@ -1,6 +1,6 @@
 //! Timestamp-related integration tests for the proof-of-sql crate.
 #![cfg(feature = "test")]
-#![cfg_attr(test, allow(clippy::missing_panics_doc))]
+#![cfg_attr(test, expect(clippy::missing_panics_doc))]
 use ark_std::test_rng;
 #[cfg(feature = "blitzar")]
 use proof_of_sql::base::commitment::InnerProductProof;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
This is a follow-up of #699. All remaining unjustified `allow`s are removed.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.