### PR TITLE
build: add the `blitzar` feature flag to the `nova-snark` crate

### DIFF
--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -44,7 +44,7 @@ indexmap = { workspace = true, features = ["serde"] }
 indicatif = { workspace = true, optional = true }
 itertools = { workspace = true }
 merlin = { workspace = true, optional = true }
-nova-snark = { workspace = true, optional = true, features = [] }
+nova-snark = { workspace = true, optional = true, features = ["blitzar"] }
 num-traits = { workspace = true }
 num-bigint = { workspace = true, default-features = false }
 postcard = { workspace = true, features = ["alloc"] }
@@ -83,7 +83,7 @@ default = ["arrow", "perf"]
 utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2", "dep:clap", "dep:tempfile"]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
-hyperkzg_proof = ["dep:nova-snark", "std", "dep:ff", "dep:halo2curves", "blitzar", "nova-snark/blitzar"]
+hyperkzg_proof = ["dep:nova-snark", "std", "dep:ff", "dep:halo2curves", "blitzar"]
 test = ["dep:rand", "std"]
 perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]

--- a/crates/proof-of-sql/Cargo.toml
+++ b/crates/proof-of-sql/Cargo.toml
@@ -44,7 +44,7 @@ indexmap = { workspace = true, features = ["serde"] }
 indicatif = { workspace = true, optional = true }
 itertools = { workspace = true }
 merlin = { workspace = true, optional = true }
-nova-snark = { workspace = true, optional = true }
+nova-snark = { workspace = true, optional = true, features = [] }
 num-traits = { workspace = true }
 num-bigint = { workspace = true, default-features = false }
 postcard = { workspace = true, features = ["alloc"] }
@@ -83,7 +83,7 @@ default = ["arrow", "perf"]
 utils = ["dep:indicatif", "dep:rand_chacha", "dep:sha2", "dep:clap", "dep:tempfile"]
 arrow = ["dep:arrow", "std"]
 blitzar = ["dep:blitzar", "dep:merlin", "std"]
-hyperkzg_proof = ["dep:nova-snark", "std", "dep:ff", "dep:halo2curves", "blitzar"]
+hyperkzg_proof = ["dep:nova-snark", "std", "dep:ff", "dep:halo2curves", "blitzar", "nova-snark/blitzar"]
 test = ["dep:rand", "std"]
 perf = ["blitzar", "cpu-perf"]
 cpu-perf = ["rayon", "ark-ec/parallel", "ark-poly/parallel", "ark-ff/asm"]


### PR DESCRIPTION
# Rationale for this change
GPU support was added to the Microsoft Nova project in a [recent PR](https://github.com/microsoft/Nova/pull/374). By building the crate with the `blitzar` feature flag, we can unlock performance gains during the `EvaluationEngine::prove` step.

Benchmarks on a Multi-A100 system using the `hyper-kzg` commitment scheme and a table size of `1,000,000` show a `1.75x` performance improvement related to `EvaluationEngine::prove`.

Without `blitzar`, `EvaluationEngine::prove` took `859.07 ms`

![image](https://github.com/user-attachments/assets/f2287f4e-18f8-4e87-b73b-1dfaf5f1d4bb)

With `blitzar`, `EvaluationEngine::prove` took `489.53 ms`

![image](https://github.com/user-attachments/assets/121617b1-9a7d-415d-8ab8-adb0c92e4b46)


# What changes are included in this PR?
- `blitzar` is added as a feature flag to the `nova-snark` crate.

# Are these changes tested?
Yes