### PR TITLE
feat: add `EVMGroupByExec`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/error.rs
@@ -16,6 +16,9 @@ pub(crate) enum EVMProofPlanError {
     /// Error indicating that table name can not be parsed into `TableRef`.
     #[snafu(display("table name can not be parsed into TableRef"))]
     InvalidTableName,
+    /// Error indicating that the output column name is invalid or missing.
+    #[snafu(display("invalid or missing output column name"))]
+    InvalidOutputColumnName,
     /// Analyze error
     #[snafu(transparent)]
     AnalyzeError {

--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -5,8 +5,10 @@ use crate::{
         map::IndexSet,
     },
     sql::{
-        proof_exprs::{AliasedDynProofExpr, TableExpr},
-        proof_plans::{DynProofPlan, EmptyExec, FilterExec, ProjectionExec, SliceExec, TableExec},
+        proof_exprs::{AliasedDynProofExpr, ColumnExpr, TableExpr},
+        proof_plans::{
+            DynProofPlan, EmptyExec, FilterExec, GroupByExec, ProjectionExec, SliceExec, TableExec,
+        },
     },
 };
 use alloc::{boxed::Box, string::String, vec::Vec};
@@ -21,6 +23,7 @@ pub(crate) enum EVMDynProofPlan {
     Table(EVMTableExec),
     Projection(EVMProjectionExec),
     Slice(EVMSliceExec),
+    GroupBy(EVMGroupByExec),
 }
 
 impl EVMDynProofPlan {
@@ -48,6 +51,10 @@ impl EVMDynProofPlan {
             DynProofPlan::Slice(slice_exec) => {
                 EVMSliceExec::try_from_proof_plan(slice_exec, table_refs, column_refs)
                     .map(Self::Slice)
+            }
+            DynProofPlan::GroupBy(group_by_exec) => {
+                EVMGroupByExec::try_from_proof_plan(group_by_exec, table_refs, column_refs)
+                    .map(Self::GroupBy)
             }
             _ => Err(EVMProofPlanError::NotSupported),
         }
@@ -78,6 +85,9 @@ impl EVMDynProofPlan {
             )),
             EVMDynProofPlan::Slice(slice_exec) => Ok(DynProofPlan::Slice(
                 slice_exec.try_into_proof_plan(table_refs, column_refs)?,
+            )),
+            EVMDynProofPlan::GroupBy(group_by_exec) => Ok(DynProofPlan::GroupBy(
+                group_by_exec.try_into_proof_plan(table_refs, column_refs, output_column_names)?,
             )),
         }
     }
@@ -288,6 +298,115 @@ impl EVMSliceExec {
             )?),
             self.skip,
             self.fetch,
+        ))
+    }
+}
+
+/// Represents a group by execution plan in EVM.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct EVMGroupByExec {
+    table_number: usize,
+    group_by_exprs: Vec<usize>,
+    sum_expr: Vec<EVMDynProofExpr>,
+    count_alias_name: String,
+    where_clause: EVMDynProofExpr,
+}
+
+impl EVMGroupByExec {
+    /// Try to create a `EVMGroupByExec` from a `GroupByExec`.
+    pub(crate) fn try_from_proof_plan(
+        plan: &GroupByExec,
+        table_refs: &IndexSet<TableRef>,
+        column_refs: &IndexSet<ColumnRef>,
+    ) -> EVMProofPlanResult<Self> {
+        // Map column expressions to their indices in column_refs
+        let group_by_exprs = plan
+            .group_by_exprs()
+            .iter()
+            .map(|col_expr| {
+                column_refs
+                    .get_index_of(&col_expr.get_column_reference())
+                    .ok_or(EVMProofPlanError::ColumnNotFound)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            table_number: table_refs
+                .get_index_of(&plan.table().table_ref)
+                .ok_or(EVMProofPlanError::TableNotFound)?,
+            group_by_exprs,
+            sum_expr: plan
+                .sum_expr()
+                .iter()
+                .map(|aliased_expr| {
+                    EVMDynProofExpr::try_from_proof_expr(&aliased_expr.expr, column_refs)
+                })
+                .collect::<Result<_, _>>()?,
+            count_alias_name: plan.count_alias().value.clone(),
+            where_clause: EVMDynProofExpr::try_from_proof_expr(plan.where_clause(), column_refs)?,
+        })
+    }
+
+    pub(crate) fn try_into_proof_plan(
+        &self,
+        table_refs: &IndexSet<TableRef>,
+        column_refs: &IndexSet<ColumnRef>,
+        output_column_names: &IndexSet<String>,
+    ) -> EVMProofPlanResult<GroupByExec> {
+        // Convert indices back to ColumnExpr objects
+        let group_by_exprs = self
+            .group_by_exprs
+            .iter()
+            .map(|&idx| {
+                let column_ref = column_refs
+                    .get_index(idx)
+                    .cloned()
+                    .ok_or(EVMProofPlanError::ColumnNotFound)?;
+                Ok(ColumnExpr::new(column_ref))
+            })
+            .collect::<EVMProofPlanResult<Vec<_>>>()?;
+
+        // Map sum expressions to AliasedDynProofExpr objects
+        let sum_aliases_offset = group_by_exprs.len();
+        let sum_expr = self
+            .sum_expr
+            .iter()
+            .enumerate()
+            .map(|(i, expr)| {
+                let alias_idx = sum_aliases_offset + i;
+                let alias_name = output_column_names
+                    .get_index(alias_idx)
+                    .ok_or(EVMProofPlanError::InvalidOutputColumnName)?;
+                Ok(AliasedDynProofExpr {
+                    expr: expr.try_into_proof_expr(column_refs)?,
+                    alias: Ident::new(alias_name),
+                })
+            })
+            .collect::<EVMProofPlanResult<Vec<_>>>()?;
+
+        // Get the count alias from output column names
+        let count_alias_idx = sum_aliases_offset + self.sum_expr.len();
+
+        // For safety, check if the provided count_alias_name matches
+        if let Some(name) = output_column_names.get_index(count_alias_idx) {
+            if name != &self.count_alias_name {
+                return Err(EVMProofPlanError::InvalidOutputColumnName);
+            }
+        } else {
+            return Err(EVMProofPlanError::InvalidOutputColumnName);
+        }
+
+        Ok(GroupByExec::new(
+            group_by_exprs,
+            sum_expr,
+            Ident::new(&self.count_alias_name),
+            TableExpr {
+                table_ref: table_refs
+                    .get_index(self.table_number)
+                    .cloned()
+                    .ok_or(EVMProofPlanError::TableNotFound)?,
+            },
+            self.where_clause.try_into_proof_expr(column_refs)?,
         ))
     }
 }
@@ -577,6 +696,359 @@ mod tests {
         assert!(matches!(
             EVMDynProofPlan::try_from_proof_plan(&plan, &table_refs, &column_refs),
             Err(EVMProofPlanError::NotSupported)
+        ));
+    }
+
+    #[test]
+    fn we_can_put_group_by_exec_in_evm() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let ident_a: Ident = "a".into();
+        let ident_b: Ident = "b".into();
+        let sum_alias = "sum_b".to_string();
+        let count_alias = "count".to_string();
+
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+
+        // Create a group by exec
+        let group_by_exec = GroupByExec::new(
+            vec![ColumnExpr::new(column_ref_a.clone())],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
+                alias: Ident::new(sum_alias.clone()),
+            }],
+            Ident::new(count_alias.clone()),
+            TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            DynProofExpr::Equals(
+                EqualsExpr::try_new(
+                    Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone()))),
+                    Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                        LiteralValue::BigInt(5),
+                    ))),
+                )
+                .unwrap(),
+            ),
+        );
+
+        // Convert to EVM plan
+        let evm_group_by_exec = EVMGroupByExec::try_from_proof_plan(
+            &group_by_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+        )
+        .unwrap();
+
+        // Verify the structure
+        assert_eq!(evm_group_by_exec.table_number, 0);
+        assert_eq!(evm_group_by_exec.group_by_exprs, vec![0]); // column_ref_a is at index 0
+        assert_eq!(evm_group_by_exec.sum_expr.len(), 1);
+        assert!(matches!(
+            evm_group_by_exec.sum_expr[0],
+            EVMDynProofExpr::Column(_)
+        ));
+        assert_eq!(evm_group_by_exec.count_alias_name, count_alias);
+        assert!(matches!(
+            evm_group_by_exec.where_clause,
+            EVMDynProofExpr::Equals(_)
+        ));
+
+        // Roundtrip
+        let roundtripped_group_by_exec = EVMGroupByExec::try_into_proof_plan(
+            &evm_group_by_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+            &indexset![
+                ident_a.value.clone(),
+                sum_alias.clone(),
+                count_alias.clone()
+            ],
+        )
+        .unwrap();
+
+        // Verify the roundtripped plan has the expected structure
+        assert_eq!(roundtripped_group_by_exec.group_by_exprs().len(), 1);
+        assert_eq!(
+            roundtripped_group_by_exec.group_by_exprs()[0].get_column_reference(),
+            column_ref_a
+        );
+        assert_eq!(roundtripped_group_by_exec.sum_expr().len(), 1);
+        assert!(matches!(
+            roundtripped_group_by_exec.sum_expr()[0].expr,
+            DynProofExpr::Column(_)
+        ));
+        assert_eq!(roundtripped_group_by_exec.count_alias().value, count_alias);
+        assert_eq!(roundtripped_group_by_exec.table().table_ref, table_ref);
+        assert!(matches!(
+            roundtripped_group_by_exec.where_clause(),
+            DynProofExpr::Equals(_)
+        ));
+    }
+
+    #[test]
+    fn group_by_exec_fails_with_column_not_found_from_proof_plan() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let ident_a: Ident = "a".into();
+        let ident_b: Ident = "b".into();
+        let missing_ident: Ident = "missing".into();
+        let sum_alias = "sum_b".to_string();
+        let count_alias = "count".to_string();
+
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+        let missing_column =
+            ColumnRef::new(table_ref.clone(), missing_ident.clone(), ColumnType::BigInt);
+
+        // Create a group by exec with a column that doesn't exist in column_refs
+        let group_by_exec = GroupByExec::new(
+            vec![ColumnExpr::new(missing_column)],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
+                alias: Ident::new(sum_alias),
+            }],
+            Ident::new(count_alias),
+            TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            DynProofExpr::Equals(
+                EqualsExpr::try_new(
+                    Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone()))),
+                    Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                        LiteralValue::BigInt(5),
+                    ))),
+                )
+                .unwrap(),
+            ),
+        );
+
+        let result = EVMGroupByExec::try_from_proof_plan(
+            &group_by_exec,
+            &indexset![table_ref],
+            &indexset![column_ref_a, column_ref_b],
+        );
+
+        assert!(matches!(result, Err(EVMProofPlanError::ColumnNotFound)));
+    }
+
+    #[test]
+    fn group_by_exec_fails_with_table_not_found_from_proof_plan() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let missing_table_ref: TableRef = "namespace.missing".parse().unwrap();
+        let ident_a: Ident = "a".into();
+        let ident_b: Ident = "b".into();
+        let sum_alias = "sum_b".to_string();
+        let count_alias = "count".to_string();
+
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+
+        // Create a group by exec with a table that doesn't exist in table_refs
+        let group_by_exec = GroupByExec::new(
+            vec![ColumnExpr::new(column_ref_a.clone())],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
+                alias: Ident::new(sum_alias),
+            }],
+            Ident::new(count_alias),
+            TableExpr {
+                table_ref: missing_table_ref,
+            },
+            DynProofExpr::Equals(
+                EqualsExpr::try_new(
+                    Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone()))),
+                    Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                        LiteralValue::BigInt(5),
+                    ))),
+                )
+                .unwrap(),
+            ),
+        );
+
+        let result = EVMGroupByExec::try_from_proof_plan(
+            &group_by_exec,
+            &indexset![table_ref],
+            &indexset![column_ref_a, column_ref_b],
+        );
+
+        assert!(matches!(result, Err(EVMProofPlanError::TableNotFound)));
+    }
+
+    #[test]
+    fn group_by_exec_fails_with_column_not_found_into_proof_plan() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let ident_a: Ident = "a".into();
+        let ident_b: Ident = "b".into();
+        let sum_alias = "sum_b".to_string();
+        let count_alias = "count".to_string();
+
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+
+        // Create a valid group by exec first
+        let group_by_exec = GroupByExec::new(
+            vec![ColumnExpr::new(column_ref_a.clone())],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
+                alias: Ident::new(sum_alias.clone()),
+            }],
+            Ident::new(count_alias.clone()),
+            TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            DynProofExpr::Equals(
+                EqualsExpr::try_new(
+                    Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone()))),
+                    Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                        LiteralValue::BigInt(5),
+                    ))),
+                )
+                .unwrap(),
+            ),
+        );
+
+        let evm_group_by_exec = EVMGroupByExec::try_from_proof_plan(
+            &group_by_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+        )
+        .unwrap();
+
+        // Now try to convert back with an empty column_refs
+        let result = EVMGroupByExec::try_into_proof_plan(
+            &evm_group_by_exec,
+            &indexset![table_ref.clone()],
+            &indexset![],
+            &indexset![
+                ident_a.value.clone(),
+                sum_alias.clone(),
+                count_alias.clone()
+            ],
+        );
+
+        assert!(matches!(result, Err(EVMProofPlanError::ColumnNotFound)));
+    }
+
+    #[test]
+    fn group_by_exec_fails_with_table_not_found_into_proof_plan() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let ident_a: Ident = "a".into();
+        let ident_b: Ident = "b".into();
+        let sum_alias = "sum_b".to_string();
+        let count_alias = "count".to_string();
+
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+
+        // Create a valid group by exec first
+        let group_by_exec = GroupByExec::new(
+            vec![ColumnExpr::new(column_ref_a.clone())],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
+                alias: Ident::new(sum_alias.clone()),
+            }],
+            Ident::new(count_alias.clone()),
+            TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            DynProofExpr::Equals(
+                EqualsExpr::try_new(
+                    Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone()))),
+                    Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                        LiteralValue::BigInt(5),
+                    ))),
+                )
+                .unwrap(),
+            ),
+        );
+
+        let evm_group_by_exec = EVMGroupByExec::try_from_proof_plan(
+            &group_by_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+        )
+        .unwrap();
+
+        // Now try to convert back with an empty table_refs
+        let result = EVMGroupByExec::try_into_proof_plan(
+            &evm_group_by_exec,
+            &indexset![],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+            &indexset![
+                ident_a.value.clone(),
+                sum_alias.clone(),
+                count_alias.clone()
+            ],
+        );
+
+        assert!(matches!(result, Err(EVMProofPlanError::TableNotFound)));
+    }
+
+    #[test]
+    fn group_by_exec_fails_with_invalid_output_column_name_into_proof_plan() {
+        let table_ref: TableRef = "namespace.table".parse().unwrap();
+        let ident_a: Ident = "a".into();
+        let ident_b: Ident = "b".into();
+        let sum_alias = "sum_b".to_string();
+        let count_alias = "count".to_string();
+
+        let column_ref_a = ColumnRef::new(table_ref.clone(), ident_a.clone(), ColumnType::BigInt);
+        let column_ref_b = ColumnRef::new(table_ref.clone(), ident_b.clone(), ColumnType::BigInt);
+
+        // Create a valid group by exec first
+        let group_by_exec = GroupByExec::new(
+            vec![ColumnExpr::new(column_ref_a.clone())],
+            vec![AliasedDynProofExpr {
+                expr: DynProofExpr::Column(ColumnExpr::new(column_ref_b.clone())),
+                alias: Ident::new(sum_alias.clone()),
+            }],
+            Ident::new(count_alias.clone()),
+            TableExpr {
+                table_ref: table_ref.clone(),
+            },
+            DynProofExpr::Equals(
+                EqualsExpr::try_new(
+                    Box::new(DynProofExpr::Column(ColumnExpr::new(column_ref_a.clone()))),
+                    Box::new(DynProofExpr::Literal(LiteralExpr::new(
+                        LiteralValue::BigInt(5),
+                    ))),
+                )
+                .unwrap(),
+            ),
+        );
+
+        let evm_group_by_exec = EVMGroupByExec::try_from_proof_plan(
+            &group_by_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+        )
+        .unwrap();
+
+        // Now try to convert back with incorrect output column names
+        let result = EVMGroupByExec::try_into_proof_plan(
+            &evm_group_by_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+            &indexset![ident_a.value.clone(), sum_alias.clone()], // Missing count_alias
+        );
+
+        assert!(matches!(
+            result,
+            Err(EVMProofPlanError::InvalidOutputColumnName)
+        ));
+
+        // Try with wrong count alias name
+        let wrong_count_alias = "wrong_count".to_string();
+        let result = EVMGroupByExec::try_into_proof_plan(
+            &evm_group_by_exec,
+            &indexset![table_ref.clone()],
+            &indexset![column_ref_a.clone(), column_ref_b.clone()],
+            &indexset![ident_a.value.clone(), sum_alias.clone(), wrong_count_alias],
+        );
+
+        assert!(matches!(
+            result,
+            Err(EVMProofPlanError::InvalidOutputColumnName)
         ));
     }
 }

--- a/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/group_by_exec.rs
@@ -65,6 +65,31 @@ impl GroupByExec {
             where_clause,
         }
     }
+
+    /// Get a reference to the table expression
+    pub fn table(&self) -> &TableExpr {
+        &self.table
+    }
+
+    /// Get a reference to the where clause
+    pub fn where_clause(&self) -> &DynProofExpr {
+        &self.where_clause
+    }
+
+    /// Get a reference to the group by expressions
+    pub fn group_by_exprs(&self) -> &[ColumnExpr] {
+        &self.group_by_exprs
+    }
+
+    /// Get a reference to the sum expressions
+    pub fn sum_expr(&self) -> &[AliasedDynProofExpr] {
+        &self.sum_expr
+    }
+
+    /// Get a reference to the count alias
+    pub fn count_alias(&self) -> &Ident {
+        &self.count_alias
+    }
 }
 
 impl ProofPlan for GroupByExec {


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change
Add more `ProofExec` to `evm_proof_plan`
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See title
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes.