### PR TITLE
refactor: replace `new` with `try_new` in `EqualsExpr`

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -228,6 +228,25 @@ pub fn try_scale_cast_types(from: ColumnType, to: ColumnType) -> ColumnOperation
     })
 }
 
+/// Verfies that the equality operator can be used on the two types
+pub fn try_equals_types(lhs: ColumnType, rhs: ColumnType) -> ColumnOperationResult<()> {
+    (matches!(
+        (lhs, rhs),
+        (ColumnType::VarChar, ColumnType::VarChar)
+            | (ColumnType::VarBinary, ColumnType::VarBinary)
+            | (ColumnType::TimestampTZ(_, _), ColumnType::TimestampTZ(_, _))
+            | (ColumnType::Boolean, ColumnType::Boolean)
+            | (_, ColumnType::Scalar)
+            | (ColumnType::Scalar, _)
+    ) || (lhs.is_numeric() && rhs.is_numeric()))
+    .then_some(())
+    .ok_or(ColumnOperationError::BinaryOperationInvalidColumnType {
+        operator: "=".to_string(),
+        left_type: lhs,
+        right_type: rhs,
+    })
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -14,7 +14,7 @@ mod slice_decimal_operation;
 
 mod column_type_operation;
 pub use column_type_operation::{
-    try_add_subtract_column_types, try_cast_types, try_divide_column_types,
+    try_add_subtract_column_types, try_cast_types, try_divide_column_types, try_equals_types,
     try_multiply_column_types, try_scale_cast_types,
 };
 

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/exprs.rs
@@ -349,10 +349,11 @@ mod tests {
         let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a, ColumnType::BigInt);
         let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b, ColumnType::BigInt);
 
-        let equals_expr = EqualsExpr::new(
+        let equals_expr = EqualsExpr::try_new(
             Box::new(DynProofExpr::new_column(column_ref_b.clone())),
             Box::new(DynProofExpr::new_literal(LiteralValue::BigInt(5))),
-        );
+        )
+        .unwrap();
 
         let evm_equals_expr = EVMEqualsExpr::try_from_proof_expr(
             &equals_expr,

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -138,12 +138,15 @@ mod tests {
             TableExpr {
                 table_ref: table_ref.clone(),
             },
-            DynProofExpr::Equals(EqualsExpr::new(
-                Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone()))),
-                Box::new(DynProofExpr::Literal(LiteralExpr::new(
-                    LiteralValue::BigInt(5),
-                ))),
-            )),
+            DynProofExpr::Equals(
+                EqualsExpr::try_new(
+                    Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone()))),
+                    Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                        LiteralValue::BigInt(5),
+                    ))),
+                )
+                .unwrap(),
+            ),
         );
 
         let evm_filter_exec = EVMFilterExec::try_from_proof_plan(

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/tests.rs
@@ -39,12 +39,15 @@ fn we_can_generate_serialized_proof_plan_for_simple_filter() {
             alias: identifier_alias,
         }],
         TableExpr { table_ref },
-        DynProofExpr::Equals(EqualsExpr::new(
-            Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a))),
-            Box::new(DynProofExpr::Literal(LiteralExpr::new(
-                LiteralValue::BigInt(5),
-            ))),
-        )),
+        DynProofExpr::Equals(
+            EqualsExpr::try_new(
+                Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a))),
+                Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                    LiteralValue::BigInt(5),
+                ))),
+            )
+            .unwrap(),
+        ),
     ));
 
     let bytes = bincode::serde::encode_to_vec(
@@ -104,12 +107,15 @@ fn we_can_deserialize_proof_plan_for_simple_filter() {
             alias: identifier_alias,
         }],
         TableExpr { table_ref },
-        DynProofExpr::Equals(EqualsExpr::new(
-            Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a))),
-            Box::new(DynProofExpr::Literal(LiteralExpr::new(
-                LiteralValue::BigInt(5),
-            ))),
-        )),
+        DynProofExpr::Equals(
+            EqualsExpr::try_new(
+                Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a))),
+                Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                    LiteralValue::BigInt(5),
+                ))),
+            )
+            .unwrap(),
+        ),
     ));
 
     let serialized: Vec<_> = iter::empty()

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -89,16 +89,7 @@ impl DynProofExpr {
     }
     /// Create a new equals expression
     pub fn try_new_equals(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
-        let lhs_datatype = lhs.data_type();
-        let rhs_datatype = rhs.data_type();
-        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Eq).is_some() {
-            Ok(Self::Equals(EqualsExpr::new(Box::new(lhs), Box::new(rhs))))
-        } else {
-            Err(AnalyzeError::DataTypeMismatch {
-                left_type: lhs_datatype.to_string(),
-                right_type: rhs_datatype.to_string(),
-            })
-        }
+        EqualsExpr::try_new(Box::new(lhs), Box::new(rhs)).map(DynProofExpr::Equals)
     }
     /// Create a new inequality expression
     pub fn try_new_inequality(


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We want the type checking for `EqualsExpr` to be done in object creation.

# What changes are included in this PR?

Replace `new` with `try_new` in `EqualsExpr`.

# Are these changes tested?
Yes
