### PR TITLE
refactor: it should be easier to add new queries to benchmarks

### DIFF
--- a/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/jaeger_benches.rs
@@ -57,7 +57,7 @@ mod utils;
 use utils::{
     benchmark_accessor::BenchmarkAccessor,
     jaeger_setup::{setup_jaeger_tracing, stop_jaeger_tracing},
-    queries::{get_query, QueryEntry, QUERIES},
+    queries::{all_queries, get_query, QueryEntry},
     random_util::generate_random_columns,
 };
 
@@ -403,30 +403,30 @@ fn main() {
     let cli = Cli::parse();
 
     let queries = if cli.query == Query::All {
-        QUERIES
+        all_queries()
     } else {
         let query = get_query(cli.query.to_string()).expect("Invalid query type specified.");
-        &[query]
+        [query].to_vec()
     };
 
     match cli.scheme {
         CommitmentScheme::All => {
-            bench_inner_product_proof(&cli, queries);
-            bench_dory(&cli, queries);
-            bench_dynamic_dory(&cli, queries);
-            bench_hyperkzg(&cli, queries);
+            bench_inner_product_proof(&cli, &queries);
+            bench_dory(&cli, &queries);
+            bench_dynamic_dory(&cli, &queries);
+            bench_hyperkzg(&cli, &queries);
         }
         CommitmentScheme::InnerProductProof => {
-            bench_inner_product_proof(&cli, queries);
+            bench_inner_product_proof(&cli, &queries);
         }
         CommitmentScheme::Dory => {
-            bench_dory(&cli, queries);
+            bench_dory(&cli, &queries);
         }
         CommitmentScheme::DynamicDory => {
-            bench_dynamic_dory(&cli, queries);
+            bench_dynamic_dory(&cli, &queries);
         }
         CommitmentScheme::HyperKZG => {
-            bench_hyperkzg(&cli, queries);
+            bench_hyperkzg(&cli, &queries);
         }
     }
 

--- a/crates/proof-of-sql/benches/jaeger/bin/utils/queries.rs
+++ b/crates/proof-of-sql/benches/jaeger/bin/utils/queries.rs
@@ -5,189 +5,275 @@ use proof_of_sql::base::database::ColumnType;
 /// Type alias for a single column definition in a query.
 type ColumnDefinition = (&'static str, ColumnType, OptionalRandBound);
 
-/// Type alias for a single query entry in the `QUERIES` constant.
+/// Type alias for a single query entry.
 pub type QueryEntry = (&'static str, &'static str, &'static [ColumnDefinition]);
 
-const SINGLE_COLUMN_FILTER_TITLE: &str = "Single Column Filter";
-const SINGLE_COLUMN_FILTER_SQL: &str = "SELECT b FROM table WHERE a = 0";
-const SINGLE_COLUMN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
-    (
-        "a",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    ("b", ColumnType::VarChar, None),
-];
-const MULTI_COLUMN_FILTER_TITLE: &str = "Multi Column Filter";
-const MULTI_COLUMN_FILTER_SQL: &str =
-    "SELECT * FROM table WHERE ((a = 0) or (b = 1)) and (not (c = 'a'))";
-const MULTI_COLUMN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
-    (
-        "a",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "b",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    ("c", ColumnType::VarChar, None),
-];
-const ARITHMETIC_TITLE: &str = "Arithmetic";
-const ARITHMETIC_SQL: &str =
-    "SELECT a + b as r0, a * b - 2 as r1, c FROM table WHERE a <= b AND a >= 0";
-const ARITHMETIC_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
-    (
-        "a",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "b",
-        ColumnType::TinyInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    ("c", ColumnType::VarChar, None),
-];
-const GROUPBY_TITLE: &str = "Group By";
-const GROUPBY_SQL: &str =
-    "SELECT a, COUNT(*) FROM table WHERE (c = TRUE) and (a <= b) and (a > 0) GROUP BY a";
-const GROUPBY_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
-    (
-        "a",
-        ColumnType::Int128,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "b",
-        ColumnType::TinyInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    ("c", ColumnType::Boolean, None),
-];
-const AGGREGATE_TITLE: &str = "Aggregate";
-const AGGREGATE_SQL: &str = "SELECT SUM(a) FROM table WHERE b = a OR c = 'yz'";
-const AGGREGATE_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
-    (
-        "a",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "b",
-        ColumnType::Int,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    ("c", ColumnType::VarChar, None),
-];
-const BOOLEAN_FILTER_TITLE: &str = "Boolean Filter";
-const BOOLEAN_FILTER_SQL: &str = "SELECT * FROM table WHERE c = TRUE and b = 'xyz' or a = 0";
-const BOOLEAN_FILTER_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
-    (
-        "a",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    ("b", ColumnType::VarChar, None),
-    ("c", ColumnType::Boolean, None),
-];
-const LARGE_COLUMN_SET_TITLE: &str = "Large Column Set";
-const LARGE_COLUMN_SET_SQL: &str = "SELECT * FROM table WHERE b = d";
-const LARGE_COLUMN_SET_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
-    ("a", ColumnType::Boolean, None),
-    (
-        "b",
-        ColumnType::TinyInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "c",
-        ColumnType::SmallInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "d",
-        ColumnType::Int,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "e",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "f",
-        ColumnType::Int128,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    ("g", ColumnType::VarChar, None),
-    ("h", ColumnType::Scalar, None),
-];
-const COMPLEX_CONDITION_TITLE: &str = "Complex Condition";
-const COMPLEX_CONDITION_SQL: &str =
-    "SELECT * FROM table WHERE (a > c * c AND b < c + 10) OR (d = 'xyz')";
-const COMPLEX_CONDITION_COLUMNS: &[(&str, ColumnType, OptionalRandBound)] = &[
-    (
-        "a",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "b",
-        ColumnType::BigInt,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    (
-        "c",
-        ColumnType::Int128,
-        Some(|size| (size / 10).max(10) as i64),
-    ),
-    ("d", ColumnType::VarChar, None),
-];
+/// Trait for defining a base query.
+pub trait BaseEntry {
+    fn title(&self) -> &'static str;
+    fn sql(&self) -> &'static str;
+    fn columns(&self) -> &'static [ColumnDefinition];
+    fn entry(&self) -> QueryEntry {
+        (self.title(), self.sql(), self.columns())
+    }
+}
 
-pub const QUERIES: &[QueryEntry] = &[
-    (
-        SINGLE_COLUMN_FILTER_TITLE,
-        SINGLE_COLUMN_FILTER_SQL,
-        SINGLE_COLUMN_FILTER_COLUMNS,
-    ),
-    (
-        MULTI_COLUMN_FILTER_TITLE,
-        MULTI_COLUMN_FILTER_SQL,
-        MULTI_COLUMN_FILTER_COLUMNS,
-    ),
-    (ARITHMETIC_TITLE, ARITHMETIC_SQL, ARITHMETIC_COLUMNS),
-    (GROUPBY_TITLE, GROUPBY_SQL, GROUPBY_COLUMNS),
-    (AGGREGATE_TITLE, AGGREGATE_SQL, AGGREGATE_COLUMNS),
-    (
-        BOOLEAN_FILTER_TITLE,
-        BOOLEAN_FILTER_SQL,
-        BOOLEAN_FILTER_COLUMNS,
-    ),
-    (
-        LARGE_COLUMN_SET_TITLE,
-        LARGE_COLUMN_SET_SQL,
-        LARGE_COLUMN_SET_COLUMNS,
-    ),
-    (
-        COMPLEX_CONDITION_TITLE,
-        COMPLEX_CONDITION_SQL,
-        COMPLEX_CONDITION_COLUMNS,
-    ),
-];
+/// Single column filter query.
+pub struct SingleColumnFilter;
+impl BaseEntry for SingleColumnFilter {
+    fn title(&self) -> &'static str {
+        "Single Column Filter"
+    }
 
-/// Retrieves a single query from the `QUERIES` constant by its title.
+    fn sql(&self) -> &'static str {
+        "SELECT b FROM table WHERE a = 0"
+    }
+
+    fn columns(&self) -> &'static [ColumnDefinition] {
+        &[
+            (
+                "a",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("b", ColumnType::VarChar, None),
+        ]
+    }
+}
+
+/// Multi-column filter query.
+pub struct MultiColumnFilter;
+impl BaseEntry for MultiColumnFilter {
+    fn title(&self) -> &'static str {
+        "Multi Column Filter"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT * FROM table WHERE ((a = 0) or (b = 1)) and (not (c = 'a'))"
+    }
+
+    fn columns(&self) -> &'static [ColumnDefinition] {
+        &[
+            (
+                "a",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "b",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("c", ColumnType::VarChar, None),
+        ]
+    }
+}
+
+/// Arithmetic query.
+pub struct Arithmetic;
+impl BaseEntry for Arithmetic {
+    fn title(&self) -> &'static str {
+        "Arithmetic"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT a + b as r0, a * b - 2 as r1, c FROM table WHERE a <= b AND a >= 0"
+    }
+
+    fn columns(&self) -> &'static [ColumnDefinition] {
+        &[
+            (
+                "a",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "b",
+                ColumnType::TinyInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("c", ColumnType::VarChar, None),
+        ]
+    }
+}
+
+/// Group by query.
+pub struct GroupBy;
+impl BaseEntry for GroupBy {
+    fn title(&self) -> &'static str {
+        "Group By"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT a, COUNT(*) FROM table WHERE (c = TRUE) and (a <= b) and (a > 0) GROUP BY a"
+    }
+
+    fn columns(&self) -> &'static [ColumnDefinition] {
+        &[
+            (
+                "a",
+                ColumnType::Int128,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "b",
+                ColumnType::TinyInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("c", ColumnType::Boolean, None),
+        ]
+    }
+}
+
+/// Aggregate query.
+pub struct Aggregate;
+impl BaseEntry for Aggregate {
+    fn title(&self) -> &'static str {
+        "Aggregate"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT SUM(a) FROM table WHERE b = a OR c = 'yz'"
+    }
+
+    fn columns(&self) -> &'static [ColumnDefinition] {
+        &[
+            (
+                "a",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "b",
+                ColumnType::Int,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("c", ColumnType::VarChar, None),
+        ]
+    }
+}
+
+/// Boolean filter query.
+pub struct BooleanFilter;
+impl BaseEntry for BooleanFilter {
+    fn title(&self) -> &'static str {
+        "Boolean Filter"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT * FROM table WHERE c = TRUE and b = 'xyz' or a = 0"
+    }
+
+    fn columns(&self) -> &'static [ColumnDefinition] {
+        &[
+            (
+                "a",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("b", ColumnType::VarChar, None),
+            ("c", ColumnType::Boolean, None),
+        ]
+    }
+}
+
+/// Large column entry query.
+pub struct LargeColumnSet;
+impl BaseEntry for LargeColumnSet {
+    fn title(&self) -> &'static str {
+        "Large Column Set"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT * FROM table WHERE b = d"
+    }
+
+    fn columns(&self) -> &'static [ColumnDefinition] {
+        &[
+            ("a", ColumnType::Boolean, None),
+            (
+                "b",
+                ColumnType::TinyInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "c",
+                ColumnType::SmallInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "d",
+                ColumnType::Int,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "e",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("g", ColumnType::VarChar, None),
+            ("h", ColumnType::Scalar, None),
+        ]
+    }
+}
+
+/// Complex condition query.
+pub struct ComplexCondition;
+impl BaseEntry for ComplexCondition {
+    fn title(&self) -> &'static str {
+        "Complex Condition"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT * FROM table WHERE (a > c * c AND b < c + 10) OR (d = 'xyz')"
+    }
+
+    fn columns(&self) -> &'static [ColumnDefinition] {
+        &[
+            (
+                "a",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "b",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "c",
+                ColumnType::Int128,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("d", ColumnType::VarChar, None),
+        ]
+    }
+}
+
+/// Retrieves all available queries.
+pub fn all_queries() -> Vec<QueryEntry> {
+    vec![
+        SingleColumnFilter.entry(),
+        MultiColumnFilter.entry(),
+        Arithmetic.entry(),
+        GroupBy.entry(),
+        Aggregate.entry(),
+        BooleanFilter.entry(),
+        LargeColumnSet.entry(),
+        ComplexCondition.entry(),
+    ]
+}
+
+/// Retrieves a single query by its title.
 ///
 /// # Arguments
 /// * `title` - The title of the query to retrieve.
 ///
 /// # Returns
-/// * `Some((&str, &str, &[(&str, ColumnType, OptionalRandBound)]))` if the query is found.
+/// * `Some<QueryEntry>` if the query is found.
 /// * `None` if no query with the given title exists.
 pub fn get_query(title: &str) -> Option<QueryEntry> {
-    QUERIES
-        .iter()
+    all_queries()
+        .into_iter()
         .find(|(query_title, _, _)| *query_title == title)
-        .copied()
 }


### PR DESCRIPTION
# Rationale for this change
This PR refactors the `queries` module in the `proof-of-sql` benchmarks. The goal is to make it easier to add new queries by deriving from a base trait instead of defining a number of new constants.

# What changes are included in this PR?
- The `queries` module is updated from using defined constants to have a base trait and deriving new queries from the base trait.

# Are these changes tested?
Yes