### PR TITLE
refactor: split `AddSubtractExpr` into `AddExpr` and `SubtractExpr`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -1,0 +1,113 @@
+use super::{add_subtract_columns, scale_and_add_subtract_eval, DynProofExpr, ProofExpr};
+use crate::{
+    base::{
+        database::{
+            try_add_subtract_column_types, Column, ColumnRef, ColumnType, LiteralValue, Table,
+        },
+        map::{IndexMap, IndexSet},
+        proof::{PlaceholderResult, ProofError},
+        scalar::Scalar,
+    },
+    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    utils::log,
+};
+use alloc::boxed::Box;
+use bumpalo::Bump;
+use serde::{Deserialize, Serialize};
+
+/// Provable numerical `+` expression
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AddExpr {
+    lhs: Box<DynProofExpr>,
+    rhs: Box<DynProofExpr>,
+}
+
+impl AddExpr {
+    /// Create numerical `+` expression
+    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
+        Self { lhs, rhs }
+    }
+}
+
+impl ProofExpr for AddExpr {
+    fn data_type(&self) -> ColumnType {
+        try_add_subtract_column_types(self.lhs.data_type(), self.rhs.data_type())
+            .expect("Failed to add/subtract column types")
+    }
+
+    fn first_round_evaluate<'a, S: Scalar>(
+        &self,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        let lhs_column: Column<'a, S> = self.lhs.first_round_evaluate(alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self.rhs.first_round_evaluate(alloc, table, params)?;
+        Ok(Column::Scalar(add_subtract_columns(
+            lhs_column,
+            rhs_column,
+            self.lhs.data_type().scale().unwrap_or(0),
+            self.rhs.data_type().scale().unwrap_or(0),
+            alloc,
+            false,
+        )))
+    }
+
+    #[tracing::instrument(
+        name = "proofs.sql.ast.add_expr.final_round_evaluate",
+        level = "info",
+        skip_all
+    )]
+    fn final_round_evaluate<'a, S: Scalar>(
+        &self,
+        builder: &mut FinalRoundBuilder<'a, S>,
+        alloc: &'a Bump,
+        table: &Table<'a, S>,
+        params: &[LiteralValue],
+    ) -> PlaceholderResult<Column<'a, S>> {
+        log::log_memory_usage("Start");
+
+        let lhs_column: Column<'a, S> = self
+            .lhs
+            .final_round_evaluate(builder, alloc, table, params)?;
+        let rhs_column: Column<'a, S> = self
+            .rhs
+            .final_round_evaluate(builder, alloc, table, params)?;
+        let res = Column::Scalar(add_subtract_columns(
+            lhs_column,
+            rhs_column,
+            self.lhs.data_type().scale().unwrap_or(0),
+            self.rhs.data_type().scale().unwrap_or(0),
+            alloc,
+            false,
+        ));
+
+        log::log_memory_usage("End");
+
+        Ok(res)
+    }
+
+    fn verifier_evaluate<S: Scalar>(
+        &self,
+        builder: &mut impl VerificationBuilder<S>,
+        accessor: &IndexMap<ColumnRef, S>,
+        chi_eval: S,
+        params: &[LiteralValue],
+    ) -> Result<S, ProofError> {
+        let lhs_eval = self
+            .lhs
+            .verifier_evaluate(builder, accessor, chi_eval, params)?;
+        let rhs_eval = self
+            .rhs
+            .verifier_evaluate(builder, accessor, chi_eval, params)?;
+        let lhs_scale = self.lhs.data_type().scale().unwrap_or(0);
+        let rhs_scale = self.rhs.data_type().scale().unwrap_or(0);
+        let res = scale_and_add_subtract_eval(lhs_eval, rhs_eval, lhs_scale, rhs_scale, false);
+        Ok(res)
+    }
+
+    fn get_column_references(&self, columns: &mut IndexSet<ColumnRef>) {
+        self.lhs.get_column_references(columns);
+        self.rhs.get_column_references(columns);
+    }
+}

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -1,7 +1,6 @@
 use super::{
-    cast_expr::CastExpr, decimal_scaling_cast_expr::DecimalScalingCastExpr, AddSubtractExpr,
-    AndExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr, MultiplyExpr, NotExpr, OrExpr,
-    PlaceholderExpr, ProofExpr,
+    AddExpr, AndExpr, CastExpr, ColumnExpr, DecimalScalingCastExpr, EqualsExpr, InequalityExpr,
+    LiteralExpr, MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr, SubtractExpr,
 };
 use crate::{
     base::{
@@ -42,8 +41,10 @@ pub enum DynProofExpr {
     Equals(EqualsExpr),
     /// Provable AST expression for an inequality expression
     Inequality(InequalityExpr),
-    /// Provable numeric `+` / `-` expression
-    AddSubtract(AddSubtractExpr),
+    /// Provable numeric `+` expression
+    Add(AddExpr),
+    /// Provable numeric `-` expression
+    Subtract(SubtractExpr),
     /// Provable numeric `*` expression
     Multiply(MultiplyExpr),
     /// Provable CAST expression
@@ -126,11 +127,7 @@ impl DynProofExpr {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Plus).is_some() {
-            Ok(Self::AddSubtract(AddSubtractExpr::new(
-                Box::new(lhs),
-                Box::new(rhs),
-                false,
-            )))
+            Ok(Self::Add(AddExpr::new(Box::new(lhs), Box::new(rhs))))
         } else {
             Err(AnalyzeError::DataTypeMismatch {
                 left_type: lhs_datatype.to_string(),
@@ -144,10 +141,9 @@ impl DynProofExpr {
         let lhs_datatype = lhs.data_type();
         let rhs_datatype = rhs.data_type();
         if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Minus).is_some() {
-            Ok(Self::AddSubtract(AddSubtractExpr::new(
+            Ok(Self::Subtract(SubtractExpr::new(
                 Box::new(lhs),
                 Box::new(rhs),
-                true,
             )))
         } else {
             Err(AnalyzeError::DataTypeMismatch {

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -7,8 +7,10 @@ mod proof_expr_test;
 mod aliased_dyn_proof_expr;
 pub use aliased_dyn_proof_expr::AliasedDynProofExpr;
 
-mod add_subtract_expr;
-pub(crate) use add_subtract_expr::AddSubtractExpr;
+mod add_expr;
+pub(crate) use add_expr::AddExpr;
+mod subtract_expr;
+pub(crate) use subtract_expr::SubtractExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod add_subtract_expr_test;
 
@@ -77,9 +79,11 @@ pub use column_expr::ColumnExpr;
 mod column_expr_test;
 
 mod cast_expr;
+pub(crate) use cast_expr::CastExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod cast_expr_test;
 
 mod decimal_scaling_cast_expr;
+pub(crate) use decimal_scaling_cast_expr::DecimalScalingCastExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod decimal_scaling_cast_expr_test;


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
In line with new Solidity code in #719 we need to split `AddSubtractExpr` into `AddExpr` and `SubtractExpr`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See title.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.