### PR TITLE
feat: split `ColumnRef` into `ColumnRef` without type and `ResolvedColumnField`

### DIFF
--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -60,9 +60,7 @@ impl<C: Commitment> ColumnCommitments<C> {
             ColumnCommitmentMetadataMap::from_column_fields_with_max_bounds(columns);
         let commitments = columns
             .iter()
-            .map(|c| {
-                accessor.get_commitment(ColumnRef::new(table.clone(), c.name(), c.data_type()))
-            })
+            .map(|c| accessor.get_commitment(ColumnRef::new(table.clone(), c.name())))
             .collect();
         ColumnCommitments {
             commitments,

--- a/crates/proof-of-sql/src/base/database/column.rs
+++ b/crates/proof-of-sql/src/base/database/column.rs
@@ -633,11 +633,41 @@ impl Display for ColumnType {
 pub struct ColumnRef {
     column_id: Ident,
     table_ref: TableRef,
-    column_type: ColumnType,
 }
 
 impl ColumnRef {
-    /// Create a new `ColumnRef` from a table, column identifier and column type
+    /// Create a new `ColumnRef` from a table and column identifier
+    #[must_use]
+    pub fn new(table_ref: TableRef, column_id: Ident) -> Self {
+        Self {
+            column_id,
+            table_ref,
+        }
+    }
+
+    /// Returns the table reference of this column
+    #[must_use]
+    pub fn table_ref(&self) -> TableRef {
+        self.table_ref.clone()
+    }
+
+    /// Returns the column identifier of this column
+    #[must_use]
+    pub fn column_id(&self) -> Ident {
+        self.column_id.clone()
+    }
+}
+
+/// Column field with resolved table reference
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub struct ResolvedColumnField {
+    column_id: Ident,
+    table_ref: TableRef,
+    column_type: ColumnType,
+}
+
+impl ResolvedColumnField {
+    /// Create a new `ResolvedColumnField` from a table, column identifier and column type
     #[must_use]
     pub fn new(table_ref: TableRef, column_id: Ident, column_type: ColumnType) -> Self {
         Self {

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -5,7 +5,7 @@ mod accessor;
 pub use accessor::{CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor};
 
 mod column;
-pub use column::{Column, ColumnField, ColumnRef, ColumnType};
+pub use column::{Column, ColumnField, ColumnRef, ColumnType, ResolvedColumnField};
 
 #[cfg_attr(not(test), expect(dead_code))]
 pub(crate) mod slice_operation;

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -111,12 +111,12 @@ impl TryFrom<CompactPlan> for EVMProofPlan {
         let column_refs: IndexSet<ColumnRef> = value
             .columns
             .iter()
-            .map(|(i, ident, column_type)| {
+            .map(|(i, ident, _)| {
                 let table_ref = table_refs_clone
                     .get_index(*i)
                     .cloned()
                     .ok_or(EVMProofPlanError::TableNotFound)?;
-                Ok(ColumnRef::new(table_ref, Ident::new(ident), *column_type))
+                Ok(ColumnRef::new(table_ref, Ident::new(ident)))
             })
             .try_collect()?;
         let output_column_names: IndexSet<String> = value.output_column_names.into_iter().collect();

--- a/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
+++ b/crates/proof-of-sql/src/sql/parse/enriched_expr.rs
@@ -1,6 +1,6 @@
 use super::DynProofExprBuilder;
 use crate::{
-    base::{database::ColumnRef, map::IndexMap},
+    base::{database::ResolvedColumnField, map::IndexMap},
     sql::proof_exprs::DynProofExpr,
 };
 use alloc::boxed::Box;
@@ -24,7 +24,10 @@ impl EnrichedExpr {
     /// If the expression is not provable, the `dyn_proof_expr` will be `None`.
     /// Otherwise the `dyn_proof_expr` will contain the provable expression plan
     /// and the `residue_expression` will contain the remaining expression.
-    pub fn new(expression: AliasedResultExpr, column_mapping: &IndexMap<Ident, ColumnRef>) -> Self {
+    pub fn new(
+        expression: AliasedResultExpr,
+        column_mapping: &IndexMap<Ident, ResolvedColumnField>,
+    ) -> Self {
         let res_dyn_proof_expr = DynProofExprBuilder::new(column_mapping).build(&expression.expr);
         match res_dyn_proof_expr {
             Ok(dyn_proof_expr) => {

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -3,7 +3,7 @@ use crate::base::{
     database::{
         can_and_or_types, try_add_subtract_column_types_with_scaling,
         try_equals_types_with_scaling, try_inequality_types_with_scaling,
-        try_multiply_column_types, ColumnRef, ColumnType, SchemaAccessor, TableRef,
+        try_multiply_column_types, ColumnType, ResolvedColumnField, SchemaAccessor, TableRef,
     },
     map::IndexSet,
     math::{
@@ -330,9 +330,10 @@ impl QueryContextBuilder<'_> {
             table_ref: table_ref.clone(),
         })?;
 
-        let column = ColumnRef::new(table_ref.clone(), column_name.clone(), column_type);
+        let column = ResolvedColumnField::new(table_ref.clone(), column_name.clone(), column_type);
 
-        self.context.push_column_ref(column_name.clone(), column);
+        self.context
+            .push_resolved_column_field(column_name.clone(), column);
 
         Ok(column_type)
     }

--- a/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/where_expr_builder.rs
@@ -1,7 +1,7 @@
 use super::{ConversionError, DynProofExprBuilder};
 use crate::{
     base::{
-        database::{ColumnRef, ColumnType},
+        database::{ColumnType, ResolvedColumnField},
         map::IndexMap,
     },
     sql::proof_exprs::{DynProofExpr, ProofExpr},
@@ -17,7 +17,7 @@ pub struct WhereExprBuilder<'a> {
 }
 impl<'a> WhereExprBuilder<'a> {
     /// Creates a new `WhereExprBuilder` with the given column mapping.
-    pub fn new(column_mapping: &'a IndexMap<Ident, ColumnRef>) -> Self {
+    pub fn new(column_mapping: &'a IndexMap<Ident, ResolvedColumnField>) -> Self {
         Self {
             builder: DynProofExprBuilder::new(column_mapping),
         }

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -17,13 +17,17 @@ use sqlparser::ast::Ident;
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ColumnExpr {
     pub(crate) column_ref: ColumnRef,
+    pub(crate) column_type: ColumnType,
 }
 
 impl ColumnExpr {
     /// Create a new column expression
     #[must_use]
-    pub fn new(column_ref: ColumnRef) -> Self {
-        Self { column_ref }
+    pub fn new(column_ref: ColumnRef, column_type: ColumnType) -> Self {
+        Self {
+            column_ref,
+            column_type,
+        }
     }
 
     /// Return the column referenced by this [`ColumnExpr`]
@@ -35,7 +39,7 @@ impl ColumnExpr {
     /// Wrap the column output name and its type within the [`ColumnField`]
     #[must_use]
     pub fn get_column_field(&self) -> ColumnField {
-        ColumnField::new(self.column_ref.column_id(), *self.column_ref.column_type())
+        ColumnField::new(self.column_ref.column_id(), self.column_type)
     }
 
     /// Get the column identifier
@@ -61,7 +65,7 @@ impl ColumnExpr {
 impl ProofExpr for ColumnExpr {
     /// Get the data type of the expression
     fn data_type(&self) -> ColumnType {
-        *self.get_column_reference().column_type()
+        self.column_type
     }
 
     /// Evaluate the column expression and

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -53,8 +53,8 @@ pub enum DynProofExpr {
 impl DynProofExpr {
     /// Create column expression
     #[must_use]
-    pub fn new_column(column_ref: ColumnRef) -> Self {
-        Self::Column(ColumnExpr::new(column_ref))
+    pub fn new_column(column_ref: ColumnRef, column_type: ColumnType) -> Self {
+        Self::Column(ColumnExpr::new(column_ref, column_type))
     }
     /// Create logical AND expression
     pub fn try_new_and(lhs: DynProofExpr, rhs: DynProofExpr) -> AnalyzeResult<Self> {

--- a/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/projection_exec.rs
@@ -77,11 +77,7 @@ impl ProofPlan for ProjectionExec {
             .zip(input_eval.column_evals())
             .map(|(field, eval)| {
                 (
-                    ColumnRef::new(
-                        input_table_ref.clone(),
-                        field.name().clone(),
-                        field.data_type(),
-                    ),
+                    ColumnRef::new(input_table_ref.clone(), field.name().clone()),
                     *eval,
                 )
             })

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -49,8 +49,7 @@ impl ProofPlan for TableExec {
             .schema
             .iter()
             .map(|field| {
-                let column_ref =
-                    ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type());
+                let column_ref = ColumnRef::new(self.table_ref.clone(), field.name());
                 *accessor.get(&column_ref).expect("Column does not exist")
             })
             .collect::<Vec<_>>();
@@ -67,7 +66,7 @@ impl ProofPlan for TableExec {
     fn get_column_references(&self) -> IndexSet<ColumnRef> {
         self.schema
             .iter()
-            .map(|field| ColumnRef::new(self.table_ref.clone(), field.name(), field.data_type()))
+            .map(|field| ColumnRef::new(self.table_ref.clone(), field.name()))
             .collect()
     }
 


### PR DESCRIPTION


Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
