### PR TITLE
bench: the benchmarks should use the `proof-of-sql-planner` crate when creating proof plans

### DIFF
--- a/crates/proof-of-sql-benches/Cargo.toml
+++ b/crates/proof-of-sql-benches/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.5.4", features = ["derive", "env"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 csv = { version = "1.3.1" }
 curve25519-dalek = { version = "4", features = ["rand_core"] }
+datafusion = { version = '38.0.0', default-features = false }
 ff = { version = "0.13.0"}
 halo2curves = { version = "0.8.0", default-features = false }
 indexmap = { version = "2.8", default-features = false }
@@ -22,6 +23,7 @@ nova-snark = { version = "0.41.0" }
 opentelemetry = { version = "0.23.0" }
 opentelemetry-jaeger = { version = "0.20.0" }
 proof-of-sql = { path = "../proof-of-sql", default-features = false, features = ["arrow", "hyperkzg_proof"] }
+proof-of-sql-planner = { path = "../proof-of-sql-planner" }
 rand = { version = "0.8", default-features = false }
 sqlparser = { version = "0.45.0", default-features = false }
 tracing = { version = "0.1.36", default-features = false }

--- a/crates/proof-of-sql-benches/src/README.md
+++ b/crates/proof-of-sql-benches/src/README.md
@@ -25,7 +25,7 @@ All the options are outlined in the help and `main.rs` module.
 To run a benchmark on the `HyperKZG` commitment scheme using the `Single Column Filter` query with a table size of `1_000_000` for `3` iterations, your command would be the following.
 
 ```bash
-cargo run --release --bin proof-of-sql-benches -- --s hyper-kzg -i 3 -t 1000000 -q single-column-filter
+cargo run --release --bin proof-of-sql-benches -- -s hyper-kzg -i 3 -t 1000000 -q single-column-filter
 ```
 
 ### Memory logging (optional)

--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -111,6 +111,8 @@ enum Query {
     LargeColumnSet,
     /// Complex condition query
     ComplexCondition,
+    /// Sum count query
+    SumCount,
 }
 
 impl Query {
@@ -126,6 +128,7 @@ impl Query {
             Query::BooleanFilter => "Boolean Filter",
             Query::LargeColumnSet => "Large Column Set",
             Query::ComplexCondition => "Complex Condition",
+            Query::SumCount => "Sum Count",
         }
     }
 }

--- a/crates/proof-of-sql-benches/src/main.rs
+++ b/crates/proof-of-sql-benches/src/main.rs
@@ -113,6 +113,8 @@ enum Query {
     ComplexCondition,
     /// Sum count query
     SumCount,
+    /// Coin query
+    Coin,
 }
 
 impl Query {
@@ -129,6 +131,7 @@ impl Query {
             Query::LargeColumnSet => "Large Column Set",
             Query::ComplexCondition => "Complex Condition",
             Query::SumCount => "Sum Count",
+            Query::Coin => "Coin",
         }
     }
 }

--- a/crates/proof-of-sql-benches/src/utils/benchmark_accessor.rs
+++ b/crates/proof-of-sql-benches/src/utils/benchmark_accessor.rs
@@ -1,110 +1,17 @@
 use indexmap::IndexMap;
 use proof_of_sql::base::{
-    commitment::Commitment,
-    database::{
-        Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor,
-        TableRef,
-    },
+    commitment::CommitmentEvaluationProof,
+    database::{Table, TableRef, TableTestAccessor, TestAccessor},
 };
-use sqlparser::ast::Ident;
-#[derive(Default)]
-pub struct BenchmarkAccessor<'a, C: Commitment> {
-    columns: IndexMap<(TableRef, Ident), Column<'a, C::Scalar>>,
-    lengths: IndexMap<TableRef, usize>,
-    commitments: IndexMap<(TableRef, Ident), C>,
-    column_types: IndexMap<(TableRef, Ident), ColumnType>,
-    table_schemas: IndexMap<TableRef, Vec<(Ident, ColumnType)>>,
-}
 
-impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {
-    /// # Panics
-    ///
-    /// Will panic if the length of the columns does not match after insertion or if the commitment computation fails.
-    pub fn insert_table(
-        &mut self,
-        table_ref: TableRef,
-        columns: &[(Ident, Column<'a, C::Scalar>)],
-        setup: &C::PublicSetup<'_>,
-    ) {
-        self.table_schemas.insert(
-            table_ref.clone(),
-            columns
-                .iter()
-                .map(|(id, col)| (id.clone(), col.column_type()))
-                .collect(),
-        );
-
-        let committable_columns = columns
-            .iter()
-            .map(|(_, col)| col.into())
-            .collect::<Vec<_>>();
-
-        let commitments = C::compute_commitments(&committable_columns, 0, setup);
-
-        let mut length = None;
-        for (column, commitment) in columns.iter().zip(commitments) {
-            self.columns
-                .insert((table_ref.clone(), column.0.clone()), column.1);
-            self.commitments
-                .insert((table_ref.clone(), column.0.clone()), commitment);
-            self.column_types.insert(
-                (table_ref.clone(), column.0.clone()),
-                column.1.column_type(),
-            );
-
-            if let Some(len) = length {
-                assert!(len == column.1.len());
-            } else {
-                length = Some(column.1.len());
-            }
-        }
-        self.lengths.insert(table_ref, length.unwrap());
+/// Get a new `TableTestAccessor` with the provided tables
+pub fn new_test_accessor<'a, CP: CommitmentEvaluationProof>(
+    tables: &IndexMap<TableRef, Table<'a, CP::Scalar>>,
+    prover_setup: CP::ProverPublicSetup<'a>,
+) -> TableTestAccessor<'a, CP> {
+    let mut accessor = TableTestAccessor::<CP>::new_empty_with_setup(prover_setup);
+    for (table_ref, table) in tables {
+        accessor.add_table(table_ref.clone(), table.clone(), 0);
     }
-}
-
-impl<C: Commitment> DataAccessor<C::Scalar> for BenchmarkAccessor<'_, C> {
-    /// # Panics
-    ///
-    /// Will panic if the [`TableRef`]-[`Ident`] pair does not exist in the accessor.
-    fn get_column(&self, table_ref: &TableRef, column_id: &Ident) -> Column<C::Scalar> {
-        *self
-            .columns
-            .get(&(table_ref.clone(), column_id.clone()))
-            .unwrap()
-    }
-}
-impl<C: Commitment> MetadataAccessor for BenchmarkAccessor<'_, C> {
-    /// # Panics
-    ///
-    /// Will panic if the table reference does not exist in the lengths map.
-    fn get_length(&self, table_ref: &TableRef) -> usize {
-        *self.lengths.get(&table_ref).unwrap()
-    }
-    fn get_offset(&self, _table_ref: &TableRef) -> usize {
-        0
-    }
-}
-impl<C: Commitment> CommitmentAccessor<C> for BenchmarkAccessor<'_, C> {
-    /// # Panics
-    ///
-    /// Will panic if the [`TableRef`]-[`Ident`] pair does not exist in the commitments map.
-    fn get_commitment(&self, table_ref: &TableRef, column_id: &Ident) -> C {
-        self.commitments
-            .get(&(table_ref.clone(), column_id.clone()))
-            .unwrap()
-            .clone()
-    }
-}
-impl<C: Commitment> SchemaAccessor for BenchmarkAccessor<'_, C> {
-    fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
-        self.column_types
-            .get(&(table_ref.clone(), column_id.clone()))
-            .copied()
-    }
-    /// # Panics
-    ///
-    /// Will panic if the table reference does not exist in the table schemas map.
-    fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
-        self.table_schemas.get(&table_ref).unwrap().clone()
-    }
+    accessor
 }

--- a/crates/proof-of-sql-benches/src/utils/benchmark_accessor.rs
+++ b/crates/proof-of-sql-benches/src/utils/benchmark_accessor.rs
@@ -1,17 +1,110 @@
 use indexmap::IndexMap;
 use proof_of_sql::base::{
-    commitment::CommitmentEvaluationProof,
-    database::{Table, TableRef, TableTestAccessor, TestAccessor},
+    commitment::Commitment,
+    database::{
+        Column, ColumnType, CommitmentAccessor, DataAccessor, MetadataAccessor, SchemaAccessor,
+        TableRef,
+    },
 };
+use sqlparser::ast::Ident;
+#[derive(Default, Clone)]
+pub struct BenchmarkAccessor<'a, C: Commitment> {
+    columns: IndexMap<(TableRef, Ident), Column<'a, C::Scalar>>,
+    lengths: IndexMap<TableRef, usize>,
+    commitments: IndexMap<(TableRef, Ident), C>,
+    column_types: IndexMap<(TableRef, Ident), ColumnType>,
+    table_schemas: IndexMap<TableRef, Vec<(Ident, ColumnType)>>,
+}
 
-/// Get a new `TableTestAccessor` with the provided tables
-pub fn new_test_accessor<'a, CP: CommitmentEvaluationProof>(
-    tables: &IndexMap<TableRef, Table<'a, CP::Scalar>>,
-    prover_setup: CP::ProverPublicSetup<'a>,
-) -> TableTestAccessor<'a, CP> {
-    let mut accessor = TableTestAccessor::<CP>::new_empty_with_setup(prover_setup);
-    for (table_ref, table) in tables {
-        accessor.add_table(table_ref.clone(), table.clone(), 0);
+impl<'a, C: Commitment> BenchmarkAccessor<'a, C> {
+    /// # Panics
+    ///
+    /// Will panic if the length of the columns does not match after insertion or if the commitment computation fails.
+    pub fn insert_table(
+        &mut self,
+        table_ref: TableRef,
+        columns: &[(Ident, Column<'a, C::Scalar>)],
+        setup: &C::PublicSetup<'_>,
+    ) {
+        self.table_schemas.insert(
+            table_ref.clone(),
+            columns
+                .iter()
+                .map(|(id, col)| (id.clone(), col.column_type()))
+                .collect(),
+        );
+
+        let committable_columns = columns
+            .iter()
+            .map(|(_, col)| col.into())
+            .collect::<Vec<_>>();
+
+        let commitments = C::compute_commitments(&committable_columns, 0, setup);
+
+        let mut length = None;
+        for (column, commitment) in columns.iter().zip(commitments) {
+            self.columns
+                .insert((table_ref.clone(), column.0.clone()), column.1);
+            self.commitments
+                .insert((table_ref.clone(), column.0.clone()), commitment);
+            self.column_types.insert(
+                (table_ref.clone(), column.0.clone()),
+                column.1.column_type(),
+            );
+
+            if let Some(len) = length {
+                assert!(len == column.1.len());
+            } else {
+                length = Some(column.1.len());
+            }
+        }
+        self.lengths.insert(table_ref, length.unwrap());
     }
-    accessor
+}
+
+impl<C: Commitment> DataAccessor<C::Scalar> for BenchmarkAccessor<'_, C> {
+    /// # Panics
+    ///
+    /// Will panic if the [`TableRef`]-[`Ident`] pair does not exist in the accessor.
+    fn get_column(&self, table_ref: &TableRef, column_id: &Ident) -> Column<C::Scalar> {
+        *self
+            .columns
+            .get(&(table_ref.clone(), column_id.clone()))
+            .unwrap()
+    }
+}
+impl<C: Commitment> MetadataAccessor for BenchmarkAccessor<'_, C> {
+    /// # Panics
+    ///
+    /// Will panic if the table reference does not exist in the lengths map.
+    fn get_length(&self, table_ref: &TableRef) -> usize {
+        *self.lengths.get(&table_ref).unwrap()
+    }
+    fn get_offset(&self, _table_ref: &TableRef) -> usize {
+        0
+    }
+}
+impl<C: Commitment> CommitmentAccessor<C> for BenchmarkAccessor<'_, C> {
+    /// # Panics
+    ///
+    /// Will panic if the [`TableRef`]-[`Ident`] pair does not exist in the commitments map.
+    fn get_commitment(&self, table_ref: &TableRef, column_id: &Ident) -> C {
+        self.commitments
+            .get(&(table_ref.clone(), column_id.clone()))
+            .unwrap()
+            .clone()
+    }
+}
+impl<C: Commitment> SchemaAccessor for BenchmarkAccessor<'_, C> {
+    fn lookup_column(&self, table_ref: &TableRef, column_id: &Ident) -> Option<ColumnType> {
+        self.column_types
+            .get(&(table_ref.clone(), column_id.clone()))
+            .copied()
+    }
+    /// # Panics
+    ///
+    /// Will panic if the table reference does not exist in the table schemas map.
+    fn lookup_schema(&self, table_ref: &TableRef) -> Vec<(Ident, ColumnType)> {
+        self.table_schemas.get(&table_ref).unwrap().clone()
+    }
 }

--- a/crates/proof-of-sql-benches/src/utils/queries.rs
+++ b/crates/proof-of-sql-benches/src/utils/queries.rs
@@ -311,6 +311,47 @@ impl BaseEntry for ComplexCondition {
     }
 }
 
+/// Sum Count query.
+pub struct SumCount;
+impl BaseEntry for SumCount {
+    fn title(&self) -> &'static str {
+        "Sum Count"
+    }
+
+    fn sql(&self) -> &'static str {
+        "SELECT SUM(a*b*c) AS foo, SUM(a*b) AS bar, COUNT(1) FROM bench_table WHERE a = $1 OR c-b = $2 AND d = $3"
+    }
+
+    fn columns(&self) -> Vec<ColumnDefinition> {
+        vec![
+            (
+                "a",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "b",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            (
+                "c",
+                ColumnType::BigInt,
+                Some(|size| (size / 10).max(10) as i64),
+            ),
+            ("d", ColumnType::VarChar, None),
+        ]
+    }
+
+    fn params(&self) -> Vec<LiteralValue> {
+        vec![
+            LiteralValue::BigInt(0),
+            LiteralValue::BigInt(2),
+            LiteralValue::VarChar("a".to_string()),
+        ]
+    }
+}
+
 /// Retrieves all available queries.
 pub fn all_queries() -> Vec<QueryEntry> {
     vec![
@@ -322,6 +363,7 @@ pub fn all_queries() -> Vec<QueryEntry> {
         BooleanFilter.entry(),
         LargeColumnSet.entry(),
         ComplexCondition.entry(),
+        SumCount.entry(),
     ]
 }
 

--- a/crates/proof-of-sql-benches/src/utils/random_util.rs
+++ b/crates/proof-of-sql-benches/src/utils/random_util.rs
@@ -1,7 +1,6 @@
 use bumpalo::Bump;
-use indexmap::{indexmap, IndexMap};
 use proof_of_sql::base::{
-    database::{table_utility::table, Column, ColumnType, Table, TableRef},
+    database::{Column, ColumnType},
     scalar::Scalar,
 };
 use rand::Rng;
@@ -146,18 +145,4 @@ pub fn generate_random_columns<'a, S: Scalar>(
             )
         })
         .collect()
-}
-
-/// Generates a random table with the specified name and columns
-pub fn generate_random_table<'a, S: Scalar>(
-    alloc: &'a Bump,
-    rng: &mut impl Rng,
-    columns: &[(&str, ColumnType, OptionalRandBound)],
-    num_rows: usize,
-) -> IndexMap<TableRef, Table<'a, S>> {
-    indexmap! {
-        TableRef::from_names(None, "bench_table") => table(
-            generate_random_columns(alloc, rng, columns, num_rows)
-        )
-    }
 }

--- a/crates/proof-of-sql-benches/src/utils/random_util.rs
+++ b/crates/proof-of-sql-benches/src/utils/random_util.rs
@@ -1,6 +1,7 @@
 use bumpalo::Bump;
+use indexmap::{indexmap, IndexMap};
 use proof_of_sql::base::{
-    database::{Column, ColumnType},
+    database::{table_utility::table, Column, ColumnType, Table, TableRef},
     scalar::Scalar,
 };
 use rand::Rng;
@@ -145,4 +146,18 @@ pub fn generate_random_columns<'a, S: Scalar>(
             )
         })
         .collect()
+}
+
+/// Generates a random table with the specified name and columns
+pub fn generate_random_table<'a, S: Scalar>(
+    alloc: &'a Bump,
+    rng: &mut impl Rng,
+    columns: &[(&str, ColumnType, OptionalRandBound)],
+    num_rows: usize,
+) -> IndexMap<TableRef, Table<'a, S>> {
+    indexmap! {
+        TableRef::from_names(None, "bench_table") => table(
+            generate_random_columns(alloc, rng, columns, num_rows)
+        )
+    }
 }


### PR DESCRIPTION
# Rationale for this change
The next step in improving benchmarks is to use the `proof-of-sql-planner` crate when creating the proof plan. This PR moves all the old benchmarks to new proof planner. Additionally, two new queries are added to the benchmarks along with a number of quality of code improvements. 

# What changes are included in this PR?
- The `proof-of-sql-benches` crate now only uses `proof-of-sql-planner` for proof plans.
- Random column generation for `Decimal75` and `TimeStampTZ` column types are added.
- The query module is refactored.
- Two new queries are added to the query module.

# Are these changes tested?
Yes