### PR TITLE
refactor: use `try_new` logic on cast exprs

### DIFF
--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     base::{
-        database::{try_cast_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -14,7 +14,7 @@ use crate::{
         AnalyzeError, AnalyzeResult,
     },
 };
-use alloc::{boxed::Box, string::ToString};
+use alloc::boxed::Box;
 use bumpalo::Bump;
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
@@ -115,13 +115,7 @@ impl DynProofExpr {
 
     /// Create a new cast expression
     pub fn try_new_cast(from_column: DynProofExpr, to_datatype: ColumnType) -> AnalyzeResult<Self> {
-        let from_datatype = from_column.data_type();
-        try_cast_types(from_datatype, to_datatype)
-            .map(|()| Self::Cast(CastExpr::new(Box::new(from_column), to_datatype)))
-            .map_err(|_| AnalyzeError::DataTypeMismatch {
-                left_type: from_datatype.to_string(),
-                right_type: to_datatype.to_string(),
-            })
+        CastExpr::try_new(Box::new(from_column), to_datatype).map(DynProofExpr::Cast)
     }
 
     /// Create a new decimal scale cast expression
@@ -129,13 +123,7 @@ impl DynProofExpr {
         from_expr: DynProofExpr,
         to_datatype: ColumnType,
     ) -> AnalyzeResult<Self> {
-        let from_datatype = from_expr.data_type();
-        ScalingCastExpr::try_new(Box::new(from_expr), to_datatype)
-            .map(DynProofExpr::ScalingCast)
-            .map_err(|_| AnalyzeError::DataTypeMismatch {
-                left_type: from_datatype.to_string(),
-                right_type: to_datatype.to_string(),
-            })
+        ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
     }
 
     /// Check that the plan has the correct data type


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
