### PR TITLE
refactor: replace `new` with `try_new` on `InequalityExpr`

### DIFF
--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -15,7 +15,7 @@ mod slice_decimal_operation;
 mod column_type_operation;
 pub use column_type_operation::{
     try_add_subtract_column_types, try_cast_types, try_divide_column_types, try_equals_types,
-    try_multiply_column_types, try_scale_cast_types,
+    try_inequality_types, try_multiply_column_types, try_scale_cast_types,
 };
 
 mod column_arithmetic_operation;

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -97,20 +97,7 @@ impl DynProofExpr {
         rhs: DynProofExpr,
         is_lt: bool,
     ) -> AnalyzeResult<Self> {
-        let lhs_datatype = lhs.data_type();
-        let rhs_datatype = rhs.data_type();
-        if try_binary_operation_type(lhs_datatype, rhs_datatype, &BinaryOperator::Lt).is_some() {
-            Ok(Self::Inequality(InequalityExpr::new(
-                Box::new(lhs),
-                Box::new(rhs),
-                is_lt,
-            )))
-        } else {
-            Err(AnalyzeError::DataTypeMismatch {
-                left_type: lhs_datatype.to_string(),
-                right_type: rhs_datatype.to_string(),
-            })
-        }
+        InequalityExpr::try_new(Box::new(lhs), Box::new(rhs), is_lt).map(DynProofExpr::Inequality)
     }
 
     /// Create a new add expression


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We want the type checking for `InequalityExpr` to be done in object creation.

# What changes are included in this PR?

Replace `new` with `try_new` in `InequalityExpr`.

# Are these changes tested?
Yes
