### PR TITLE
refactor: rename `new` to `try_new` for and, or, and not

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_type_operation.rs
+++ b/crates/proof-of-sql/src/base/database/column_type_operation.rs
@@ -362,6 +362,18 @@ pub fn try_inequality_types_with_scaling(
     })
 }
 
+/// Verifies that two types can be used in a logical AND or OR expressions
+#[must_use]
+pub fn can_and_or_types(lhs: ColumnType, rhs: ColumnType) -> bool {
+    lhs == ColumnType::Boolean && rhs == ColumnType::Boolean
+}
+
+/// Verifies that the NOT expr can be used on an expression
+#[must_use]
+pub fn can_not_type(datatype: ColumnType) -> bool {
+    datatype == ColumnType::Boolean
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -14,8 +14,9 @@ mod slice_decimal_operation;
 
 mod column_type_operation;
 pub use column_type_operation::{
-    try_add_subtract_column_types, try_add_subtract_column_types_with_scaling, try_cast_types,
-    try_divide_column_types, try_equals_types, try_equals_types_with_scaling, try_inequality_types,
+    can_and_or_types, can_not_type, try_add_subtract_column_types,
+    try_add_subtract_column_types_with_scaling, try_cast_types, try_divide_column_types,
+    try_equals_types, try_equals_types_with_scaling, try_inequality_types,
     try_inequality_types_with_scaling, try_multiply_column_types, try_scale_cast_types,
 };
 

--- a/crates/proof-of-sql/src/sql/error.rs
+++ b/crates/proof-of-sql/src/sql/error.rs
@@ -11,13 +11,11 @@ use snafu::Snafu;
 /// Will be replaced once we fully switch to the planner.
 #[derive(Snafu, Debug, PartialEq, Eq)]
 pub enum AnalyzeError {
-    #[snafu(display("Expected '{expected}' but found '{actual}'"))]
+    #[snafu(display("Expression has datatype {expr_type}, which was not valid"))]
     /// Invalid data type received
     InvalidDataType {
-        /// Expected data type
-        expected: ColumnType,
-        /// Actual data type found
-        actual: ColumnType,
+        /// data type found
+        expr_type: ColumnType,
     },
 
     #[snafu(display("Left side has '{left_type}' type but right side has '{right_type}' type"))]

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -1,15 +1,18 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{can_and_or_types, Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, SumcheckSubpolynomialType, VerificationBuilder},
+        AnalyzeError, AnalyzeResult,
+    },
     utils::log,
 };
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 
@@ -22,8 +25,15 @@ pub struct AndExpr {
 
 impl AndExpr {
     /// Create logical AND expression
-    pub fn new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> Self {
-        Self { lhs, rhs }
+    pub fn try_new(lhs: Box<DynProofExpr>, rhs: Box<DynProofExpr>) -> AnalyzeResult<Self> {
+        let left_datatype = lhs.data_type();
+        let right_datatype = rhs.data_type();
+        can_and_or_types(left_datatype, right_datatype)
+            .then_some(Self { lhs, rhs })
+            .ok_or_else(|| AnalyzeError::DataTypeMismatch {
+                left_type: left_datatype.to_string(),
+                right_type: right_datatype.to_string(),
+            })
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     sql::{
         proof::{FinalRoundBuilder, VerificationBuilder},
-        AnalyzeError, AnalyzeResult,
+        AnalyzeResult,
     },
 };
 use alloc::boxed::Box;
@@ -58,20 +58,15 @@ impl DynProofExpr {
     }
     /// Create logical AND expression
     pub fn try_new_and(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
-        lhs.check_data_type(ColumnType::Boolean)?;
-        rhs.check_data_type(ColumnType::Boolean)?;
-        Ok(Self::And(AndExpr::new(Box::new(lhs), Box::new(rhs))))
+        AndExpr::try_new(Box::new(lhs), Box::new(rhs)).map(DynProofExpr::And)
     }
     /// Create logical OR expression
     pub fn try_new_or(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {
-        lhs.check_data_type(ColumnType::Boolean)?;
-        rhs.check_data_type(ColumnType::Boolean)?;
-        Ok(Self::Or(OrExpr::new(Box::new(lhs), Box::new(rhs))))
+        OrExpr::try_new(Box::new(lhs), Box::new(rhs)).map(DynProofExpr::Or)
     }
     /// Create logical NOT expression
     pub fn try_new_not(expr: DynProofExpr) -> AnalyzeResult<Self> {
-        expr.check_data_type(ColumnType::Boolean)?;
-        Ok(Self::Not(NotExpr::new(Box::new(expr))))
+        NotExpr::try_new(Box::new(expr)).map(DynProofExpr::Not)
     }
     /// Create CONST expression
     #[must_use]
@@ -124,17 +119,5 @@ impl DynProofExpr {
         to_datatype: ColumnType,
     ) -> AnalyzeResult<Self> {
         ScalingCastExpr::try_new(Box::new(from_expr), to_datatype).map(DynProofExpr::ScalingCast)
-    }
-
-    /// Check that the plan has the correct data type
-    fn check_data_type(&self, data_type: ColumnType) -> AnalyzeResult<()> {
-        if self.data_type() == data_type {
-            Ok(())
-        } else {
-            Err(AnalyzeError::InvalidDataType {
-                actual: self.data_type(),
-                expected: data_type,
-            })
-        }
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -1,12 +1,15 @@
 use super::{DynProofExpr, ProofExpr};
 use crate::{
     base::{
-        database::{Column, ColumnRef, ColumnType, LiteralValue, Table},
+        database::{can_not_type, Column, ColumnRef, ColumnType, LiteralValue, Table},
         map::{IndexMap, IndexSet},
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
     },
-    sql::proof::{FinalRoundBuilder, VerificationBuilder},
+    sql::{
+        proof::{FinalRoundBuilder, VerificationBuilder},
+        AnalyzeError, AnalyzeResult,
+    },
     utils::log,
 };
 use alloc::boxed::Box;
@@ -21,8 +24,11 @@ pub struct NotExpr {
 
 impl NotExpr {
     /// Create logical NOT expression
-    pub fn new(expr: Box<DynProofExpr>) -> Self {
-        Self { expr }
+    pub fn try_new(expr: Box<DynProofExpr>) -> AnalyzeResult<Self> {
+        let expr_type = expr.data_type();
+        can_not_type(expr_type)
+            .then_some(Self { expr })
+            .ok_or(AnalyzeError::InvalidDataType { expr_type })
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr_test.rs
@@ -8,8 +8,9 @@ use crate::{
     },
     sql::{
         proof::{exercise_verification, VerifiableQueryResult},
-        proof_exprs::{test_utility::*, DynProofExpr, ProofExpr},
+        proof_exprs::{or_expr::OrExpr, test_utility::*, DynProofExpr, ProofExpr},
         proof_plans::test_utility::*,
+        AnalyzeError,
     },
 };
 use bumpalo::Bump;
@@ -204,4 +205,26 @@ fn we_can_compute_the_correct_output_of_an_or_expr_using_first_round_evaluate() 
     let res = and_expr.first_round_evaluate(&alloc, &data, &[]).unwrap();
     let expected_res = Column::Boolean(&[false, true, true, true]);
     assert_eq!(res, expected_res);
+}
+
+#[test]
+fn we_cannot_or_mismatching_types() {
+    let alloc = Bump::new();
+    let data = table([
+        borrowed_smallint("a", [1_i16, 2, 3, 4], &alloc),
+        borrowed_varchar("b", ["a", "b", "s", "z"], &alloc),
+    ]);
+    let t = TableRef::new("sxt", "t");
+    let accessor =
+        TableTestAccessor::<InnerProductProof>::new_from_table(t.clone(), data.clone(), 0, ());
+    let lhs = Box::new(column(&t, "a", &accessor));
+    let rhs = Box::new(column(&t, "b", &accessor));
+    let and_err = OrExpr::try_new(lhs.clone(), rhs.clone()).unwrap_err();
+    assert!(matches!(
+        and_err,
+        AnalyzeError::DataTypeMismatch {
+            left_type: _,
+            right_type: _
+        }
+    ));
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

We want type checks on the construction of `AndExpr`, `OrExpr`, and `NotExpr`.

# What changes are included in this PR?

The function `new` replaced with `try_new` for the above expressions.

# Are these changes tested?
Yes
