### PR TITLE
refactor: exchange `new` for `try_new` on `AddExpr` and `SubtractExpr`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -383,10 +383,11 @@ mod tests {
         let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
         let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
-        let add_expr = AddExpr::new(
+        let add_expr = AddExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
             Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(5))),
-        );
+        )
+        .unwrap();
 
         let evm_add_expr = EVMAddExpr::try_from_proof_expr(
             &add_expr,
@@ -417,10 +418,11 @@ mod tests {
         let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
         let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
-        let subtract_expr = SubtractExpr::new(
+        let subtract_expr = SubtractExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
             Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(5))),
-        );
+        )
+        .unwrap();
 
         let evm_subtract_expr = EVMSubtractExpr::try_from_proof_expr(
             &subtract_expr,

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -124,33 +124,12 @@ impl DynProofExpr {
 
     /// Create a new add expression
     pub fn try_new_add(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
-        let lhs_datatype = lhs.data_type();
-        let rhs_datatype = rhs.data_type();
-        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Plus).is_some() {
-            Ok(Self::Add(AddExpr::new(Box::new(lhs), Box::new(rhs))))
-        } else {
-            Err(AnalyzeError::DataTypeMismatch {
-                left_type: lhs_datatype.to_string(),
-                right_type: rhs_datatype.to_string(),
-            })
-        }
+        AddExpr::try_new(Box::new(lhs), Box::new(rhs)).map(DynProofExpr::Add)
     }
 
     /// Create a new subtract expression
     pub fn try_new_subtract(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
-        let lhs_datatype = lhs.data_type();
-        let rhs_datatype = rhs.data_type();
-        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Minus).is_some() {
-            Ok(Self::Subtract(SubtractExpr::new(
-                Box::new(lhs),
-                Box::new(rhs),
-            )))
-        } else {
-            Err(AnalyzeError::DataTypeMismatch {
-                left_type: lhs_datatype.to_string(),
-                right_type: rhs_datatype.to_string(),
-            })
-        }
+        SubtractExpr::try_new(Box::new(lhs), Box::new(rhs)).map(DynProofExpr::Subtract)
     }
 
     /// Create a new multiply expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -8,10 +8,13 @@ use crate::{
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        AnalyzeError, AnalyzeResult,
+    },
     utils::log,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 
@@ -24,8 +27,15 @@ pub struct SubtractExpr {
 
 impl SubtractExpr {
     /// Create numerical `-` expression
-    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
-        Self { lhs, rhs }
+    pub fn try_new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> AnalyzeResult<Self> {
+        let left_datatype = lhs.data_type();
+        let right_datatype = rhs.data_type();
+        try_add_subtract_column_types(left_datatype, right_datatype)
+            .map(|_| Self { lhs, rhs })
+            .map_err(|_| AnalyzeError::DataTypeMismatch {
+                left_type: left_datatype.to_string(),
+                right_type: right_datatype.to_string(),
+            })
     }
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

In order to guarantee that `AddExpr` and `SubtractExpr` are not ever constructed with invalid datatypes, the `new` functions shall be replaced with `try_new` functions.

# What changes are included in this PR?

The `new` functions are replaced with `try_new` functions.

# Are these changes tested?
Existing tests test these changes.
