### PR TITLE
refactor: clean up names in `evm_proof_plan`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -2,7 +2,7 @@ use snafu::Snafu;
 
 /// Represents errors that can occur in the EVM proof plan module.
 #[derive(Snafu, Debug, PartialEq)]
-pub(crate) enum Error {
+pub(crate) enum EVMProofPlanError {
     /// Error indicating that the plan is not supported.
     #[snafu(display("plan not yet supported"))]
     NotSupported,
@@ -16,3 +16,6 @@ pub(crate) enum Error {
     #[snafu(display("table name can not be parsed into TableRef"))]
     InvalidTableName,
 }
+
+/// Result type for EVM proof plan operations.
+pub(crate) type EVMProofPlanResult<T> = core::result::Result<T, EVMProofPlanError>;

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/mod.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/mod.rs
@@ -1,5 +1,7 @@
 mod error;
+pub(crate) use error::{EVMProofPlanError, EVMProofPlanResult};
 mod exprs;
+pub(crate) use exprs::EVMDynProofExpr;
 mod plans;
 mod proof_plan;
 #[cfg(test)]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
The current code base in `evm_proof_plan` needs to be cleaned up for enhancement since a lot of the names are either too generic or identical to structs and enums in the rest of the crate.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
The following renames have been done:
- `Error` -> `EVMProofPlanError`
- `Expr` -> `EVMDynProofExpr`
- `ColumnExpr` -> `EVMColumnExpr`
- `LiteralExpr` -> `EVMLiteralExpr`
- `EqualsExpr` -> `EVMEqualsExpr`
- `Plan` -> `EVMDynProofPlan`
- `FilterExec` -> `EVMFilterExec`

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.