### PR TITLE
refactor!: move scale cast code into `proof-of-sql` && use it in `sql/parse`

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -2,7 +2,6 @@ use super::{
     column_to_column_ref, placeholder_to_placeholder_expr, scalar_value_to_literal_value,
     PlannerError, PlannerResult,
 };
-use core::cmp::Ordering;
 use datafusion::{
     common::DFSchema,
     logical_expr::{
@@ -10,69 +9,7 @@ use datafusion::{
         BinaryExpr, Expr, Operator,
     },
 };
-use proof_of_sql::{
-    base::{database::ColumnType, math::decimal::Precision},
-    sql::{
-        proof_exprs::{DynProofExpr, ProofExpr},
-        AnalyzeError,
-    },
-};
-
-/// Add a layer of decimal scaling cast to the expression
-/// so that we can do binary operations on it
-#[expect(clippy::missing_panics_doc, reason = "Precision can not be invalid")]
-fn decimal_scale_cast_expr(
-    from_proof_expr: DynProofExpr,
-    from_scale: i8,
-    to_scale: i8,
-) -> PlannerResult<DynProofExpr> {
-    if !from_proof_expr.data_type().is_numeric() {
-        return Err(PlannerError::AnalyzeError {
-            source: AnalyzeError::DataTypeMismatch {
-                left_type: from_proof_expr.data_type().to_string(),
-                right_type: "Some numeric type".to_string(),
-            },
-        });
-    }
-    let from_precision_value = from_proof_expr.data_type().precision_value().unwrap_or(0);
-    let to_precision_value = u8::try_from(
-        i16::from(from_precision_value) + i16::from(to_scale - from_scale).min(75_i16),
-    )
-    .expect("Precision is definitely valid");
-    Ok(DynProofExpr::try_new_decimal_scaling_cast(
-        from_proof_expr,
-        ColumnType::Decimal75(
-            Precision::new(to_precision_value).expect("Precision is definitely valid"),
-            to_scale,
-        ),
-    )?)
-}
-
-/// Scale cast one side so that both sides have the same scale
-///
-/// We use this function so that binary ops for numeric types no longer
-/// need to keep track of scale
-fn scale_cast_binary_op(
-    left_proof_expr: DynProofExpr,
-    right_proof_expr: DynProofExpr,
-) -> PlannerResult<(DynProofExpr, DynProofExpr)> {
-    let left_type = left_proof_expr.data_type();
-    let right_type = right_proof_expr.data_type();
-    let left_scale = left_type.scale().unwrap_or(0);
-    let right_scale = right_type.scale().unwrap_or(0);
-    let scale = left_scale.max(right_scale);
-    match left_scale.cmp(&right_scale) {
-        Ordering::Less => Ok((
-            decimal_scale_cast_expr(left_proof_expr, left_scale, scale)?,
-            right_proof_expr,
-        )),
-        Ordering::Greater => Ok((
-            left_proof_expr,
-            decimal_scale_cast_expr(right_proof_expr, right_scale, scale)?,
-        )),
-        Ordering::Equal => Ok((left_proof_expr, right_proof_expr)),
-    }
-}
+use proof_of_sql::sql::{proof_exprs::DynProofExpr, scale_cast_binary_op};
 
 /// Convert a [`BinaryExpr`] to [`DynProofExpr`]
 #[expect(
@@ -275,40 +212,6 @@ mod tests {
                 5,
             ),
         ))
-    }
-
-    // decimal_scale_cast_expr
-    #[test]
-    fn we_can_convert_decimal_scale_cast_expr() {
-        let expr = COLUMN1_SMALLINT();
-        let scale = 0;
-        let to_scale = 5;
-        let proof_expr = decimal_scale_cast_expr(expr, scale, to_scale).unwrap();
-        assert_eq!(
-            proof_expr,
-            DynProofExpr::try_new_decimal_scaling_cast(
-                COLUMN1_SMALLINT(),
-                ColumnType::Decimal75(
-                    Precision::new(10).expect("Precision is definitely valid"),
-                    5
-                )
-            )
-            .unwrap()
-        );
-    }
-
-    #[test]
-    fn we_cannot_convert_nonnumeric_types_using_decimal_scale_cast_expr() {
-        let expr = COLUMN1_BOOLEAN();
-        let scale = 0;
-        let to_scale = 5;
-        let proof_expr = decimal_scale_cast_expr(expr, scale, to_scale);
-        assert!(matches!(
-            proof_expr,
-            Err(PlannerError::AnalyzeError {
-                source: AnalyzeError::DataTypeMismatch { .. }
-            })
-        ));
     }
 
     // Alias

--- a/crates/proof-of-sql/src/sql/mod.rs
+++ b/crates/proof-of-sql/src/sql/mod.rs
@@ -11,4 +11,6 @@ pub mod proof;
 pub mod proof_exprs;
 pub mod proof_gadgets;
 pub mod proof_plans;
+mod scale;
+pub use scale::scale_cast_binary_op;
 pub(crate) mod util;

--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -1,0 +1,119 @@
+use crate::{
+    base::{database::ColumnType, math::decimal::Precision},
+    sql::{
+        proof_exprs::{DynProofExpr, ProofExpr},
+        AnalyzeError, AnalyzeResult,
+    },
+};
+use alloc::string::ToString;
+use core::cmp::Ordering;
+
+/// Add a layer of decimal scaling cast to the expression
+/// so that we can do binary operations on it
+#[expect(clippy::missing_panics_doc, reason = "Precision can not be invalid")]
+fn decimal_scale_cast_expr(
+    from_proof_expr: DynProofExpr,
+    from_scale: i8,
+    to_scale: i8,
+) -> AnalyzeResult<DynProofExpr> {
+    if !from_proof_expr.data_type().is_numeric() {
+        return Err(AnalyzeError::DataTypeMismatch {
+            left_type: from_proof_expr.data_type().to_string(),
+            right_type: "Some numeric type".to_string(),
+        });
+    }
+    let from_precision_value = from_proof_expr.data_type().precision_value().unwrap_or(0);
+    let to_precision_value = u8::try_from(
+        i16::from(from_precision_value) + i16::from(to_scale - from_scale).min(75_i16),
+    )
+    .expect("Precision is definitely valid");
+    DynProofExpr::try_new_decimal_scaling_cast(
+        from_proof_expr,
+        ColumnType::Decimal75(
+            Precision::new(to_precision_value).expect("Precision is definitely valid"),
+            to_scale,
+        ),
+    )
+}
+
+/// Scale cast one side so that both sides have the same scale
+///
+/// We use this function so that binary ops for numeric types no longer
+/// need to keep track of scale
+pub fn scale_cast_binary_op(
+    left_proof_expr: DynProofExpr,
+    right_proof_expr: DynProofExpr,
+) -> AnalyzeResult<(DynProofExpr, DynProofExpr)> {
+    let left_type = left_proof_expr.data_type();
+    let right_type = right_proof_expr.data_type();
+    let left_scale = left_type.scale().unwrap_or(0);
+    let right_scale = right_type.scale().unwrap_or(0);
+    let scale = left_scale.max(right_scale);
+    match left_scale.cmp(&right_scale) {
+        Ordering::Less => Ok((
+            decimal_scale_cast_expr(left_proof_expr, left_scale, scale)?,
+            right_proof_expr,
+        )),
+        Ordering::Greater => Ok((
+            left_proof_expr,
+            decimal_scale_cast_expr(right_proof_expr, right_scale, scale)?,
+        )),
+        Ordering::Equal => Ok((left_proof_expr, right_proof_expr)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::database::{ColumnRef, TableRef};
+
+    #[expect(non_snake_case)]
+    fn COLUMN1_BOOLEAN() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::Boolean,
+        ))
+    }
+
+    #[expect(non_snake_case)]
+    fn COLUMN1_SMALLINT() -> DynProofExpr {
+        DynProofExpr::new_column(ColumnRef::new(
+            TableRef::from_names(Some("namespace"), "table_name"),
+            "column1".into(),
+            ColumnType::SmallInt,
+        ))
+    }
+
+    // decimal_scale_cast_expr
+    #[test]
+    fn we_can_convert_decimal_scale_cast_expr() {
+        let expr = COLUMN1_SMALLINT();
+        let scale = 0;
+        let to_scale = 5;
+        let proof_expr = decimal_scale_cast_expr(expr, scale, to_scale).unwrap();
+        assert_eq!(
+            proof_expr,
+            DynProofExpr::try_new_decimal_scaling_cast(
+                COLUMN1_SMALLINT(),
+                ColumnType::Decimal75(
+                    Precision::new(10).expect("Precision is definitely valid"),
+                    5
+                )
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn we_cannot_convert_nonnumeric_types_using_decimal_scale_cast_expr() {
+        let expr = COLUMN1_BOOLEAN();
+        let scale = 0;
+        let to_scale = 5;
+        let proof_expr = decimal_scale_cast_expr(expr, scale, to_scale);
+        assert!(matches!(
+            proof_expr,
+            Err(AnalyzeError::DataTypeMismatch { .. })
+        ));
+    }
+}


### PR DESCRIPTION

Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Scale cast needs to be used for `sql/parse` or #737 will break integration tests
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- move scale cast code to `scale.rs` inside `proof-of-sql/sql`
- add more tests to `scale.rs`
- refactor `DynProofExprBuilder` to use it for binary ops
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.