### PR TITLE
fix!: downgrade datafusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ criterion = { version = "0.5.1" }
 chrono = { version = "=0.4.39", default-features = false }
 csv = { version = "1.3.1" }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
-datafusion = { version = "38.0.0", default-features = false }
+datafusion = { version = "37.1", default-features = false }
 derive_more = { version = "0.99" }
 enum_dispatch = { version = "0.3.13" }
 getrandom = { version = "0.2.15", default-features = false }
@@ -68,7 +68,7 @@ serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10.8", default-features = false }
 snafu = { version = "0.8.4", default-features = false }
-sqlparser = { version = "0.45.0", default-features = false }
+sqlparser = { version = "0.44.0", default-features = false }
 sysinfo = { version = "0.33" }
 tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 tempfile = { version = "3.13.0", default-features = false }

--- a/crates/proof-of-sql-planner/src/conversion.rs
+++ b/crates/proof-of-sql-planner/src/conversion.rs
@@ -6,7 +6,7 @@ use alloc::{sync::Arc, vec::Vec};
 use datafusion::{
     config::ConfigOptions,
     logical_expr::LogicalPlan,
-    optimizer::{Analyzer, Optimizer, OptimizerContext, OptimizerRule},
+    optimizer::{analyzer::Analyzer, optimizer::Optimizer, OptimizerContext, OptimizerRule},
     sql::planner::SqlToRel,
 };
 use indexmap::IndexSet;
@@ -65,12 +65,12 @@ where
             // 3. Analyze the `LogicalPlan` using `Analyzer`
             let analyzer = Analyzer::new();
             let analyzed_logical_plan =
-                analyzer.execute_and_check(raw_logical_plan, config, |_, _| {})?;
+                analyzer.execute_and_check(&raw_logical_plan, config, |_, _| {})?;
             // 4. Optimize the `LogicalPlan` using `Optimizer`
             let optimizer = optimizer();
             let optimizer_context = OptimizerContext::default();
             let optimized_logical_plan =
-                optimizer.optimize(analyzed_logical_plan, &optimizer_context, |_, _| {})?;
+                optimizer.optimize(&analyzed_logical_plan, &optimizer_context, |_, _| {})?;
             // 5. Convert the optimized `LogicalPlan` into a Proof of SQL plan
             planner_converter(&optimized_logical_plan, schemas)
         })

--- a/crates/proof-of-sql-planner/src/df_util.rs
+++ b/crates/proof-of-sql-planner/src/df_util.rs
@@ -6,11 +6,9 @@ use datafusion::{
 };
 
 /// Create a `Expr::Column` from full table name and column
-pub(crate) fn df_column(table_name: &str, column: &str) -> Expr {
-    Expr::Column(Column::new(
-        Some(TableReference::from(table_name)),
-        column.to_string(),
-    ))
+pub(crate) fn df_column(table_name: &'static str, column: &str) -> Expr {
+    let test = TableReference::from(table_name);
+    Expr::Column(Column::new(Some(test), column.to_string()))
 }
 
 /// Create a `DFSchema` from table name, column name and data type pairs

--- a/crates/proof-of-sql-planner/src/expr.rs
+++ b/crates/proof-of-sql-planner/src/expr.rs
@@ -679,7 +679,9 @@ mod tests {
     // Unsupported logical expression
     #[test]
     fn we_cannot_convert_unsupported_expr_to_proof_expr() {
-        let expr = Expr::Unnest(Unnest::new(Expr::Literal(ScalarValue::Int32(Some(100)))));
+        let expr = Expr::Unnest(Unnest {
+            exprs: vec![Expr::Literal(ScalarValue::Int32(Some(100)))],
+        });
         assert!(matches!(
             expr_to_proof_expr(&expr, &Vec::new()),
             Err(PlannerError::UnsupportedLogicalExpression { .. })

--- a/crates/proof-of-sql-planner/src/plan.rs
+++ b/crates/proof-of-sql-planner/src/plan.rs
@@ -110,9 +110,8 @@ fn try_get_schema_as_vec_from_df_schema(
     df_schema: &DFSchema,
 ) -> PlannerResult<Vec<(Ident, ColumnType)>> {
     df_schema
-        .inner()
         .fields()
-        .into_iter()
+        .iter()
         .map(|f| {
             ColumnType::try_from(f.data_type().clone())
                 .map_err(|_| PlannerError::UnsupportedDataType {
@@ -134,7 +133,7 @@ fn projection_to_proof_plan(
     let input_schema = try_get_schema_as_vec_from_df_schema(input.schema())?;
     let aliased_exprs = expr
         .iter()
-        .zip(output_schema.fields().into_iter())
+        .zip(output_schema.fields().iter())
         .map(|(e, field)| -> PlannerResult<AliasedDynProofExpr> {
             let proof_expr = expr_to_proof_expr(e, &input_schema)?;
             let alias = field.name().as_str().into();


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [ ] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [ ] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

In order to allow sxt-db to reference datafusion `ConfigOptions` that is used in the planner, the versions need to match between the planner and sxt-db.

# What changes are included in this PR?

Datafusion and sqlparser downgrade.

# Are these changes tested?
Yes
