### PR TITLE
fix!: timestamp scale casting

### DIFF
--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -689,4 +689,11 @@ mod tests {
             Err(PlannerError::UnsupportedLogicalExpression { .. })
         ));
     }
+
+    #[test]
+    fn we_can_get_proof_expr_for_timestamps_of_different_scale() {
+        let lhs = Expr::Literal(ScalarValue::TimestampSecond(Some(1), None));
+        let rhs = Expr::Literal(ScalarValue::TimestampNanosecond(Some(1), None));
+        binary_expr_to_proof_expr(&lhs, &rhs, Operator::Gt, &DFSchema::empty()).unwrap();
+    }
 }

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -307,7 +307,7 @@ mod tests {
         assert_eq!(
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_equals(
-                DynProofExpr::try_new_decimal_scaling_cast(
+                DynProofExpr::try_new_scaling_cast(
                     COLUMN1_SMALLINT(),
                     ColumnType::Decimal75(
                         Precision::new(10).expect("Precision is definitely valid"),
@@ -326,7 +326,7 @@ mod tests {
         assert_eq!(
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_inequality(
-                DynProofExpr::try_new_decimal_scaling_cast(
+                DynProofExpr::try_new_scaling_cast(
                     COLUMN1_SMALLINT(),
                     ColumnType::Decimal75(
                         Precision::new(10).expect("Precision is definitely valid"),
@@ -346,7 +346,7 @@ mod tests {
         assert_eq!(
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_inequality(
-                DynProofExpr::try_new_decimal_scaling_cast(
+                DynProofExpr::try_new_scaling_cast(
                     COLUMN1_SMALLINT(),
                     ColumnType::Decimal75(
                         Precision::new(10).expect("Precision is definitely valid"),
@@ -367,7 +367,7 @@ mod tests {
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_not(
                 DynProofExpr::try_new_inequality(
-                    DynProofExpr::try_new_decimal_scaling_cast(
+                    DynProofExpr::try_new_scaling_cast(
                         COLUMN1_SMALLINT(),
                         ColumnType::Decimal75(
                             Precision::new(10).expect("Precision is definitely valid"),
@@ -390,7 +390,7 @@ mod tests {
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_not(
                 DynProofExpr::try_new_inequality(
-                    DynProofExpr::try_new_decimal_scaling_cast(
+                    DynProofExpr::try_new_scaling_cast(
                         COLUMN1_SMALLINT(),
                         ColumnType::Decimal75(
                             Precision::new(10).expect("Precision is definitely valid"),
@@ -465,7 +465,7 @@ mod tests {
         assert_eq!(
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_add(
-                DynProofExpr::try_new_decimal_scaling_cast(
+                DynProofExpr::try_new_scaling_cast(
                     COLUMN1_SMALLINT(),
                     ColumnType::Decimal75(
                         Precision::new(10).expect("Precision is definitely valid"),
@@ -484,7 +484,7 @@ mod tests {
         assert_eq!(
             expr_to_proof_expr(&expr, &schema).unwrap(),
             DynProofExpr::try_new_subtract(
-                DynProofExpr::try_new_decimal_scaling_cast(
+                DynProofExpr::try_new_scaling_cast(
                     COLUMN1_SMALLINT(),
                     ColumnType::Decimal75(
                         Precision::new(10).expect("Precision is definitely valid"),

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -216,6 +216,9 @@ pub fn try_scale_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperation
             let to_scale = i16::from(scale);
             to_scale >= from_scale && (to_precision - to_scale) >= (from_precision - from_scale)
         }
+        (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _)) => {
+            to.scale().unwrap() >= from.scale().unwrap()
+        }
         _ => false,
     }
     .then_some(())

--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -198,7 +198,7 @@ pub fn try_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult
 /// Casting can only be supported if the resulting data type is a superset of the input data type.
 /// For example Deciaml(6,1) can be cast to Decimal(7,1), but not vice versa.
 #[expect(clippy::missing_panics_doc)]
-pub fn try_decimal_scale_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult<()> {
+pub fn try_scale_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperationResult<()> {
     match (from, to) {
         (
             ColumnType::TinyInt
@@ -948,7 +948,6 @@ mod test {
         ));
     }
 
-    #[expect(clippy::too_many_lines)]
     #[test]
     fn we_can_properly_determine_if_types_are_scale_castable() {
         for from in [
@@ -962,17 +961,15 @@ mod test {
             let from_precision = Precision::new(from.precision_value().unwrap()).unwrap();
             let two_prec = Precision::new(2).unwrap();
             let forty_prec = Precision::new(40).unwrap();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(two_prec, 0)).unwrap_err();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(two_prec, -1)).unwrap_err();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(two_prec, 1)).unwrap_err();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(from_precision, 0)).unwrap();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(from_precision, -1))
-                .unwrap_err();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(from_precision, 1))
-                .unwrap_err();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(forty_prec, 0)).unwrap();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(forty_prec, -1)).unwrap_err();
-            try_decimal_scale_cast_types(from, ColumnType::Decimal75(forty_prec, 1)).unwrap();
+            try_scale_cast_types(from, ColumnType::Decimal75(two_prec, 0)).unwrap_err();
+            try_scale_cast_types(from, ColumnType::Decimal75(two_prec, -1)).unwrap_err();
+            try_scale_cast_types(from, ColumnType::Decimal75(two_prec, 1)).unwrap_err();
+            try_scale_cast_types(from, ColumnType::Decimal75(from_precision, 0)).unwrap();
+            try_scale_cast_types(from, ColumnType::Decimal75(from_precision, -1)).unwrap_err();
+            try_scale_cast_types(from, ColumnType::Decimal75(from_precision, 1)).unwrap_err();
+            try_scale_cast_types(from, ColumnType::Decimal75(forty_prec, 0)).unwrap();
+            try_scale_cast_types(from, ColumnType::Decimal75(forty_prec, -1)).unwrap_err();
+            try_scale_cast_types(from, ColumnType::Decimal75(forty_prec, 1)).unwrap();
         }
 
         let twenty_prec = Precision::new(20).unwrap();
@@ -980,100 +977,68 @@ mod test {
         // from_with_negative_scale
         let neg_scale = ColumnType::Decimal75(twenty_prec, -3);
 
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -4))
-            .unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -3)).unwrap();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -2))
-            .unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, 1)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -4)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -3)).unwrap();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, -2)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_prec, 1)).unwrap_err();
 
         let nineteen_prec = Precision::new(19).unwrap();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -4))
-            .unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -3))
-            .unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -2))
-            .unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, 0))
-            .unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, 1))
-            .unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -4)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -3)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, -2)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, 0)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(nineteen_prec, 1)).unwrap_err();
 
         let twenty_one_prec = Precision::new(21).unwrap();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -4))
-            .unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -3))
-            .unwrap();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -2))
-            .unwrap();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, 0))
-            .unwrap_err();
-        try_decimal_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, 1))
-            .unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -4)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -3)).unwrap();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, -2)).unwrap();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, 0)).unwrap_err();
+        try_scale_cast_types(neg_scale, ColumnType::Decimal75(twenty_one_prec, 1)).unwrap_err();
 
         // from_with_zero_scale
         let zero_scale = ColumnType::Decimal75(twenty_prec, 0);
 
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, -1))
-            .unwrap_err();
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap();
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, 1))
-            .unwrap_err();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, -1)).unwrap_err();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_prec, 1)).unwrap_err();
 
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, -1))
-            .unwrap_err();
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 0))
-            .unwrap_err();
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 1))
-            .unwrap_err();
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 2))
-            .unwrap_err();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, -1)).unwrap_err();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 0)).unwrap_err();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 1)).unwrap_err();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(nineteen_prec, 2)).unwrap_err();
 
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, -1))
-            .unwrap_err();
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 0))
-            .unwrap();
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 1))
-            .unwrap();
-        try_decimal_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 2))
-            .unwrap_err();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, -1)).unwrap_err();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 0)).unwrap();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 1)).unwrap();
+        try_scale_cast_types(zero_scale, ColumnType::Decimal75(twenty_one_prec, 2)).unwrap_err();
 
         // from_with_positive_scale
         let pos_scale = ColumnType::Decimal75(twenty_prec, 3);
 
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, -1))
-            .unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 2)).unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 3)).unwrap();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 4)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, -1)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 0)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 2)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 3)).unwrap();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_prec, 4)).unwrap_err();
 
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, -1))
-            .unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 0))
-            .unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 2))
-            .unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 3))
-            .unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 4))
-            .unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, -1)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 0)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 2)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 3)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(nineteen_prec, 4)).unwrap_err();
 
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, -1))
-            .unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 0))
-            .unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 2))
-            .unwrap_err();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 3)).unwrap();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 4)).unwrap();
-        try_decimal_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 5))
-            .unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, -1)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 0)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 2)).unwrap_err();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 3)).unwrap();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 4)).unwrap();
+        try_scale_cast_types(pos_scale, ColumnType::Decimal75(twenty_one_prec, 5)).unwrap_err();
     }
 
     #[test]
     fn we_cannot_scale_cast_nonsense_pairings() {
-        try_decimal_scale_cast_types(ColumnType::Int128, ColumnType::Boolean).unwrap_err();
+        try_scale_cast_types(ColumnType::Int128, ColumnType::Boolean).unwrap_err();
     }
 }

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -14,8 +14,8 @@ mod slice_decimal_operation;
 
 mod column_type_operation;
 pub use column_type_operation::{
-    try_add_subtract_column_types, try_cast_types, try_decimal_scale_cast_types,
-    try_divide_column_types, try_multiply_column_types,
+    try_add_subtract_column_types, try_cast_types, try_divide_column_types,
+    try_multiply_column_types, try_scale_cast_types,
 };
 
 mod column_arithmetic_operation;

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -1,6 +1,6 @@
 use super::{
-    AddExpr, AndExpr, CastExpr, ColumnExpr, DecimalScalingCastExpr, EqualsExpr, InequalityExpr,
-    LiteralExpr, MultiplyExpr, NotExpr, OrExpr, PlaceholderExpr, ProofExpr, SubtractExpr,
+    AddExpr, AndExpr, CastExpr, ColumnExpr, EqualsExpr, InequalityExpr, LiteralExpr, MultiplyExpr,
+    NotExpr, OrExpr, PlaceholderExpr, ProofExpr, ScalingCastExpr, SubtractExpr,
 };
 use crate::{
     base::{
@@ -50,7 +50,7 @@ pub enum DynProofExpr {
     /// Provable CAST expression
     Cast(CastExpr),
     /// Provable expression for casting numeric expressions to decimal expressions
-    DecimalScalingCast(DecimalScalingCastExpr),
+    ScalingCast(ScalingCastExpr),
 }
 impl DynProofExpr {
     /// Create column expression
@@ -184,13 +184,13 @@ impl DynProofExpr {
     }
 
     /// Create a new decimal scale cast expression
-    pub fn try_new_decimal_scaling_cast(
+    pub fn try_new_scaling_cast(
         from_expr: DynProofExpr,
         to_datatype: ColumnType,
     ) -> AnalyzeResult<Self> {
         let from_datatype = from_expr.data_type();
-        DecimalScalingCastExpr::try_new(Box::new(from_expr), to_datatype)
-            .map(DynProofExpr::DecimalScalingCast)
+        ScalingCastExpr::try_new(Box::new(from_expr), to_datatype)
+            .map(DynProofExpr::ScalingCast)
             .map_err(|_| AnalyzeError::DataTypeMismatch {
                 left_type: from_datatype.to_string(),
                 right_type: to_datatype.to_string(),

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -84,7 +84,7 @@ pub(crate) use cast_expr::CastExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod cast_expr_test;
 
-mod decimal_scaling_cast_expr;
-pub(crate) use decimal_scaling_cast_expr::DecimalScalingCastExpr;
+mod scaling_cast_expr;
+pub(crate) use scaling_cast_expr::ScalingCastExpr;
 #[cfg(all(test, feature = "blitzar"))]
-mod decimal_scaling_cast_expr_test;
+mod scaling_cast_expr_test;

--- a/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/numerical_util.rs
@@ -1,7 +1,5 @@
 use crate::base::{
-    database::{
-        try_cast_types, try_decimal_scale_cast_types, Column, ColumnOperationResult, ColumnType,
-    },
+    database::{try_cast_types, try_scale_cast_types, Column, ColumnOperationResult, ColumnType},
     math::decimal::Precision,
     scalar::{Scalar, ScalarExt},
 };
@@ -612,7 +610,7 @@ pub fn try_get_scaling_factor_with_precision_and_scale(
     from_type: ColumnType,
     to_type: ColumnType,
 ) -> ColumnOperationResult<(U256, u8, i8)> {
-    try_decimal_scale_cast_types(from_type, to_type)?;
+    try_scale_cast_types(from_type, to_type)?;
     let to_precision = to_type.precision_value().unwrap();
     let to_scale = to_type.scale().unwrap();
     let power = u32::try_from(to_scale - from_type.scale().unwrap()).unwrap();
@@ -623,7 +621,7 @@ pub fn try_get_scaling_factor_with_precision_and_scale(
 ///
 /// # Panics
 /// Panics if casting is invalid between the two types
-pub fn cast_column_to_decimal_with_scaling<'a, S: Scalar>(
+pub fn cast_column_with_scaling<'a, S: Scalar>(
     alloc: &'a Bump,
     from_column: Column<'a, S>,
     to_type: ColumnType,
@@ -657,7 +655,7 @@ mod tests {
             scalar::{test_scalar::TestScalar, Scalar},
         },
         sql::proof_exprs::numerical_util::{
-            cast_column_to_decimal_with_scaling, modulo_columns, modulo_integer_columns,
+            cast_column_with_scaling, modulo_columns, modulo_integer_columns,
             try_get_scaling_factor_with_precision_and_scale,
         },
     };
@@ -1187,11 +1185,7 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                tiny_int_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, tiny_int_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1204,11 +1198,7 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                uint8_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, uint8_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1219,11 +1209,7 @@ mod tests {
         let scale = 0i8;
         let scalar_slice = small_int_slice.map(TestScalar::from);
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                small_int_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, small_int_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1234,11 +1220,7 @@ mod tests {
         let scale = 0i8;
         let scalar_slice = int_slice.map(TestScalar::from);
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                int_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, int_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1251,11 +1233,7 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(100));
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                big_int_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, big_int_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1268,11 +1246,7 @@ mod tests {
             .map(TestScalar::from)
             .map(|s| s * TestScalar::from(10));
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                int_128_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, int_128_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
     }
@@ -1289,11 +1263,7 @@ mod tests {
         let scale = -1i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::TEN);
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                decimal_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1305,11 +1275,7 @@ mod tests {
         let scale = 1i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::from(1_000));
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                decimal_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
 
@@ -1321,11 +1287,7 @@ mod tests {
         let scale = 2i8;
         let scalar_slice = decimal_slice.map(|s| s * TestScalar::TEN);
         assert_eq!(
-            cast_column_to_decimal_with_scaling(
-                &alloc,
-                decimal_column,
-                ColumnType::Decimal75(prec, scale)
-            ),
+            cast_column_with_scaling(&alloc, decimal_column, ColumnType::Decimal75(prec, scale)),
             Column::<TestScalar>::Decimal75(prec, scale, &scalar_slice)
         );
     }

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -1,7 +1,5 @@
 use super::{
-    numerical_util::{
-        cast_column_to_decimal_with_scaling, try_get_scaling_factor_with_precision_and_scale,
-    },
+    numerical_util::{cast_column_with_scaling, try_get_scaling_factor_with_precision_and_scale},
     DynProofExpr, ProofExpr,
 };
 use crate::{
@@ -18,13 +16,13 @@ use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct DecimalScalingCastExpr {
+pub struct ScalingCastExpr {
     from_expr: Box<DynProofExpr>,
     to_type: ColumnType,
     scaling_factor: [u64; 4],
 }
 
-impl DecimalScalingCastExpr {
+impl ScalingCastExpr {
     /// Creates a new `CastExpr`
     pub fn try_new(
         from_expr: Box<DynProofExpr>,
@@ -40,7 +38,7 @@ impl DecimalScalingCastExpr {
     }
 }
 
-impl ProofExpr for DecimalScalingCastExpr {
+impl ProofExpr for ScalingCastExpr {
     fn data_type(&self) -> ColumnType {
         self.to_type
     }
@@ -52,7 +50,7 @@ impl ProofExpr for DecimalScalingCastExpr {
         params: &[LiteralValue],
     ) -> PlaceholderResult<Column<'a, S>> {
         let uncasted_result = self.from_expr.first_round_evaluate(alloc, table, params)?;
-        Ok(cast_column_to_decimal_with_scaling(
+        Ok(cast_column_with_scaling(
             alloc,
             uncasted_result,
             self.to_type,
@@ -69,7 +67,7 @@ impl ProofExpr for DecimalScalingCastExpr {
         let uncasted_result = self
             .from_expr
             .final_round_evaluate(builder, alloc, table, params)?;
-        Ok(cast_column_to_decimal_with_scaling(
+        Ok(cast_column_with_scaling(
             alloc,
             uncasted_result,
             self.to_type,

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr_test.rs
@@ -11,7 +11,7 @@ use crate::{
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
         proof_exprs::{
-            test_utility::{aliased_plan, column, decimal_scaling_cast, tab},
+            test_utility::{aliased_plan, column, scaling_cast, tab},
             LiteralExpr,
         },
         proof_plans::test_utility::filter,
@@ -20,7 +20,7 @@ use crate::{
 use blitzar::proof::InnerProductProof;
 
 #[test]
-fn we_can_prove_a_simple_decimal_scale_cast_expr_from_int_to_decimal() {
+fn we_can_prove_a_simple_scale_cast_expr_from_int_to_decimal() {
     let data = owned_table([
         tinyint("a", [1]),
         uint8("b", [1]),
@@ -35,42 +35,42 @@ fn we_can_prove_a_simple_decimal_scale_cast_expr_from_int_to_decimal() {
     let ast = filter(
         vec![
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "a", &accessor),
                     ColumnType::Decimal75(Precision::new(4).unwrap(), 1),
                 ),
                 "a_cast",
             ),
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "b", &accessor),
                     ColumnType::Decimal75(Precision::new(4).unwrap(), 1),
                 ),
                 "b_cast",
             ),
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "c", &accessor),
                     ColumnType::Decimal75(Precision::new(6).unwrap(), 1),
                 ),
                 "c_cast",
             ),
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "d", &accessor),
                     ColumnType::Decimal75(Precision::new(11).unwrap(), 1),
                 ),
                 "d_cast",
             ),
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "e", &accessor),
                     ColumnType::Decimal75(Precision::new(20).unwrap(), 1),
                 ),
                 "e_cast",
             ),
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "f", &accessor),
                     ColumnType::Decimal75(Precision::new(40).unwrap(), 1),
                 ),
@@ -98,7 +98,7 @@ fn we_can_prove_a_simple_decimal_scale_cast_expr_from_int_to_decimal() {
 }
 
 #[test]
-fn we_can_prove_a_simple_decimal_scale_cast_expr_from_decimal_to_decimal() {
+fn we_can_prove_a_simple_scale_cast_expr_from_decimal_to_decimal() {
     let data = owned_table([
         decimal75("a", 4, -2, [10]),
         decimal75("b", 4, 1, [1]),
@@ -110,21 +110,21 @@ fn we_can_prove_a_simple_decimal_scale_cast_expr_from_decimal_to_decimal() {
     let ast = filter(
         vec![
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "a", &accessor),
                     ColumnType::Decimal75(Precision::new(5).unwrap(), -1),
                 ),
                 "a_cast",
             ),
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "b", &accessor),
                     ColumnType::Decimal75(Precision::new(5).unwrap(), 2),
                 ),
                 "b_cast",
             ),
             aliased_plan(
-                decimal_scaling_cast(
+                scaling_cast(
                     column(&t, "c", &accessor),
                     ColumnType::Decimal75(Precision::new(7).unwrap(), 0),
                 ),

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -88,8 +88,8 @@ pub fn cast(left: DynProofExpr, right: ColumnType) -> DynProofExpr {
     DynProofExpr::try_new_cast(left, right).unwrap()
 }
 
-pub fn decimal_scaling_cast(left: DynProofExpr, right: ColumnType) -> DynProofExpr {
-    DynProofExpr::try_new_decimal_scaling_cast(left, right).unwrap()
+pub fn scaling_cast(left: DynProofExpr, right: ColumnType) -> DynProofExpr {
+    DynProofExpr::try_new_scaling_cast(left, right).unwrap()
 }
 
 pub fn const_bool(val: bool) -> DynProofExpr {

--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -51,12 +51,20 @@ pub fn scale_cast_binary_op(
     let scale = left_scale.max(right_scale);
     match left_scale.cmp(&right_scale) {
         Ordering::Less => Ok((
-            decimal_scale_cast_expr(left_proof_expr, left_scale, scale)?,
+            if matches!(left_type, ColumnType::TimestampTZ(_, _)) {
+                DynProofExpr::try_new_scaling_cast(left_proof_expr, right_type)?
+            } else {
+                decimal_scale_cast_expr(left_proof_expr, left_scale, scale)?
+            },
             right_proof_expr,
         )),
         Ordering::Greater => Ok((
             left_proof_expr,
-            decimal_scale_cast_expr(right_proof_expr, right_scale, scale)?,
+            if matches!(right_type, ColumnType::TimestampTZ(_, _)) {
+                DynProofExpr::try_new_scaling_cast(right_proof_expr, left_type)?
+            } else {
+                decimal_scale_cast_expr(right_proof_expr, right_scale, scale)?
+            },
         )),
         Ordering::Equal => Ok((left_proof_expr, right_proof_expr)),
     }

--- a/crates/proof-of-sql/src/sql/scale.rs
+++ b/crates/proof-of-sql/src/sql/scale.rs
@@ -27,7 +27,7 @@ fn decimal_scale_cast_expr(
         i16::from(from_precision_value) + i16::from(to_scale - from_scale).min(75_i16),
     )
     .expect("Precision is definitely valid");
-    DynProofExpr::try_new_decimal_scaling_cast(
+    DynProofExpr::try_new_scaling_cast(
         from_proof_expr,
         ColumnType::Decimal75(
             Precision::new(to_precision_value).expect("Precision is definitely valid"),
@@ -142,7 +142,7 @@ mod tests {
         let proof_expr = decimal_scale_cast_expr(expr, scale, to_scale).unwrap();
         assert_eq!(
             proof_expr,
-            DynProofExpr::try_new_decimal_scaling_cast(
+            DynProofExpr::try_new_scaling_cast(
                 COLUMN1_SMALLINT(),
                 ColumnType::Decimal75(
                     Precision::new(10).expect("Precision is definitely valid"),
@@ -179,7 +179,7 @@ mod tests {
             assert_eq!(
                 proof_exprs,
                 (
-                    DynProofExpr::try_new_decimal_scaling_cast(
+                    DynProofExpr::try_new_scaling_cast(
                         left,
                         ColumnType::Decimal75(
                             Precision::new(15).expect("Precision is definitely valid"),
@@ -207,7 +207,7 @@ mod tests {
                 proof_exprs,
                 (
                     COLUMN3_DECIMAL_75_10(),
-                    DynProofExpr::try_new_decimal_scaling_cast(
+                    DynProofExpr::try_new_scaling_cast(
                         right,
                         ColumnType::Decimal75(
                             Precision::new(15).expect("Precision is definitely valid"),


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We need to have timestamp scale casting, because inequalities rely on scaling.

# What changes are included in this PR?

New support for timestamp scale casting in the planner and the ScalingCastExpr. Note that the ScalingCastExpr has been renamed to eliminate Decimal from the name.

# Are these changes tested?
Yes.
