### PR TITLE
refactor!: Switch to using getters in `proof_exprs` and `proof_plans`

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs
@@ -123,7 +123,7 @@ impl EVMTableExec {
     ) -> EVMProofPlanResult<Self> {
         Ok(Self {
             table_number: table_refs
-                .get_index_of(&plan.table_ref)
+                .get_index_of(plan.table_ref())
                 .ok_or(EVMProofPlanError::TableNotFound)?,
         })
     }
@@ -166,14 +166,14 @@ impl EVMFilterExec {
     ) -> EVMProofPlanResult<Self> {
         Ok(Self {
             table_number: table_refs
-                .get_index_of(&plan.table.table_ref)
+                .get_index_of(&plan.table().table_ref)
                 .ok_or(EVMProofPlanError::TableNotFound)?,
             results: plan
-                .aliased_results
+                .aliased_results()
                 .iter()
                 .map(|result| EVMDynProofExpr::try_from_proof_expr(&result.expr, column_refs))
                 .collect::<Result<_, _>>()?,
-            where_clause: EVMDynProofExpr::try_from_proof_expr(&plan.where_clause, column_refs)?,
+            where_clause: EVMDynProofExpr::try_from_proof_expr(plan.where_clause(), column_refs)?,
         })
     }
 
@@ -586,8 +586,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(roundtripped_table_exec.table_ref, table_exec.table_ref);
-        assert_eq!(roundtripped_table_exec.schema.len(), 2);
+        assert_eq!(
+            *roundtripped_table_exec.table_ref(),
+            *table_exec.table_ref()
+        );
+        assert_eq!(roundtripped_table_exec.schema().len(), 2);
     }
 
     #[test]

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -21,8 +21,8 @@ use serde::{Deserialize, Serialize};
 /// Provable numerical `+` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AddExpr {
-    pub(crate) lhs: Box<DynProofExpr>,
-    pub(crate) rhs: Box<DynProofExpr>,
+    lhs: Box<DynProofExpr>,
+    rhs: Box<DynProofExpr>,
 }
 
 impl AddExpr {
@@ -36,6 +36,16 @@ impl AddExpr {
                 left_type: left_datatype.to_string(),
                 right_type: right_datatype.to_string(),
             })
+    }
+
+    /// Get the left-hand side expression
+    pub fn lhs(&self) -> &DynProofExpr {
+        &self.lhs
+    }
+
+    /// Get the right-hand side expression
+    pub fn rhs(&self) -> &DynProofExpr {
+        &self.rhs
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -16,7 +16,7 @@ use sqlparser::ast::Ident;
 /// Note: this is currently limited to named column expressions.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ColumnExpr {
-    pub(crate) column_ref: ColumnRef,
+    column_ref: ColumnRef,
 }
 
 impl ColumnExpr {
@@ -30,6 +30,12 @@ impl ColumnExpr {
     #[must_use]
     pub fn get_column_reference(&self) -> ColumnRef {
         self.column_ref.clone()
+    }
+
+    /// Get the column reference
+    #[must_use]
+    pub fn column_ref(&self) -> &ColumnRef {
+        &self.column_ref
     }
 
     /// Wrap the column output name and its type within the [`ColumnField`]

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 /// Provable AST expression for an equals expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct EqualsExpr {
-    pub(crate) lhs: Box<DynProofExpr>,
-    pub(crate) rhs: Box<DynProofExpr>,
+    lhs: Box<DynProofExpr>,
+    rhs: Box<DynProofExpr>,
 }
 
 impl EqualsExpr {
@@ -35,6 +35,16 @@ impl EqualsExpr {
                 left_type: left_datatype.to_string(),
                 right_type: right_datatype.to_string(),
             })
+    }
+
+    /// Get the left-hand side expression
+    pub fn lhs(&self) -> &DynProofExpr {
+        &self.lhs
+    }
+
+    /// Get the right-hand side expression
+    pub fn rhs(&self) -> &DynProofExpr {
+        &self.rhs
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -43,6 +43,21 @@ impl InequalityExpr {
                 right_type: right_datatype.to_string(),
             })
     }
+
+    /// Get the left-hand side expression
+    pub fn lhs(&self) -> &DynProofExpr {
+        &self.lhs
+    }
+
+    /// Get the right-hand side expression
+    pub fn rhs(&self) -> &DynProofExpr {
+        &self.rhs
+    }
+
+    /// Get whether this is a less-than comparison
+    pub fn is_lt(&self) -> bool {
+        self.is_lt
+    }
 }
 
 impl ProofExpr for InequalityExpr {

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -25,13 +25,18 @@ use serde::{Deserialize, Serialize};
 /// changes, and the performance is sufficient for present.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiteralExpr {
-    pub(crate) value: LiteralValue,
+    value: LiteralValue,
 }
 
 impl LiteralExpr {
     /// Create literal expression
     pub fn new(value: LiteralValue) -> Self {
         Self { value }
+    }
+
+    /// Get the literal value
+    pub fn value(&self) -> &LiteralValue {
+        &self.value
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -21,8 +21,8 @@ use serde::{Deserialize, Serialize};
 /// Provable numerical `-` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SubtractExpr {
-    pub(crate) lhs: Box<DynProofExpr>,
-    pub(crate) rhs: Box<DynProofExpr>,
+    lhs: Box<DynProofExpr>,
+    rhs: Box<DynProofExpr>,
 }
 
 impl SubtractExpr {
@@ -36,6 +36,16 @@ impl SubtractExpr {
                 left_type: left_datatype.to_string(),
                 right_type: right_datatype.to_string(),
             })
+    }
+
+    /// Get the left-hand side expression
+    pub fn lhs(&self) -> &DynProofExpr {
+        &self.lhs
+    }
+
+    /// Get the right-hand side expression
+    pub fn rhs(&self) -> &DynProofExpr {
+        &self.rhs
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs
@@ -33,10 +33,10 @@ use serde::{Deserialize, Serialize};
 /// This differs from the [`FilterExec`] in that the result is not a sparse table.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct OstensibleFilterExec<H: ProverHonestyMarker> {
-    pub(crate) aliased_results: Vec<AliasedDynProofExpr>,
-    pub(crate) table: TableExpr,
+    aliased_results: Vec<AliasedDynProofExpr>,
+    table: TableExpr,
     /// TODO: add docs
-    pub(crate) where_clause: DynProofExpr,
+    where_clause: DynProofExpr,
     phantom: PhantomData<H>,
 }
 
@@ -53,6 +53,21 @@ impl<H: ProverHonestyMarker> OstensibleFilterExec<H> {
             where_clause,
             phantom: PhantomData,
         }
+    }
+
+    /// Get the aliased results
+    pub fn aliased_results(&self) -> &[AliasedDynProofExpr] {
+        &self.aliased_results
+    }
+
+    /// Get the table expression
+    pub fn table(&self) -> &TableExpr {
+        &self.table
+    }
+
+    /// Get the where clause expression
+    pub fn where_clause(&self) -> &DynProofExpr {
+        &self.where_clause
     }
 }
 

--- a/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/filter_exec_test_dishonest_prover.rs
@@ -45,11 +45,11 @@ impl ProverEvaluate for DishonestFilterExec {
         log::log_memory_usage("Start");
 
         let table = table_map
-            .get(&self.table.table_ref)
+            .get(&self.table().table_ref)
             .expect("Table not found");
         // 1. selection
         let selection_column: Column<'a, S> = self
-            .where_clause
+            .where_clause()
             .first_round_evaluate(alloc, table, params)?;
         let selection = selection_column
             .as_boolean()
@@ -57,7 +57,7 @@ impl ProverEvaluate for DishonestFilterExec {
         let output_length = selection.iter().filter(|b| **b).count();
         // 2. columns
         let columns: Vec<_> = self
-            .aliased_results
+            .aliased_results()
             .iter()
             .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr.expr.first_round_evaluate(alloc, table, params)
@@ -67,7 +67,7 @@ impl ProverEvaluate for DishonestFilterExec {
         let (filtered_columns, _) = filter_columns(alloc, &columns, selection);
         let filtered_columns = tamper_column(alloc, filtered_columns);
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.aliased_results
+            self.aliased_results()
                 .iter()
                 .map(|expr| expr.alias.clone())
                 .zip(filtered_columns),
@@ -97,11 +97,11 @@ impl ProverEvaluate for DishonestFilterExec {
         log::log_memory_usage("Start");
 
         let table = table_map
-            .get(&self.table.table_ref)
+            .get(&self.table().table_ref)
             .expect("Table not found");
         // 1. selection
         let selection_column: Column<'a, S> = self
-            .where_clause
+            .where_clause()
             .final_round_evaluate(builder, alloc, table, params)?;
         let selection = selection_column
             .as_boolean()
@@ -109,7 +109,7 @@ impl ProverEvaluate for DishonestFilterExec {
         let output_length = selection.iter().filter(|b| **b).count();
         // 2. columns
         let columns: Vec<_> = self
-            .aliased_results
+            .aliased_results()
             .iter()
             .map(|aliased_expr| -> PlaceholderResult<Column<'a, S>> {
                 aliased_expr
@@ -140,7 +140,7 @@ impl ProverEvaluate for DishonestFilterExec {
             result_len,
         );
         let res = Table::<'a, S>::try_from_iter_with_options(
-            self.aliased_results
+            self.aliased_results()
                 .iter()
                 .map(|expr| expr.alias.clone())
                 .zip(filtered_columns),

--- a/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/table_exec.rs
@@ -22,9 +22,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct TableExec {
     /// Table reference
-    pub table_ref: TableRef,
+    table_ref: TableRef,
     /// Schema of the table
-    pub schema: Vec<ColumnField>,
+    schema: Vec<ColumnField>,
 }
 
 impl TableExec {
@@ -32,6 +32,18 @@ impl TableExec {
     #[must_use]
     pub fn new(table_ref: TableRef, schema: Vec<ColumnField>) -> Self {
         Self { table_ref, schema }
+    }
+
+    /// Get the table reference
+    #[must_use]
+    pub fn table_ref(&self) -> &TableRef {
+        &self.table_ref
+    }
+
+    /// Get the schema
+    #[must_use]
+    pub fn schema(&self) -> &[ColumnField] {
+        &self.schema
     }
 }
 


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

This refactor improves encapsulation of our `proof_exprs` and `proof_plans` types by hiding internal fields behind explicit getter methods. It paves the way for future internal representation changes without breaking downstream code, and ensures we’re consistently using a stable, well-defined API rather than relying on direct struct field access.

---

# What changes are included in this PR?

- **Expose public getters** for all AST and proof-plan structs:
  - `AddExpr`, `SubtractExpr`, `EqualsExpr`, `InequalityExpr` each get `lhs()` and `rhs()` accessors.  
  - `ColumnExpr` gets `column_ref()` and `get_column_field()`.  
  - `LiteralExpr` gets `value()`.  
- **Hide internal fields** by removing `pub(crate)` from those struct definitions, forcing consumers to use the new getters.  
- **Update all call sites** to use getters instead of direct field access:
  - In `/crates/proof-of-sql/src/sql/proof_exprs/*` and `/crates/proof-of-sql/src/sql/proof_plans/filter_exec.rs`.  
  - In `/crates/proof-of-sql/src/sql/evm_proof_plan/plans.rs`, replacing `.field` access with methods like `.table()`, `.aliased_results()`, `.where_clause()`, etc.  
- **Revise tests** under both `proof_exprs` and `evm_proof_plan` to assert via getters (e.g. `assert_eq!(*expr.column_ref(), expected_ref)`).  
- **No behavioral changes**—all logic and test coverage remain identical.

---

# Are these changes tested?
Yes