### PR TITLE
refactor!: replace column ref with ident in accessor

### DIFF
--- a/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/evm_proof_plan/proof_plan.rs
@@ -153,7 +153,7 @@ impl ProofPlan for EVMProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
         params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof/proof_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof/proof_plan.rs
@@ -10,6 +10,7 @@ use crate::base::{
 use alloc::vec::Vec;
 use bumpalo::Bump;
 use core::fmt::Debug;
+use sqlparser::ast::Ident;
 
 /// Provable nodes in the provable AST.
 #[enum_dispatch::enum_dispatch(DynProofPlan)]
@@ -18,7 +19,7 @@ pub trait ProofPlan: Debug + Send + Sync + ProverEvaluate {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
         params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof/query_proof.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof.rs
@@ -468,6 +468,12 @@ impl<CP: CommitmentEvaluationProof> QueryProof<CP> {
         let evaluation_accessor: IndexMap<_, _> = column_references
             .into_iter()
             .zip(self.pcs_proof_evaluations.column_ref.iter().copied())
+            .chunk_by(|(r, _)| r.table_ref())
+            .into_iter()
+            .map(|(tr, g)| {
+                let im: IndexMap<_, _> = g.map(|(cr, eval)| (cr.column_id(), eval)).collect();
+                (tr, im)
+            })
             .collect();
 
         let verifier_evaluations = expr.verifier_evaluate(

--- a/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/query_proof_test.rs
@@ -88,7 +88,7 @@ impl ProofPlan for TrivialTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],
@@ -305,18 +305,16 @@ impl ProofPlan for SquareTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         let x_eval = S::from(self.anchored_commit_multiplier)
             * *accessor
-                .get(&ColumnRef::new(
-                    TableRef::new("sxt", "test"),
-                    "x".into(),
-                    ColumnType::BigInt,
-                ))
+                .get(&TableRef::new("sxt", "test"))
+                .unwrap()
+                .get(&Ident::new("x"))
                 .unwrap();
         let res_eval = builder.try_consume_final_round_mle_evaluation()?;
         builder.try_produce_sumcheck_subpolynomial_evaluation(
@@ -500,17 +498,15 @@ impl ProofPlan for DoubleSquareTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         let x_eval = *accessor
-            .get(&ColumnRef::new(
-                TableRef::new("sxt", "test"),
-                "x".into(),
-                ColumnType::BigInt,
-            ))
+            .get(&TableRef::new("sxt", "test"))
+            .unwrap()
+            .get(&Ident::new("x"))
             .unwrap();
         let z_eval = builder.try_consume_final_round_mle_evaluation()?;
         let res_eval = builder.try_consume_final_round_mle_evaluation()?;
@@ -705,7 +701,7 @@ impl ProofPlan for ChallengeTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],
@@ -713,11 +709,9 @@ impl ProofPlan for ChallengeTestProofPlan {
         let alpha = builder.try_consume_post_result_challenge()?;
         let _beta = builder.try_consume_post_result_challenge()?;
         let x_eval = *accessor
-            .get(&ColumnRef::new(
-                TableRef::new("sxt", "test"),
-                "x".into(),
-                ColumnType::BigInt,
-            ))
+            .get(&TableRef::new("sxt", "test"))
+            .unwrap()
+            .get(&Ident::new("x"))
             .unwrap();
         let res_eval = builder.try_consume_final_round_mle_evaluation()?;
         builder.try_produce_sumcheck_subpolynomial_evaluation(
@@ -848,18 +842,16 @@ impl ProofPlan for FirstRoundSquareTestProofPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],
     ) -> Result<TableEvaluation<S>, ProofError> {
         let x_eval = S::from(self.anchored_commit_multiplier)
             * *accessor
-                .get(&ColumnRef::new(
-                    TableRef::new("sxt", "test"),
-                    "x".into(),
-                    ColumnType::BigInt,
-                ))
+                .get(&TableRef::new("sxt", "test"))
+                .unwrap()
+                .get(&Ident::new("x"))
                 .unwrap();
         let first_round_res_eval = builder.try_consume_first_round_mle_evaluation()?;
         let final_round_res_eval = builder.try_consume_final_round_mle_evaluation()?;

--- a/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
+++ b/crates/proof-of-sql/src/sql/proof/verifiable_query_result_test.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
+use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize, Default)]
 pub(super) struct EmptyTestQueryExpr {
@@ -64,7 +65,7 @@ impl ProofPlan for EmptyTestQueryExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/add_expr.rs
@@ -17,6 +17,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable numerical `+` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -96,7 +97,7 @@ impl ProofExpr for AddExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr.rs
@@ -15,6 +15,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable logical AND expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -116,7 +117,7 @@ impl ProofExpr for AndExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/and_expr_test.rs
@@ -229,8 +229,8 @@ fn we_can_verify_a_simple_proof() {
         3,
         |verification_builder, chi_eval, evaluation_point| {
             let accessor = indexmap! {
-                a.clone() => lhs.inner_product(evaluation_point),
-                b.clone() => rhs.inner_product(evaluation_point)
+                a.clone().column_id() => lhs.inner_product(evaluation_point),
+                b.clone().column_id() => rhs.inner_product(evaluation_point)
             };
             and_expr
                 .verifier_evaluate(verification_builder, &accessor, chi_eval, &[])
@@ -284,8 +284,8 @@ fn we_can_reject_a_simple_tampered_proof() {
     for evaluation_point in evaluation_points {
         let chi_eval = (&[1, 1, 1, 1]).inner_product(evaluation_point);
         let accessor = indexmap! {
-            a.clone() => lhs.inner_product(evaluation_point),
-            b.clone() => rhs.inner_product(evaluation_point)
+            a.clone().column_id() => lhs.inner_product(evaluation_point),
+            b.clone().column_id() => rhs.inner_product(evaluation_point)
         };
         and_expr
             .verifier_evaluate(&mut verification_builder, &accessor, chi_eval, &[])

--- a/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/cast_expr.rs
@@ -14,6 +14,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable CAST expression
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -76,7 +77,7 @@ impl ProofExpr for CastExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/column_expr.rs
@@ -98,12 +98,12 @@ impl ProofExpr for ColumnExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         _builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         _chi_eval: S,
         _params: &[LiteralValue],
     ) -> Result<S, ProofError> {
         Ok(*accessor
-            .get(&self.column_ref)
+            .get(&self.column_ref.column_id())
             .ok_or(ProofError::VerificationError {
                 error: "Column Not Found",
             })?)

--- a/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/dyn_proof_expr.rs
@@ -18,6 +18,7 @@ use alloc::boxed::Box;
 use bumpalo::Bump;
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Enum of AST column expression types that implement `ProofExpr`. Is itself a `ProofExpr`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/equals_expr.rs
@@ -16,6 +16,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable AST expression for an equals expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -108,7 +109,7 @@ impl ProofExpr for EqualsExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/inequality_expr.rs
@@ -18,6 +18,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable AST expression for an inequality expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -132,7 +133,7 @@ impl ProofExpr for InequalityExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/literal_expr.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable CONST expression
 ///
@@ -82,7 +83,7 @@ impl ProofExpr for LiteralExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         _builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         _params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/multiply_expr.rs
@@ -16,6 +16,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable numerical * expression
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -109,7 +110,7 @@ impl ProofExpr for MultiplyExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/not_expr.rs
@@ -15,6 +15,7 @@ use crate::{
 use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable logical NOT expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -84,7 +85,7 @@ impl ProofExpr for NotExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/or_expr.rs
@@ -15,6 +15,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString, vec};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable logical OR expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -100,7 +101,7 @@ impl ProofExpr for OrExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/placeholder_expr.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable placeholder expression, that is, a placeholder in a SQL query
 ///
@@ -120,7 +121,7 @@ impl ProofExpr for PlaceholderExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         _builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/proof_expr.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use core::fmt::Debug;
+use sqlparser::ast::Ident;
 
 /// Provable AST column expression that evaluates to a `Column`
 #[enum_dispatch::enum_dispatch(DynProofExpr)]
@@ -43,7 +44,7 @@ pub trait ProofExpr: Debug + Send + Sync {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError>;

--- a/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/scaling_cast_expr.rs
@@ -17,6 +17,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ScalingCastExpr {
@@ -81,7 +82,7 @@ impl ProofExpr for ScalingCastExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_exprs/subtract_expr.rs
@@ -17,6 +17,7 @@ use crate::{
 use alloc::{boxed::Box, string::ToString};
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Provable numerical `-` expression
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -97,7 +98,7 @@ impl ProofExpr for SubtractExpr {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         chi_eval: S,
         params: &[LiteralValue],
     ) -> Result<S, ProofError> {

--- a/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/divide_and_modulo_expr.rs
@@ -1,6 +1,6 @@
 use crate::{
     base::{
-        database::{Column, ColumnRef, LiteralValue, Table},
+        database::{Column, LiteralValue, Table},
         map::IndexMap,
         proof::{PlaceholderResult, ProofError},
         scalar::Scalar,
@@ -14,6 +14,7 @@ use crate::{
 use alloc::boxed::Box;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// TODO: This struct is only partially complete. This should not be used yet. Several constraints still need to be added.
 /// A gadget for proving divide and modulo expressions in tandem.
@@ -118,7 +119,7 @@ impl DivideAndModuloExpr {
     fn verifier_evaluate<S: Scalar, B: VerificationBuilder<S>>(
         &self,
         builder: &mut B,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<Ident, S>,
         one_eval: S,
         params: &[LiteralValue],
     ) -> Result<(S, S), ProofError> {
@@ -190,8 +191,8 @@ mod tests {
             4,
             |verification_builder, chi_eval, evaluation_point| {
                 let accessor = indexmap! {
-                    lhs_ref.clone() => lhs.inner_product(evaluation_point),
-                    rhs_ref.clone() => rhs.inner_product(evaluation_point)
+                    lhs_ref.clone().column_id() => lhs.inner_product(evaluation_point),
+                    rhs_ref.clone().column_id() => rhs.inner_product(evaluation_point)
                 };
                 divide_and_modulo_expr
                     .verifier_evaluate(verification_builder, &accessor, chi_eval, &[])

--- a/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/membership_check_test.rs
@@ -166,7 +166,7 @@ impl ProofPlan for MembershipCheckTestPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/monotonic_test.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
+use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub struct MonotonicTestPlan<const STRICT: bool, const ASC: bool> {
@@ -97,7 +98,7 @@ impl<const STRICT: bool, const ASC: bool> ProofPlan for MonotonicTestPlan<STRICT
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/permutation_check_test.rs
@@ -20,6 +20,7 @@ use bumpalo::{
     Bump,
 };
 use serde::Serialize;
+use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub struct PermutationCheckTestPlan {
@@ -130,7 +131,7 @@ impl ProofPlan for PermutationCheckTestPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
+++ b/crates/proof-of-sql/src/sql/proof_gadgets/shift_test.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use serde::Serialize;
+use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub struct ShiftTestPlan {
@@ -112,7 +113,7 @@ impl ProofPlan for ShiftTestPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/demo_mock_plan.rs
@@ -14,6 +14,7 @@ use crate::{
 use alloc::vec::Vec;
 use bumpalo::Bump;
 use serde::Serialize;
+use sqlparser::ast::Ident;
 
 #[derive(Debug, Serialize)]
 pub(crate) struct DemoMockPlan {
@@ -24,7 +25,7 @@ impl ProofPlan for DemoMockPlan {
     fn verifier_evaluate<S: Scalar>(
         &self,
         _builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],
@@ -32,7 +33,7 @@ impl ProofPlan for DemoMockPlan {
         // place verification logic you want to test here
 
         Ok(TableEvaluation::new(
-            vec![accessor[&self.column]],
+            vec![accessor[&self.column.table_ref()][&self.column.column_id()]],
             chi_eval_map[&self.column.table_ref()],
         ))
     }

--- a/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/empty_exec.rs
@@ -16,6 +16,7 @@ use crate::{
 use alloc::vec::Vec;
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// Source [`ProofPlan`] for (sub)queries without table source such as `SELECT "No table here" as msg;`
 /// Inspired by [`DataFusion EmptyExec`](https://docs.rs/datafusion/latest/datafusion/physical_plan/empty/struct.EmptyExec.html)
@@ -40,7 +41,7 @@ impl ProofPlan for EmptyExec {
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        _accessor: &IndexMap<ColumnRef, S>,
+        _accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         _chi_eval_map: &IndexMap<TableRef, S>,
         _params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/slice_exec.rs
@@ -22,6 +22,7 @@ use bumpalo::Bump;
 use core::iter::repeat;
 use itertools::repeat_n;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// `ProofPlan` for queries of the form
 /// ```ignore
@@ -72,7 +73,7 @@ where
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
         params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/sort_merge_join_exec.rs
@@ -102,7 +102,7 @@ where
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
         params: &[LiteralValue],

--- a/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
+++ b/crates/proof-of-sql/src/sql/proof_plans/union_exec.rs
@@ -20,6 +20,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use bumpalo::Bump;
 use num_traits::{One, Zero};
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Ident;
 
 /// `ProofPlan` for queries of the form
 /// ```ignore
@@ -51,7 +52,7 @@ where
     fn verifier_evaluate<S: Scalar>(
         &self,
         builder: &mut impl VerificationBuilder<S>,
-        accessor: &IndexMap<ColumnRef, S>,
+        accessor: &IndexMap<TableRef, IndexMap<Ident, S>>,
         _result: Option<&OwnedTable<S>>,
         chi_eval_map: &IndexMap<TableRef, S>,
         params: &[LiteralValue],


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [x] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [x] I have run the ci check script with `source scripts/run_ci_checks.sh`.
- [x] I have run the clean commit check script with `source scripts/check_commits.sh`, and the commit history is certified to follow clean commit guidelines as described here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/COMMIT_GUIDELINES.md
- [x] The latest changes from `main` have been incorporated to this PR by simple rebase if possible, if not, then conflicts are resolved appropriately.

# Rationale for this change

`ProofPlan` and `ProofExpr` do not need the `ColumnRef` in the verifier, just the `Ident`

# What changes are included in this PR?

Modifying the `ProofPlan` and `ProofExpr` traits to replace `ColumnRef` with `Ident` in the accessor.

# Are these changes tested?
Yes
