### PR TITLE
feat(sol): add `MultiplyExpr`, `AndExpr`, `OrExpr`, `NotExpr` in Solidity

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -185,7 +185,7 @@ jobs:
       #- name: Run Tests to Generate Coverage Data (std only)
       #  run: cargo llvm-cov --no-report --no-default-features --features="std"
       - name: Generate Final LCOV Report (Merged Coverage)
-        run: cargo llvm-cov report --lcov --output-path lcov.info
+        run: cargo llvm-cov report --lcov --ignore-filename-regex '[/\\]evm_tests\.rs$' --output-path lcov.info
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v5
         env:

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/evm_tests.rs
@@ -210,14 +210,16 @@ fn we_can_verify_a_complex_filter_using_the_evm() {
         owned_table([
             bigint("a", [5, 3, 2, 5, 3, 2, 102, 104, 107, 108]),
             bigint("b", [0, 1, 2, 3, 4, 5, 33, 44, 55, 6]),
-            bigint("c", [6, 7, 8, 9, 10, 11, 14, 15, 73, 23]),
+            bigint("c", [0, 7, 8, 9, 10, 11, 14, 15, 73, 23]),
             bigint("d", [5, 7, 2, 5, 4, 1, 12, 22, 22, 22]),
         ]),
         0,
         &ps[..],
     );
     let query = QueryExpr::try_new(
-        "SELECT b,c FROM table WHERE a = d".parse().unwrap(),
+        "SELECT b,c FROM table WHERE (a + b = d) and (b = a * c)"
+            .parse()
+            .unwrap(),
         "namespace".into(),
         &accessor,
     )

--- a/solidity/src/base/Constants.sol
+++ b/solidity/src/base/Constants.sol
@@ -61,6 +61,14 @@ uint32 constant EQUALS_EXPR_VARIANT = 2;
 uint32 constant ADD_EXPR_VARIANT = 3;
 /// @dev Subtract variant constant for proof expressions
 uint32 constant SUBTRACT_EXPR_VARIANT = 4;
+/// @dev Multiply variant constant for proof expressions
+uint32 constant MULTIPLY_EXPR_VARIANT = 5;
+/// @dev And variant constant for proof expressions
+uint32 constant AND_EXPR_VARIANT = 6;
+/// @dev Or variant constant for proof expressions
+uint32 constant OR_EXPR_VARIANT = 7;
+/// @dev Not variant constant for proof expressions
+uint32 constant NOT_EXPR_VARIANT = 8;
 
 /// @dev Filter variant constant for proof plans
 uint32 constant FILTER_EXEC_VARIANT = 0;

--- a/solidity/src/proof_exprs/EqualsExpr.pre.sol
+++ b/solidity/src/proof_exprs/EqualsExpr.pre.sol
@@ -103,6 +103,22 @@ library EqualsExpr {
             function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL MultiplyExpr.pre.sol
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL AndExpr.pre.sol
+            function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL OrExpr.pre.sol
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL NotExpr.pre.sol
+            function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_exprs/MultiplyExpr.pre.sol
+++ b/solidity/src/proof_exprs/MultiplyExpr.pre.sol
@@ -6,15 +6,15 @@ import "../base/Constants.sol";
 import "../base/Errors.sol";
 import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
 
-/// @title AddExpr
-/// @dev Library for handling adding two proof expressions
-library AddExpr {
-    /// @notice Evaluates an add expression by adding two sub-expressions
+/// @title MultiplyExpr
+/// @dev Library for handling multiplying two proof expressions
+library MultiplyExpr {
+    /// @notice Evaluates an multiply expression by multiplying two sub-expressions
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
     /// ##### Signature
     /// ```yul
-    /// add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval
+    /// multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval
     /// ```
     /// ##### Parameters
     /// * `expr_ptr` - calldata pointer to the expression data
@@ -23,18 +23,18 @@ library AddExpr {
     /// ##### Return Values
     /// * `expr_ptr_out` - pointer to the remaining expression after consuming both sub-expressions
     /// * `eval` - the evaluation result from the builder's final round MLE
-    /// @notice Evaluates two sub-expressions and adds them together
+    /// @notice Evaluates two sub-expressions and multiplies them together
     /// ##### Proof Plan Encoding
-    /// The add expression is encoded as follows:
+    /// The multiply expression is encoded as follows:
     /// 1. The left hand side expression
     /// 2. The right hand side expression
-    /// @param __expr The add expression data
+    /// @param __expr The multiply expression data
     /// @param __builder The verification builder
     /// @param __chiEval The chi value for evaluation
     /// @return __exprOut The remaining expression after processing
     /// @return __builderOut The verification builder result
     /// @return __eval The evaluated result
-    function __addExprEvaluate( // solhint-disable-line gas-calldata-parameters
+    function __multiplyExprEvaluate( // solhint-disable-line gas-calldata-parameters
     bytes calldata __expr, VerificationBuilder.Builder memory __builder, uint256 __chiEval)
         external
         pure
@@ -73,12 +73,12 @@ library AddExpr {
             function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL SubtractExpr.pre.sol
-            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+            // IMPORT-YUL AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
-            // IMPORT-YUL MultiplyExpr.pre.sol
-            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+            // IMPORT-YUL SubtractExpr.pre.sol
+            function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL AndExpr.pre.sol
@@ -106,19 +106,27 @@ library AddExpr {
                 revert(0, 0)
             }
 
-            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 let lhs_eval
                 expr_ptr, lhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
                 let rhs_eval
                 expr_ptr, rhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
-                result_eval := addmod(lhs_eval, rhs_eval, MODULUS)
+                result_eval := mod(builder_consume_final_round_mle(builder_ptr), MODULUS)
+                builder_produce_identity_constraint(
+                    builder_ptr,
+                    addmod(
+                        result_eval, mulmod(MODULUS_MINUS_ONE, mulmod(lhs_eval, rhs_eval, MODULUS), MODULUS), MODULUS
+                    ),
+                    2
+                )
+
                 expr_ptr_out := expr_ptr
             }
 
             let __exprOutOffset
-            __exprOutOffset, __eval := add_expr_evaluate(__expr.offset, __builder, __chiEval)
+            __exprOutOffset, __eval := multiply_expr_evaluate(__expr.offset, __builder, __chiEval)
             __exprOut.offset := __exprOutOffset
             // slither-disable-next-line write-after-write
             __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))

--- a/solidity/src/proof_exprs/OrExpr.pre.sol
+++ b/solidity/src/proof_exprs/OrExpr.pre.sol
@@ -6,15 +6,15 @@ import "../base/Constants.sol";
 import "../base/Errors.sol";
 import {VerificationBuilder} from "../builder/VerificationBuilder.pre.sol";
 
-/// @title AddExpr
-/// @dev Library for handling adding two proof expressions
-library AddExpr {
-    /// @notice Evaluates an add expression by adding two sub-expressions
+/// @title OrExpr
+/// @dev Library for handling running OR on two proof expressions
+library OrExpr {
+    /// @notice Evaluates an or expression by running OR on two sub-expressions
     /// @custom:as-yul-wrapper
     /// #### Wrapped Yul Function
     /// ##### Signature
     /// ```yul
-    /// add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval
+    /// or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval
     /// ```
     /// ##### Parameters
     /// * `expr_ptr` - calldata pointer to the expression data
@@ -23,18 +23,18 @@ library AddExpr {
     /// ##### Return Values
     /// * `expr_ptr_out` - pointer to the remaining expression after consuming both sub-expressions
     /// * `eval` - the evaluation result from the builder's final round MLE
-    /// @notice Evaluates two sub-expressions and adds them together
+    /// @notice Evaluates two sub-expressions or multiplies them together
     /// ##### Proof Plan Encoding
-    /// The add expression is encoded as follows:
+    /// The or expression is encoded as follows:
     /// 1. The left hand side expression
     /// 2. The right hand side expression
-    /// @param __expr The add expression data
+    /// @param __expr The or expression data
     /// @param __builder The verification builder
     /// @param __chiEval The chi value for evaluation
     /// @return __exprOut The remaining expression after processing
     /// @return __builderOut The verification builder result
     /// @return __eval The evaluated result
-    function __addExprEvaluate( // solhint-disable-line gas-calldata-parameters
+    function __orExprEvaluate( // solhint-disable-line gas-calldata-parameters
     bytes calldata __expr, VerificationBuilder.Builder memory __builder, uint256 __chiEval)
         external
         pure
@@ -73,6 +73,10 @@ library AddExpr {
             function equals_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL AddExpr.pre.sol
+            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL SubtractExpr.pre.sol
             function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
@@ -83,10 +87,6 @@ library AddExpr {
             }
             // IMPORT-YUL AndExpr.pre.sol
             function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
-                revert(0, 0)
-            }
-            // IMPORT-YUL OrExpr.pre.sol
-            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
             // IMPORT-YUL NotExpr.pre.sol
@@ -106,19 +106,33 @@ library AddExpr {
                 revert(0, 0)
             }
 
-            function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 let lhs_eval
                 expr_ptr, lhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
                 let rhs_eval
                 expr_ptr, rhs_eval := proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
 
-                result_eval := addmod(lhs_eval, rhs_eval, MODULUS)
+                let lhs_times_rhs_eval := builder_consume_final_round_mle(builder_ptr)
+                result_eval :=
+                    addmod(
+                        addmod(lhs_eval, rhs_eval, MODULUS), mulmod(MODULUS_MINUS_ONE, lhs_times_rhs_eval, MODULUS), MODULUS
+                    )
+                builder_produce_identity_constraint(
+                    builder_ptr,
+                    addmod(
+                        lhs_times_rhs_eval,
+                        mulmod(MODULUS_MINUS_ONE, mulmod(lhs_eval, rhs_eval, MODULUS), MODULUS),
+                        MODULUS
+                    ),
+                    2
+                )
+
                 expr_ptr_out := expr_ptr
             }
 
             let __exprOutOffset
-            __exprOutOffset, __eval := add_expr_evaluate(__expr.offset, __builder, __chiEval)
+            __exprOutOffset, __eval := or_expr_evaluate(__expr.offset, __builder, __chiEval)
             __exprOut.offset := __exprOutOffset
             // slither-disable-next-line write-after-write
             __exprOut.length := sub(__expr.length, sub(__exprOutOffset, __expr.offset))

--- a/solidity/src/proof_exprs/ProofExpr.pre.sol
+++ b/solidity/src/proof_exprs/ProofExpr.pre.sol
@@ -14,7 +14,11 @@ library ProofExpr {
         Literal,
         Equals,
         Add,
-        Subtract
+        Subtract,
+        Multiply,
+        And,
+        Or,
+        Not
     }
 
     /// @notice Evaluates a proof expression
@@ -100,6 +104,22 @@ library ProofExpr {
             function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL MultiplyExpr.pre.sol
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL AndExpr.pre.sol
+            function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL OrExpr.pre.sol
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL NotExpr.pre.sol
+            function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
 
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 let proof_expr_variant := shr(UINT32_PADDING_BITS, calldataload(expr_ptr))
@@ -125,6 +145,22 @@ library ProofExpr {
                 case 4 {
                     case_const(4, SUBTRACT_EXPR_VARIANT)
                     expr_ptr_out, eval := subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
+                }
+                case 5 {
+                    case_const(5, MULTIPLY_EXPR_VARIANT)
+                    expr_ptr_out, eval := multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
+                }
+                case 6 {
+                    case_const(6, AND_EXPR_VARIANT)
+                    expr_ptr_out, eval := and_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
+                }
+                case 7 {
+                    case_const(7, OR_EXPR_VARIANT)
+                    expr_ptr_out, eval := or_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
+                }
+                case 8 {
+                    case_const(8, NOT_EXPR_VARIANT)
+                    expr_ptr_out, eval := not_expr_evaluate(expr_ptr, builder_ptr, chi_eval)
                 }
                 default { err(ERR_UNSUPPORTED_PROOF_EXPR_VARIANT) }
             }

--- a/solidity/src/proof_exprs/SubtractExpr.pre.sol
+++ b/solidity/src/proof_exprs/SubtractExpr.pre.sol
@@ -77,6 +77,22 @@ library SubtractExpr {
             function add_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL MultiplyExpr.pre.sol
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL AndExpr.pre.sol
+            function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL OrExpr.pre.sol
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL NotExpr.pre.sol
+            function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../builder/VerificationBuilder.pre.sol
             function builder_consume_final_round_mle(builder_ptr) -> value {
                 revert(0, 0)

--- a/solidity/src/proof_plans/FilterExec.pre.sol
+++ b/solidity/src/proof_plans/FilterExec.pre.sol
@@ -140,6 +140,22 @@ library FilterExec {
             function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/MultiplyExpr.pre.sol
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/AndExpr.pre.sol
+            function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/OrExpr.pre.sol
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/NotExpr.pre.sol
+            function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/src/proof_plans/ProofPlan.pre.sol
+++ b/solidity/src/proof_plans/ProofPlan.pre.sol
@@ -103,6 +103,22 @@ library ProofPlan {
             function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/MultiplyExpr.pre.sol
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/AndExpr.pre.sol
+            function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/OrExpr.pre.sol
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/NotExpr.pre.sol
+            function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/src/verifier/Verifier.pre.sol
+++ b/solidity/src/verifier/Verifier.pre.sol
@@ -278,6 +278,22 @@ library Verifier {
             function subtract_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
                 revert(0, 0)
             }
+            // IMPORT-YUL ../proof_exprs/MultiplyExpr.pre.sol
+            function multiply_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, result_eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/AndExpr.pre.sol
+            function and_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/OrExpr.pre.sol
+            function or_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
+            // IMPORT-YUL ../proof_exprs/NotExpr.pre.sol
+            function not_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
+                revert(0, 0)
+            }
             // IMPORT-YUL ../proof_exprs/ProofExpr.pre.sol
             function proof_expr_evaluate(expr_ptr, builder_ptr, chi_eval) -> expr_ptr_out, eval {
                 revert(0, 0)

--- a/solidity/test/proof_exprs/AndExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/AndExpr.t.pre.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {AndExpr} from "../../src/proof_exprs/AndExpr.pre.sol";
+import {FF, F} from "../base/FieldUtil.sol";
+
+contract AndExprTest is Test {
+    function testSimpleAndExpr() public pure {
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(0)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(1)),
+            hex"abcdef"
+        );
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.finalRoundMLEs = new uint256[](1);
+        builder.finalRoundMLEs[0] = 20;
+        builder.constraintMultipliers = new uint256[](1);
+        builder.constraintMultipliers[0] = 5;
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = 1;
+
+        uint256 eval;
+        (expr, builder, eval) = AndExpr.__andExprEvaluate(expr, builder, 10);
+
+        assert(eval == 20);
+        assert(builder.aggregateEvaluation == 100);
+        assert(builder.finalRoundMLEs.length == 0);
+        assert(builder.constraintMultipliers.length == 0);
+
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function computeAndExprAggregateEvaluation(VerificationBuilder.Builder memory builder, FF lhsEval, FF rhsEval)
+        public
+        pure
+        returns (FF aggregateEvaluation)
+    {
+        FF eval = F.from(builder.finalRoundMLEs[0]);
+
+        FF identityConstraint0Eval = eval - lhsEval * rhsEval;
+
+        aggregateEvaluation = F.from(builder.aggregateEvaluation);
+        aggregateEvaluation = aggregateEvaluation
+            + F.from(builder.constraintMultipliers[0]) * F.from(builder.rowMultipliersEvaluation) * identityConstraint0Eval;
+    }
+
+    function computeAndExprResultEvaluation(VerificationBuilder.Builder memory builder)
+        public
+        pure
+        returns (FF resultEvaluation)
+    {
+        resultEvaluation = F.from(builder.finalRoundMLEs[0]);
+    }
+
+    function testFuzzAndExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        int64 lhsValue,
+        int64 rhsValue,
+        bytes memory trailingExpr
+    ) public pure {
+        vm.assume(builder.finalRoundMLEs.length > 0);
+        vm.assume(builder.constraintMultipliers.length > 0);
+        vm.assume(builder.maxDegree > 2);
+
+        FF expectedAggregateEvaluation = computeAndExprAggregateEvaluation(
+            builder, F.from(lhsValue) * F.from(chiEvaluation), F.from(rhsValue) * F.from(chiEvaluation)
+        );
+        FF expectedEval = computeAndExprResultEvaluation(builder);
+
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, lhsValue),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, rhsValue),
+            trailingExpr
+        );
+
+        uint256 eval;
+        (expr, builder, eval) = AndExpr.__andExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == expectedEval.into());
+        assert(builder.aggregateEvaluation == expectedAggregateEvaluation.into());
+
+        uint256 exprLength = expr.length;
+        assert(exprLength == trailingExpr.length);
+        for (uint256 i = 0; i < exprLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+}

--- a/solidity/test/proof_exprs/MultiplyExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/MultiplyExpr.t.pre.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {MultiplyExpr} from "../../src/proof_exprs/MultiplyExpr.pre.sol";
+import {FF, F} from "../base/FieldUtil.sol";
+
+contract MultiplyExprTest is Test {
+    function testSimpleMultiplyExpr() public pure {
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(5)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(2)),
+            hex"abcdef"
+        );
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.finalRoundMLEs = new uint256[](1);
+        builder.finalRoundMLEs[0] = addmod(MODULUS, mulmod(MODULUS_MINUS_ONE, 500, MODULUS), MODULUS);
+        builder.constraintMultipliers = new uint256[](1);
+        builder.constraintMultipliers[0] = 5;
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = addmod(MODULUS, mulmod(MODULUS_MINUS_ONE, 2, MODULUS), MODULUS);
+
+        uint256 eval;
+        (expr, builder, eval) = MultiplyExpr.__multiplyExprEvaluate(expr, builder, 10);
+
+        assert(eval == addmod(MODULUS, mulmod(MODULUS_MINUS_ONE, 500, MODULUS), MODULUS));
+        assert(builder.aggregateEvaluation == 15000);
+        assert(builder.finalRoundMLEs.length == 0);
+        assert(builder.constraintMultipliers.length == 0);
+
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function computeMultiplyExprAggregateEvaluation(VerificationBuilder.Builder memory builder, FF lhsEval, FF rhsEval)
+        public
+        pure
+        returns (FF aggregateEvaluation)
+    {
+        FF eval = F.from(builder.finalRoundMLEs[0]);
+
+        FF identityConstraint0Eval = eval - lhsEval * rhsEval;
+
+        aggregateEvaluation = F.from(builder.aggregateEvaluation);
+        aggregateEvaluation = aggregateEvaluation
+            + F.from(builder.constraintMultipliers[0]) * F.from(builder.rowMultipliersEvaluation) * identityConstraint0Eval;
+    }
+
+    function computeMultiplyExprResultEvaluation(VerificationBuilder.Builder memory builder)
+        public
+        pure
+        returns (FF resultEvaluation)
+    {
+        resultEvaluation = F.from(builder.finalRoundMLEs[0]);
+    }
+
+    function testFuzzMultiplyExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        int64 lhsValue,
+        int64 rhsValue,
+        bytes memory trailingExpr
+    ) public pure {
+        vm.assume(builder.finalRoundMLEs.length > 0);
+        vm.assume(builder.constraintMultipliers.length > 0);
+        vm.assume(builder.maxDegree > 2);
+
+        FF expectedAggregateEvaluation = computeMultiplyExprAggregateEvaluation(
+            builder, F.from(lhsValue) * F.from(chiEvaluation), F.from(rhsValue) * F.from(chiEvaluation)
+        );
+        FF expectedEval = computeMultiplyExprResultEvaluation(builder);
+
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, lhsValue),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, rhsValue),
+            trailingExpr
+        );
+
+        uint256 eval;
+        (expr, builder, eval) = MultiplyExpr.__multiplyExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == expectedEval.into());
+        assert(builder.aggregateEvaluation == expectedAggregateEvaluation.into());
+
+        uint256 exprLength = expr.length;
+        assert(exprLength == trailingExpr.length);
+        for (uint256 i = 0; i < exprLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+}

--- a/solidity/test/proof_exprs/NotExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/NotExpr.t.pre.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {NotExpr} from "../../src/proof_exprs/NotExpr.pre.sol";
+import {F} from "../base/FieldUtil.sol";
+
+contract NotExprTest is Test {
+    function testSimpleNotExpr() public pure {
+        bytes memory expr =
+            abi.encodePacked(abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(1)), hex"abcdef");
+        VerificationBuilder.Builder memory builder;
+
+        uint256 eval;
+        (expr, builder, eval) = NotExpr.__notExprEvaluate(expr, builder, 10);
+
+        assert(eval == 0);
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testFuzzNotExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        int64 inputValue,
+        bytes memory trailingExpr
+    ) public pure {
+        bytes memory expr =
+            abi.encodePacked(abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, inputValue), trailingExpr);
+
+        uint256 eval;
+        (expr, builder, eval) = NotExpr.__notExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == (F.from(chiEvaluation) - F.from(inputValue) * F.from(chiEvaluation)).into());
+        assert(expr.length == trailingExpr.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+}

--- a/solidity/test/proof_exprs/OrExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/OrExpr.t.pre.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: UNLICENSED
+// This is licensed under the Cryptographic Open Software License 1.0
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import "../../src/base/Constants.sol";
+import {VerificationBuilder} from "../../src/builder/VerificationBuilder.pre.sol";
+import {OrExpr} from "../../src/proof_exprs/OrExpr.pre.sol";
+import {FF, F} from "../base/FieldUtil.sol";
+
+contract OrExprTest is Test {
+    function testSimpleOrExpr() public pure {
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(1)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(0)),
+            hex"abcdef"
+        );
+        VerificationBuilder.Builder memory builder;
+        builder.maxDegree = 3;
+        builder.finalRoundMLEs = new uint256[](1);
+        builder.finalRoundMLEs[0] = 20;
+        builder.constraintMultipliers = new uint256[](1);
+        builder.constraintMultipliers[0] = 5;
+        builder.aggregateEvaluation = 0;
+        builder.rowMultipliersEvaluation = 1;
+
+        uint256 eval;
+        (expr, builder, eval) = OrExpr.__orExprEvaluate(expr, builder, 10);
+
+        assert(eval == addmod(MODULUS, mulmod(MODULUS_MINUS_ONE, 10, MODULUS), MODULUS));
+        assert(builder.aggregateEvaluation == 100);
+        assert(builder.finalRoundMLEs.length == 0);
+        assert(builder.constraintMultipliers.length == 0);
+
+        bytes memory expectedExprOut = hex"abcdef";
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function computeOrExprAggregateEvaluation(VerificationBuilder.Builder memory builder, FF lhsEval, FF rhsEval)
+        public
+        pure
+        returns (FF aggregateEvaluation)
+    {
+        FF eval = F.from(builder.finalRoundMLEs[0]);
+
+        FF identityConstraint0Eval = eval - lhsEval * rhsEval;
+
+        aggregateEvaluation = F.from(builder.aggregateEvaluation);
+        aggregateEvaluation = aggregateEvaluation
+            + F.from(builder.constraintMultipliers[0]) * F.from(builder.rowMultipliersEvaluation) * identityConstraint0Eval;
+    }
+
+    function computeOrExprResultEvaluation(VerificationBuilder.Builder memory builder, FF lhsEval, FF rhsEval)
+        public
+        pure
+        returns (FF resultEvaluation)
+    {
+        resultEvaluation = lhsEval + rhsEval - F.from(builder.finalRoundMLEs[0]);
+    }
+
+    function testFuzzOrExpr(
+        VerificationBuilder.Builder memory builder,
+        uint256 chiEvaluation,
+        int64 lhsValue,
+        int64 rhsValue,
+        bytes memory trailingExpr
+    ) public pure {
+        vm.assume(builder.finalRoundMLEs.length > 0);
+        vm.assume(builder.constraintMultipliers.length > 0);
+        vm.assume(builder.maxDegree > 2);
+
+        FF expectedAggregateEvaluation = computeOrExprAggregateEvaluation(
+            builder, F.from(lhsValue) * F.from(chiEvaluation), F.from(rhsValue) * F.from(chiEvaluation)
+        );
+        FF expectedEval = computeOrExprResultEvaluation(
+            builder, F.from(lhsValue) * F.from(chiEvaluation), F.from(rhsValue) * F.from(chiEvaluation)
+        );
+
+        bytes memory expr = abi.encodePacked(
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, lhsValue),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, rhsValue),
+            trailingExpr
+        );
+
+        uint256 eval;
+        (expr, builder, eval) = OrExpr.__orExprEvaluate(expr, builder, chiEvaluation);
+
+        assert(eval == expectedEval.into());
+        assert(builder.aggregateEvaluation == expectedAggregateEvaluation.into());
+
+        uint256 exprLength = expr.length;
+        assert(exprLength == trailingExpr.length);
+        for (uint256 i = 0; i < exprLength; ++i) {
+            assert(expr[i] == trailingExpr[i]);
+        }
+    }
+}

--- a/solidity/test/proof_exprs/ProofExpr.t.pre.sol
+++ b/solidity/test/proof_exprs/ProofExpr.t.pre.sol
@@ -117,10 +117,115 @@ contract ProofExprTest is Test {
         }
     }
 
+    function testMultiplyExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        builder.finalRoundMLEs = new uint256[](1);
+        builder.finalRoundMLEs[0] = 405;
+        builder.constraintMultipliers = new uint256[](1);
+        builder.constraintMultipliers[0] = 20;
+        builder.rowMultipliersEvaluation = 2;
+        builder.maxDegree = 3;
+
+        bytes memory expr = abi.encodePacked(
+            MULTIPLY_EXPR_VARIANT,
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(2)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(2)),
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 10);
+
+        assert(eval == 405);
+        assert(builder.aggregateEvaluation == 200);
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testAndExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        builder.finalRoundMLEs = new uint256[](1);
+        builder.finalRoundMLEs[0] = 105;
+        builder.constraintMultipliers = new uint256[](1);
+        builder.constraintMultipliers[0] = 20;
+        builder.rowMultipliersEvaluation = 2;
+        builder.maxDegree = 3;
+
+        bytes memory expr = abi.encodePacked(
+            AND_EXPR_VARIANT,
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(1)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(1)),
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 10);
+
+        assert(eval == 105);
+        assert(builder.aggregateEvaluation == 200);
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testOrExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        builder.finalRoundMLEs = new uint256[](1);
+        builder.finalRoundMLEs[0] = 105;
+        builder.constraintMultipliers = new uint256[](1);
+        builder.constraintMultipliers[0] = 20;
+        builder.rowMultipliersEvaluation = 2;
+        builder.maxDegree = 3;
+
+        bytes memory expr = abi.encodePacked(
+            OR_EXPR_VARIANT,
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(1)),
+            abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(1)),
+            hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 10);
+
+        assert(eval == addmod(MODULUS, mulmod(MODULUS_MINUS_ONE, 85, MODULUS), MODULUS));
+        assert(builder.aggregateEvaluation == 200);
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
+    function testNotExprVariant() public pure {
+        VerificationBuilder.Builder memory builder;
+        bytes memory expr = abi.encodePacked(
+            NOT_EXPR_VARIANT, abi.encodePacked(LITERAL_EXPR_VARIANT, LITERAL_BIGINT_VARIANT, int64(0)), hex"abcdef"
+        );
+        bytes memory expectedExprOut = hex"abcdef";
+
+        uint256 eval;
+        (expr, builder, eval) = ProofExpr.__proofExprEvaluate(expr, builder, 3);
+
+        assert(eval == 3); // 1 * 3 - 0 * 3
+        assert(expr.length == expectedExprOut.length);
+        uint256 exprOutLength = expr.length;
+        for (uint256 i = 0; i < exprOutLength; ++i) {
+            assert(expr[i] == expectedExprOut[i]);
+        }
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testUnsupportedVariant() public {
         VerificationBuilder.Builder memory builder;
-        bytes memory exprIn = abi.encodePacked(uint32(5), hex"abcdef");
+        bytes memory exprIn = abi.encodePacked(uint32(25), hex"abcdef");
         vm.expectRevert(Errors.UnsupportedProofExprVariant.selector);
         ProofExpr.__proofExprEvaluate(exprIn, builder, 0);
     }
@@ -131,5 +236,9 @@ contract ProofExprTest is Test {
         assert(uint32(ProofExpr.ExprVariant.Equals) == EQUALS_EXPR_VARIANT);
         assert(uint32(ProofExpr.ExprVariant.Add) == ADD_EXPR_VARIANT);
         assert(uint32(ProofExpr.ExprVariant.Subtract) == SUBTRACT_EXPR_VARIANT);
+        assert(uint32(ProofExpr.ExprVariant.Multiply) == MULTIPLY_EXPR_VARIANT);
+        assert(uint32(ProofExpr.ExprVariant.And) == AND_EXPR_VARIANT);
+        assert(uint32(ProofExpr.ExprVariant.Or) == OR_EXPR_VARIANT);
+        assert(uint32(ProofExpr.ExprVariant.Not) == NOT_EXPR_VARIANT);
     }
 }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
We need to add more `ProofExpr` to Solidity.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See title.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.