### PR TITLE
refactor: replace `new` with `try_new` in `MultiplyExpr`

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -11,7 +11,6 @@ use crate::{
     },
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
-        util::try_binary_operation_type,
         AnalyzeError, AnalyzeResult,
     },
 };
@@ -19,7 +18,6 @@ use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
-use sqlparser::ast::BinaryOperator;
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -112,21 +110,7 @@ impl DynProofExpr {
 
     /// Create a new multiply expression
     pub fn try_new_multiply(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
-        let lhs_datatype = lhs.data_type();
-        let rhs_datatype = rhs.data_type();
-        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Multiply)
-            .is_some()
-        {
-            Ok(Self::Multiply(MultiplyExpr::new(
-                Box::new(lhs),
-                Box::new(rhs),
-            )))
-        } else {
-            Err(AnalyzeError::DataTypeMismatch {
-                left_type: lhs_datatype.to_string(),
-                right_type: rhs_datatype.to_string(),
-            })
-        }
+        MultiplyExpr::try_new(Box::new(lhs), Box::new(rhs)).map(DynProofExpr::Multiply)
     }
 
     /// Create a new cast expression

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -9,10 +9,11 @@ use crate::{
     sql::{
         proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
         proof_exprs::multiply_columns,
+        AnalyzeError, AnalyzeResult,
     },
     utils::log,
 };
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 
@@ -25,8 +26,15 @@ pub struct MultiplyExpr {
 
 impl MultiplyExpr {
     /// Create numerical `*` expression
-    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
-        Self { lhs, rhs }
+    pub fn try_new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> AnalyzeResult<Self> {
+        let left_datatype = lhs.data_type();
+        let right_datatype = rhs.data_type();
+        try_multiply_column_types(left_datatype, right_datatype)
+            .map(|_| Self { lhs, rhs })
+            .map_err(|_| AnalyzeError::DataTypeMismatch {
+                left_type: left_datatype.to_string(),
+                right_type: right_datatype.to_string(),
+            })
     }
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We want the type checking for `MultiplyExpr` to be done in object creation.

# What changes are included in this PR?

Replace `new` with `try_new` in `MultiplyExpr`.

# Are these changes tested?
Yes
