### PR TITLE
refactor!: refactor accessors to remove `ColumnRef`

### DIFF
--- a/crates/proof-of-sql-planner/src/context.rs
+++ b/crates/proof-of-sql-planner/src/context.rs
@@ -42,7 +42,7 @@ impl<A: SchemaAccessor> ContextProvider for PoSqlContextProvider<A> {
     ) -> Result<Arc<dyn TableSource>, DataFusionError> {
         let table_ref = table_reference_to_table_ref(&name)
             .map_err(|err| DataFusionError::External(Box::new(err)))?;
-        let schema = self.accessor.lookup_schema(table_ref);
+        let schema = self.accessor.lookup_schema(&table_ref);
         let column_fields = schema_to_column_fields(schema);
         Ok(Arc::new(PoSqlTableSource::new(column_fields)) as Arc<dyn TableSource>)
     }

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -63,7 +63,7 @@ fn table_scan_to_projection(
 ) -> PlannerResult<DynProofPlan> {
     // Check if the table exists
     let table_ref = table_reference_to_table_ref(table_name)?;
-    let input_schema = schemas.lookup_schema(table_ref.clone());
+    let input_schema = schemas.lookup_schema(&table_ref);
     // Get aliased expressions
     let aliased_dyn_proof_exprs =
         get_aliased_dyn_proof_exprs(&table_ref, projection, &input_schema, projected_schema)?;
@@ -88,7 +88,7 @@ fn table_scan_to_filter(
 ) -> PlannerResult<DynProofPlan> {
     // Check if the table exists
     let table_ref = table_reference_to_table_ref(table_name)?;
-    let input_schema = schemas.lookup_schema(table_ref.clone());
+    let input_schema = schemas.lookup_schema(&table_ref);
     // Get aliased expressions
     let aliased_dyn_proof_exprs =
         get_aliased_dyn_proof_exprs(&table_ref, projection, &input_schema, projected_schema)?;
@@ -179,7 +179,7 @@ fn aggregate_to_proof_plan(
             ..
         }) => {
             let table_ref = table_reference_to_table_ref(table_name)?;
-            let input_schema = schemas.lookup_schema(table_ref.clone());
+            let input_schema = schemas.lookup_schema(&table_ref);
             let table_expr = TableExpr { table_ref };
             // Filter
             let consolidated_filter_proof_expr = filters

--- a/crates/proof-of-sql/examples/posql_db/commit_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/commit_accessor.rs
@@ -2,10 +2,12 @@ use core::error::Error;
 use indexmap::IndexMap;
 use proof_of_sql::base::{
     commitment::{Commitment, QueryCommitments, TableCommitment},
-    database::{CommitmentAccessor, MetadataAccessor, SchemaAccessor, TableRef},
+    database::{ColumnType, CommitmentAccessor, MetadataAccessor, SchemaAccessor, TableRef},
 };
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 use std::{fs, path::PathBuf};
+
 pub struct CommitAccessor<C: Commitment> {
     base_path: PathBuf,
     inner: QueryCommitments<C>,
@@ -38,35 +40,25 @@ impl<C: Commitment + Serialize + for<'a> Deserialize<'a>> CommitAccessor<C> {
 }
 
 impl<C: Commitment> CommitmentAccessor<C> for CommitAccessor<C> {
-    fn get_commitment(&self, column: proof_of_sql::base::database::ColumnRef) -> C {
-        self.inner.get_commitment(column)
+    fn get_commitment(&self, table_ref: &TableRef, column_id: &Ident) -> C {
+        self.inner.get_commitment(table_ref, column_id)
     }
 }
 impl<C: Commitment> MetadataAccessor for CommitAccessor<C> {
-    fn get_length(&self, table_ref: &proof_of_sql::base::database::TableRef) -> usize {
+    fn get_length(&self, table_ref: &TableRef) -> usize {
         self.inner.get_length(table_ref)
     }
 
-    fn get_offset(&self, table_ref: &proof_of_sql::base::database::TableRef) -> usize {
+    fn get_offset(&self, table_ref: &TableRef) -> usize {
         self.inner.get_offset(table_ref)
     }
 }
 impl<C: Commitment> SchemaAccessor for CommitAccessor<C> {
-    fn lookup_column(
-        &self,
-        table_ref: proof_of_sql::base::database::TableRef,
-        column_id: sqlparser::ast::Ident,
-    ) -> Option<proof_of_sql::base::database::ColumnType> {
+    fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
         self.inner.lookup_column(table_ref, column_id)
     }
 
-    fn lookup_schema(
-        &self,
-        table_ref: proof_of_sql::base::database::TableRef,
-    ) -> Vec<(
-        sqlparser::ast::Ident,
-        proof_of_sql::base::database::ColumnType,
-    )> {
+    fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
         self.inner.lookup_schema(table_ref)
     }
 }

--- a/crates/proof-of-sql/examples/posql_db/csv_accessor.rs
+++ b/crates/proof-of-sql/examples/posql_db/csv_accessor.rs
@@ -3,9 +3,10 @@ use arrow::{datatypes::Schema, record_batch::RecordBatch};
 use arrow_csv::{ReaderBuilder, WriterBuilder};
 use core::error::Error;
 use proof_of_sql::base::{
-    database::{Column, ColumnRef, DataAccessor, MetadataAccessor, SchemaAccessor, TableRef},
+    database::{Column, ColumnType, DataAccessor, MetadataAccessor, SchemaAccessor, TableRef},
     scalar::Scalar,
 };
+use sqlparser::ast::Ident;
 use std::{
     fs::{File, OpenOptions},
     path::{Path, PathBuf},
@@ -80,8 +81,8 @@ impl CsvDataAccessor {
     }
 }
 impl<S: Scalar> DataAccessor<S> for CsvDataAccessor {
-    fn get_column(&self, column: ColumnRef) -> Column<S> {
-        self.inner.get_column(column)
+    fn get_column(&self, table_ref: &TableRef, column_id: &Ident) -> Column<S> {
+        self.inner.get_column(table_ref, column_id)
     }
 }
 impl MetadataAccessor for CsvDataAccessor {
@@ -93,20 +94,10 @@ impl MetadataAccessor for CsvDataAccessor {
     }
 }
 impl SchemaAccessor for CsvDataAccessor {
-    fn lookup_column(
-        &self,
-        table_ref: TableRef,
-        column_id: sqlparser::ast::Ident,
-    ) -> Option<proof_of_sql::base::database::ColumnType> {
+    fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
         self.inner.lookup_column(table_ref, column_id)
     }
-    fn lookup_schema(
-        &self,
-        table_ref: TableRef,
-    ) -> Vec<(
-        sqlparser::ast::Ident,
-        proof_of_sql::base::database::ColumnType,
-    )> {
+    fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
         self.inner.lookup_schema(table_ref)
     }
 }

--- a/crates/proof-of-sql/examples/posql_db/main.rs
+++ b/crates/proof-of-sql/examples/posql_db/main.rs
@@ -204,7 +204,7 @@ fn main() {
             let mut table_commitment = commit_accessor.get_commit(&table_name).unwrap().clone();
             let schema = Schema::new(
                 commit_accessor
-                    .lookup_schema(table_name.clone())
+                    .lookup_schema(&table_name)
                     .iter()
                     .map(|(i, t)| Field::new(i.value.as_str(), t.into(), false))
                     .collect::<Vec<_>>(),
@@ -234,7 +234,7 @@ fn main() {
                     .expect("Failed to load commit");
                 let schema = Schema::new(
                     commit_accessor
-                        .lookup_schema(table.clone())
+                        .lookup_schema(&table)
                         .iter()
                         .map(|(i, t)| Field::new(i.value.as_str(), t.into(), false))
                         .collect::<Vec<_>>(),

--- a/crates/proof-of-sql/src/base/commitment/column_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/column_commitments.rs
@@ -3,7 +3,7 @@ use super::{
     ColumnCommitmentMetadataMapExt, ColumnCommitmentsMismatch, Commitment, VecCommitmentExt,
 };
 use crate::base::{
-    database::{ColumnField, ColumnRef, CommitmentAccessor, TableRef},
+    database::{ColumnField, CommitmentAccessor, TableRef},
     map::IndexSet,
 };
 use alloc::{
@@ -60,9 +60,7 @@ impl<C: Commitment> ColumnCommitments<C> {
             ColumnCommitmentMetadataMap::from_column_fields_with_max_bounds(columns);
         let commitments = columns
             .iter()
-            .map(|c| {
-                accessor.get_commitment(ColumnRef::new(table.clone(), c.name(), c.data_type()))
-            })
+            .map(|c| accessor.get_commitment(table, &c.name()))
             .collect();
         ColumnCommitments {
             commitments,

--- a/crates/proof-of-sql/src/base/commitment/query_commitments.rs
+++ b/crates/proof-of-sql/src/base/commitment/query_commitments.rs
@@ -49,7 +49,7 @@ impl<C: Commitment> QueryCommitmentsExt<C> for QueryCommitments<C> {
             .into_iter()
             .map(|(table_ref, column_fields)| {
                 let selected_column_fields = accessor
-                    .lookup_schema(table_ref.clone())
+                    .lookup_schema(&table_ref)
                     .into_iter()
                     .filter_map(|(ident, _)| {
                         column_fields
@@ -85,38 +85,31 @@ impl<C: Commitment> MetadataAccessor for QueryCommitments<C> {
 ///
 /// Panics if the commitment for the table or column cannot be found.
 impl<C: Commitment> CommitmentAccessor<C> for QueryCommitments<C> {
-    fn get_commitment(&self, column: ColumnRef) -> C {
-        let table_commitment = self.get(&column.table_ref()).unwrap();
+    fn get_commitment(&self, table_ref: &TableRef, column_id: &Ident) -> C {
+        let table_commitment = self.get(table_ref).unwrap();
 
         table_commitment
             .column_commitments()
-            .get_commitment(&column.column_id())
+            .get_commitment(column_id)
             .unwrap()
     }
 }
 
 impl<C: Commitment> SchemaAccessor for QueryCommitments<C> {
-    fn lookup_column(
-        &self,
-        table_ref: crate::base::database::TableRef,
-        column_id: Ident,
-    ) -> Option<ColumnType> {
-        let table_commitment = self.get(&table_ref)?;
+    fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
+        let table_commitment = self.get(table_ref)?;
 
         table_commitment
             .column_commitments()
-            .get_metadata(&column_id)
+            .get_metadata(column_id)
             .map(|column_metadata| *column_metadata.column_type())
     }
 
     /// # Panics
     ///
     /// Panics if the column metadata cannot be found.
-    fn lookup_schema(
-        &self,
-        table_ref: crate::base::database::TableRef,
-    ) -> Vec<(Ident, ColumnType)> {
-        let table_commitment = self.get(&table_ref).unwrap();
+    fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
+        let table_commitment = self.get(table_ref).unwrap();
 
         table_commitment
             .column_commitments()
@@ -231,27 +224,15 @@ mod tests {
         ]);
 
         assert_eq!(
-            query_commitments.get_commitment(ColumnRef::new(
-                table_a_id.clone(),
-                column_a_id.clone(),
-                ColumnType::BigInt
-            )),
+            query_commitments.get_commitment(&table_a_id, &column_a_id,),
             table_a_commitment.column_commitments().commitments()[0]
         );
         assert_eq!(
-            query_commitments.get_commitment(ColumnRef::new(
-                table_a_id,
-                column_b_id,
-                ColumnType::VarChar
-            )),
+            query_commitments.get_commitment(&table_a_id, &column_b_id,),
             table_a_commitment.column_commitments().commitments()[1]
         );
         assert_eq!(
-            query_commitments.get_commitment(ColumnRef::new(
-                table_b_id,
-                column_a_id,
-                ColumnType::Scalar
-            )),
+            query_commitments.get_commitment(&table_b_id, &column_a_id,),
             table_b_commitment.column_commitments().commitments()[0]
         );
     }
@@ -295,18 +276,18 @@ mod tests {
 
         assert_eq!(
             query_commitments
-                .lookup_column(table_a_id.clone(), column_a_id.clone())
+                .lookup_column(&table_a_id, &column_a_id)
                 .unwrap(),
             ColumnType::BigInt
         );
         assert_eq!(
             query_commitments
-                .lookup_column(table_a_id.clone(), column_b_id.clone())
+                .lookup_column(&table_a_id, &column_b_id)
                 .unwrap(),
             ColumnType::VarChar
         );
         assert_eq!(
-            query_commitments.lookup_schema(table_a_id),
+            query_commitments.lookup_schema(&table_a_id),
             vec![
                 (column_a_id.clone(), ColumnType::BigInt),
                 (column_b_id.clone(), ColumnType::VarChar)
@@ -315,24 +296,24 @@ mod tests {
 
         assert_eq!(
             query_commitments
-                .lookup_column(table_b_id.clone(), column_a_id.clone())
+                .lookup_column(&table_b_id, &column_a_id)
                 .unwrap(),
             ColumnType::Scalar
         );
         assert_eq!(
-            query_commitments.lookup_column(table_b_id.clone(), column_b_id),
+            query_commitments.lookup_column(&table_b_id, &column_b_id),
             None
         );
         assert_eq!(
-            query_commitments.lookup_schema(table_b_id),
+            query_commitments.lookup_schema(&table_b_id),
             vec![(column_a_id.clone(), ColumnType::Scalar),]
         );
 
         assert_eq!(
-            query_commitments.lookup_column(no_columns_id.clone(), column_a_id),
+            query_commitments.lookup_column(&no_columns_id, &column_a_id),
             None
         );
-        assert_eq!(query_commitments.lookup_schema(no_columns_id), vec![]);
+        assert_eq!(query_commitments.lookup_schema(&no_columns_id), vec![]);
     }
 
     #[expect(clippy::similar_names)]

--- a/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
+++ b/crates/proof-of-sql/src/base/database/owned_table_test_accessor_test.rs
@@ -1,6 +1,6 @@
 use super::{
-    Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor,
-    OwnedTableTestAccessor, SchemaAccessor, TestAccessor,
+    Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, OwnedTableTestAccessor,
+    SchemaAccessor, TestAccessor,
 };
 use crate::base::{
     commitment::{
@@ -39,8 +39,7 @@ fn we_can_access_the_columns_of_a_table() {
     let data1 = owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 5, 6])]);
     accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1.clone(), "b".into(), ColumnType::BigInt);
-    match accessor.get_column(column) {
+    match accessor.get_column(&table_ref_1, &"b".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6]),
         _ => panic!("Invalid column type"),
     };
@@ -61,20 +60,17 @@ fn we_can_access_the_columns_of_a_table() {
     ]);
     accessor.add_table(table_ref_2.clone(), data2, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1.clone(), "a".into(), ColumnType::BigInt);
-    match accessor.get_column(column) {
+    match accessor.get_column(&table_ref_1, &"a".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![1, 2, 3]),
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2.clone(), "b".into(), ColumnType::BigInt);
-    match accessor.get_column(column) {
+    match accessor.get_column(&table_ref_2, &"b".into()) {
         Column::BigInt(col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2.clone(), "c128".into(), ColumnType::Int128);
-    match accessor.get_column(column) {
+    match accessor.get_column(&table_ref_2, &"c128".into()) {
         Column::Int128(col) => assert_eq!(col.to_vec(), vec![1, 2, 3, 4]),
         _ => panic!("Invalid column type"),
     };
@@ -84,8 +80,7 @@ fn we_can_access_the_columns_of_a_table() {
         .iter()
         .map(core::convert::Into::into)
         .collect();
-    let column = ColumnRef::new(table_ref_2.clone(), "varchar".into(), ColumnType::VarChar);
-    match accessor.get_column(column) {
+    match accessor.get_column(&table_ref_2, &"varchar".into()) {
         Column::VarChar((col, scals)) => {
             assert_eq!(col.to_vec(), col_slice);
             assert_eq!(scals.to_vec(), col_scalars);
@@ -93,8 +88,7 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2.clone(), "scalar".into(), ColumnType::Scalar);
-    match accessor.get_column(column) {
+    match accessor.get_column(&table_ref_2, &"scalar".into()) {
         Column::Scalar(col) => assert_eq!(
             col.to_vec(),
             vec![
@@ -107,18 +101,12 @@ fn we_can_access_the_columns_of_a_table() {
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(table_ref_2.clone(), "boolean".into(), ColumnType::Boolean);
-    match accessor.get_column(column) {
+    match accessor.get_column(&table_ref_2, &"boolean".into()) {
         Column::Boolean(col) => assert_eq!(col.to_vec(), vec![true, false, true, false]),
         _ => panic!("Invalid column type"),
     };
 
-    let column = ColumnRef::new(
-        table_ref_2.clone(),
-        "time".into(),
-        ColumnType::TimestampTZ(PoSQLTimeUnit::Second, PoSQLTimeZone::utc()),
-    );
-    match accessor.get_column(column) {
+    match accessor.get_column(&table_ref_2, &"time".into()) {
         Column::TimestampTZ(_, _, col) => assert_eq!(col.to_vec(), vec![4, 5, 6, 5]),
         _ => panic!("Invalid column type"),
     };
@@ -133,9 +121,8 @@ fn we_can_access_the_commitments_of_table_columns() {
     let data1 = owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 5, 6])]);
     accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
-        accessor.get_commitment(column),
+        accessor.get_commitment(&table_ref_1, &"b".into()),
         NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[4i64, 5, 6][..])],
             0_usize,
@@ -146,9 +133,8 @@ fn we_can_access_the_commitments_of_table_columns() {
     let data2 = owned_table([bigint("a", [1, 2, 3, 4]), bigint("b", [4, 5, 6, 5])]);
     accessor.add_table(table_ref_2.clone(), data2, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1.clone(), "a".into(), ColumnType::BigInt);
     assert_eq!(
-        accessor.get_commitment(column),
+        accessor.get_commitment(&table_ref_1, &"a".into()),
         NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[1i64, 2, 3][..])],
             0_usize,
@@ -156,9 +142,8 @@ fn we_can_access_the_commitments_of_table_columns() {
         )[0]
     );
 
-    let column = ColumnRef::new(table_ref_2.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
-        accessor.get_commitment(column),
+        accessor.get_commitment(&table_ref_2, &"b".into()),
         NaiveCommitment::compute_commitments(
             &[CommittableColumn::from(&[4i64, 5, 6, 5][..])],
             0_usize,
@@ -176,36 +161,27 @@ fn we_can_access_the_type_of_table_columns() {
     let data1 = owned_table([bigint("a", [1, 2, 3]), bigint("b", [4, 5, 6])]);
     accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
-        accessor.lookup_column(column.table_ref(), column.column_id()),
+        accessor.lookup_column(&table_ref_1, &"b".into()),
         Some(ColumnType::BigInt)
     );
 
-    let column = ColumnRef::new(table_ref_1.clone(), "c".into(), ColumnType::BigInt);
-    assert!(accessor
-        .lookup_column(column.table_ref(), column.column_id())
-        .is_none());
+    assert!(accessor.lookup_column(&table_ref_1, &"c".into()).is_none());
 
     let data2 = owned_table([bigint("a", [1, 2, 3, 4]), bigint("b", [4, 5, 6, 5])]);
     accessor.add_table(table_ref_2.clone(), data2, 0_usize);
 
-    let column = ColumnRef::new(table_ref_1.clone(), "a".into(), ColumnType::BigInt);
     assert_eq!(
-        accessor.lookup_column(column.table_ref(), column.column_id()),
+        accessor.lookup_column(&table_ref_1, &"a".into()),
         Some(ColumnType::BigInt)
     );
 
-    let column = ColumnRef::new(table_ref_2.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
-        accessor.lookup_column(column.table_ref(), column.column_id()),
+        accessor.lookup_column(&table_ref_2, &"b".into()),
         Some(ColumnType::BigInt)
     );
 
-    let column = ColumnRef::new(table_ref_2.clone(), "c".into(), ColumnType::BigInt);
-    assert!(accessor
-        .lookup_column(column.table_ref(), column.column_id())
-        .is_none());
+    assert!(accessor.lookup_column(&table_ref_2, &"c".into()).is_none());
 }
 
 #[test]
@@ -217,7 +193,7 @@ fn we_can_access_schema_and_column_names() {
     accessor.add_table(table_ref_1.clone(), data1, 0_usize);
 
     assert_eq!(
-        accessor.lookup_schema(table_ref_1.clone()),
+        accessor.lookup_schema(&table_ref_1),
         vec![
             ("a".into(), ColumnType::BigInt),
             ("b".into(), ColumnType::VarChar)
@@ -238,15 +214,14 @@ fn we_can_correctly_update_offsets() {
     let mut accessor2 = OwnedTableTestAccessor::<NaiveEvaluationProof>::new_empty_with_setup(());
     accessor2.add_table(table_ref.clone(), data, offset);
 
-    let column = ColumnRef::new(table_ref.clone(), "a".into(), ColumnType::BigInt);
     assert_ne!(
-        accessor1.get_commitment(column.clone()),
-        accessor2.get_commitment(column)
+        accessor1.get_commitment(&table_ref, &"a".into()),
+        accessor2.get_commitment(&table_ref, &"a".into())
     );
-    let column = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
+
     assert_ne!(
-        accessor1.get_commitment(column.clone()),
-        accessor2.get_commitment(column)
+        accessor1.get_commitment(&table_ref, &"b".into()),
+        accessor2.get_commitment(&table_ref, &"b".into())
     );
 
     assert_eq!(accessor1.get_offset(&table_ref), 0);
@@ -254,15 +229,13 @@ fn we_can_correctly_update_offsets() {
 
     accessor1.update_offset(&table_ref, offset);
 
-    let column = ColumnRef::new(table_ref.clone(), "a".into(), ColumnType::BigInt);
     assert_eq!(
-        accessor1.get_commitment(column.clone()),
-        accessor2.get_commitment(column)
+        accessor1.get_commitment(&table_ref, &"a".into()),
+        accessor2.get_commitment(&table_ref, &"a".into())
     );
-    let column = ColumnRef::new(table_ref.clone(), "b".into(), ColumnType::BigInt);
     assert_eq!(
-        accessor1.get_commitment(column.clone()),
-        accessor2.get_commitment(column)
+        accessor1.get_commitment(&table_ref, &"b".into()),
+        accessor2.get_commitment(&table_ref, &"b".into())
     );
 
     assert_eq!(accessor1.get_offset(&table_ref), offset);

--- a/crates/proof-of-sql/src/base/database/table_test_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/table_test_accessor.rs
@@ -1,6 +1,6 @@
 use super::{
-    Column, ColumnRef, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor,
-    SchemaAccessor, Table, TableRef, TestAccessor,
+    Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor, Table,
+    TableRef, TestAccessor,
 };
 use crate::base::{
     commitment::{CommitmentEvaluationProof, VecCommitmentExt},
@@ -71,18 +71,18 @@ impl<'a, CP: CommitmentEvaluationProof> TestAccessor<CP::Commitment> for TableTe
 ///
 /// # Panics
 ///
-/// Will panic if the `column.table_ref()` is not found in `self.tables`, or if
-/// the `column.column_id()` is not found in the inner table for that reference,
+/// Will panic if the `table_ref` is not found in `self.tables`, or if
+/// the `column_id` is not found in the inner table for that reference,
 /// indicating that an invalid column reference was provided.
 impl<'a, CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for TableTestAccessor<'a, CP> {
-    fn get_column(&self, column: ColumnRef) -> Column<'a, CP::Scalar> {
+    fn get_column(&self, table_ref: &TableRef, column_id: &Ident) -> Column<'a, CP::Scalar> {
         *self
             .tables
-            .get(&column.table_ref())
+            .get(table_ref)
             .unwrap()
             .0
             .inner_table()
-            .get(&column.column_id())
+            .get(column_id)
             .unwrap()
     }
 }
@@ -90,13 +90,13 @@ impl<'a, CP: CommitmentEvaluationProof> DataAccessor<CP::Scalar> for TableTestAc
 ///
 /// # Panics
 ///
-/// Will panic if the `column.table_ref()` is not found in `self.tables`, or if the `column.column_id()` is not found in the inner table for that reference,indicating that an invalid column reference was provided.
+/// Will panic if the `table_ref` is not found in `self.tables`, or if the `column_id` is not found in the inner table for that reference,indicating that an invalid column reference was provided.
 impl<CP: CommitmentEvaluationProof> CommitmentAccessor<CP::Commitment>
     for TableTestAccessor<'_, CP>
 {
-    fn get_commitment(&self, column: ColumnRef) -> CP::Commitment {
-        let (table, offset) = self.tables.get(&column.table_ref()).unwrap();
-        let borrowed_column = table.inner_table().get(&column.column_id()).unwrap();
+    fn get_commitment(&self, table_ref: &TableRef, column_id: &Ident) -> CP::Commitment {
+        let (table, offset) = self.tables.get(table_ref).unwrap();
+        let borrowed_column = table.inner_table().get(column_id).unwrap();
         Vec::<CP::Commitment>::from_columns_with_offset(
             [borrowed_column],
             *offset,
@@ -122,13 +122,13 @@ impl<CP: CommitmentEvaluationProof> MetadataAccessor for TableTestAccessor<'_, C
     }
 }
 impl<CP: CommitmentEvaluationProof> SchemaAccessor for TableTestAccessor<'_, CP> {
-    fn lookup_column(&self, table_ref: TableRef, column_id: Ident) -> Option<ColumnType> {
+    fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
         Some(
             self.tables
-                .get(&table_ref)?
+                .get(table_ref)?
                 .0
                 .inner_table()
-                .get(&column_id)?
+                .get(column_id)?
                 .column_type(),
         )
     }
@@ -136,9 +136,9 @@ impl<CP: CommitmentEvaluationProof> SchemaAccessor for TableTestAccessor<'_, CP>
     /// # Panics
     ///
     /// Will panic if the `table_ref` is not found in `self.tables`, indicating that an invalid reference was provided.
-    fn lookup_schema(&self, table_ref: TableRef) -> Vec<(Ident, ColumnType)> {
+    fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
         self.tables
-            .get(&table_ref)
+            .get(table_ref)
             .unwrap()
             .0
             .inner_table()

--- a/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
+++ b/crates/proof-of-sql/src/base/database/test_schema_accessor.rs
@@ -16,13 +16,13 @@ impl TestSchemaAccessor {
 }
 
 impl SchemaAccessor for TestSchemaAccessor {
-    fn lookup_column(&self, table_ref: TableRef, column_id: Ident) -> Option<ColumnType> {
-        self.schemas.get(&table_ref)?.get(&column_id).copied()
+    fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
+        self.schemas.get(table_ref)?.get(column_id).copied()
     }
 
-    fn lookup_schema(&self, table_ref: TableRef) -> Vec<(Ident, ColumnType)> {
+    fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
         self.schemas
-            .get(&table_ref)
+            .get(table_ref)
             .unwrap_or(&IndexMap::default())
             .iter()
             .map(|(id, col)| (id.clone(), *col))
@@ -56,32 +56,23 @@ mod tests {
         let table2 = TableRef::new("schema", "table2");
         let not_a_table = TableRef::new("schema", "not_a_table");
         assert_eq!(
-            accessor.lookup_column(table1.clone(), "col1".into()),
+            accessor.lookup_column(&table1, &"col1".into()),
             Some(ColumnType::BigInt)
         );
         assert_eq!(
-            accessor.lookup_column(table1.clone(), "col2".into()),
+            accessor.lookup_column(&table1, &"col2".into()),
             Some(ColumnType::VarChar)
         );
+        assert_eq!(accessor.lookup_column(&table1, &"not_a_col".into()), None);
         assert_eq!(
-            accessor.lookup_column(table1.clone(), "not_a_col".into()),
-            None
-        );
-        assert_eq!(
-            accessor.lookup_column(table2.clone(), "col1".into()),
+            accessor.lookup_column(&table2, &"col1".into()),
             Some(ColumnType::BigInt)
         );
-        assert_eq!(accessor.lookup_column(table2.clone(), "col2".into()), None);
+        assert_eq!(accessor.lookup_column(&table2, &"col2".into()), None);
+        assert_eq!(accessor.lookup_column(&not_a_table, &"col1".into()), None);
+        assert_eq!(accessor.lookup_column(&not_a_table, &"col2".into()), None);
         assert_eq!(
-            accessor.lookup_column(not_a_table.clone(), "col1".into()),
-            None
-        );
-        assert_eq!(
-            accessor.lookup_column(not_a_table.clone(), "col2".into()),
-            None
-        );
-        assert_eq!(
-            accessor.lookup_column(not_a_table.clone(), "not_a_col".into()),
+            accessor.lookup_column(&not_a_table, &"not_a_col".into()),
             None
         );
     }
@@ -93,16 +84,16 @@ mod tests {
         let table2 = TableRef::new("schema", "table2");
         let not_a_table = TableRef::new("schema", "not_a_table");
         assert_eq!(
-            accessor.lookup_schema(table1),
+            accessor.lookup_schema(&table1),
             vec![
                 ("col1".into(), ColumnType::BigInt),
                 ("col2".into(), ColumnType::VarChar),
             ]
         );
         assert_eq!(
-            accessor.lookup_schema(table2),
+            accessor.lookup_schema(&table2),
             vec![("col1".into(), ColumnType::BigInt),]
         );
-        assert_eq!(accessor.lookup_schema(not_a_table), vec![]);
+        assert_eq!(accessor.lookup_schema(&not_a_table), vec![]);
     }
 }

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
@@ -24,7 +24,7 @@ fn evm_verifier_with_extra_args(
     let commitments = plan
         .get_column_references()
         .into_iter()
-        .map(|c| accessor.get_commitment(c))
+        .map(|c| accessor.get_commitment(&c.table_ref(), &c.column_id()))
         .flat_map(|c| {
             c.commitment
                 .into_affine()

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -155,7 +155,7 @@ impl QueryContextBuilder<'_> {
     )]
     fn lookup_schema(&self) -> Vec<(Ident, ColumnType)> {
         let table_ref = self.context.get_table_ref();
-        let columns = self.schema_accessor.lookup_schema(table_ref.clone());
+        let columns = self.schema_accessor.lookup_schema(table_ref);
         assert!(!columns.is_empty(), "At least one column must exist");
         columns
     }
@@ -321,9 +321,7 @@ impl QueryContextBuilder<'_> {
 
     fn visit_column_identifier(&mut self, column_name: &Ident) -> ConversionResult<ColumnType> {
         let table_ref = self.context.get_table_ref();
-        let column_type = self
-            .schema_accessor
-            .lookup_column(table_ref.clone(), column_name.clone());
+        let column_type = self.schema_accessor.lookup_column(table_ref, column_name);
 
         let column_type = column_type.ok_or_else(|| ConversionError::MissingColumn {
             identifier: Box::new(column_name.clone()),

--- a/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/test_utility.rs
@@ -8,7 +8,7 @@ use sqlparser::ast::Ident;
 
 pub fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> ColumnRef {
     let name: Ident = name.into();
-    let type_col = accessor.lookup_column(tab.clone(), name.clone()).unwrap();
+    let type_col = accessor.lookup_column(tab, &name).unwrap();
     ColumnRef::new(tab.clone(), name, type_col)
 }
 
@@ -17,7 +17,7 @@ pub fn col_ref(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> Co
 /// - `accessor.lookup_column()` returns `None`, indicating the column is not found.
 pub fn column(tab: &TableRef, name: &str, accessor: &impl SchemaAccessor) -> DynProofExpr {
     let name: Ident = name.into();
-    let type_col = accessor.lookup_column(tab.clone(), name.clone()).unwrap();
+    let type_col = accessor.lookup_column(tab, &name).unwrap();
     DynProofExpr::Column(ColumnExpr::new(ColumnRef::new(tab.clone(), name, type_col)))
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
It doesn't make any sense to let `ColumnType` be a part of the key to fetch columns and commitments. Moreover it doesn't make sense for accessors to consume `TableRef`s and `Ident`s. Hence we are fixing this.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- Remove `ColumnRef` from accessors
- Accessors shouldn't consume `TableRef`s or `Ident`s
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.