### PR TITLE
refactor: use schema accessor rather than index map

### DIFF
--- a/crates/proof-of-sql-planner/src/error.rs
+++ b/crates/proof-of-sql-planner/src/error.rs
@@ -38,6 +38,9 @@ pub enum PlannerError {
         /// Underlying datafusion error
         source: DataFusionError,
     },
+    /// Returned if a column is not found
+    #[snafu(display("Column not found"))]
+    ColumnNotFound,
     /// Returned if a table is not found
     #[snafu(display("Table not found: {}", table_name))]
     TableNotFound {

--- a/crates/proof-of-sql-planner/src/lib.rs
+++ b/crates/proof-of-sql-planner/src/lib.rs
@@ -28,6 +28,6 @@ pub use proof_plan_with_postprocessing::{
 mod util;
 pub use util::column_fields_to_schema;
 pub(crate) use util::{
-    column_to_column_ref, df_schema_to_column_fields, placeholder_to_placeholder_expr,
-    scalar_value_to_literal_value, table_reference_to_table_ref,
+    column_to_column_ref, placeholder_to_placeholder_expr, scalar_value_to_literal_value,
+    schema_to_column_fields, table_reference_to_table_ref,
 };

--- a/crates/proof-of-sql/src/base/database/mod.rs
+++ b/crates/proof-of-sql/src/base/database/mod.rs
@@ -97,10 +97,8 @@ pub use expression_evaluation_error::{ExpressionEvaluationError, ExpressionEvalu
 mod test_accessor;
 pub use test_accessor::TestAccessor;
 
-#[cfg(test)]
 mod test_schema_accessor;
-#[cfg(test)]
-pub(crate) use test_schema_accessor::TestSchemaAccessor;
+pub use test_schema_accessor::TestSchemaAccessor;
 
 mod owned_table_test_accessor;
 pub use owned_table_test_accessor::OwnedTableTestAccessor;

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -1,5 +1,6 @@
 use super::{ColumnType, SchemaAccessor, TableRef};
 use crate::base::map::IndexMap;
+use alloc::vec::Vec;
 use sqlparser::ast::Ident;
 /// A simple in-memory `SchemaAccessor` for testing intermediate AST -> Provable AST conversion.
 pub struct TestSchemaAccessor {
@@ -8,6 +9,7 @@ pub struct TestSchemaAccessor {
 
 impl TestSchemaAccessor {
     /// Create a new `TestSchemaAccessor` with the given schema.
+    #[must_use]
     pub fn new(schemas: IndexMap<TableRef, IndexMap<Ident, ColumnType>>) -> Self {
         Self { schemas }
     }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

The planner is currently using `DFSchema` in more places than is necessary, which makes use by external applications more difficult.

# What changes are included in this PR?

Replacing `IndexMap<TableReference, DFSchema>` with `impl SchemaAccessor`. This necessitates other changes as well.

# Are these changes tested?
Yes
