### PR TITLE
feat: add `get_table_refs_from_statement` to planner

### DIFF
--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -8,7 +8,9 @@ pub use context::PoSqlContextProvider;
 #[cfg(test)]
 pub(crate) use context::PoSqlTableSource;
 mod conversion;
-pub use conversion::{sql_to_proof_plans, sql_to_proof_plans_with_postprocessing};
+pub use conversion::{
+    get_table_refs_from_statement, sql_to_proof_plans, sql_to_proof_plans_with_postprocessing,
+};
 #[cfg(test)]
 mod df_util;
 mod expr;

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -45,6 +45,7 @@ mod literal_value;
 pub use literal_value::LiteralValue;
 
 mod error;
+pub use error::ParseError;
 
 mod table_ref;
 #[cfg(feature = "arrow")]


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

There a couple locations that are doing pre-parsing of sql text in order to retrieve the `TableRef`s for that sql. This seeks to centralize that logic.

# What changes are included in this PR?

New planner function `get_table_refs_from_statement` that retrieves the `TableRef`s from a `Statement`.

# Are these changes tested?
Yes.
