### PR TITLE
feat: add scale cast to `proof-of-sql-planner`

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -2,6 +2,7 @@ use super::{
     column_to_column_ref, placeholder_to_placeholder_expr, scalar_value_to_literal_value,
     PlannerError, PlannerResult,
 };
+use core::cmp::Ordering;
 use datafusion::{
     common::DFSchema,
     logical_expr::{
@@ -9,7 +10,143 @@ use datafusion::{
         BinaryExpr, Expr, Operator,
     },
 };
-use proof_of_sql::sql::proof_exprs::DynProofExpr;
+use proof_of_sql::{
+    base::{database::ColumnType, math::decimal::Precision},
+    sql::{
+        proof_exprs::{DynProofExpr, ProofExpr},
+        AnalyzeError,
+    },
+};
+
+/// Add a layer of decimal scaling cast to the expression
+/// so that we can do binary operations on it
+#[expect(clippy::missing_panics_doc, reason = "Precision can not be invalid")]
+fn decimal_scale_cast_expr(
+    from_proof_expr: DynProofExpr,
+    from_scale: i8,
+    to_scale: i8,
+) -> PlannerResult<DynProofExpr> {
+    if !from_proof_expr.data_type().is_numeric() {
+        return Err(PlannerError::AnalyzeError {
+            source: AnalyzeError::DataTypeMismatch {
+                left_type: from_proof_expr.data_type().to_string(),
+                right_type: "Some numeric type".to_string(),
+            },
+        });
+    }
+    let from_precision_value = from_proof_expr.data_type().precision_value().unwrap_or(0);
+    let to_precision_value = u8::try_from(
+        i16::from(from_precision_value) + i16::from(to_scale - from_scale).min(75_i16),
+    )
+    .expect("Precision is definitely valid");
+    Ok(DynProofExpr::try_new_decimal_scaling_cast(
+        from_proof_expr,
+        ColumnType::Decimal75(
+            Precision::new(to_precision_value).expect("Precision is definitely valid"),
+            to_scale,
+        ),
+    )?)
+}
+
+/// Scale cast one side so that both sides have the same scale
+///
+/// We use this function so that binary ops for numeric types no longer
+/// need to keep track of scale
+fn scale_cast_binary_op(
+    left_proof_expr: DynProofExpr,
+    right_proof_expr: DynProofExpr,
+) -> PlannerResult<(DynProofExpr, DynProofExpr)> {
+    let left_type = left_proof_expr.data_type();
+    let right_type = right_proof_expr.data_type();
+    let left_scale = left_type.scale().unwrap_or(0);
+    let right_scale = right_type.scale().unwrap_or(0);
+    let scale = left_scale.max(right_scale);
+    match left_scale.cmp(&right_scale) {
+        Ordering::Less => Ok((
+            decimal_scale_cast_expr(left_proof_expr, left_scale, scale)?,
+            right_proof_expr,
+        )),
+        Ordering::Greater => Ok((
+            left_proof_expr,
+            decimal_scale_cast_expr(right_proof_expr, right_scale, scale)?,
+        )),
+        Ordering::Equal => Ok((left_proof_expr, right_proof_expr)),
+    }
+}
+
+/// Convert a [`BinaryExpr`] to [`DynProofExpr`]
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "Output of comparisons is always boolean"
+)]
+fn binary_expr_to_proof_expr(
+    left: &Expr,
+    right: &Expr,
+    op: Operator,
+    schema: &DFSchema,
+) -> PlannerResult<DynProofExpr> {
+    let left_proof_expr = expr_to_proof_expr(left, schema)?;
+    let right_proof_expr = expr_to_proof_expr(right, schema)?;
+
+    let (left_proof_expr, right_proof_expr) = match op {
+        Operator::Eq
+        | Operator::Lt
+        | Operator::Gt
+        | Operator::LtEq
+        | Operator::GtEq
+        | Operator::Plus
+        | Operator::Minus => scale_cast_binary_op(left_proof_expr, right_proof_expr)?,
+        _ => (left_proof_expr, right_proof_expr),
+    };
+
+    match op {
+        Operator::And => Ok(DynProofExpr::try_new_and(
+            left_proof_expr,
+            right_proof_expr,
+        )?),
+        Operator::Or => Ok(DynProofExpr::try_new_or(left_proof_expr, right_proof_expr)?),
+        Operator::Multiply => Ok(DynProofExpr::try_new_multiply(
+            left_proof_expr,
+            right_proof_expr,
+        )?),
+        Operator::Eq => Ok(DynProofExpr::try_new_equals(
+            left_proof_expr,
+            right_proof_expr,
+        )?),
+        Operator::Lt => Ok(DynProofExpr::try_new_inequality(
+            left_proof_expr,
+            right_proof_expr,
+            true,
+        )?),
+        Operator::Gt => Ok(DynProofExpr::try_new_inequality(
+            left_proof_expr,
+            right_proof_expr,
+            false,
+        )?),
+        Operator::LtEq => Ok(DynProofExpr::try_new_not(DynProofExpr::try_new_inequality(
+            left_proof_expr,
+            right_proof_expr,
+            false,
+        )?)
+        .expect("An inequality expression must have a boolean data type...")),
+        Operator::GtEq => Ok(DynProofExpr::try_new_not(DynProofExpr::try_new_inequality(
+            left_proof_expr,
+            right_proof_expr,
+            true,
+        )?)
+        .expect("An inequality expression must have a boolean data type...")),
+        Operator::Plus => Ok(DynProofExpr::try_new_add(
+            left_proof_expr,
+            right_proof_expr,
+        )?),
+        Operator::Minus => Ok(DynProofExpr::try_new_subtract(
+            left_proof_expr,
+            right_proof_expr,
+        )?),
+        // Any other operator is unsupported
+        _ => Err(PlannerError::UnsupportedBinaryOperator { op }),
+    }
+}
 
 /// Convert an [`datafusion::expr::Expr`] to [`DynProofExpr`]
 ///
@@ -21,48 +158,7 @@ pub fn expr_to_proof_expr(expr: &Expr, schema: &DFSchema) -> PlannerResult<DynPr
         Expr::Column(col) => Ok(DynProofExpr::new_column(column_to_column_ref(col, schema)?)),
         Expr::Placeholder(placeholder) => placeholder_to_placeholder_expr(placeholder),
         Expr::BinaryExpr(BinaryExpr { left, right, op }) => {
-            let left_proof_expr = expr_to_proof_expr(left, schema)?;
-            let right_proof_expr = expr_to_proof_expr(right, schema)?;
-            match op {
-                Operator::Eq => Ok(DynProofExpr::try_new_equals(
-                    left_proof_expr,
-                    right_proof_expr,
-                )?),
-                Operator::Lt => Ok(DynProofExpr::try_new_inequality(
-                    left_proof_expr,
-                    right_proof_expr,
-                    true,
-                )?),
-                Operator::Gt => Ok(DynProofExpr::try_new_inequality(
-                    left_proof_expr,
-                    right_proof_expr,
-                    false,
-                )?),
-                Operator::LtEq => Ok(DynProofExpr::try_new_not(
-                    DynProofExpr::try_new_inequality(left_proof_expr, right_proof_expr, false)?,
-                ).expect("an inequality expression must have a boolean data type, and try_new_not only fails when the datatype is non-boolean.")),
-                Operator::GtEq => Ok(DynProofExpr::try_new_not(
-                    DynProofExpr::try_new_inequality(left_proof_expr, right_proof_expr, true)?,
-                ).expect("an inequality expression must have a boolean data type, and try_new_not only fails when the datatype is non-boolean.")),
-                Operator::Plus => Ok(DynProofExpr::try_new_add(
-                    left_proof_expr,
-                    right_proof_expr,
-                )?),
-                Operator::Minus => Ok(DynProofExpr::try_new_subtract(
-                    left_proof_expr,
-                    right_proof_expr,
-                )?),
-                Operator::Multiply => Ok(DynProofExpr::try_new_multiply(
-                    left_proof_expr,
-                    right_proof_expr,
-                )?),
-                Operator::And => Ok(DynProofExpr::try_new_and(
-                    left_proof_expr,
-                    right_proof_expr,
-                )?),
-                Operator::Or => Ok(DynProofExpr::try_new_or(left_proof_expr, right_proof_expr)?),
-                _ => Err(PlannerError::UnsupportedBinaryOperator { op: *op }),
-            }
+            binary_expr_to_proof_expr(left, right, *op, schema)
         }
         Expr::Literal(val) => Ok(DynProofExpr::new_literal(scalar_value_to_literal_value(
             val.clone(),
@@ -99,6 +195,7 @@ mod tests {
     use super::*;
     use crate::df_util::*;
     use arrow::datatypes::DataType;
+    use core::ops::{Add, Mul, Sub};
     use datafusion::{
         common::ScalarValue,
         logical_expr::{
@@ -106,7 +203,10 @@ mod tests {
             Cast,
         },
     };
-    use proof_of_sql::base::database::{ColumnRef, ColumnType, LiteralValue, TableRef};
+    use proof_of_sql::base::{
+        database::{ColumnRef, ColumnType, LiteralValue, TableRef},
+        math::decimal::Precision,
+    };
 
     #[expect(non_snake_case)]
     fn COLUMN_INT() -> DynProofExpr {
@@ -151,6 +251,64 @@ mod tests {
             "column2".into(),
             ColumnType::Boolean,
         ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN3_DECIMAL_75_5() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column3".into(),
+            ColumnType::Decimal75(
+                Precision::new(75).expect("Precision is definitely valid"),
+                5,
+            ),
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN2_DECIMAL_25_5() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column2".into(),
+            ColumnType::Decimal75(
+                Precision::new(25).expect("Precision is definitely valid"),
+                5,
+            ),
+        ))
+    }
+
+    // decimal_scale_cast_expr
+    #[test]
+    fn we_can_convert_decimal_scale_cast_expr() {
+        let expr = COLUMN1_SMALLINT();
+        let scale = 0;
+        let to_scale = 5;
+        let proof_expr = decimal_scale_cast_expr(expr, scale, to_scale).unwrap();
+        assert_eq!(
+            proof_expr,
+            DynProofExpr::try_new_decimal_scaling_cast(
+                COLUMN1_SMALLINT(),
+                ColumnType::Decimal75(
+                    Precision::new(10).expect("Precision is definitely valid"),
+                    5
+                )
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_nonnumeric_types_using_decimal_scale_cast_expr() {
+        let expr = COLUMN1_BOOLEAN();
+        let scale = 0;
+        let to_scale = 5;
+        let proof_expr = decimal_scale_cast_expr(expr, scale, to_scale);
+        assert!(matches!(
+            proof_expr,
+            Err(PlannerError::AnalyzeError {
+                source: AnalyzeError::DataTypeMismatch { .. }
+            })
+        ));
     }
 
     // Alias
@@ -228,6 +386,124 @@ mod tests {
         );
     }
 
+    #[expect(clippy::too_many_lines)]
+    #[test]
+    fn we_can_convert_comparison_binary_expr_to_proof_expr_with_scale_cast() {
+        let schema = df_schema(
+            "namespace.table_name",
+            vec![
+                ("column1", DataType::Int16),
+                ("column2", DataType::Decimal256(25, 5)),
+                ("column3", DataType::Decimal256(75, 5)),
+            ],
+        );
+
+        // Eq
+        let expr = df_column("namespace.table_name", "column1")
+            .eq(df_column("namespace.table_name", "column3"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_equals(
+                DynProofExpr::try_new_decimal_scaling_cast(
+                    COLUMN1_SMALLINT(),
+                    ColumnType::Decimal75(
+                        Precision::new(10).expect("Precision is definitely valid"),
+                        5
+                    )
+                )
+                .unwrap(),
+                COLUMN3_DECIMAL_75_5()
+            )
+            .unwrap()
+        );
+
+        // Lt
+        let expr = df_column("namespace.table_name", "column1")
+            .lt(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_inequality(
+                DynProofExpr::try_new_decimal_scaling_cast(
+                    COLUMN1_SMALLINT(),
+                    ColumnType::Decimal75(
+                        Precision::new(10).expect("Precision is definitely valid"),
+                        5
+                    )
+                )
+                .unwrap(),
+                COLUMN2_DECIMAL_25_5(),
+                true
+            )
+            .unwrap()
+        );
+
+        // Gt
+        let expr = df_column("namespace.table_name", "column1")
+            .gt(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_inequality(
+                DynProofExpr::try_new_decimal_scaling_cast(
+                    COLUMN1_SMALLINT(),
+                    ColumnType::Decimal75(
+                        Precision::new(10).expect("Precision is definitely valid"),
+                        5
+                    )
+                )
+                .unwrap(),
+                COLUMN2_DECIMAL_25_5(),
+                false
+            )
+            .unwrap()
+        );
+
+        // LtEq
+        let expr = df_column("namespace.table_name", "column1")
+            .lt_eq(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_not(
+                DynProofExpr::try_new_inequality(
+                    DynProofExpr::try_new_decimal_scaling_cast(
+                        COLUMN1_SMALLINT(),
+                        ColumnType::Decimal75(
+                            Precision::new(10).expect("Precision is definitely valid"),
+                            5
+                        )
+                    )
+                    .unwrap(),
+                    COLUMN2_DECIMAL_25_5(),
+                    false
+                )
+                .unwrap()
+            )
+            .unwrap()
+        );
+
+        // GtEq
+        let expr = df_column("namespace.table_name", "column1")
+            .gt_eq(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_not(
+                DynProofExpr::try_new_inequality(
+                    DynProofExpr::try_new_decimal_scaling_cast(
+                        COLUMN1_SMALLINT(),
+                        ColumnType::Decimal75(
+                            Precision::new(10).expect("Precision is definitely valid"),
+                            5
+                        )
+                    )
+                    .unwrap(),
+                    COLUMN2_DECIMAL_25_5(),
+                    true
+                )
+                .unwrap()
+            )
+            .unwrap()
+        );
+    }
+
     #[test]
     fn we_can_convert_arithmetic_binary_expr_to_proof_expr() {
         let schema = df_schema(
@@ -266,6 +542,64 @@ mod tests {
         assert_eq!(
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_multiply(COLUMN1_SMALLINT(), COLUMN2_BIGINT(),).unwrap()
+        );
+    }
+
+    #[test]
+    fn we_can_convert_arithmetic_binary_expr_to_proof_expr_with_scale_cast() {
+        let schema = df_schema(
+            "namespace.table_name",
+            vec![
+                ("column1", DataType::Int16),
+                ("column2", DataType::Decimal256(25, 5)),
+                ("column3", DataType::Decimal256(75, 5)),
+            ],
+        );
+
+        // Add
+        let expr = df_column("namespace.table_name", "column1")
+            .add(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_add(
+                DynProofExpr::try_new_decimal_scaling_cast(
+                    COLUMN1_SMALLINT(),
+                    ColumnType::Decimal75(
+                        Precision::new(10).expect("Precision is definitely valid"),
+                        5
+                    )
+                )
+                .unwrap(),
+                COLUMN2_DECIMAL_25_5()
+            )
+            .unwrap()
+        );
+
+        // Subtract
+        let expr = df_column("namespace.table_name", "column1")
+            .sub(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_subtract(
+                DynProofExpr::try_new_decimal_scaling_cast(
+                    COLUMN1_SMALLINT(),
+                    ColumnType::Decimal75(
+                        Precision::new(10).expect("Precision is definitely valid"),
+                        5
+                    )
+                )
+                .unwrap(),
+                COLUMN2_DECIMAL_25_5()
+            )
+            .unwrap()
+        );
+
+        // Multiply - No scale cast!
+        let expr = df_column("namespace.table_name", "column1")
+            .mul(df_column("namespace.table_name", "column2"));
+        assert_eq!(
+            expr_to_proof_expr(&expr, &schema).unwrap(),
+            DynProofExpr::try_new_multiply(COLUMN1_SMALLINT(), COLUMN2_DECIMAL_25_5()).unwrap()
         );
     }
 
@@ -347,7 +681,6 @@ mod tests {
     // Cast
     #[test]
     fn we_can_convert_cast_expr_to_proof_expr() {
-        // Unsupported logical expression
         let expr = Expr::Cast(Cast::new(
             Box::new(Expr::Literal(ScalarValue::Boolean(Some(true)))),
             DataType::Int32,


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
We added `DecimalScaleCastExpr` in #701. Now we need to enable it in `proof-of-sql-planner`.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
Allow `DecimalScaleCastExpr` in `proof-of-sql-planner`
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.