### PR TITLE
feat: add * and logical exprs to `evm_proof_plan`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -1,3 +1,4 @@
+use crate::sql::AnalyzeError;
 use snafu::Snafu;
 
 /// Represents errors that can occur in the EVM proof plan module.
@@ -15,6 +16,12 @@ pub(crate) enum EVMProofPlanError {
     /// Error indicating that table name can not be parsed into `TableRef`.
     #[snafu(display("table name can not be parsed into TableRef"))]
     InvalidTableName,
+    /// Analyze error
+    #[snafu(transparent)]
+    AnalyzeError {
+        /// The underlying source error
+        source: AnalyzeError,
+    },
 }
 
 /// Result type for EVM proof plan operations.

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -93,7 +93,7 @@ impl EVMFilterExec {
                         alias: Ident::new(name),
                     })
                 })
-                .collect::<Result<Vec<_>, _>>()?,
+                .collect::<EVMProofPlanResult<Vec<_>>>()?,
             TableExpr {
                 table_ref: table_refs
                     .get_index(self.table_number)

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -1,4 +1,4 @@
-use super::{plans::EVMDynProofPlan, EVMProofPlanError};
+use super::{plans::EVMDynProofPlan, EVMProofPlanError, EVMProofPlanResult};
 use crate::{
     base::{
         database::{
@@ -76,7 +76,7 @@ impl TryFrom<&EVMProofPlan> for CompactPlan {
         let plan = EVMDynProofPlan::try_from_proof_plan(value.inner(), &table_refs, &column_refs)?;
         let columns = column_refs
             .into_iter()
-            .map(|column_ref| {
+            .map(|column_ref| -> EVMProofPlanResult<_> {
                 let table_index = table_refs
                     .get_index_of(&column_ref.table_ref())
                     .ok_or(EVMProofPlanError::TableNotFound)?;
@@ -111,7 +111,7 @@ impl TryFrom<CompactPlan> for EVMProofPlan {
         let column_refs: IndexSet<ColumnRef> = value
             .columns
             .iter()
-            .map(|(i, ident, column_type)| {
+            .map(|(i, ident, column_type)| -> EVMProofPlanResult<_> {
                 let table_ref = table_refs_clone
                     .get_index(*i)
                     .cloned()

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -35,6 +35,16 @@ impl AndExpr {
                 right_type: right_datatype.to_string(),
             })
     }
+
+    /// Get the left-hand side expression
+    pub fn lhs(&self) -> &DynProofExpr {
+        &self.lhs
+    }
+
+    /// Get the right-hand side expression
+    pub fn rhs(&self) -> &DynProofExpr {
+        &self.rhs
+    }
 }
 
 impl ProofExpr for AndExpr {

--- a/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use subtract_expr::SubtractExpr;
 mod add_subtract_expr_test;
 
 mod multiply_expr;
-use multiply_expr::MultiplyExpr;
+pub(crate) use multiply_expr::MultiplyExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod multiply_expr_test;
 
@@ -44,12 +44,12 @@ use inequality_expr::InequalityExpr;
 mod inequality_expr_test;
 
 mod or_expr;
-use or_expr::OrExpr;
+pub(crate) use or_expr::OrExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod or_expr_test;
 
 mod not_expr;
-use not_expr::NotExpr;
+pub(crate) use not_expr::NotExpr;
 #[cfg(all(test, feature = "blitzar"))]
 mod not_expr_test;
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -36,6 +36,16 @@ impl MultiplyExpr {
                 right_type: right_datatype.to_string(),
             })
     }
+
+    /// Get the left-hand side expression
+    pub fn lhs(&self) -> &DynProofExpr {
+        &self.lhs
+    }
+
+    /// Get the right-hand side expression
+    pub fn rhs(&self) -> &DynProofExpr {
+        &self.rhs
+    }
 }
 
 impl ProofExpr for MultiplyExpr {

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -30,6 +30,11 @@ impl NotExpr {
             .then_some(Self { expr })
             .ok_or(AnalyzeError::InvalidDataType { expr_type })
     }
+
+    /// Get the input expression
+    pub fn input(&self) -> &DynProofExpr {
+        &self.expr
+    }
 }
 
 impl ProofExpr for NotExpr {

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -35,6 +35,16 @@ impl OrExpr {
                 right_type: right_datatype.to_string(),
             })
     }
+
+    /// Get the left-hand side expression
+    pub fn lhs(&self) -> &DynProofExpr {
+        &self.lhs
+    }
+
+    /// Get the right-hand side expression
+    pub fn rhs(&self) -> &DynProofExpr {
+        &self.rhs
+    }
 }
 
 impl ProofExpr for OrExpr {


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
We need to add * and logical exprs to `evm_proof_plan` so that we can do cross-language tests.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See title.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.